### PR TITLE
fix: update GitHub Pages deployment action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,4 +49,5 @@ jobs:
       - run: bundle exec rake rdoc
       - uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
         with:
+          branch: gh-pages
           folder: ./doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
         with:
           bundler-cache: true
       - run: bundle exec rake rdoc
-      - uses: peaceiris/actions-gh-pages@v4
+      - uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc
+          folder: ./doc


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for documentation deployment. The main change is switching the action used to deploy generated documentation to GitHub Pages, as the previous action was not whitelisted by our github action configuration.

Documentation deployment workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L50-R52): Replaced `peaceiris/actions-gh-pages` with `JamesIves/github-pages-deploy-action` for publishing documentation, and updated configuration to use the `folder` parameter instead of `publish_dir`.