### PR TITLE
fix: remove unnecessary require statement for openai

### DIFF
--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "openai"
-
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
   # Initializes the OpenAI provider.
   # @param options [Hash] optional client options. Use `:api_key` to override `Riffer.config.openai.api_key`.


### PR DESCRIPTION
This line causes projects that do not have the openai gem installed to fail.