### PR TITLE
fix: update gem details to reflect janeapp ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,75 +5,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0](https://github.com/bottrall/riffer/compare/riffer/v0.4.2...riffer/v0.5.0) (2026-01-06)
-
-
-### Features
-
-* streaming via agents ([#63](https://github.com/bottrall/riffer/issues/63)) ([b4171c2](https://github.com/bottrall/riffer/commit/b4171c20f64a7ada1264ce90ab5278c19ff8a47a))
-
-## [0.4.2](https://github.com/bottrall/riffer/compare/riffer/v0.4.1...riffer/v0.4.2) (2025-12-29)
-
-
-### Bug Fixes
-
-* update README for clarity on provider usage and examples ([#60](https://github.com/bottrall/riffer/issues/60)) ([b12835c](https://github.com/bottrall/riffer/commit/b12835ce71c29e02074a0897551db50283ac8be6))
-
-## [0.4.1](https://github.com/bottrall/riffer/compare/riffer/v0.4.0...riffer/v0.4.1) (2025-12-29)
-
-
-### Bug Fixes
-
-* add conditional check for docs job execution based on release creation ([#58](https://github.com/bottrall/riffer/issues/58)) ([97bc6f7](https://github.com/bottrall/riffer/commit/97bc6f79b20902f94edac35b7d9d25c2e033d8bd))
-* add permissions for contents in docs job ([#57](https://github.com/bottrall/riffer/issues/57)) ([1dd5f7a](https://github.com/bottrall/riffer/commit/1dd5f7a817d4f73c1a0cad1a93fee0148ef10705))
-* suppress output during documentation generation ([#53](https://github.com/bottrall/riffer/issues/53)) ([6b7f2d9](https://github.com/bottrall/riffer/commit/6b7f2d9aa7adb5450855097840c971dcf201d8c0))
-* update rdoc command to target the lib directory ([#56](https://github.com/bottrall/riffer/issues/56)) ([c319efe](https://github.com/bottrall/riffer/commit/c319efe039ddb118411ad9e270dc0994d3b8cf5c))
-
-## [0.4.0](https://github.com/bottrall/riffer/compare/riffer/v0.3.2...riffer/v0.4.0) (2025-12-29)
-
+## [0.5.0](https://github.com/janeapp/riffer/compare/riffer/v0.4.2...riffer/v0.5.0) (2026-01-06)
 
 ### Features
 
-* add documentation generation and publishing workflow ([#51](https://github.com/bottrall/riffer/issues/51)) ([49e3b04](https://github.com/bottrall/riffer/commit/49e3b046c2011f56bb8803b76e152df9ffb26617))
+- streaming via agents ([#63](https://github.com/janeapp/riffer/issues/63)) ([b4171c2](https://github.com/janeapp/riffer/commit/b4171c20f64a7ada1264ce90ab5278c19ff8a47a))
 
-## [0.3.2](https://github.com/bottrall/riffer/compare/riffer/v0.3.1...riffer/v0.3.2) (2025-12-29)
-
-
-### Bug Fixes
-
-* add Rubygems credentials configuration step in release workflow ([#49](https://github.com/bottrall/riffer/issues/49)) ([dcc71e0](https://github.com/bottrall/riffer/commit/dcc71e01f541510ab73986237adaabfab1ef2401))
-
-## [0.3.1](https://github.com/bottrall/riffer/compare/riffer/v0.3.0...riffer/v0.3.1) (2025-12-29)
-
+## [0.4.2](https://github.com/janeapp/riffer/compare/riffer/v0.4.1...riffer/v0.4.2) (2025-12-29)
 
 ### Bug Fixes
 
-* update checkout action version in release workflow ([#47](https://github.com/bottrall/riffer/issues/47)) ([c6b1361](https://github.com/bottrall/riffer/commit/c6b1361b20d7cc4522e20c46fa1a75ad3a8a80d7))
+- update README for clarity on provider usage and examples ([#60](https://github.com/janeapp/riffer/issues/60)) ([b12835c](https://github.com/janeapp/riffer/commit/b12835ce71c29e02074a0897551db50283ac8be6))
 
-## [0.3.0](https://github.com/bottrall/riffer/compare/riffer-v0.2.0...riffer/v0.3.0) (2025-12-29)
+## [0.4.1](https://github.com/janeapp/riffer/compare/riffer/v0.4.0...riffer/v0.4.1) (2025-12-29)
 
+### Bug Fixes
+
+- add conditional check for docs job execution based on release creation ([#58](https://github.com/janeapp/riffer/issues/58)) ([97bc6f7](https://github.com/janeapp/riffer/commit/97bc6f79b20902f94edac35b7d9d25c2e033d8bd))
+- add permissions for contents in docs job ([#57](https://github.com/janeapp/riffer/issues/57)) ([1dd5f7a](https://github.com/janeapp/riffer/commit/1dd5f7a817d4f73c1a0cad1a93fee0148ef10705))
+- suppress output during documentation generation ([#53](https://github.com/janeapp/riffer/issues/53)) ([6b7f2d9](https://github.com/janeapp/riffer/commit/6b7f2d9aa7adb5450855097840c971dcf201d8c0))
+- update rdoc command to target the lib directory ([#56](https://github.com/janeapp/riffer/issues/56)) ([c319efe](https://github.com/janeapp/riffer/commit/c319efe039ddb118411ad9e270dc0994d3b8cf5c))
+
+## [0.4.0](https://github.com/janeapp/riffer/compare/riffer/v0.3.2...riffer/v0.4.0) (2025-12-29)
 
 ### Features
 
-* add release and publish workflows ([#35](https://github.com/bottrall/riffer/issues/35)) ([3eb0389](https://github.com/bottrall/riffer/commit/3eb03897d0e96c01ef1857c04b2bafa53e37dde0))
+- add documentation generation and publishing workflow ([#51](https://github.com/janeapp/riffer/issues/51)) ([49e3b04](https://github.com/janeapp/riffer/commit/49e3b046c2011f56bb8803b76e152df9ffb26617))
 
+## [0.3.2](https://github.com/janeapp/riffer/compare/riffer/v0.3.1...riffer/v0.3.2) (2025-12-29)
 
 ### Bug Fixes
 
-* add manifest file to release configuration ([#43](https://github.com/bottrall/riffer/issues/43)) ([8d46135](https://github.com/bottrall/riffer/commit/8d46135ccd1c4315d624fa11a639e51aa1f1e5b8))
-* auto-publishing on new release ([#38](https://github.com/bottrall/riffer/issues/38)) ([5a1d267](https://github.com/bottrall/riffer/commit/5a1d267e046c1531e01c80b9e40b94eed216360c))
-* remove manifest file from release configuration ([#41](https://github.com/bottrall/riffer/issues/41)) ([2f898d8](https://github.com/bottrall/riffer/commit/2f898d8e1bdf6787583f22c83e83e90f2a75142e))
-* remove release-type configuration from release workflow ([#42](https://github.com/bottrall/riffer/issues/42)) ([e270a6c](https://github.com/bottrall/riffer/commit/e270a6c906f7e04f1b0ce57b7d29808c98e7dce8))
-* reset release manifest to empty object ([#44](https://github.com/bottrall/riffer/issues/44)) ([26f1b6d](https://github.com/bottrall/riffer/commit/26f1b6d2dcb622295026cc7fb247559156864d74))
-* restructure release configuration and update manifest format ([#45](https://github.com/bottrall/riffer/issues/45)) ([d07694c](https://github.com/bottrall/riffer/commit/d07694c05d49166740f3408a343c351d33749edf))
-* simplify release configuration by removing unnecessary package structure ([#40](https://github.com/bottrall/riffer/issues/40)) ([8472967](https://github.com/bottrall/riffer/commit/84729670fd202208256e6de69f1b81366ad0a688))
+- add Rubygems credentials configuration step in release workflow ([#49](https://github.com/janeapp/riffer/issues/49)) ([dcc71e0](https://github.com/janeapp/riffer/commit/dcc71e01f541510ab73986237adaabfab1ef2401))
 
-## [0.2.0](https://github.com/bottrall/riffer/compare/v0.1.0...v0.2.0) (2025-12-28)
+## [0.3.1](https://github.com/janeapp/riffer/compare/riffer/v0.3.0...riffer/v0.3.1) (2025-12-29)
 
+### Bug Fixes
+
+- update checkout action version in release workflow ([#47](https://github.com/janeapp/riffer/issues/47)) ([c6b1361](https://github.com/janeapp/riffer/commit/c6b1361b20d7cc4522e20c46fa1a75ad3a8a80d7))
+
+## [0.3.0](https://github.com/janeapp/riffer/compare/riffer-v0.2.0...riffer/v0.3.0) (2025-12-29)
 
 ### Features
 
-* add release and publish workflows ([#35](https://github.com/bottrall/riffer/issues/35)) ([3eb0389](https://github.com/bottrall/riffer/commit/3eb03897d0e96c01ef1857c04b2bafa53e37dde0))
+- add release and publish workflows ([#35](https://github.com/janeapp/riffer/issues/35)) ([3eb0389](https://github.com/janeapp/riffer/commit/3eb03897d0e96c01ef1857c04b2bafa53e37dde0))
+
+### Bug Fixes
+
+- add manifest file to release configuration ([#43](https://github.com/janeapp/riffer/issues/43)) ([8d46135](https://github.com/janeapp/riffer/commit/8d46135ccd1c4315d624fa11a639e51aa1f1e5b8))
+- auto-publishing on new release ([#38](https://github.com/janeapp/riffer/issues/38)) ([5a1d267](https://github.com/janeapp/riffer/commit/5a1d267e046c1531e01c80b9e40b94eed216360c))
+- remove manifest file from release configuration ([#41](https://github.com/janeapp/riffer/issues/41)) ([2f898d8](https://github.com/janeapp/riffer/commit/2f898d8e1bdf6787583f22c83e83e90f2a75142e))
+- remove release-type configuration from release workflow ([#42](https://github.com/janeapp/riffer/issues/42)) ([e270a6c](https://github.com/janeapp/riffer/commit/e270a6c906f7e04f1b0ce57b7d29808c98e7dce8))
+- reset release manifest to empty object ([#44](https://github.com/janeapp/riffer/issues/44)) ([26f1b6d](https://github.com/janeapp/riffer/commit/26f1b6d2dcb622295026cc7fb247559156864d74))
+- restructure release configuration and update manifest format ([#45](https://github.com/janeapp/riffer/issues/45)) ([d07694c](https://github.com/janeapp/riffer/commit/d07694c05d49166740f3408a343c351d33749edf))
+- simplify release configuration by removing unnecessary package structure ([#40](https://github.com/janeapp/riffer/issues/40)) ([8472967](https://github.com/janeapp/riffer/commit/84729670fd202208256e6de69f1b81366ad0a688))
+
+## [0.2.0](https://github.com/janeapp/riffer/compare/v0.1.0...v0.2.0) (2025-12-28)
+
+### Features
+
+- add release and publish workflows ([#35](https://github.com/janeapp/riffer/issues/35)) ([3eb0389](https://github.com/janeapp/riffer/commit/3eb03897d0e96c01ef1857c04b2bafa53e37dde0))
 
 ## [0.1.0] - 2024-12-20
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2025 Jake Bottrall
+Copyright (c) 2025 Jane Software Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ gem 'riffer'
 Install the development branch directly from GitHub:
 
 ```ruby
-gem 'riffer', git: 'https://github.com/bottrall/riffer.git'
+gem 'riffer', git: 'https://github.com/janeapp/riffer.git'
 ```
 
 ## Quick Start
@@ -110,7 +110,7 @@ bin/console
 2. Run tests and linters locally: `bundle exec rake`
 3. Submit a pull request with a clear description of the change
 
-Please follow the [Code of Conduct](https://github.com/bottrall/riffer/blob/main/CODE_OF_CONDUCT.md).
+Please follow the [Code of Conduct](https://github.com/bottrall/janeapp/blob/main/CODE_OF_CONDUCT.md).
 
 ## Changelog
 

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/bottrall/riffer"
-  spec.metadata["changelog_uri"] = "https://github.com/bottrall/riffer/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/janeapp/riffer"
+  spec.metadata["changelog_uri"] = "https://github.com/janeapp/riffer/blob/main/CHANGELOG.md"
 
   # Extra files to include in generated documentation
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md", "LICENSE.txt"]


### PR DESCRIPTION
This pull request updates project references and copyright information throughout the repository to reflect the transfer of ownership from an individual to Jane Software Inc. The changes ensure all documentation, metadata, and licensing accurately point to the new organization and repository location.

Repository and ownership updates:

* Changed all GitHub URLs in `CHANGELOG.md`, `README.md`, and gemspec metadata from `bottrall/riffer` to `janeapp/riffer` to reflect the new repository location. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R67) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45) [[3]](diffhunk://#diff-283c16733a1027352a93fa88a8b8d0e58b090088aa3265500d6e8e9ce4aa6ff1L20-R21)
* Updated the license copyright in `LICENSE.txt` from Jake Bottrall to Jane Software Inc.

Documentation updates:

* Updated the Code of Conduct link in `README.md` to point to the new `janeapp` organization.