### PR TITLE
feat: implement Riffer::Tools::Response for consistent tool result handling

### DIFF
--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -180,7 +180,7 @@ Riffer::Tools::Response.text(42)
 
 #### .json
 
-Converts the result to JSON via `JSON.generate`:
+Converts the result to JSON via `to_json`:
 
 ```ruby
 Riffer::Tools::Response.json({name: "Alice", age: 30})

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -279,37 +279,24 @@ class Riffer::Agent
     tool_class = find_tool_class(tool_call[:name])
 
     if tool_class.nil?
-      return {
-        content: "Error: Unknown tool '#{tool_call[:name]}'",
-        error: "Unknown tool '#{tool_call[:name]}'",
-        error_type: :unknown_tool
-      }
+      return Riffer::Tools::Response.error(
+        "Unknown tool '#{tool_call[:name]}'",
+        type: :unknown_tool
+      ).to_h
     end
 
     tool_instance = tool_class.new
     arguments = parse_tool_arguments(tool_call[:arguments])
 
     begin
-      result = tool_instance.call_with_validation(context: @tool_context, **arguments)
-      {content: result.to_s, error: nil, error_type: nil}
+      response = tool_instance.call_with_validation(context: @tool_context, **arguments)
+      response.to_h
     rescue Riffer::TimeoutError => e
-      {
-        content: "Error: #{e.message}",
-        error: e.message,
-        error_type: :timeout_error
-      }
+      Riffer::Tools::Response.error(e.message, type: :timeout_error).to_h
     rescue Riffer::ValidationError => e
-      {
-        content: "Validation error: #{e.message}",
-        error: e.message,
-        error_type: :validation_error
-      }
+      Riffer::Tools::Response.error(e.message, type: :validation_error).to_h
     rescue => e
-      {
-        content: "Error executing tool: #{e.message}",
-        error: e.message,
-        error_type: :execution_error
-      }
+      Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error).to_h
     end
   end
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -266,11 +266,11 @@ class Riffer::Agent
     response.tool_calls.each do |tool_call|
       result = execute_tool_call(tool_call)
       add_message(Riffer::Messages::Tool.new(
-        result[:content],
+        result.content,
         tool_call_id: tool_call[:id],
         name: tool_call[:name],
-        error: result[:error],
-        error_type: result[:error_type]
+        error: result.error_message,
+        error_type: result.error_type
       ))
     end
   end
@@ -282,21 +282,20 @@ class Riffer::Agent
       return Riffer::Tools::Response.error(
         "Unknown tool '#{tool_call[:name]}'",
         type: :unknown_tool
-      ).to_h
+      )
     end
 
     tool_instance = tool_class.new
     arguments = parse_tool_arguments(tool_call[:arguments])
 
     begin
-      response = tool_instance.call_with_validation(context: @tool_context, **arguments)
-      response.to_h
+      tool_instance.call_with_validation(context: @tool_context, **arguments)
     rescue Riffer::TimeoutError => e
-      Riffer::Tools::Response.error(e.message, type: :timeout_error).to_h
+      Riffer::Tools::Response.error(e.message, type: :timeout_error)
     rescue Riffer::ValidationError => e
-      Riffer::Tools::Response.error(e.message, type: :validation_error).to_h
+      Riffer::Tools::Response.error(e.message, type: :validation_error)
     rescue => e
-      Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error).to_h
+      Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
     end
   end
 

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -98,6 +98,34 @@ class Riffer::Tool
     raise NotImplementedError, "#{self.class} must implement #call"
   end
 
+  # Creates a text response. Shorthand for Riffer::Tools::Response.text.
+  #
+  # result:: Object - the tool result (converted via to_s)
+  #
+  # Returns Riffer::Tools::Response.
+  def text(result)
+    Riffer::Tools::Response.text(result)
+  end
+
+  # Creates a JSON response. Shorthand for Riffer::Tools::Response.json.
+  #
+  # result:: Object - the tool result (converted via JSON.generate)
+  #
+  # Returns Riffer::Tools::Response.
+  def json(result)
+    Riffer::Tools::Response.json(result)
+  end
+
+  # Creates an error response. Shorthand for Riffer::Tools::Response.error.
+  #
+  # message:: String - the error message
+  # type:: Symbol - the error type (default: :execution_error)
+  #
+  # Returns Riffer::Tools::Response.
+  def error(message, type: :execution_error)
+    Riffer::Tools::Response.error(message, type: type)
+  end
+
   # Executes the tool with validation and timeout (used by Agent).
   #
   # context:: Object or nil - context passed from the agent

--- a/lib/riffer/tools.rb
+++ b/lib/riffer/tools.rb
@@ -3,8 +3,8 @@
 # Namespace for tool-related classes in the Riffer framework.
 #
 # Contains:
-# - Riffer::Tools::Response - Required return type for tool execution
-# - Riffer::Tools::Params - DSL for defining tool parameters
 # - Riffer::Tools::Param - Individual parameter definition
+# - Riffer::Tools::Params - DSL for defining tool parameters
+# - Riffer::Tools::Response - Required return type for tool execution
 module Riffer::Tools
 end

--- a/lib/riffer/tools.rb
+++ b/lib/riffer/tools.rb
@@ -3,6 +3,7 @@
 # Namespace for tool-related classes in the Riffer framework.
 #
 # Contains:
+# - Riffer::Tools::Response - Required return type for tool execution
 # - Riffer::Tools::Params - DSL for defining tool parameters
 # - Riffer::Tools::Param - Individual parameter definition
 module Riffer::Tools

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 # Riffer::Tools::Response represents the result of a tool execution.
 #
 # All tools must return a Response object from their +call+ method.

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Riffer::Tools::Response represents the result of a tool execution.
+#
+# All tools must return a Response object from their +call+ method.
+# Use +Response.success+ for successful results and +Response.error+ for failures.
+#
+#   class MyTool < Riffer::Tool
+#     def call(context:, **kwargs)
+#       result = perform_operation
+#       Riffer::Tools::Response.success(result)
+#     rescue MyError => e
+#       Riffer::Tools::Response.error(e.message)
+#     end
+#   end
+#
+class Riffer::Tools::Response
+  VALID_FORMATS = %i[text json].freeze
+
+  attr_reader :content, :error_message, :error_type
+
+  # Creates a success response.
+  #
+  # result:: Object - the tool result
+  # format:: Symbol - the format (:text or :json; default: :text)
+  #
+  # Returns Riffer::Tools::Response.
+  #
+  # Raises Riffer::ArgumentError if format is invalid.
+  def self.success(result, format: :text)
+    unless VALID_FORMATS.include?(format)
+      raise Riffer::ArgumentError, "Invalid format: #{format}. Must be one of: #{VALID_FORMATS.join(", ")}"
+    end
+
+    content = (format == :json) ? result.to_json : result.to_s
+    new(content: content, success: true)
+  end
+
+  # Creates a success response with text format.
+  #
+  # result:: Object - the tool result (converted via to_s)
+  #
+  # Returns Riffer::Tools::Response.
+  def self.text(result)
+    success(result, format: :text)
+  end
+
+  # Creates a success response with JSON format.
+  #
+  # result:: Object - the tool result (converted via to_json)
+  #
+  # Returns Riffer::Tools::Response.
+  def self.json(result)
+    success(result, format: :json)
+  end
+
+  # Creates an error response.
+  #
+  # message:: String - the error message
+  # type:: Symbol - the error type (default: :execution_error)
+  #
+  # Returns Riffer::Tools::Response.
+  def self.error(message, type: :execution_error)
+    new(content: message, success: false, error_message: message, error_type: type)
+  end
+
+  # Returns true if the response is successful.
+  def success? = @success
+
+  # Returns true if the response is an error.
+  def error? = !@success
+
+  # Returns a hash representation of the response.
+  #
+  # Returns Hash with :content, :error, and :error_type keys.
+  def to_h
+    {content: @content, error: @error_message, error_type: @error_type}
+  end
+
+  private
+
+  def initialize(content:, success:, error_message: nil, error_type: nil)
+    @content = content
+    @success = success
+    @error_message = error_message
+    @error_type = error_type
+  end
+end

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
+require "json"
 
 # Riffer::Tools::Response represents the result of a tool execution.
 #

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-
 # Riffer::Tools::Response represents the result of a tool execution.
 #
 # All tools must return a Response object from their +call+ method.

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -476,7 +476,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, city:)
-          "Weather in #{city}: 20 degrees"
+          Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
         end
       end
     end
@@ -517,7 +517,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, city:)
-          "Weather in #{city}: 20 degrees"
+          Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
         end
       end
     end
@@ -531,7 +531,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, field:)
-          context[field.to_sym] || "unknown"
+          Riffer::Tools::Response.success(context[field.to_sym] || "unknown")
         end
       end
     end
@@ -678,7 +678,7 @@ describe Riffer::Agent do
         agent.generate("What's the weather?")
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
-        expect(tool_messages.first.content).must_match(/Validation error/)
+        expect(tool_messages.first.content).must_match(/city is required/)
       end
 
       it "sets error attributes for validation errors" do
@@ -830,7 +830,7 @@ describe Riffer::Agent do
 
           def call(context:)
             sleep 0.02
-            "done"
+            Riffer::Tools::Response.success("done")
           end
         end
       end
@@ -840,7 +840,7 @@ describe Riffer::Agent do
           description "A fast tool"
 
           def call(context:)
-            "fast result"
+            Riffer::Tools::Response.success("fast result")
           end
         end
       end
@@ -982,7 +982,7 @@ describe Riffer::Agent do
           description "Admin only tool"
           params {}
           def call(context:)
-            "admin action"
+            Riffer::Tools::Response.success("admin action")
           end
         end
         admin_tool_class.identifier("admin_tool")
@@ -1103,7 +1103,7 @@ describe Riffer::Agent do
             required :city, String
           end
           def call(context:, city:)
-            "Weather in #{city}: 20 degrees"
+            Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
           end
         end.tap { |t| t.identifier("emit_weather_tool") }
       end
@@ -1227,7 +1227,7 @@ describe Riffer::Agent do
             required :city, String
           end
           def call(context:, city:)
-            "Weather in #{city}: 20 degrees"
+            Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
           end
         end.tap { |t| t.identifier("stream_emit_weather_tool") }
       end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -476,7 +476,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, city:)
-          Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
+          text("Weather in #{city}: 20 degrees")
         end
       end
     end
@@ -517,7 +517,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, city:)
-          Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
+          text("Weather in #{city}: 20 degrees")
         end
       end
     end
@@ -531,7 +531,7 @@ describe Riffer::Agent do
         end
 
         def call(context:, field:)
-          Riffer::Tools::Response.success(context[field.to_sym] || "unknown")
+          text(context[field.to_sym] || "unknown")
         end
       end
     end
@@ -830,7 +830,7 @@ describe Riffer::Agent do
 
           def call(context:)
             sleep 0.02
-            Riffer::Tools::Response.success("done")
+            text("done")
           end
         end
       end
@@ -840,7 +840,7 @@ describe Riffer::Agent do
           description "A fast tool"
 
           def call(context:)
-            Riffer::Tools::Response.success("fast result")
+            text("fast result")
           end
         end
       end
@@ -982,7 +982,7 @@ describe Riffer::Agent do
           description "Admin only tool"
           params {}
           def call(context:)
-            Riffer::Tools::Response.success("admin action")
+            text("admin action")
           end
         end
         admin_tool_class.identifier("admin_tool")
@@ -1103,7 +1103,7 @@ describe Riffer::Agent do
             required :city, String
           end
           def call(context:, city:)
-            Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
+            text("Weather in #{city}: 20 degrees")
           end
         end.tap { |t| t.identifier("emit_weather_tool") }
       end
@@ -1227,7 +1227,7 @@ describe Riffer::Agent do
             required :city, String
           end
           def call(context:, city:)
-            Riffer::Tools::Response.success("Weather in #{city}: 20 degrees")
+            text("Weather in #{city}: 20 degrees")
           end
         end.tap { |t| t.identifier("stream_emit_weather_tool") }
       end

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -13,7 +13,7 @@ describe Riffer::Tool do
       end
 
       def call(context:, city:, units: nil)
-        Riffer::Tools::Response.success("Weather in #{city}: 20 #{units || "celsius"}")
+        text("Weather in #{city}: 20 #{units || "celsius"}")
       end
     end
   end
@@ -23,7 +23,7 @@ describe Riffer::Tool do
       description "A simple tool"
 
       def call(context:, **kwargs)
-        Riffer::Tools::Response.success("Simple result")
+        text("Simple result")
       end
     end
   end
@@ -132,7 +132,7 @@ describe Riffer::Tool do
     it "receives context" do
       tool_class = Class.new(Riffer::Tool) do
         def call(context:, **kwargs)
-          Riffer::Tools::Response.success(context[:user_id])
+          text(context[:user_id])
         end
       end
       tool = tool_class.new
@@ -166,7 +166,7 @@ describe Riffer::Tool do
         end
 
         def call(context:, name:)
-          Riffer::Tools::Response.success("#{context[:greeting]}, #{name}!")
+          text("#{context[:greeting]}, #{name}!")
         end
       end
       tool = tool_class.new
@@ -186,7 +186,7 @@ describe Riffer::Tool do
 
         def call(context:)
           sleep 0.02
-          Riffer::Tools::Response.success("done")
+          text("done")
         end
       end
 
@@ -200,7 +200,7 @@ describe Riffer::Tool do
 
         def call(context:)
           sleep 0.02
-          Riffer::Tools::Response.success("done")
+          text("done")
         end
       end
 
@@ -214,7 +214,7 @@ describe Riffer::Tool do
         timeout 1
 
         def call(context:)
-          Riffer::Tools::Response.success("fast result")
+          text("fast result")
         end
       end
 
@@ -233,6 +233,42 @@ describe Riffer::Tool do
       tool = bad_tool_class.new
       error = expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::Error)
       expect(error.message).must_match(/must return a Riffer::Tools::Response/)
+    end
+  end
+
+  describe "#text" do
+    it "creates a text response" do
+      tool = simple_tool_class.new
+      response = tool.text("hello")
+      expect(response).must_be_instance_of Riffer::Tools::Response
+      expect(response.content).must_equal "hello"
+      expect(response.success?).must_equal true
+    end
+  end
+
+  describe "#json" do
+    it "creates a JSON response" do
+      tool = simple_tool_class.new
+      response = tool.json({name: "Alice"})
+      expect(response).must_be_instance_of Riffer::Tools::Response
+      expect(response.content).must_equal '{"name":"Alice"}'
+      expect(response.success?).must_equal true
+    end
+  end
+
+  describe "#error" do
+    it "creates an error response" do
+      tool = simple_tool_class.new
+      response = tool.error("something failed")
+      expect(response).must_be_instance_of Riffer::Tools::Response
+      expect(response.content).must_equal "something failed"
+      expect(response.error?).must_equal true
+    end
+
+    it "accepts custom error type" do
+      tool = simple_tool_class.new
+      response = tool.error("not found", type: :not_found)
+      expect(response.error_type).must_equal :not_found
     end
   end
 end

--- a/test/riffer/tools/response_test.rb
+++ b/test/riffer/tools/response_test.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tools::Response do
+  describe ".success" do
+    it "creates a successful response" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.success?).must_equal true
+    end
+
+    it "sets the content" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.content).must_equal "result"
+    end
+
+    it "converts result to string with text format" do
+      response = Riffer::Tools::Response.success(123)
+      expect(response.content).must_equal "123"
+    end
+
+    it "defaults to text format" do
+      response = Riffer::Tools::Response.success({name: "Alice"})
+      expect(response.content).must_include "Alice"
+    end
+
+    it "converts to JSON with json format" do
+      response = Riffer::Tools::Response.success({name: "Alice", age: 30}, format: :json)
+      expect(response.content).must_equal '{"name":"Alice","age":30}'
+    end
+
+    it "converts nested structures to JSON" do
+      response = Riffer::Tools::Response.success({user: {name: "Bob"}, items: [1, 2, 3]}, format: :json)
+      expect(response.content).must_equal '{"user":{"name":"Bob"},"items":[1,2,3]}'
+    end
+
+    it "converts arrays to JSON" do
+      response = Riffer::Tools::Response.success([1, 2, 3], format: :json)
+      expect(response.content).must_equal "[1,2,3]"
+    end
+
+    it "raises for invalid format" do
+      error = expect {
+        Riffer::Tools::Response.success("result", format: :xml)
+      }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Invalid format/)
+    end
+
+    it "has no error_message" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.error_message).must_be_nil
+    end
+
+    it "has no error_type" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.error_type).must_be_nil
+    end
+
+    it "is not an error" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.error?).must_equal false
+    end
+  end
+
+  describe ".text" do
+    it "creates a success response with text format" do
+      response = Riffer::Tools::Response.text("hello")
+      expect(response.success?).must_equal true
+      expect(response.content).must_equal "hello"
+    end
+
+    it "converts to string" do
+      response = Riffer::Tools::Response.text(123)
+      expect(response.content).must_equal "123"
+    end
+  end
+
+  describe ".json" do
+    it "creates a success response with JSON format" do
+      response = Riffer::Tools::Response.json({name: "Alice"})
+      expect(response.success?).must_equal true
+      expect(response.content).must_equal '{"name":"Alice"}'
+    end
+
+    it "converts arrays to JSON" do
+      response = Riffer::Tools::Response.json([1, 2, 3])
+      expect(response.content).must_equal "[1,2,3]"
+    end
+  end
+
+  describe ".error" do
+    it "creates an error response" do
+      response = Riffer::Tools::Response.error("something failed")
+      expect(response.error?).must_equal true
+    end
+
+    it "is not successful" do
+      response = Riffer::Tools::Response.error("something failed")
+      expect(response.success?).must_equal false
+    end
+
+    it "sets the content to the message" do
+      response = Riffer::Tools::Response.error("something failed")
+      expect(response.content).must_equal "something failed"
+    end
+
+    it "sets the error_message" do
+      response = Riffer::Tools::Response.error("something failed")
+      expect(response.error_message).must_equal "something failed"
+    end
+
+    it "defaults error_type to execution_error" do
+      response = Riffer::Tools::Response.error("something failed")
+      expect(response.error_type).must_equal :execution_error
+    end
+
+    it "accepts any symbol as error_type" do
+      response = Riffer::Tools::Response.error("failed", type: :custom_error)
+      expect(response.error_type).must_equal :custom_error
+    end
+  end
+
+  describe "#to_h" do
+    it "returns hash with content for success" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.to_h[:content]).must_equal "result"
+    end
+
+    it "returns hash with nil error for success" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.to_h[:error]).must_be_nil
+    end
+
+    it "returns hash with nil error_type for success" do
+      response = Riffer::Tools::Response.success("result")
+      expect(response.to_h[:error_type]).must_be_nil
+    end
+
+    it "returns hash with content for error" do
+      response = Riffer::Tools::Response.error("failed")
+      expect(response.to_h[:content]).must_equal "failed"
+    end
+
+    it "returns hash with error message for error" do
+      response = Riffer::Tools::Response.error("failed")
+      expect(response.to_h[:error]).must_equal "failed"
+    end
+
+    it "returns hash with error_type for error" do
+      response = Riffer::Tools::Response.error("failed", type: :validation_error)
+      expect(response.to_h[:error_type]).must_equal :validation_error
+    end
+  end
+
+  describe "VALID_FORMATS" do
+    it "includes text" do
+      expect(Riffer::Tools::Response::VALID_FORMATS).must_include :text
+    end
+
+    it "includes json" do
+      expect(Riffer::Tools::Response::VALID_FORMATS).must_include :json
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a standardized response object, `Riffer::Tools::Response`, as the required return type for all tool executions in the Riffer framework. It updates the documentation, core library, and tests to enforce and demonstrate this new pattern, ensuring consistent handling of tool results and errors across the system.

**Core framework changes:**

- Introduced the `Riffer::Tools::Response` class, which provides `.success`, `.text`, `.json`, and `.error` methods for generating standardized tool responses. All tools must now return a `Response` object from their `call` method.
- Updated `Riffer::Tool#call_with_validation` to enforce that the `call` method returns a `Response` object and raise an error otherwise.
- Modified `Riffer::Agent#execute_tool_call` to expect and handle `Response` objects, including error wrapping for unknown tools, timeouts, validation errors, and execution errors.
- Added documentation in `lib/riffer/tools.rb` referencing the new `Response` class.

