### PR TITLE
feat: add on_message callback for real-time message emission

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -161,10 +161,10 @@ Registers a callback to receive messages as they're added during generation:
 
 ```ruby
 agent.on_message do |message|
-  case message
-  when Riffer::Messages::Assistant
+  case message.role
+  when :assistant
     puts "[Assistant] #{message.content}"
-  when Riffer::Messages::Tool
+  when :tool
     puts "[Tool:#{message.name}] #{message.content}"
   end
 end

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -155,6 +155,32 @@ agent.messages.each do |msg|
 end
 ```
 
+### on_message
+
+Registers a callback to receive messages as they're added during generation:
+
+```ruby
+agent.on_message do |message|
+  case message
+  when Riffer::Messages::Assistant
+    puts "[Assistant] #{message.content}"
+  when Riffer::Messages::Tool
+    puts "[Tool:#{message.name}] #{message.content}"
+  end
+end
+```
+
+Multiple callbacks can be registered. Returns `self` for method chaining:
+
+```ruby
+agent
+  .on_message { |msg| persist_message(msg) }
+  .on_message { |msg| log_message(msg) }
+  .generate('Hello')
+```
+
+Works with both `generate` and `stream`. Only emits agent-generated messages (Assistant, Tool), not inputs (System, User).
+
 ## Class Methods
 
 ### find

--- a/docs/05_MESSAGES.md
+++ b/docs/05_MESSAGES.md
@@ -10,9 +10,9 @@ System messages provide instructions to the LLM:
 
 ```ruby
 msg = Riffer::Messages::System.new("You are a helpful assistant.")
-msg.role     # => "system"
+msg.role     # => :system
 msg.content  # => "You are a helpful assistant."
-msg.to_h     # => {role: "system", content: "You are a helpful assistant."}
+msg.to_h     # => {role: :system, content: "You are a helpful assistant."}
 ```
 
 System messages are typically set via agent `instructions` and automatically prepended to conversations.
@@ -23,9 +23,9 @@ User messages represent input from the user:
 
 ```ruby
 msg = Riffer::Messages::User.new("Hello, how are you?")
-msg.role     # => "user"
+msg.role     # => :user
 msg.content  # => "Hello, how are you?"
-msg.to_h     # => {role: "user", content: "Hello, how are you?"}
+msg.to_h     # => {role: :user, content: "Hello, how are you?"}
 ```
 
 ### Assistant
@@ -35,7 +35,7 @@ Assistant messages represent LLM responses, potentially including tool calls:
 ```ruby
 # Text-only response
 msg = Riffer::Messages::Assistant.new("I'm doing well, thank you!")
-msg.role        # => "assistant"
+msg.role        # => :assistant
 msg.content     # => "I'm doing well, thank you!"
 msg.tool_calls  # => []
 
@@ -57,7 +57,7 @@ msg = Riffer::Messages::Tool.new(
   tool_call_id: "call_123",
   name: "weather_tool"
 )
-msg.role          # => "tool"
+msg.role          # => :tool
 msg.content       # => "The weather in Tokyo is 22C and sunny."
 msg.tool_call_id  # => "call_123"
 msg.name          # => "weather_tool"
@@ -95,9 +95,9 @@ For multi-turn conversations, pass an array of messages:
 
 ```ruby
 messages = [
-  {role: "user", content: "What's the weather?"},
-  {role: "assistant", content: "I'll check that for you."},
-  {role: "user", content: "Thanks, I meant in Tokyo specifically."}
+  {role: :user, content: "What's the weather?"},
+  {role: :assistant, content: "I'll check that for you."},
+  {role: :user, content: "Thanks, I meant in Tokyo specifically."}
 ]
 
 response = agent.generate(messages)
@@ -129,20 +129,6 @@ end
 # [system] You are a helpful assistant.
 # [user] Hello!
 # [assistant] Hi there! How can I help you today?
