### PR TITLE
fix: handle multiple tools correctly for bedrock

### DIFF
--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -137,15 +137,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       when Riffer::Messages::Assistant
         conversation_messages << convert_assistant_to_bedrock_format(message)
       when Riffer::Messages::Tool
-        conversation_messages << {
-          role: "user",
-          content: [{
-            tool_result: {
-              tool_use_id: message.tool_call_id,
-              content: [{text: message.content}]
-            }
-          }]
-        }
+        append_tool_result(conversation_messages, message)
       end
     end
 
@@ -153,6 +145,22 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       system: system_prompts,
       conversation: conversation_messages
     }
+  end
+
+  def append_tool_result(conversation_messages, message)
+    tool_result = {
+      tool_result: {
+        tool_use_id: message.tool_call_id,
+        content: [{text: message.content}]
+      }
+    }
+
+    prev = conversation_messages.last
+    if prev && prev[:role] == "user" && prev[:content]&.first&.key?(:tool_result)
+      prev[:content] << tool_result
+    else
+      conversation_messages << {role: "user", content: [tool_result]}
+    end
   end
 
   def convert_assistant_to_bedrock_format(message)

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/tool_calling/_generate_text/with_multiple_tool_messages.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/tool_calling/_generate_text/with_multiple_tool_messages.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-haiku-20240307-v1:0/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"What is the weather
+        in Toronto and Vancouver?"}]},{"role":"assistant","content":[{"toolUse":{"toolUseId":"tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M","name":"get_weather","input":{"city":"Toronto"}}},{"toolUse":{"toolUseId":"tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ","name":"get_weather","input":{"city":"Vancouver"}}}]},{"role":"user","content":[{"toolResult":{"toolUseId":"tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M","content":[{"text":"Toronto:
+        15°C"}]}},{"toolResult":{"toolUseId":"tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ","content":[{"text":"Vancouver:
+        12°C"}]}}]}],"system":[],"toolConfig":{"tools":[{"toolSpec":{"name":"get_weather","description":"Get
+        the current weather for a city","inputSchema":{"json":{"type":"object","properties":{"city":{"type":"string","description":"The
+        city name"}},"required":["city"],"additionalProperties":false}}}}]}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 1a7eb14c-d3c9-45b6-a856-c8b46e0c64c0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.241.4 ua/2.1 api/bedrock_runtime#1.72.0 os/macos#25 md/arm64
+        lang/ruby#3.4.8 md/3.4.8 m/Z,b,D
+      Content-Length:
+      - '898'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Jan 2026 23:50:49 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '309'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 4475f8e3-a79a-4090-bc13-019182c3c96d
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        eyJtZXRyaWNzIjp7ImxhdGVuY3lNcyI6ODc4fSwib3V0cHV0Ijp7Im1lc3NhZ2UiOnsiY29udGVudCI6W3sidGV4dCI6IkFjY29yZGluZyB0byB0aGUgd2VhdGhlciBpbmZvcm1hdGlvbiwgdGhlIGN1cnJlbnQgdGVtcGVyYXR1cmUgaXMgMTXCsEMgaW4gVG9yb250byBhbmQgMTLCsEMgaW4gVmFuY291dmVyLiJ9XSwicm9sZSI6ImFzc2lzdGFudCJ9fSwic3RvcFJlYXNvbiI6ImVuZF90dXJuIiwidXNhZ2UiOnsiaW5wdXRUb2tlbnMiOjUxNCwib3V0cHV0VG9rZW5zIjoyOCwic2VydmVyVG9vbFVzYWdlIjp7fSwidG90YWxUb2tlbnMiOjU0Mn19
+  recorded_at: Thu, 29 Jan 2026 23:50:49 GMT
+recorded_with: VCR 6.4.0

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -294,6 +294,50 @@ describe Riffer::Providers::AmazonBedrock do
       end
     end
 
+    describe "#generate_text with multiple Tool messages" do
+      it "returns Assistant message" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/tool_calling/_generate_text/with_multiple_tool_messages") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          messages = [
+            Riffer::Messages::User.new("What is the weather in Toronto and Vancouver?"),
+            Riffer::Messages::Assistant.new("", tool_calls: [
+              {id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'},
+              {id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}'}
+            ]),
+            Riffer::Messages::Tool.new("Toronto: 15°C", tool_call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather"),
+            Riffer::Messages::Tool.new("Vancouver: 12°C", tool_call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather")
+          ]
+          result = provider.generate_text(
+            messages: messages,
+            model: "anthropic.claude-3-haiku-20240307-v1:0",
+            tools: [weather_tool]
+          )
+          expect(result).must_be_instance_of Riffer::Messages::Assistant
+        end
+      end
+
+      it "returns response with content" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/tool_calling/_generate_text/with_multiple_tool_messages") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          messages = [
+            Riffer::Messages::User.new("What is the weather in Toronto and Vancouver?"),
+            Riffer::Messages::Assistant.new("", tool_calls: [
+              {id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'},
+              {id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}'}
+            ]),
+            Riffer::Messages::Tool.new("Toronto: 15°C", tool_call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather"),
+            Riffer::Messages::Tool.new("Vancouver: 12°C", tool_call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather")
+          ]
+          result = provider.generate_text(
+            messages: messages,
+            model: "anthropic.claude-3-haiku-20240307-v1:0",
+            tools: [weather_tool]
+          )
+          expect(result.content).wont_be_empty
+        end
+      end
+    end
+
     describe "#stream_text with tools" do
       it "yields ToolCallDelta events" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/tool_calling/_stream_text/yields_tool_call_delta") do


### PR DESCRIPTION
This pull request fixes how multiple tool messages are handled in the Amazon Bedrock provider and adds comprehensive test coverage for this scenario. The main changes include refactoring the logic for appending tool results to conversation messages, ensuring multiple tool messages are grouped correctly, and adding new tests and fixtures to verify the behavior.

**Refactoring and logic improvements:**

- Extracted the logic for appending tool results into a new `append_tool_result` method in `lib/riffer/providers/amazon_bedrock.rb`, ensuring that consecutive tool messages are grouped under a single user message as required by the Bedrock API. [[1]](diffhunk://#diff-e153d01914cb0c0aa1490596ad086005bbd918c5b19727e5675374532fa07feeL140-R140) [[2]](diffhunk://#diff-e153d01914cb0c0aa1490596ad086005bbd918c5b19727e5675374532fa07feeR150-R165)

**Testing and fixtures:**

- Added a new VCR cassette fixture `test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/tool_calling/_generate_text/with_multiple_tool_messages.yml` to simulate and record interactions involving multiple tool messages.
- Introduced new tests in `test/riffer/providers/amazon_bedrock_test.rb` to verify that the provider correctly handles multiple tool messages and returns the expected assistant responses.