### PR TITLE
feat: add class methods for generate and stream to Riffer::Agent

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -107,20 +107,24 @@ end
 Generates a response synchronously:
 
 ```ruby
-agent = MyAgent.new
+# Class method (recommended for simple calls)
+response = MyAgent.generate('Hello')
 
-# With a string prompt
+# Instance method (when you need message history or callbacks)
+agent = MyAgent.new
+agent.on_message { |msg| log(msg) }
 response = agent.generate('Hello')
+agent.messages  # Access message history
 
 # With message objects/hashes
-response = agent.generate([
+response = MyAgent.generate([
   {role: 'user', content: 'Hello'},
   {role: 'assistant', content: 'Hi there!'},
   {role: 'user', content: 'How are you?'}
 ])
 
 # With tool context
-response = agent.generate('Look up my orders', tool_context: {user_id: 123})
+response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
 ```
 
 ### stream
@@ -128,9 +132,8 @@ response = agent.generate('Look up my orders', tool_context: {user_id: 123})
 Streams a response as an Enumerator:
 
 ```ruby
-agent = MyAgent.new
-
-agent.stream('Tell me a story').each do |event|
+# Class method (recommended for simple calls)
+MyAgent.stream('Tell me a story').each do |event|
   case event
   when Riffer::StreamEvents::TextDelta
     print event.content
@@ -140,6 +143,12 @@ agent.stream('Tell me a story').each do |event|
     puts "[Tool: #{event.name}]"
   end
 end
+
+# Instance method (when you need message history or callbacks)
+agent = MyAgent.new
+agent.on_message { |msg| persist_message(msg) }
+agent.stream('Tell me a story').each { |event| handle(event) }
+agent.messages  # Access message history
 ```
 
 ### messages

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -101,6 +101,20 @@ class Riffer::Agent
     def all
       subclasses
     end
+
+    # Generates a response using a new agent instance.
+    #
+    # See #generate for parameters and return value.
+    def generate(...)
+      new.generate(...)
+    end
+
+    # Streams a response using a new agent instance.
+    #
+    # See #stream for parameters and return value.
+    def stream(...)
+      new.stream(...)
+    end
   end
 
   # The message history for the agent.

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -466,6 +466,77 @@ describe Riffer::Agent do
     end
   end
 
+  describe ".generate" do
+    it "returns a text response" do
+      result = agent_class.generate("Hello")
+      expect(result).must_be_instance_of String
+    end
+
+    it "passes tool_context to tools" do
+      context_tool = Class.new(Riffer::Tool) do
+        description "Gets user info"
+        params do
+          required :field, String
+        end
+        def call(context:, field:)
+          text(context[field.to_sym] || "unknown")
+        end
+      end
+      context_tool.identifier("class_generate_context_tool")
+
+      tool = context_tool
+      received_context = nil
+      custom_agent_class = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        uses_tools ->(ctx) {
+          received_context = ctx
+          [tool]
+        }
+      end
+
+      custom_agent_class.generate("Hello", tool_context: {user_name: "Bob"})
+      expect(received_context).must_equal({user_name: "Bob"})
+    end
+  end
+
+  describe ".stream" do
+    it "returns an enumerator" do
+      result = agent_class.stream("Hello")
+      expect(result).must_be_instance_of Enumerator
+    end
+
+    it "yields stream events" do
+      events = agent_class.stream("Hello").to_a
+      expect(events).wont_be_empty
+    end
+
+    it "passes tool_context to tools" do
+      context_tool = Class.new(Riffer::Tool) do
+        description "Gets user info"
+        params do
+          required :field, String
+        end
+        def call(context:, field:)
+          text(context[field.to_sym] || "unknown")
+        end
+      end
+      context_tool.identifier("class_stream_context_tool")
+
+      tool = context_tool
+      received_context = nil
+      custom_agent_class = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        uses_tools ->(ctx) {
+          received_context = ctx
+          [tool]
+        }
+      end
+
+      custom_agent_class.stream("Hello", tool_context: {user_id: "42"}).each { |_| }
+      expect(received_context).must_equal({user_id: "42"})
+    end
+  end
+
   describe ".uses_tools" do
     let(:weather_tool_class) do
       Class.new(Riffer::Tool) do


### PR DESCRIPTION
This pull request adds new class-level convenience methods to the `Riffer::Agent` class, allowing users to generate and stream responses without explicitly instantiating an agent. Documentation and tests have also been updated to reflect and verify this new usage pattern.

**API enhancements:**

* Added `.generate` and `.stream` class methods to `Riffer::Agent`, which create a new instance and delegate to the corresponding instance methods. This simplifies usage for cases where message history or callbacks are not needed.

**Documentation updates:**

* Updated `docs/03_AGENTS.md` to recommend the new class methods for simple calls, while clarifying when to use instance methods (e.g., for message history or callbacks). Examples now show both usage patterns for `generate` and `stream`. [[1]](diffhunk://#diff-956adb1c808d1d66b09a3979bdc9959fade44259073129fe01b04c6ec8900438L110-R136) [[2]](diffhunk://#diff-956adb1c808d1d66b09a3979bdc9959fade44259073129fe01b04c6ec8900438R146-R151)

**Testing improvements:**

* Added tests for the new `.generate` and `.stream` class methods in `test/riffer/agent_test.rb`, including checks for return types, event yielding, and passing `tool_context` to tools.