-```
-
-## Message Conversion
-
-Messages can be created from hashes using the internal converter:
-
-```ruby
-# Hash to message object
-msg = agent.send(:convert_to_message_object, {role: "user", content: "Hello"})
-# => #<Riffer::Messages::User ...>
-
-# Message to hash
-msg.to_h
-# => {role: "user", content: "Hello"}
 ```
 
 ## Tool Call Structure

--- a/docs/05_MESSAGES.md
+++ b/docs/05_MESSAGES.md
@@ -160,6 +160,12 @@ Tool calls in assistant messages have this structure:
 
 When creating tool result messages, use the `id` as `tool_call_id`.
 
+## Message Emission
+
+Agents can emit messages as they're added during generation via the `on_message` callback. This is useful for persistence or real-time logging. Only agent-generated messages (Assistant, Tool) are emitted—not inputs (System, User).
+
+See [Agents - on_message](03_AGENTS.md#on_message) for details.
+
 ## Base Class
 
 All messages inherit from `Riffer::Messages::Base`:

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -5,7 +5,7 @@
 # May include tool calls when the LLM requests tool execution.
 #
 #   msg = Riffer::Messages::Assistant.new("Hello!")
-#   msg.role        # => "assistant"
+#   msg.role        # => :assistant
 #   msg.content     # => "Hello!"
 #   msg.tool_calls  # => []
 #
@@ -26,9 +26,9 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     @tool_calls = tool_calls
   end
 
-  # Returns "assistant".
+  # Returns :assistant.
   def role
-    "assistant"
+    :assistant
   end
 
   # Converts the message to a hash.

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -31,15 +31,15 @@ module Riffer::Messages::Converter
       raise Riffer::ArgumentError, "Message hash must include a 'role' key"
     end
 
-    case role
-    when "user"
+    case role.to_sym
+    when :user
       Riffer::Messages::User.new(content)
-    when "assistant"
+    when :assistant
       tool_calls = hash[:tool_calls] || hash["tool_calls"] || []
       Riffer::Messages::Assistant.new(content, tool_calls: tool_calls)
-    when "system"
+    when :system
       Riffer::Messages::System.new(content)
-    when "tool"
+    when :tool
       tool_call_id = hash[:tool_call_id] || hash["tool_call_id"]
       name = hash[:name] || hash["name"]
       Riffer::Messages::Tool.new(content, tool_call_id: tool_call_id, name: name)

--- a/lib/riffer/messages/system.rb
+++ b/lib/riffer/messages/system.rb
@@ -3,12 +3,12 @@
 # Represents a system message (instructions) in a conversation.
 #
 #   msg = Riffer::Messages::System.new("You are a helpful assistant.")
-#   msg.role     # => "system"
+#   msg.role     # => :system
 #   msg.content  # => "You are a helpful assistant."
 #
 class Riffer::Messages::System < Riffer::Messages::Base
-  # Returns "system".
+  # Returns :system.
   def role
-    "system"
+    :system
   end
 end

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -7,7 +7,7 @@
 #     tool_call_id: "call_123",
 #     name: "weather_tool"
 #   )
-#   msg.role          # => "tool"
+#   msg.role          # => :tool
 #   msg.tool_call_id  # => "call_123"
 #   msg.error?        # => false
 #
@@ -54,9 +54,9 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
     !@error.nil?
   end
 
-  # Returns "tool".
+  # Returns :tool.
   def role
-    "tool"
+    :tool
   end
 
   # Converts the message to a hash.

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -3,12 +3,12 @@
 # Represents a user message in a conversation.
 #
 #   msg = Riffer::Messages::User.new("Hello!")
-#   msg.role     # => "user"
+#   msg.role     # => :user
 #   msg.content  # => "Hello!"
 #
 class Riffer::Messages::User < Riffer::Messages::Base
-  # Returns "user".
+  # Returns :user.
   def role
-    "user"
+    :user
   end
 end

--- a/lib/riffer/stream_events/base.rb
+++ b/lib/riffer/stream_events/base.rb
@@ -4,15 +4,15 @@
 #
 # Subclasses must implement the +to_h+ method.
 class Riffer::StreamEvents::Base
-  # The message role (typically "assistant").
+  # The message role (typically :assistant).
   #
-  # Returns String.
+  # Returns Symbol.
   attr_reader :role
 
   # Creates a new stream event.
   #
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(role: :assistant)
     @role = role
   end
 

--- a/lib/riffer/stream_events/reasoning_delta.rb
+++ b/lib/riffer/stream_events/reasoning_delta.rb
@@ -13,8 +13,8 @@ class Riffer::StreamEvents::ReasoningDelta < Riffer::StreamEvents::Base
   # Creates a new reasoning delta event.
   #
   # content:: String - the incremental reasoning content
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(content, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end

--- a/lib/riffer/stream_events/reasoning_done.rb
+++ b/lib/riffer/stream_events/reasoning_done.rb
@@ -13,8 +13,8 @@ class Riffer::StreamEvents::ReasoningDone < Riffer::StreamEvents::Base
   # Creates a new reasoning done event.
   #
   # content:: String - the complete reasoning content
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(content, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end

--- a/lib/riffer/stream_events/text_delta.rb
+++ b/lib/riffer/stream_events/text_delta.rb
@@ -12,8 +12,8 @@ class Riffer::StreamEvents::TextDelta < Riffer::StreamEvents::Base
   # Creates a new text delta event.
   #
   # content:: String - the incremental text content
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(content, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end

--- a/lib/riffer/stream_events/text_done.rb
+++ b/lib/riffer/stream_events/text_done.rb
@@ -12,8 +12,8 @@ class Riffer::StreamEvents::TextDone < Riffer::StreamEvents::Base
   # Creates a new text done event.
   #
   # content:: String - the complete text content
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(content, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end

--- a/lib/riffer/stream_events/tool_call_delta.rb
+++ b/lib/riffer/stream_events/tool_call_delta.rb
@@ -18,8 +18,8 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
   # item_id:: String - the tool call item identifier
   # name:: String or nil - the tool name (may only be present in first delta)
   # arguments_delta:: String - the incremental arguments JSON fragment
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(item_id:, arguments_delta:, name: nil, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(item_id:, arguments_delta:, name: nil, role: :assistant)
     super(role: role)
     @item_id = item_id
     @name = name

--- a/lib/riffer/stream_events/tool_call_done.rb
+++ b/lib/riffer/stream_events/tool_call_done.rb
@@ -22,8 +22,8 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
   # call_id:: String - the call identifier for response matching
   # name:: String - the tool name
   # arguments:: String - the complete arguments JSON string
-  # role:: String - the message role (defaults to "assistant")
-  def initialize(item_id:, call_id:, name:, arguments:, role: "assistant")
+  # role:: Symbol - the message role (defaults to :assistant)
+  def initialize(item_id:, call_id:, name:, arguments:, role: :assistant)
     super(role: role)
     @item_id = item_id
     @call_id = call_id

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -6,14 +6,14 @@ describe Riffer::Messages::Assistant do
   describe "#role" do
     it "returns assistant" do
       message = Riffer::Messages::Assistant.new("I can help")
-      expect(message.role).must_equal "assistant"
+      expect(message.role).must_equal :assistant
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::Assistant.new("I can help")
-      expect(message.to_h).must_equal({role: "assistant", content: "I can help"})
+      expect(message.to_h).must_equal({role: :assistant, content: "I can help"})
     end
 
     it "includes tool_calls when provided" do
@@ -23,7 +23,7 @@ describe Riffer::Messages::Assistant do
 
     it "excludes tool_calls when empty" do
       message = Riffer::Messages::Assistant.new("No tools")
-      expect(message.to_h).must_equal({role: "assistant", content: "No tools"})
+      expect(message.to_h).must_equal({role: :assistant, content: "No tools"})
     end
   end
 end

--- a/test/riffer/messages/system_test.rb
+++ b/test/riffer/messages/system_test.rb
@@ -6,14 +6,14 @@ describe Riffer::Messages::System do
   describe "#role" do
     it "returns system" do
       message = Riffer::Messages::System.new("You are helpful")
-      expect(message.role).must_equal "system"
+      expect(message.role).must_equal :system
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::System.new("You are helpful")
-      expect(message.to_h).must_equal({role: "system", content: "You are helpful"})
+      expect(message.to_h).must_equal({role: :system, content: "You are helpful"})
     end
   end
 end

--- a/test/riffer/messages/tool_test.rb
+++ b/test/riffer/messages/tool_test.rb
@@ -6,14 +6,14 @@ describe Riffer::Messages::Tool do
   describe "#role" do
     it "returns tool" do
       message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool")
-      expect(message.role).must_equal "tool"
+      expect(message.role).must_equal :tool
     end
   end
 
   describe "#to_h" do
     it "returns hash with role, content, tool_call_id, and name" do
       message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool")
-      expected = {role: "tool", content: "Result", tool_call_id: "123", name: "my_tool"}
+      expected = {role: :tool, content: "Result", tool_call_id: "123", name: "my_tool"}
       expect(message.to_h).must_equal expected
     end
 
@@ -26,7 +26,7 @@ describe Riffer::Messages::Tool do
         error_type: :unknown_tool
       )
       expected = {
-        role: "tool",
+        role: :tool,
         content: "Error: Unknown tool 'foo'",
         tool_call_id: "123",
         name: "foo",

--- a/test/riffer/messages/user_test.rb
+++ b/test/riffer/messages/user_test.rb
@@ -6,14 +6,14 @@ describe Riffer::Messages::User do
   describe "#role" do
     it "returns user" do
       message = Riffer::Messages::User.new("Hello")
-      expect(message.role).must_equal "user"
+      expect(message.role).must_equal :user
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::User.new("Hello")
-      expect(message.to_h).must_equal({role: "user", content: "Hello"})
+      expect(message.to_h).must_equal({role: :user, content: "Hello"})
     end
   end
 end

--- a/test/riffer/providers/test_test.rb
+++ b/test/riffer/providers/test_test.rb
@@ -38,14 +38,14 @@ describe Riffer::Providers::Test do
 
     it "stores normalized messages in calls" do
       provider.generate_text(prompt: "Hello")
-      expect(provider.calls.last[:messages]).must_equal [{role: "user", content: "Hello"}]
+      expect(provider.calls.last[:messages]).must_equal [{role: :user, content: "Hello"}]
     end
 
     it "stores system and user messages in calls when both provided" do
       provider.generate_text(prompt: "Hello", system: "You are helpful")
       expect(provider.calls.last[:messages]).must_equal [
-        {role: "system", content: "You are helpful"},
-        {role: "user", content: "Hello"}
+        {role: :system, content: "You are helpful"},
+        {role: :user, content: "Hello"}
       ]
     end
 

--- a/test/riffer/stream_events/base_test.rb
+++ b/test/riffer/stream_events/base_test.rb
@@ -6,12 +6,12 @@ describe Riffer::StreamEvents::Base do
   describe "#initialize" do
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::Base.new
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::Base.new(role: "user")
-      expect(event.role).must_equal "user"
+      event = Riffer::StreamEvents::Base.new(role: :user)
+      expect(event.role).must_equal :user
     end
   end
 

--- a/test/riffer/stream_events/reasoning_delta_test.rb
+++ b/test/riffer/stream_events/reasoning_delta_test.rb
@@ -11,19 +11,19 @@ describe Riffer::StreamEvents::ReasoningDelta do
 
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::ReasoningDelta.new("Hello")
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::ReasoningDelta.new("Hello", role: "user")
-      expect(event.role).must_equal "user"
+      event = Riffer::StreamEvents::ReasoningDelta.new("Hello", role: :user)
+      expect(event.role).must_equal :user
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       event = Riffer::StreamEvents::ReasoningDelta.new("Hello")
-      expect(event.to_h).must_equal({role: "assistant", content: "Hello"})
+      expect(event.to_h).must_equal({role: :assistant, content: "Hello"})
     end
   end
 end

--- a/test/riffer/stream_events/reasoning_done_test.rb
+++ b/test/riffer/stream_events/reasoning_done_test.rb
@@ -11,19 +11,19 @@ describe Riffer::StreamEvents::ReasoningDone do
 
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::ReasoningDone.new("Hello")
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::ReasoningDone.new("Hello", role: "user")
-      expect(event.role).must_equal "user"
+      event = Riffer::StreamEvents::ReasoningDone.new("Hello", role: :user)
+      expect(event.role).must_equal :user
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       event = Riffer::StreamEvents::ReasoningDone.new("Hello")
-      expect(event.to_h).must_equal({role: "assistant", content: "Hello"})
+      expect(event.to_h).must_equal({role: :assistant, content: "Hello"})
     end
   end
 end

--- a/test/riffer/stream_events/text_delta_test.rb
+++ b/test/riffer/stream_events/text_delta_test.rb
@@ -11,19 +11,19 @@ describe Riffer::StreamEvents::TextDelta do
 
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::TextDelta.new("Hello")
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::TextDelta.new("Hello", role: "user")
-      expect(event.role).must_equal "user"
+      event = Riffer::StreamEvents::TextDelta.new("Hello", role: :user)
+      expect(event.role).must_equal :user
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       event = Riffer::StreamEvents::TextDelta.new("Hello")
-      expect(event.to_h).must_equal({role: "assistant", content: "Hello"})
+      expect(event.to_h).must_equal({role: :assistant, content: "Hello"})
     end
   end
 end

--- a/test/riffer/stream_events/text_done_test.rb
+++ b/test/riffer/stream_events/text_done_test.rb
@@ -11,19 +11,19 @@ describe Riffer::StreamEvents::TextDone do
 
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::TextDone.new("Hello")
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::TextDone.new("Hello", role: "user")
-      expect(event.role).must_equal "user"
+      event = Riffer::StreamEvents::TextDone.new("Hello", role: :user)
+      expect(event.role).must_equal :user
     end
   end
 
   describe "#to_h" do
     it "returns hash with role and content" do
       event = Riffer::StreamEvents::TextDone.new("Hello")
-      expect(event.to_h).must_equal({role: "assistant", content: "Hello"})
+      expect(event.to_h).must_equal({role: :assistant, content: "Hello"})
     end
   end
 end

--- a/test/riffer/stream_events/tool_call_delta_test.rb
+++ b/test/riffer/stream_events/tool_call_delta_test.rb
@@ -21,12 +21,12 @@ describe Riffer::StreamEvents::ToolCallDelta do
 
     it "sets default role to assistant" do
       event = Riffer::StreamEvents::ToolCallDelta.new(item_id: "call_123", arguments_delta: '{"city":')
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
 
     it "allows setting custom role" do
-      event = Riffer::StreamEvents::ToolCallDelta.new(item_id: "call_123", arguments_delta: '{"city":', role: "custom")
-      expect(event.role).must_equal "custom"
+      event = Riffer::StreamEvents::ToolCallDelta.new(item_id: "call_123", arguments_delta: '{"city":', role: :custom)
+      expect(event.role).must_equal :custom
     end
   end
 
@@ -37,7 +37,7 @@ describe Riffer::StreamEvents::ToolCallDelta do
         name: "weather_lookup",
         arguments_delta: '{"city":'
       )
-      expected = {role: "assistant", item_id: "call_123", name: "weather_lookup", arguments_delta: '{"city":'}
+      expected = {role: :assistant, item_id: "call_123", name: "weather_lookup", arguments_delta: '{"city":'}
       expect(event.to_h).must_equal expected
     end
 

--- a/test/riffer/stream_events/tool_call_done_test.rb
+++ b/test/riffer/stream_events/tool_call_done_test.rb
@@ -51,7 +51,7 @@ describe Riffer::StreamEvents::ToolCallDone do
         name: "weather_lookup",
         arguments: '{"city":"Toronto"}'
       )
-      expect(event.role).must_equal "assistant"
+      expect(event.role).must_equal :assistant
     end
   end
 
@@ -64,7 +64,7 @@ describe Riffer::StreamEvents::ToolCallDone do
         arguments: '{"city":"Toronto"}'
       )
       expected = {
-        role: "assistant",
+        role: :assistant,
         item_id: "item_123",
         call_id: "call_123",
         name: "weather_lookup",


### PR DESCRIPTION
Introduce an `on_message` callback to allow agents to emit messages in real-time during generation. This feature supports multiple callbacks for persistence and logging, enhancing the interaction with agent-generated messages. Only messages from the Assistant and Tool types are emitted, excluding user inputs.