### PR TITLE
feat: add timeout functionality to tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@janeapp/jane-ai
+* @janeapp/jane-ai

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -154,6 +154,23 @@ def call(context:, query:)
 end
 ```
 
+## Timeout Configuration
+
+Configure timeouts to prevent tools from running indefinitely. The default timeout is 10 seconds.
+
+```ruby
+class SlowExternalApiTool < Riffer::Tool
+  description "Calls a slow external API"
+  timeout 30  # 30 seconds
+
+  def call(context:, query:)
+    ExternalAPI.search(query)
+  end
+end
+```
+
+When a tool times out, the error is reported to the LLM with error type `:timeout_error`, allowing it to respond appropriately (e.g., suggest retrying or using a different approach).
+
 ## Validation
 
 Arguments are automatically validated before `call` is invoked:

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -23,6 +23,9 @@ module Riffer
   # Raised when tool parameter validation fails.
   class ValidationError < Error; end
 
+  # Raised when tool execution times out.
+  class TimeoutError < Error; end
+
   class << self
     # Returns the Riffer configuration.
     #

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -273,10 +273,10 @@ class Riffer::Agent
     begin
       result = tool_instance.call_with_validation(context: @tool_context, **arguments)
       {content: result.to_s, error: nil, error_type: nil}
-    rescue Timeout::Error
+    rescue Riffer::TimeoutError => e
       {
-        content: "Error: Tool '#{tool_call[:name]}' timed out after #{tool_class.timeout} seconds",
-        error: "Tool '#{tool_call[:name]}' timed out after #{tool_class.timeout} seconds",
+        content: "Error: #{e.message}",
+        error: e.message,
         error_type: :timeout_error
       }
     rescue Riffer::ValidationError => e

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -273,6 +273,12 @@ class Riffer::Agent
     begin
       result = tool_instance.call_with_validation(context: @tool_context, **arguments)
       {content: result.to_s, error: nil, error_type: nil}
+    rescue Timeout::Error
+      {
+        content: "Error: Tool '#{tool_call[:name]}' timed out after #{tool_class.timeout} seconds",
+        error: "Tool '#{tool_call[:name]}' timed out after #{tool_class.timeout} seconds",
+        error_type: :timeout_error
+      }
     rescue Riffer::ValidationError => e
       {
         content: "Validation error: #{e.message}",

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -27,7 +27,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # Returns String or nil.
   attr_reader :error
 
-  # The type of error (:unknown_tool, :validation_error, :execution_error).
+  # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
   #
   # Returns Symbol or nil.
   attr_reader :error_type

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 # Riffer::Tool is the base class for all tools in the Riffer framework.
 #
 # Provides a DSL for defining tool description and parameters.
@@ -47,6 +49,16 @@ class Riffer::Tool
     # Alias for identifier - used by providers
     alias_method :name, :identifier
 
+    # Gets or sets the tool timeout in seconds.
+    #
+    # value:: Numeric or nil - the timeout to set in seconds, or nil to get
+    #
+    # Returns Numeric - the tool timeout (defaults to 10).
+    def timeout(value = nil)
+      return @timeout || 10 if value.nil?
+      @timeout = value.to_f
+    end
+
     # Defines parameters using the Params DSL.
     #
     # Yields to the parameter definition block.
@@ -84,7 +96,7 @@ class Riffer::Tool
     raise NotImplementedError, "#{self.class} must implement #call"
   end
 
-  # Executes the tool with validation (used by Agent).
+  # Executes the tool with validation and timeout (used by Agent).
   #
   # context:: Object or nil - context passed from the agent
   # kwargs:: Hash - the tool arguments
@@ -92,9 +104,13 @@ class Riffer::Tool
   # Returns Object - the tool result.
   #
   # Raises Riffer::ValidationError if validation fails.
+  # Raises Timeout::Error if execution exceeds the configured timeout.
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params
     validated_args = params_builder ? params_builder.validate(kwargs) : kwargs
-    call(context: context, **validated_args)
+
+    Timeout.timeout(self.class.timeout) do
+      call(context: context, **validated_args)
+    end
   end
 end

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -104,7 +104,7 @@ class Riffer::Tool
   # Returns Object - the tool result.
   #
   # Raises Riffer::ValidationError if validation fails.
-  # Raises Timeout::Error if execution exceeds the configured timeout.
+  # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params
     validated_args = params_builder ? params_builder.validate(kwargs) : kwargs
@@ -112,5 +112,7 @@ class Riffer::Tool
     Timeout.timeout(self.class.timeout) do
       call(context: context, **validated_args)
     end
+  rescue Timeout::Error
+    raise Riffer::TimeoutError, "Tool execution timed out after #{self.class.timeout} seconds"
   end
 end

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -23,6 +23,8 @@ require "timeout"
 #   end
 #
 class Riffer::Tool
+  DEFAULT_TIMEOUT = 10
+
   class << self
     include Riffer::Helpers::ClassNameConverter
 
@@ -55,7 +57,7 @@ class Riffer::Tool
     #
     # Returns Numeric - the tool timeout (defaults to 10).
     def timeout(value = nil)
-      return @timeout || 10 if value.nil?
+      return @timeout || DEFAULT_TIMEOUT if value.nil?
       @timeout = value.to_f
     end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -826,10 +826,10 @@ describe Riffer::Agent do
       let(:slow_tool_class) do
         Class.new(Riffer::Tool) do
           description "A slow tool"
-          timeout 0.1
+          timeout 0.01
 
           def call(context:)
-            sleep 2
+            sleep 0.02
             "done"
           end
         end
@@ -910,7 +910,7 @@ describe Riffer::Agent do
 
         tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal true
-        expect(tool_message.error).must_match(/0\.1 seconds/)
+        expect(tool_message.error).must_match(/0\.01 seconds/)
       end
 
       it "fast tools do not timeout" do

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -179,5 +179,48 @@ describe Riffer::Tool do
       result = tool.call_with_validation(context: nil)
       expect(result).must_equal "Simple result"
     end
+
+    it "raises TimeoutError when execution exceeds timeout" do
+      slow_tool_class = Class.new(Riffer::Tool) do
+        timeout 0.01
+
+        def call(context:)
+          sleep 0.02
+          "done"
+        end
+      end
+
+      tool = slow_tool_class.new
+      expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::TimeoutError)
+    end
+
+    it "includes timeout duration in error message" do
+      slow_tool_class = Class.new(Riffer::Tool) do
+        timeout 0.01
+
+        def call(context:)
+          sleep 0.02
+          "done"
+        end
+      end
+
+      tool = slow_tool_class.new
+      error = expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::TimeoutError)
+      expect(error.message).must_match(/0\.01 seconds/)
+    end
+
+    it "completes successfully when within timeout" do
+      fast_tool_class = Class.new(Riffer::Tool) do
+        timeout 1
+
+        def call(context:)
+          "fast result"
+        end
+      end
+
+      tool = fast_tool_class.new
+      result = tool.call_with_validation(context: nil)
+      expect(result).must_equal "fast result"
+    end
   end
 end

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -47,6 +47,27 @@ describe Riffer::Tool do
     end
   end
 
+  describe ".timeout" do
+    it "returns 10 when not set" do
+      tool_class = Class.new(Riffer::Tool)
+      expect(tool_class.timeout).must_equal 10
+    end
+
+    it "sets the timeout value" do
+      tool_class = Class.new(Riffer::Tool) do
+        timeout 30
+      end
+      expect(tool_class.timeout).must_equal 30.0
+    end
+
+    it "converts to float" do
+      tool_class = Class.new(Riffer::Tool) do
+        timeout 15
+      end
+      expect(tool_class.timeout).must_be_instance_of Float
+    end
+  end
+
   describe ".params" do
     it "returns the params builder" do
       expect(weather_tool_class.params).must_be_instance_of Riffer::Tools::Params

--- a/test/riffer_test.rb
+++ b/test/riffer_test.rb
@@ -3,6 +3,12 @@
 require "test_helper"
 
 describe Riffer do
+  describe "TimeoutError" do
+    it "is a subclass of Riffer::Error" do
+      expect(Riffer::TimeoutError.superclass).must_equal Riffer::Error
+    end
+  end
+
   describe ".version" do
     it "has a version number" do
       expect(Riffer.version).wont_be_nil

--- a/test/riffer_test.rb
+++ b/test/riffer_test.rb
@@ -3,12 +3,6 @@
 require "test_helper"
 
 describe Riffer do
-  describe "TimeoutError" do
-    it "is a subclass of Riffer::Error" do
-      expect(Riffer::TimeoutError.superclass).must_equal Riffer::Error
-    end
-  end
-
   describe ".version" do
     it "has a version number" do
       expect(Riffer.version).wont_be_nil


### PR DESCRIPTION
Introduce a timeout feature for tools in the Riffer framework, including a new `TimeoutError` class. Update documentation and tests to reflect the new timeout handling, ensuring tools do not run indefinitely and errors are reported appropriately. Update CODEOWNERS to include wildcard for all paths.