### PR TITLE
fix: update class name conversion to use double underscore format

### DIFF
--- a/lib/riffer/helpers/class_name_converter.rb
+++ b/lib/riffer/helpers/class_name_converter.rb
@@ -2,15 +2,15 @@
 
 # Helper module for converting class names.
 module Riffer::Helpers::ClassNameConverter
-  # Converts a class name to snake_case path format.
+  # Converts a class name to snake_case identifier format.
   #
   # class_name:: String - the class name (e.g., "Riffer::Agent")
   #
-  # Returns String - the snake_case path (e.g., "riffer/agent").
+  # Returns String - the snake_case identifier (e.g., "riffer__agent").
   def class_name_to_path(class_name)
     class_name
       .to_s
-      .gsub("::", "/")
+      .gsub("::", "__")
       .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
       .gsub(/([a-z\d])([A-Z])/, '\1_\2')
       .downcase

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -22,7 +22,7 @@ describe Riffer::Agent do
     end
 
     it "defaults to snake_case class name when not set" do
-      expect(Riffer::Agent.identifier).must_equal "riffer/agent"
+      expect(Riffer::Agent.identifier).must_equal "riffer__agent"
     end
   end
 

--- a/test/riffer/helpers/class_name_converter_test.rb
+++ b/test/riffer/helpers/class_name_converter_test.rb
@@ -15,9 +15,9 @@ describe Riffer::Helpers::ClassNameConverter do
       assert_equal "agent", result
     end
 
-    it "converts namespaced class to path with slashes" do
+    it "converts namespaced class to double underscore format" do
       result = converter_class.class_name_to_path("Riffer::Agent")
-      assert_equal "riffer/agent", result
+      assert_equal "riffer__agent", result
     end
 
     it "converts multi-word class names to snake_case" do
@@ -27,7 +27,7 @@ describe Riffer::Helpers::ClassNameConverter do
 
     it "converts deeply nested namespaces" do
       result = converter_class.class_name_to_path("Riffer::Providers::OpenAI")
-      assert_equal "riffer/providers/open_ai", result
+      assert_equal "riffer__providers__open_ai", result
     end
 
     it "handles consecutive capitals correctly" do
@@ -37,17 +37,17 @@ describe Riffer::Helpers::ClassNameConverter do
 
     it "handles symbols" do
       result = converter_class.class_name_to_path(:"Riffer::Agent")
-      assert_equal "riffer/agent", result
+      assert_equal "riffer__agent", result
     end
 
     it "handles already snake_cased names" do
-      result = converter_class.class_name_to_path("riffer/agent")
-      assert_equal "riffer/agent", result
+      result = converter_class.class_name_to_path("riffer__agent")
+      assert_equal "riffer__agent", result
     end
 
     it "converts complex real-world example" do
       result = converter_class.class_name_to_path("Riffer::Messages::Assistant")
-      assert_equal "riffer/messages/assistant", result
+      assert_equal "riffer__messages__assistant", result
     end
   end
 end


### PR DESCRIPTION
This pull request updates the logic for converting class names to identifiers by replacing slashes (`/`) with double underscores (`__`) in the generated snake_case strings. This affects both the implementation and the related tests to ensure consistency. This is necessary as some providers do not allow "/" in tool call names.

Identifier conversion logic:

* Changed the `class_name_to_path` method in `Riffer::Helpers::ClassNameConverter` to use double underscores (`__`) instead of slashes (`/`) when converting namespaced class names to snake_case identifiers.

Test updates:

* Updated all relevant tests in `class_name_converter_test.rb` to expect double underscores in identifiers instead of slashes, including cases for namespaced, deeply nested, symbol, and already snake_cased names. [[1]](diffhunk://#diff-bc9f1b2b8151bcfa10c72a9b99cc86caa787660815471fb3111bb8687c2fb945L18-R20) [[2]](diffhunk://#diff-bc9f1b2b8151bcfa10c72a9b99cc86caa787660815471fb3111bb8687c2fb945L30-R30) [[3]](diffhunk://#diff-bc9f1b2b8151bcfa10c72a9b99cc86caa787660815471fb3111bb8687c2fb945L40-R50)
* Updated the agent identifier test in `agent_test.rb` to match the new double underscore format.