**Documentation updates:**

- Revised `docs/04_TOOLS.md` to require that all tools return a `Riffer::Tools::Response`, with clear examples for `.text`, `.json`, and `.error` usage. Expanded sections on error handling, validation, and response object methods. [[1]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L20-R20) [[2]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L113-R120) [[3]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L132-R240) [[4]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L169-R252) [[5]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L184-R267) [[6]](diffhunk://#diff-9f2b28647b4f93eca0352ecb17449a94ecb3d125854b82111cedd40a84f6b712L240-R338)

**Test suite updates:**

- Updated all test tool implementations to return `Riffer::Tools::Response` objects instead of raw strings, and adjusted assertions to check the `.content` property. [[1]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL479-R479) [[2]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL520-R520) [[3]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL534-R534) [[4]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL681-R681) [[5]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL833-R833) [[6]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL843-R843) [[7]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL985-R985) [[8]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL1106-R1106) [[9]](diffhunk://#diff-51a518313c10708bf2551ebfce9950ad844287065e6cdeafdf88e1976db8049fL1230-R1230) [[10]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L16-R16) [[11]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L26-R26) [[12]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L129-R140) [[13]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L159-R159) [[14]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L169-R180) [[15]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L189-R189) [[16]](diffhunk://#diff-4e5336a40fc643209303fbc5beb713ac97e941c1d5ed33e87596d24d65624ff1L203-R203)

These changes enforce a consistent and extensible pattern for tool result handling, error reporting, and downstream processing throughout the Riffer framework.