### PR TITLE
feat: add evals primitive for LLM-as-judge evaluations

### DIFF
--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -17,7 +17,7 @@ Key concepts:
 
 ```ruby
 # 1. Configure the judge model
-Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+Riffer.config.evals.judge_model = "anthropic/claude-opus-4-5-20251101"
 
 # 2. Define an eval profile
 module QualityEvals
@@ -31,7 +31,7 @@ end
 # 3. Include in your agent
 class MyAgent < Riffer::Agent
   include QualityEvals
-  model "openai/gpt-4o"
+  model "anthropic/claude-haiku-4-5-20251001"
   instructions "You are a helpful assistant."
 end
 
@@ -46,7 +46,7 @@ result.aggregate_score # => 0.91
 Before using evals, configure the judge model:
 
 ```ruby
-Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+Riffer.config.evals.judge_model = "anthropic/claude-opus-4-5-20251101"
 ```
 
 The judge model is the LLM that evaluates agent outputs. You can use any configured provider.
@@ -106,7 +106,7 @@ end
 ```ruby
 class MyAgent < Riffer::Agent
   include QualityEvals
-  model "openai/gpt-4o"
+  model "anthropic/claude-haiku-4-5-20251001"
 end
 ```
 
@@ -151,11 +151,12 @@ result.results.first.higher_is_better # => true
 Create evaluators by subclassing `Riffer::Evals::Evaluator`:
 
 ```ruby
+# app/evals/medical_accuracy_evaluator.rb
 class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
   identifier "medical_accuracy"
   description "Evaluates medical information accuracy"
   higher_is_better true
-  judge_model "anthropic/claude-sonnet-4-20250514"  # Optional override
+  judge_model "anthropic/claude-opus-4-5-20251101"  # Optional override
 
   SYSTEM_PROMPT = <<~PROMPT
     You are an evaluation assistant that assesses medical accuracy.
@@ -178,12 +179,15 @@ class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
     result(score: evaluation[:score], reason: evaluation[:reason])
   end
 end
+```
 
-# Register the evaluator
-Riffer::Evals::Evaluators::Registry.register(
-  "medical_accuracy",
-  MedicalAccuracyEvaluator
-)
+### Registering Custom Evaluators
+
+Register custom evaluators in your app initialization. Built-in evaluators are always available.
+
+```ruby
+# config/initializers/riffer.rb
+Riffer::Evals::Evaluators::Repository.register(:medical_accuracy, MedicalAccuracyEvaluator)
 ```
 
 ### Evaluator DSL
@@ -200,6 +204,26 @@ Instance methods:
 - `evaluate(input:, output:, context:)` - Must be implemented, returns a Result
 - `judge` - Returns a Judge instance for LLM-as-judge calls
 - `result(score:, reason:, metadata:)` - Helper to build Result objects
+
+### Judge Options
+
+The `judge.evaluate` method accepts either `system_prompt:` and `user_prompt:` or a `messages:` array:
+
+```ruby
+# Using system_prompt and user_prompt
+evaluation = judge.evaluate(
+  system_prompt: "You are a judge.",
+  user_prompt: "Evaluate this response."
+)
+
+# Using messages array (for more control)
+evaluation = judge.evaluate(
+  messages: [
+    { role: "system", content: "You are a judge." },
+    { role: "user", content: "Evaluate this response." }
+  ]
+)
+```
 
 ### Rule-Based Evaluators
 
@@ -257,7 +281,7 @@ Scores are then weighted:
 # config/initializers/riffer.rb
 Riffer.configure do |config|
   config.anthropic.api_key = ENV["ANTHROPIC_API_KEY"]
-  config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+  config.evals.judge_model = "anthropic/claude-opus-4-5-20251101"
 end
 
 # app/evals/quality_evals.rb
@@ -273,7 +297,7 @@ end
 class SupportAgent < Riffer::Agent
   include QualityEvals
 
-  model "anthropic/claude-sonnet-4-20250514"
+  model "anthropic/claude-opus-4-5-20251101"
   instructions "You are a helpful customer support agent."
 end
 

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -1,0 +1,292 @@
+# Evals
+
+Evals let you measure the quality of agent outputs using LLM-as-judge evaluations.
+
+## Overview
+
+Riffer Evals provides a framework for evaluating agent responses against configurable quality metrics. It uses an LLM-as-judge approach where a separate model evaluates the outputs of your agents.
+
+Key concepts:
+
+- **Evaluators** - Classes that evaluate input/output pairs and return scores
+- **Metrics** - Evaluator configurations with pass/fail thresholds
+- **Profiles** - Collections of metrics that can be included in agents
+- **Results** - Individual evaluation scores and aggregate pass/fail status
+
+## Quick Start
+
+```ruby
+# 1. Configure the judge model
+Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+
+# 2. Define an eval profile
+module QualityEvals
+  include Riffer::Evals::Profile
+
+  ai_evals do
+    metric :answer_relevancy, min: 0.85
+  end
+end
+
+# 3. Include in your agent
+class MyAgent < Riffer::Agent
+  include QualityEvals
+  model "openai/gpt-4o"
+  instructions "You are a helpful assistant."
+end
+
+# 4. Run evals
+result = MyAgent.eval(input: "What is Ruby?")
+result.passed?         # => true/false
+result.aggregate_score # => 0.91
+```
+
+## Configuration
+
+Before using evals, configure the judge model:
+
+```ruby
+Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+```
+
+The judge model is the LLM that evaluates agent outputs. You can use any configured provider.
+
+## Built-in Evaluators
+
+### answer_relevancy
+
+Evaluates how well a response addresses the input question.
+
+- **higher_is_better**: true
+- **Score range**: 0.0 to 1.0
+- **1.0**: Perfectly relevant, directly addresses the question
+- **0.7-0.9**: Mostly relevant with minor tangents
+- **0.4-0.6**: Partially relevant, some off-topic content
+- **0.1-0.3**: Mostly irrelevant
+- **0.0**: Completely irrelevant
+
+```ruby
+ai_evals do
+  metric :answer_relevancy, min: 0.85
+end
+```
+
+## Eval Profiles
+
+Eval profiles define which evaluators to run and their pass/fail thresholds.
+
+### Defining a Profile
+
+```ruby
+module QualityEvals
+  include Riffer::Evals::Profile
+
+  ai_evals do
+    metric :answer_relevancy, min: 0.85
+    metric :toxicity, max: 0.10  # For future evaluators
+  end
+end
+```
+
+### Metric Options
+
+- `min` - Minimum score to pass (for higher_is_better evaluators)
+- `max` - Maximum score to pass (for lower_is_better evaluators)
+- `weight` - Weight for aggregate scoring (default: 1.0)
+
+```ruby
+ai_evals do
+  metric :answer_relevancy, min: 0.85, weight: 2.0  # Weighted more heavily
+  metric :toxicity, max: 0.05, weight: 1.0
+end
+```
+
+### Including in Agents
+
+```ruby
+class MyAgent < Riffer::Agent
+  include QualityEvals
+  model "openai/gpt-4o"
+end
+```
+
+## Running Evals
+
+Once a profile is included, call `.eval` on the agent class:
+
+```ruby
+result = MyAgent.eval(
+  input: "What is the capital of France?",
+  context: { ground_truth: "Paris" }  # Optional context
+)
+```
+
+### RunResult Object
+
+The eval method returns a `Riffer::Evals::RunResult`:
+
+```ruby
+result.passed?          # => true if all metrics pass thresholds
+result.aggregate_score  # => Weighted average of normalized scores (0.0-1.0)
+result.failures         # => Array of Result objects that failed
+result.results          # => Array of all Result objects
+result.input            # => The input that was evaluated
+result.output           # => The agent's output
+result.to_h             # => Hash representation
+```
+
+### Result Object
+
+Individual evaluation results:
+
+```ruby
+result.results.first.evaluator       # => "answer_relevancy"
+result.results.first.score           # => 0.92
+result.results.first.reason          # => "The response directly addresses..."
+result.results.first.higher_is_better # => true
+```
+
+## Defining Custom Evaluators
+
+Create evaluators by subclassing `Riffer::Evals::Evaluator`:
+
+```ruby
+class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
+  identifier "medical_accuracy"
+  description "Evaluates medical information accuracy"
+  higher_is_better true
+  judge_model "anthropic/claude-sonnet-4-20250514"  # Optional override
+
+  SYSTEM_PROMPT = <<~PROMPT
+    You are an evaluation assistant that assesses medical accuracy.
+
+    Respond with JSON: {"score": 0.0-1.0, "reason": "explanation"}
+  PROMPT
+
+  def evaluate(input:, output:, context: nil)
+    user_prompt = <<~PROMPT
+      Question: #{input}
+      Response: #{output}
+      Ground truth: #{context&.dig(:ground_truth)}
+    PROMPT
+
+    evaluation = judge.evaluate(
+      system_prompt: SYSTEM_PROMPT,
+      user_prompt: user_prompt
+    )
+
+    result(score: evaluation[:score], reason: evaluation[:reason])
+  end
+end
+
+# Register the evaluator
+Riffer::Evals::Evaluators::Registry.register(
+  "medical_accuracy",
+  MedicalAccuracyEvaluator
+)
+```
+
+### Evaluator DSL
+
+Class methods:
+
+- `identifier(value)` - Set the evaluator identifier (defaults to snake_case class name)
+- `description(value)` - Human-readable description
+- `higher_is_better(value)` - Whether higher scores are better (default: true)
+- `judge_model(value)` - Override the global judge model
+
+Instance methods:
+
+- `evaluate(input:, output:, context:)` - Must be implemented, returns a Result
+- `judge` - Returns a Judge instance for LLM-as-judge calls
+- `result(score:, reason:, metadata:)` - Helper to build Result objects
+
+### Rule-Based Evaluators
+
+Evaluators don't have to use LLM-as-judge:
+
+```ruby
+class LengthEvaluator < Riffer::Evals::Evaluator
+  identifier "response_length"
+  description "Checks response is within expected length"
+  higher_is_better true
+
+  def evaluate(input:, output:, context: nil)
+    min_length = context&.dig(:min_length) || 50
+    max_length = context&.dig(:max_length) || 500
+
+    length = output.length
+
+    if length < min_length
+      score = length.to_f / min_length
+      reason = "Response too short (#{length} < #{min_length})"
+    elsif length > max_length
+      score = max_length.to_f / length
+      reason = "Response too long (#{length} > #{max_length})"
+    else
+      score = 1.0
+      reason = "Response length is appropriate"
+    end
+
+    result(score: score, reason: reason)
+  end
+end
+```
+
+## Aggregate Scoring
+
+The `aggregate_score` normalizes all scores so higher is always better:
+
+- For `higher_is_better` evaluators: score is used directly
+- For `lower_is_better` evaluators: score is inverted (1.0 - score)
+
+Scores are then weighted:
+
+```ruby
+# With weights: relevancy=2.0, toxicity=1.0
+# relevancy score: 0.9 (higher_is_better)
+# toxicity score: 0.1 (lower_is_better)
+
+# Normalized: relevancy=0.9, toxicity=0.9 (1.0 - 0.1)
+# Weighted average: (0.9 * 2.0 + 0.9 * 1.0) / (2.0 + 1.0) = 0.9
+```
+
+## Example: Full Integration
+
+```ruby
+# config/initializers/riffer.rb
+Riffer.configure do |config|
+  config.anthropic.api_key = ENV["ANTHROPIC_API_KEY"]
+  config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+end
+
+# app/evals/quality_evals.rb
+module QualityEvals
+  include Riffer::Evals::Profile
+
+  ai_evals do
+    metric :answer_relevancy, min: 0.85, weight: 2.0
+  end
+end
+
+# app/agents/support_agent.rb
+class SupportAgent < Riffer::Agent
+  include QualityEvals
+
+  model "anthropic/claude-sonnet-4-20250514"
+  instructions "You are a helpful customer support agent."
+end
+
+# test/agents/support_agent_test.rb
+class SupportAgentTest < Minitest::Test
+  def test_response_quality
+    result = SupportAgent.eval(
+      input: "How do I reset my password?",
+      context: {}
+    )
+
+    assert result.passed?, "Expected eval to pass: #{result.failures.map(&:reason)}"
+    assert result.aggregate_score >= 0.85
+  end
+end
+```

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -83,7 +83,6 @@ module QualityEvals
 
   ai_evals do
     metric :answer_relevancy, min: 0.85
-    metric :toxicity, max: 0.10  # For future evaluators
   end
 end
 ```
@@ -97,7 +96,6 @@ end
 ```ruby
 ai_evals do
   metric :answer_relevancy, min: 0.85, weight: 2.0  # Weighted more heavily
-  metric :toxicity, max: 0.05, weight: 1.0
 end
 ```
 

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -36,7 +36,7 @@ class MyAgent < Riffer::Agent
 end
 
 # 4. Run evals
-result = MyAgent.eval(input: "What is Ruby?")
+result = MyAgent.run_evalinput: "What is Ruby?")
 result.passed?         # => true/false
 result.aggregate_score # => 0.91
 ```
@@ -113,7 +113,7 @@ end
 Once a profile is included, call `.eval` on the agent class:
 
 ```ruby
-result = MyAgent.eval(
+result = MyAgent.run_eval(
   input: "What is the capital of France?",
   context: { ground_truth: "Paris" }  # Optional context
 )
@@ -304,7 +304,7 @@ end
 # test/agents/support_agent_test.rb
 class SupportAgentTest < Minitest::Test
   def test_response_quality
-    result = SupportAgent.eval(
+    result = SupportAgent.run_eval
       input: "How do I reset my password?",
       context: {}
     )

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -161,7 +161,7 @@ class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
   SYSTEM_PROMPT = <<~PROMPT
     You are an evaluation assistant that assesses medical accuracy.
 
-    Respond with JSON: {"score": 0.0-1.0, "reason": "explanation"}
+    Use the evaluation tool to submit your score (0.0-1.0) and reasoning.
   PROMPT
 
   def evaluate(input:, output:, context: nil)
@@ -224,6 +224,8 @@ evaluation = judge.evaluate(
   ]
 )
 ```
+
+The Judge uses tool calling internally to get structured output. An `evaluation` tool with `score` (Float) and `reason` (String) parameters is automatically provided to the judge model, so your prompts should instruct the model to use the evaluation tool rather than respond with raw JSON.
 
 ### Rule-Based Evaluators
 

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -166,7 +166,7 @@ class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
     user_prompt = <<~PROMPT
       Question: #{input}
       Response: #{output}
-      Ground truth: #{context&.dig(:ground_truth)}
+      Ground truth: #{context[:ground_truth]}
     PROMPT
 
     evaluation = judge.evaluate(

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -36,7 +36,7 @@ class MyAgent < Riffer::Agent
 end
 
 # 4. Run evals
-result = MyAgent.run_evalinput: "What is Ruby?")
+result = MyAgent.run_eval(input: "What is Ruby?")
 result.passed?         # => true/false
 result.aggregate_score # => 0.91
 ```

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -11,6 +11,8 @@
 #
 #   Riffer.config.anthropic.api_key = "sk-ant-..."
 #
+#   Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+#
 class Riffer::Config
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   #
@@ -27,10 +29,16 @@ class Riffer::Config
   # Returns Struct.
   attr_reader :openai
 
+  # Evals configuration (Struct with +judge_model+).
+  #
+  # Returns Struct.
+  attr_reader :evals
+
   # Initializes the configuration.
   def initialize
     @amazon_bedrock = Struct.new(:api_token, :region).new
     @anthropic = Struct.new(:api_key).new
     @openai = Struct.new(:api_key).new
+    @evals = Struct.new(:judge_model).new
   end
 end

--- a/lib/riffer/evals.rb
+++ b/lib/riffer/evals.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Riffer::Evals provides LLM-as-judge evaluation capabilities.
+#
+# Evals allow you to measure the quality of agent outputs using
+# configurable evaluators and thresholds.
+#
+# See Riffer::Evals::Evaluator, Riffer::Evals::Profile, and Riffer::Evals::Runner.
+module Riffer::Evals
+end

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# Base class for all evaluators in the Riffer framework.
+#
+# Provides a DSL for defining evaluator metadata and the evaluate method.
+# Subclasses must implement the +evaluate+ method.
+#
+# See Riffer::Evals::Evaluators.
+#
+#   class MyEvaluator < Riffer::Evals::Evaluator
+#     identifier "my_evaluator"
+#     description "Evaluates response quality"
+#     higher_is_better true
+#     judge_model "anthropic/claude-sonnet-4-20250514"
+#
+#     def evaluate(input:, output:, context: nil)
+#       evaluation = judge.evaluate(
+#         system_prompt: "...",
+#         user_prompt: "..."
+#       )
+#       result(score: evaluation[:score], reason: evaluation[:reason])
+#     end
+#   end
+#
+class Riffer::Evals::Evaluator
+  class << self
+    include Riffer::Helpers::ClassNameConverter
+
+    # Gets or sets the evaluator identifier.
+    #
+    # value:: String or nil - the identifier to set, or nil to get
+    #
+    # Returns String - the evaluator identifier.
+    def identifier(value = nil)
+      return @identifier || class_name_to_identifier(name) if value.nil?
+      @identifier = value.to_s
+    end
+
+    # Gets or sets the evaluator description.
+    #
+    # value:: String or nil - the description to set, or nil to get
+    #
+    # Returns String or nil - the evaluator description.
+    def description(value = nil)
+      return @description if value.nil?
+      @description = value.to_s
+    end
+
+    # Gets or sets whether higher scores are better.
+    #
+    # value:: Boolean or nil - the value to set, or nil to get
+    #
+    # Returns Boolean - whether higher is better (default: true).
+    def higher_is_better(value = nil)
+      return @higher_is_better.nil? ? true : @higher_is_better if value.nil?
+      @higher_is_better = value
+    end
+
+    # Gets or sets the judge model for LLM-as-judge evaluations.
+    #
+    # value:: String or nil - the model to set (provider/model format), or nil to get
+    #
+    # Returns String or nil - the judge model.
+    def judge_model(value = nil)
+      return @judge_model if value.nil?
+      @judge_model = value.to_s
+    end
+
+    private
+
+    def class_name_to_identifier(name)
+      return nil if name.nil?
+
+      # Extract just the class name (last part after ::)
+      class_name = name.split("::").last
+      return nil if class_name.nil?
+
+      # Convert CamelCase to snake_case and remove _evaluator suffix
+      identifier = class_name
+        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .downcase
+        .sub(/_evaluator$/, "")
+
+      identifier
+    end
+  end
+
+  # Evaluates an input/output pair.
+  #
+  # input:: String - the input that was given to the agent
+  # output:: String - the output produced by the agent
+  # context:: Hash or nil - optional context (e.g., ground_truth)
+  #
+  # Returns Riffer::Evals::Result.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  def evaluate(input:, output:, context: nil)
+    raise NotImplementedError, "#{self.class} must implement #evaluate"
+  end
+
+  protected
+
+  # Returns a Judge instance configured for this evaluator.
+  #
+  # Returns Riffer::Evals::Judge.
+  def judge
+    @judge ||= begin
+      model = self.class.judge_model || Riffer.config.evals.judge_model
+      raise Riffer::ArgumentError, "No judge model configured. Set judge_model on the evaluator or Riffer.config.evals.judge_model" unless model
+      Riffer::Evals::Judge.new(model: model)
+    end
+  end
+
+  # Helper to build a Result object.
+  #
+  # score:: Float - the evaluation score (0.0 to 1.0)
+  # reason:: String or nil - optional explanation
+  # metadata:: Hash - optional additional data
+  #
+  # Returns Riffer::Evals::Result.
+  def result(score:, reason: nil, metadata: {})
+    Riffer::Evals::Result.new(
+      evaluator: self.class.identifier,
+      score: score,
+      reason: reason,
+      metadata: metadata,
+      higher_is_better: self.class.higher_is_better
+    )
+  end
+end

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -11,7 +11,7 @@
 #     identifier "my_evaluator"
 #     description "Evaluates response quality"
 #     higher_is_better true
-#     judge_model "anthropic/claude-sonnet-4-20250514"
+#     judge_model "anthropic/claude-opus-4-5-20251101"
 #
 #     def evaluate(input:, output:, context: nil)
 #       evaluation = judge.evaluate(
@@ -70,17 +70,9 @@ class Riffer::Evals::Evaluator
 
     def class_name_to_identifier(name)
       return nil if name.nil?
-
-      # Extract just the class name (last part after ::)
       class_name = name.split("::").last
       return nil if class_name.nil?
-
-      # Convert CamelCase to snake_case and remove _evaluator suffix
-      class_name
-        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-        .downcase
-        .sub(/_evaluator$/, "")
+      class_name_to_path(class_name).sub(/_evaluator$/, "")
     end
   end
 

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -52,7 +52,7 @@ class Riffer::Evals::Evaluator
     #
     # Returns Boolean - whether higher is better (default: true).
     def higher_is_better(value = nil)
-      return @higher_is_better.nil? ? true : @higher_is_better if value.nil?
+      return @higher_is_better.nil? || @higher_is_better if value.nil?
       @higher_is_better = value
     end
 
@@ -76,13 +76,11 @@ class Riffer::Evals::Evaluator
       return nil if class_name.nil?
 
       # Convert CamelCase to snake_case and remove _evaluator suffix
-      identifier = class_name
+      class_name
         .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
         .gsub(/([a-z\d])([A-Z])/, '\1_\2')
         .downcase
         .sub(/_evaluator$/, "")
-
-      identifier
     end
   end
 

--- a/lib/riffer/evals/evaluators.rb
+++ b/lib/riffer/evals/evaluators.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Namespace for built-in evaluators and the evaluator registry.
+#
+# See Riffer::Evals::Evaluators::Registry for registering custom evaluators.
+module Riffer::Evals::Evaluators
+  # Registry for looking up evaluators by identifier.
+  #
+  # Built-in evaluators are automatically registered. Custom evaluators
+  # can be registered using Registry.register.
+  #
+  #   # Register a custom evaluator
+  #   Riffer::Evals::Evaluators::Registry.register(:my_evaluator, MyEvaluator)
+  #
+  #   # Find an evaluator
+  #   Riffer::Evals::Evaluators::Registry.find("answer_relevancy")
+  #   # => Riffer::Evals::Evaluators::AnswerRelevancy
+  #
+  module Registry
+    class << self
+      # Registers an evaluator class with an identifier.
+      #
+      # identifier:: String or Symbol - the identifier to register
+      # evaluator_class:: Class - the evaluator class
+      #
+      # Returns void.
+      def register(identifier, evaluator_class)
+        registry[identifier.to_s] = evaluator_class
+      end
+
+      # Finds an evaluator class by identifier.
+      #
+      # identifier:: String or Symbol - the identifier to look up
+      #
+      # Returns Class or nil.
+      def find(identifier)
+        registry[identifier.to_s]
+      end
+
+      # Returns all registered evaluators.
+      #
+      # Returns Hash mapping identifiers to evaluator classes.
+      def all
+        registry.dup
+      end
+
+      # Clears all registered evaluators.
+      #
+      # Primarily for testing.
+      #
+      # Returns void.
+      def clear
+        @registry = {}
+      end
+
+      private
+
+      def registry
+        @registry ||= {}
+      end
+    end
+  end
+end

--- a/lib/riffer/evals/evaluators.rb
+++ b/lib/riffer/evals/evaluators.rb
@@ -1,31 +1,38 @@
 # frozen_string_literal: true
 
-# Namespace for built-in evaluators and the evaluator registry.
+# Namespace for built-in evaluators and the evaluator repository.
 #
-# See Riffer::Evals::Evaluators::Registry for registering custom evaluators.
+# See Riffer::Evals::Evaluators::Repository for registering custom evaluators.
 module Riffer::Evals::Evaluators
-  # Registry for looking up evaluators by identifier.
+  # Repository for looking up evaluators by identifier.
   #
-  # Built-in evaluators are automatically registered. Custom evaluators
-  # can be registered using Registry.register.
+  # Built-in evaluators are always available. Custom evaluators
+  # can be registered using Repository.register in your app initialization.
   #
-  #   # Register a custom evaluator
-  #   Riffer::Evals::Evaluators::Registry.register(:my_evaluator, MyEvaluator)
+  #   # Register a custom evaluator (config/initializers/riffer.rb)
+  #   Riffer::Evals::Evaluators::Repository.register(:my_evaluator, MyEvaluator)
   #
   #   # Find an evaluator
-  #   Riffer::Evals::Evaluators::Registry.find("answer_relevancy")
+  #   Riffer::Evals::Evaluators::Repository.find(:answer_relevancy)
   #   # => Riffer::Evals::Evaluators::AnswerRelevancy
   #
-  module Registry
+  class Repository
+    # Built-in evaluators (always available).
+    BUILT_IN = {
+      answer_relevancy: -> { Riffer::Evals::Evaluators::AnswerRelevancy }
+    }.freeze
+
+    @custom = {}
+
     class << self
-      # Registers an evaluator class with an identifier.
+      # Registers a custom evaluator class with an identifier.
       #
       # identifier:: String or Symbol - the identifier to register
       # evaluator_class:: Class - the evaluator class
       #
       # Returns void.
       def register(identifier, evaluator_class)
-        registry[identifier.to_s] = evaluator_class
+        @custom[identifier.to_sym] = -> { evaluator_class }
       end
 
       # Finds an evaluator class by identifier.
@@ -34,29 +41,22 @@ module Riffer::Evals::Evaluators
       #
       # Returns Class or nil.
       def find(identifier)
-        registry[identifier.to_s]
+        id = identifier.to_sym
+        (@custom[id] || BUILT_IN[id])&.call
       end
 
-      # Returns all registered evaluators.
+      # Returns all registered evaluators (built-in and custom).
       #
       # Returns Hash mapping identifiers to evaluator classes.
       def all
-        registry.dup
+        BUILT_IN.merge(@custom).transform_values(&:call)
       end
 
-      # Clears all registered evaluators.
-      #
-      # Primarily for testing.
+      # Clears custom registrations (for testing). Built-ins remain.
       #
       # Returns void.
       def clear
-        @registry = {}
-      end
-
-      private
-
-      def registry
-        @registry ||= {}
+        @custom = {}
       end
     end
   end

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -58,9 +58,3 @@ class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
     PROMPT
   end
 end
-
-# Register the evaluator
-Riffer::Evals::Evaluators::Registry.register(
-  "answer_relevancy",
-  Riffer::Evals::Evaluators::AnswerRelevancy
-)

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Evaluates how well a response addresses the input question.
+#
+# Uses LLM-as-judge to assess whether the response is relevant,
+# on-topic, and directly addresses what was asked.
+#
+#   evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
+#   result = evaluator.evaluate(
+#     input: "What is the capital of France?",
+#     output: "The capital of France is Paris."
+#   )
+#   result.score  # => 0.95
+#
+class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
+  identifier "answer_relevancy"
+  description "Evaluates how well the response addresses the input question"
+  higher_is_better true
+
+  SYSTEM_PROMPT = <<~PROMPT
+    You are an evaluation assistant that assesses answer relevancy.
+
+    Your task is to evaluate how well a response addresses the given input/question.
+
+    Consider the following criteria:
+    1. Does the response directly address what was asked?
+    2. Is the response on-topic and relevant?
+    3. Does the response provide the type of information requested?
+    4. Does the response avoid going off on tangents?
+
+    You must respond with a JSON object containing:
+    - "score": A float between 0.0 and 1.0 where:
+      - 1.0 = Perfectly relevant, directly addresses the question
+      - 0.7-0.9 = Mostly relevant with minor tangents
+      - 0.4-0.6 = Partially relevant, some off-topic content
+      - 0.1-0.3 = Mostly irrelevant
+      - 0.0 = Completely irrelevant
+    - "reason": A brief explanation of your score
+
+    Respond ONLY with the JSON object, no other text.
+  PROMPT
+
+  def evaluate(input:, output:, context: nil)
+    user_prompt = build_user_prompt(input: input, output: output)
+    evaluation = judge.evaluate(system_prompt: SYSTEM_PROMPT, user_prompt: user_prompt)
+    result(score: evaluation[:score], reason: evaluation[:reason])
+  end
+
+  private
+
+  def build_user_prompt(input:, output:)
+    <<~PROMPT
+      Input/Question:
+      #{input}
+
+      Response to evaluate:
+      #{output}
+    PROMPT
+  end
+end
+
+# Register the evaluator
+Riffer::Evals::Evaluators::Registry.register(
+  "answer_relevancy",
+  Riffer::Evals::Evaluators::AnswerRelevancy
+)

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -28,16 +28,13 @@ class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
     3. Does the response provide the type of information requested?
     4. Does the response avoid going off on tangents?
 
-    You must respond with a JSON object containing:
-    - "score": A float between 0.0 and 1.0 where:
+    Use the evaluation tool to submit your score and reasoning. The score should be
+    a float between 0.0 and 1.0 where:
       - 1.0 = Perfectly relevant, directly addresses the question
       - 0.7-0.9 = Mostly relevant with minor tangents
       - 0.4-0.6 = Partially relevant, some off-topic content
       - 0.1-0.3 = Mostly irrelevant
       - 0.0 = Completely irrelevant
-    - "reason": A brief explanation of your score
-
-    Respond ONLY with the JSON object, no other text.
   PROMPT
 
   def evaluate(input:, output:, context: nil)

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -5,7 +5,8 @@ require "json"
 # Executes LLM-as-judge evaluations using the provider infrastructure.
 #
 # The Judge class handles calling an LLM to evaluate agent outputs
-# and parsing the structured response.
+# and parsing the structured response. It uses tool calling internally
+# to get guaranteed structured output from the judge model.
 #
 #   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-opus-4-5-20251101")
 #   result = judge.evaluate(
@@ -16,6 +17,21 @@ require "json"
 #   result[:reason] # => "The response is relevant..."
 #
 class Riffer::Evals::Judge
+  # Internal tool for structured evaluation output.
+  class EvaluationTool < Riffer::Tool
+    identifier "evaluation"
+    description "Submit your evaluation score and reasoning"
+
+    params do
+      required :score, Float, description: "Evaluation score between 0.0 and 1.0"
+      required :reason, String, description: "Brief explanation for the score"
+    end
+
+    def call(context:, score:, reason:)
+      json({score: score, reason: reason})
+    end
+  end
+
   # The model string (provider/model format).
   #
   # Returns String.
@@ -43,13 +59,13 @@ class Riffer::Evals::Judge
   def evaluate(messages: nil, system_prompt: nil, user_prompt: nil)
     response = if messages
       raise Riffer::ArgumentError, "cannot provide both messages and system_prompt/user_prompt" if system_prompt || user_prompt
-      provider_instance.generate_text(messages: messages, model: model_name)
+      provider_instance.generate_text(messages: messages, model: model_name, tools: [EvaluationTool])
     else
       raise Riffer::ArgumentError, "user_prompt is required when messages is not provided" unless user_prompt
-      provider_instance.generate_text(system: system_prompt, prompt: user_prompt, model: model_name)
+      provider_instance.generate_text(system: system_prompt, prompt: user_prompt, model: model_name, tools: [EvaluationTool])
     end
 
-    parse_response(response.content)
+    parse_tool_response(response)
   end
 
   private
@@ -70,11 +86,11 @@ class Riffer::Evals::Judge
     @model_name ||= @model.split("/", 2).last
   end
 
-  def parse_response(content)
-    json_match = content.match(/\{[^{}]*"score"[^{}]*\}/m)
-    raise Riffer::Error, "Invalid judge response: no JSON found" unless json_match
+  def parse_tool_response(response)
+    tool_call = response.tool_calls.first
+    raise Riffer::Error, "Invalid judge response: no tool call found" unless tool_call
 
-    parsed = JSON.parse(json_match[0])
+    parsed = JSON.parse(tool_call[:arguments])
     score = parsed["score"]
     reason = parsed["reason"]
 

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -42,6 +42,11 @@ class Riffer::Evals::Judge
   # model:: String - the model to use (provider/model format)
   # provider_options:: Hash - options passed to the provider
   def initialize(model:, provider_options: {})
+    provider_name, model_name = model.split("/", 2)
+    unless [provider_name, model_name].all? { |part| part.is_a?(String) && !part.strip.empty? }
+      raise Riffer::ArgumentError, "Invalid model string: #{model}"
+    end
+
     @model = model
     @provider_options = provider_options
   end

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -7,7 +7,7 @@ require "json"
 # The Judge class handles calling an LLM to evaluate agent outputs
 # and parsing the structured response.
 #
-#   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-sonnet-4-20250514")
+#   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-opus-4-5-20251101")
 #   result = judge.evaluate(
 #     system_prompt: "You are an evaluation assistant...",
 #     user_prompt: "Evaluate this response..."
@@ -32,16 +32,22 @@ class Riffer::Evals::Judge
 
   # Evaluates using the configured LLM.
   #
+  # messages:: Array - array of message hashes (alternative to system_prompt/user_prompt)
   # system_prompt:: String - the system prompt for the judge
   # user_prompt:: String - the user prompt containing the evaluation request
   #
   # Returns Hash with :score (Float) and :reason (String).
-  def evaluate(system_prompt:, user_prompt:)
-    response = provider_instance.generate_text(
-      system: system_prompt,
-      prompt: user_prompt,
-      model: model_name
-    )
+  #
+  # Raises Riffer::ArgumentError if both messages and system_prompt/user_prompt are provided,
+  # or if user_prompt is missing when messages is not provided.
+  def evaluate(messages: nil, system_prompt: nil, user_prompt: nil)
+    response = if messages
+      raise Riffer::ArgumentError, "cannot provide both messages and system_prompt/user_prompt" if system_prompt || user_prompt
+      provider_instance.generate_text(messages: messages, model: model_name)
+    else
+      raise Riffer::ArgumentError, "user_prompt is required when messages is not provided" unless user_prompt
+      provider_instance.generate_text(system: system_prompt, prompt: user_prompt, model: model_name)
+    end
 
     parse_response(response.content)
   end

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Executes LLM-as-judge evaluations using the provider infrastructure.
+#
+# The Judge class handles calling an LLM to evaluate agent outputs
+# and parsing the structured response.
+#
+#   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-sonnet-4-20250514")
+#   result = judge.evaluate(
+#     system_prompt: "You are an evaluation assistant...",
+#     user_prompt: "Evaluate this response..."
+#   )
+#   result[:score]  # => 0.85
+#   result[:reason] # => "The response is relevant..."
+#
+class Riffer::Evals::Judge
+  # The model string (provider/model format).
+  #
+  # Returns String.
+  attr_reader :model
+
+  # Initializes a new judge.
+  #
+  # model:: String - the model to use (provider/model format)
+  # provider_options:: Hash - options passed to the provider
+  def initialize(model:, provider_options: {})
+    @model = model
+    @provider_options = provider_options
+  end
+
+  # Evaluates using the configured LLM.
+  #
+  # system_prompt:: String - the system prompt for the judge
+  # user_prompt:: String - the user prompt containing the evaluation request
+  #
+  # Returns Hash with :score (Float) and :reason (String).
+  def evaluate(system_prompt:, user_prompt:)
+    response = provider_instance.generate_text(
+      system: system_prompt,
+      prompt: user_prompt,
+      model: model_name
+    )
+
+    parse_response(response.content)
+  end
+
+  private
+
+  def provider_instance
+    @provider_instance ||= begin
+      provider_class = Riffer::Providers::Repository.find(provider_name)
+      raise Riffer::ArgumentError, "Provider not found: #{provider_name}" unless provider_class
+      provider_class.new(**@provider_options)
+    end
+  end
+
+  def provider_name
+    @provider_name ||= @model.split("/", 2).first
+  end
+
+  def model_name
+    @model_name ||= @model.split("/", 2).last
+  end
+
+  def parse_response(content)
+    json_match = content.match(/\{[^{}]*"score"[^{}]*\}/m)
+    raise Riffer::Error, "Invalid judge response: no JSON found" unless json_match
+
+    parsed = JSON.parse(json_match[0])
+    score = parsed["score"]
+    reason = parsed["reason"]
+
+    raise Riffer::Error, "Invalid judge response: missing score" if score.nil?
+
+    {
+      score: score.to_f,
+      reason: reason
+    }
+  rescue JSON::ParserError => e
+    raise Riffer::Error, "Invalid judge response: #{e.message}"
+  end
+end

--- a/lib/riffer/evals/metric.rb
+++ b/lib/riffer/evals/metric.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Represents a metric configuration with thresholds.
+#
+# Metrics define which evaluator to use and what thresholds determine pass/fail.
+#
+#   metric = Riffer::Evals::Metric.new(
+#     evaluator_identifier: "answer_relevancy",
+#     min: 0.85,
+#     weight: 1.0
+#   )
+#
+#   metric.passes?(result)  # => true/false based on thresholds
+#
+class Riffer::Evals::Metric
+  # The identifier of the evaluator to use.
+  #
+  # Returns String.
+  attr_reader :evaluator_identifier
+
+  # Minimum acceptable score (for higher_is_better evaluators).
+  #
+  # Returns Float or nil.
+  attr_reader :min
+
+  # Maximum acceptable score (for lower_is_better evaluators).
+  #
+  # Returns Float or nil.
+  attr_reader :max
+
+  # Weight for aggregate scoring (default: 1.0).
+  #
+  # Returns Float.
+  attr_reader :weight
+
+  # Initializes a new metric.
+  #
+  # evaluator_identifier:: String - the evaluator to use
+  # min:: Float or nil - minimum score threshold
+  # max:: Float or nil - maximum score threshold
+  # weight:: Float - weight for aggregation (default: 1.0)
+  def initialize(evaluator_identifier:, min: nil, max: nil, weight: 1.0)
+    @evaluator_identifier = evaluator_identifier.to_s
+    @min = min&.to_f
+    @max = max&.to_f
+    @weight = weight.to_f
+  end
+
+  # Returns the evaluator class for this metric.
+  #
+  # Returns Class or nil.
+  def evaluator_class
+    Riffer::Evals::Evaluators::Registry.find(@evaluator_identifier)
+  end
+
+  # Checks if a result passes this metric's thresholds.
+  #
+  # result:: Riffer::Evals::Result - the evaluation result to check
+  #
+  # Returns Boolean.
+  def passes?(result)
+    return false if @min && result.score < @min
+    return false if @max && result.score > @max
+    true
+  end
+
+  # Returns a hash representation of the metric.
+  #
+  # Returns Hash.
+  def to_h
+    {
+      evaluator_identifier: @evaluator_identifier,
+      min: @min,
+      max: @max,
+      weight: @weight
+    }
+  end
+end

--- a/lib/riffer/evals/metric.rb
+++ b/lib/riffer/evals/metric.rb
@@ -50,7 +50,7 @@ class Riffer::Evals::Metric
   #
   # Returns Class or nil.
   def evaluator_class
-    Riffer::Evals::Evaluators::Registry.find(@evaluator_identifier)
+    Riffer::Evals::Evaluators::Repository.find(@evaluator_identifier)
   end
 
   # Checks if a result passes this metric's thresholds.

--- a/lib/riffer/evals/metric.rb
+++ b/lib/riffer/evals/metric.rb
@@ -50,7 +50,7 @@ class Riffer::Evals::Metric
   #
   # Returns Class or nil.
   def evaluator_class
-    Riffer::Evals::Evaluators::Repository.find(@evaluator_identifier)
+    Riffer::Evals::Evaluators::Repository.find(evaluator_identifier)
   end
 
   # Checks if a result passes this metric's thresholds.
@@ -59,8 +59,8 @@ class Riffer::Evals::Metric
   #
   # Returns Boolean.
   def passes?(result)
-    return false if @min && result.score < @min
-    return false if @max && result.score > @max
+    return false if min && result.score < min
+    return false if max && result.score > max
     true
   end
 
@@ -69,10 +69,10 @@ class Riffer::Evals::Metric
   # Returns Hash.
   def to_h
     {
-      evaluator_identifier: @evaluator_identifier,
-      min: @min,
-      max: @max,
-      weight: @weight
+      evaluator_identifier: evaluator_identifier,
+      min: min,
+      max: max,
+      weight: weight
     }
   end
 end

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -19,7 +19,7 @@
 #     model "openai/gpt-4o"
 #   end
 #
-#   result = MyAgent.eval(input: "What is Ruby?")
+#   result = MyAgent.run_eval(input: "What is Ruby?")
 #   result.passed?  # => true/false
 #
 module Riffer::Evals::Profile
@@ -92,7 +92,7 @@ module Riffer::Evals::Profile
     # tool_context:: Object or nil - optional context passed to tools during generation
     #
     # Returns Riffer::Evals::RunResult.
-    def eval(input:, context: nil, tool_context: nil)
+    def run_eval(input:, context: nil, tool_context: nil)
       profile = @eval_profile
       raise Riffer::ArgumentError, "No eval profile configured" unless profile
 

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -89,10 +89,10 @@ module Riffer::Evals::Profile
     #
     # input:: String - the input to send to the agent
     # context:: Hash or nil - optional context for evaluation (e.g., ground_truth)
-    # generate_options:: Hash - options passed to the agent's generate method
+    # tool_context:: Object or nil - optional context passed to tools during generation
     #
     # Returns Riffer::Evals::RunResult.
-    def eval(input:, context: nil, **generate_options)
+    def eval(input:, context: nil, tool_context: nil)
       profile = @eval_profile
       raise Riffer::ArgumentError, "No eval profile configured" unless profile
 
@@ -100,7 +100,7 @@ module Riffer::Evals::Profile
       raise Riffer::ArgumentError, "No metrics configured in eval profile" if metrics.empty?
 
       # Generate output from agent
-      output = generate(input, **generate_options)
+      output = generate(input, tool_context: tool_context)
 
       # Run evaluations
       runner = Riffer::Evals::Runner.new(metrics: metrics)

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+# Module factory providing the ai_evals DSL for defining eval profiles.
+#
+# Include this module in a module to create an eval profile that can be
+# included in agents.
+#
+#   module EvalProfiles::QualityEvals
+#     include Riffer::Evals::Profile
+#
+#     ai_evals do
+#       metric :answer_relevancy, min: 0.85
+#       metric :hallucination, max: 0.10
+#     end
+#   end
+#
+#   class MyAgent < Riffer::Agent
+#     include EvalProfiles::QualityEvals
+#     model "openai/gpt-4o"
+#   end
+#
+#   result = MyAgent.eval(input: "What is Ruby?")
+#   result.passed?  # => true/false
+#
+module Riffer::Evals::Profile
+  def self.included(base)
+    base.extend(ClassMethods)
+
+    # When the profile module is included in an Agent, add the eval method
+    base.define_singleton_method(:included) do |target|
+      if target < Riffer::Agent
+        target.extend(AgentClassMethods)
+        target.instance_variable_set(:@eval_profile, base)
+      end
+    end
+  end
+
+  # DSL builder for configuring metrics within ai_evals block.
+  class Builder
+    # The configured metrics.
+    #
+    # Returns Array of Riffer::Evals::Metric.
+    attr_reader :metrics
+
+    def initialize
+      @metrics = []
+    end
+
+    # Defines a metric with thresholds.
+    #
+    # identifier:: Symbol or String - the evaluator identifier
+    # min:: Float or nil - minimum score threshold
+    # max:: Float or nil - maximum score threshold
+    # weight:: Float - weight for aggregation (default: 1.0)
+    #
+    # Returns void.
+    def metric(identifier, min: nil, max: nil, weight: 1.0)
+      @metrics << Riffer::Evals::Metric.new(
+        evaluator_identifier: identifier,
+        min: min,
+        max: max,
+        weight: weight
+      )
+    end
+  end
+
+  module ClassMethods
+    # Defines the eval metrics for this profile.
+    #
+    # Yields to a block where metrics can be defined using the metric method.
+    #
+    # Returns void.
+    def ai_evals(&block)
+      builder = Builder.new
+      builder.instance_eval(&block)
+      @eval_metrics = builder.metrics
+    end
+
+    # Returns the configured metrics.
+    #
+    # Returns Array of Riffer::Evals::Metric.
+    def eval_metrics
+      @eval_metrics || []
+    end
+  end
+
+  module AgentClassMethods
+    # Runs evaluations against the agent.
+    #
+    # input:: String - the input to send to the agent
+    # context:: Hash or nil - optional context for evaluation (e.g., ground_truth)
+    # generate_options:: Hash - options passed to the agent's generate method
+    #
+    # Returns Riffer::Evals::RunResult.
+    def eval(input:, context: nil, **generate_options)
+      profile = @eval_profile
+      raise Riffer::ArgumentError, "No eval profile configured" unless profile
+
+      metrics = profile.eval_metrics
+      raise Riffer::ArgumentError, "No metrics configured in eval profile" if metrics.empty?
+
+      # Generate output from agent
+      output = generate(input, **generate_options)
+
+      # Run evaluations
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+      runner.run(input: input, output: output, context: context)
+    end
+  end
+end

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -55,7 +55,7 @@ module Riffer::Evals::Profile
     #
     # Returns void.
     def metric(identifier, min: nil, max: nil, weight: 1.0)
-      @metrics << Riffer::Evals::Metric.new(
+      metrics << Riffer::Evals::Metric.new(
         evaluator_identifier: identifier,
         min: min,
         max: max,

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -48,9 +48,12 @@ class Riffer::Evals::Result
   # reason:: String or nil - optional explanation
   # metadata:: Hash - optional additional data
   # higher_is_better:: Boolean - whether higher is better (default: true)
+  #
+  # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
     @evaluator = evaluator
     @score = score.to_f
+    validate_score!
     @reason = reason
     @metadata = metadata
     @higher_is_better = higher_is_better
@@ -67,5 +70,13 @@ class Riffer::Evals::Result
       metadata: metadata,
       higher_is_better: higher_is_better
     }
+  end
+
+  private
+
+  def validate_score!
+    return if score.is_a?(Numeric) && score >= 0.0 && score <= 1.0
+
+    raise Riffer::ArgumentError, "score must be between 0.0 and 1.0, got #{score}"
   end
 end

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Represents the result of a single evaluation.
+#
+# Contains the score, reason, and metadata from running an evaluator.
+#
+#   result = Riffer::Evals::Result.new(
+#     evaluator: "answer_relevancy",
+#     score: 0.85,
+#     reason: "The response addresses the question directly.",
+#     higher_is_better: true
+#   )
+#
+#   result.score           # => 0.85
+#   result.evaluator       # => "answer_relevancy"
+#   result.higher_is_better # => true
+#
+class Riffer::Evals::Result
+  # The identifier of the evaluator that produced this result.
+  #
+  # Returns String.
+  attr_reader :evaluator
+
+  # The evaluation score (0.0 to 1.0).
+  #
+  # Returns Float.
+  attr_reader :score
+
+  # Human-readable explanation of the score.
+  #
+  # Returns String or nil.
+  attr_reader :reason
+
+  # Additional metadata from the evaluation.
+  #
+  # Returns Hash.
+  attr_reader :metadata
+
+  # Whether higher scores are better for this evaluator.
+  #
+  # Returns Boolean.
+  attr_reader :higher_is_better
+
+  # Initializes a new evaluation result.
+  #
+  # evaluator:: String - the evaluator identifier
+  # score:: Float - the score (0.0 to 1.0)
+  # reason:: String or nil - optional explanation
+  # metadata:: Hash - optional additional data
+  # higher_is_better:: Boolean - whether higher is better (default: true)
+  def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
+    @evaluator = evaluator
+    @score = score.to_f
+    @reason = reason
+    @metadata = metadata
+    @higher_is_better = higher_is_better
+  end
+
+  # Returns a hash representation of the result.
+  #
+  # Returns Hash.
+  def to_h
+    {
+      evaluator: @evaluator,
+      score: @score,
+      reason: @reason,
+      metadata: @metadata,
+      higher_is_better: @higher_is_better
+    }
+  end
+end

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -61,11 +61,11 @@ class Riffer::Evals::Result
   # Returns Hash.
   def to_h
     {
-      evaluator: @evaluator,
-      score: @score,
-      reason: @reason,
-      metadata: @metadata,
-      higher_is_better: @higher_is_better
+      evaluator: evaluator,
+      score: score,
+      reason: reason,
+      metadata: metadata,
+      higher_is_better: higher_is_better
     }
   end
 end

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Represents the complete result of an evaluation run.
+#
+# Contains all individual results and provides aggregate metrics.
+#
+#   run_result = Riffer::Evals::RunResult.new(
+#     input: "question",
+#     output: "answer",
+#     context: {},
+#     results: [result1, result2],
+#     metrics: [metric1, metric2]
+#   )
+#
+#   run_result.passed?          # => true/false
+#   run_result.aggregate_score  # => 0.87
+#   run_result.failures         # => [result1] (results that failed thresholds)
+#
+class Riffer::Evals::RunResult
+  # The input that was evaluated.
+  #
+  # Returns String.
+  attr_reader :input
+
+  # The output that was evaluated.
+  #
+  # Returns String.
+  attr_reader :output
+
+  # The context used during evaluation.
+  #
+  # Returns Hash or nil.
+  attr_reader :context
+
+  # Individual evaluation results.
+  #
+  # Returns Array of Riffer::Evals::Result.
+  attr_reader :results
+
+  # The metrics that were evaluated.
+  #
+  # Returns Array of Riffer::Evals::Metric.
+  attr_reader :metrics
+
+  # Initializes a new run result.
+  #
+  # input:: String - the input that was evaluated
+  # output:: String - the output that was evaluated
+  # context:: Hash or nil - the evaluation context
+  # results:: Array of Riffer::Evals::Result - individual results
+  # metrics:: Array of Riffer::Evals::Metric - the metrics evaluated
+  def initialize(input:, output:, context:, results:, metrics:)
+    @input = input
+    @output = output
+    @context = context
+    @results = results
+    @metrics = metrics
+  end
+
+  # Checks if all metrics passed their thresholds.
+  #
+  # Returns Boolean.
+  def passed?
+    failures.empty?
+  end
+
+  # Returns results that failed their metric thresholds.
+  #
+  # Returns Array of Riffer::Evals::Result.
+  def failures
+    @failures ||= @results.select.with_index do |result, index|
+      metric = @metrics[index]
+      !metric.passes?(result)
+    end
+  end
+
+  # Calculates the weighted aggregate score.
+  #
+  # Scores are normalized so that higher is always better for aggregation.
+  # For evaluators where lower is better (e.g., toxicity), the score is
+  # inverted (1 - score) before aggregation.
+  #
+  # Returns Float.
+  def aggregate_score
+    return 0.0 if @results.empty?
+
+    total_weight = @metrics.sum(&:weight)
+    return 0.0 if total_weight.zero?
+
+    weighted_sum = @results.zip(@metrics).sum do |result, metric|
+      # Normalize score: for higher_is_better=false, invert so higher is better
+      normalized_score = result.higher_is_better ? result.score : (1.0 - result.score)
+      normalized_score * metric.weight
+    end
+
+    weighted_sum / total_weight
+  end
+
+  # Returns a hash representation of the run result.
+  #
+  # Returns Hash.
+  def to_h
+    {
+      input: @input,
+      output: @output,
+      context: @context,
+      results: @results.map(&:to_h),
+      passed: passed?,
+      aggregate_score: aggregate_score
+    }
+  end
+end

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -68,8 +68,8 @@ class Riffer::Evals::RunResult
   #
   # Returns Array of Riffer::Evals::Result.
   def failures
-    @failures ||= @results.select.with_index do |result, index|
-      metric = @metrics[index]
+    @failures ||= results.select.with_index do |result, index|
+      metric = metrics[index]
       !metric.passes?(result)
     end
   end
@@ -82,12 +82,12 @@ class Riffer::Evals::RunResult
   #
   # Returns Float.
   def aggregate_score
-    return 0.0 if @results.empty?
+    return 0.0 if results.empty?
 
-    total_weight = @metrics.sum(&:weight)
+    total_weight = metrics.sum(&:weight)
     return 0.0 if total_weight.zero?
 
-    weighted_sum = @results.zip(@metrics).sum do |result, metric|
+    weighted_sum = results.zip(metrics).sum do |result, metric|
       # Normalize score: for higher_is_better=false, invert so higher is better
       normalized_score = result.higher_is_better ? result.score : (1.0 - result.score)
       normalized_score * metric.weight
@@ -101,10 +101,10 @@ class Riffer::Evals::RunResult
   # Returns Hash.
   def to_h
     {
-      input: @input,
-      output: @output,
-      context: @context,
-      results: @results.map(&:to_h),
+      input: input,
+      output: output,
+      context: context,
+      results: results.map(&:to_h),
       passed: passed?,
       aggregate_score: aggregate_score
     }

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -33,7 +33,7 @@ class Riffer::Evals::Runner
   #
   # Returns Riffer::Evals::RunResult.
   def run(input:, output:, context: nil)
-    results = @metrics.map do |metric|
+    results = metrics.map do |metric|
       evaluator_class = metric.evaluator_class
       raise Riffer::ArgumentError, "Evaluator not found: #{metric.evaluator_identifier}" unless evaluator_class
 
@@ -46,7 +46,7 @@ class Riffer::Evals::Runner
       output: output,
       context: context,
       results: results,
-      metrics: @metrics
+      metrics: metrics
     )
   end
 end

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Orchestrates running multiple evaluators against agent output.
+#
+# The Runner takes a set of metrics and runs each evaluator,
+# collecting results into a RunResult.
+#
+#   runner = Riffer::Evals::Runner.new(metrics: [metric1, metric2])
+#   run_result = runner.run(
+#     input: "What is the capital of France?",
+#     output: "The capital of France is Paris.",
+#     context: {}
+#   )
+#
+class Riffer::Evals::Runner
+  # The metrics to evaluate.
+  #
+  # Returns Array of Riffer::Evals::Metric.
+  attr_reader :metrics
+
+  # Initializes a new runner.
+  #
+  # metrics:: Array of Riffer::Evals::Metric - the metrics to evaluate
+  def initialize(metrics:)
+    @metrics = metrics
+  end
+
+  # Runs all evaluators and collects results.
+  #
+  # input:: String - the input given to the agent
+  # output:: String - the output produced by the agent
+  # context:: Hash or nil - optional context (e.g., ground_truth)
+  #
+  # Returns Riffer::Evals::RunResult.
+  def run(input:, output:, context: nil)
+    results = @metrics.map do |metric|
+      evaluator_class = metric.evaluator_class
+      raise Riffer::ArgumentError, "Evaluator not found: #{metric.evaluator_identifier}" unless evaluator_class
+
+      evaluator = evaluator_class.new
+      evaluator.evaluate(input: input, output: output, context: context)
+    end
+
+    Riffer::Evals::RunResult.new(
+      input: input,
+      output: output,
+      context: context,
+      results: results,
+      metrics: @metrics
+    )
+  end
+end

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -22,4 +22,17 @@ describe Riffer::Config do
       expect(config.openai.api_key).must_equal "test-key"
     end
   end
+
+  describe "evals namespace" do
+    it "initializes with nil judge_model" do
+      config = Riffer::Config.new
+      expect(config.evals.judge_model).must_be_nil
+    end
+
+    it "allows setting the judge_model" do
+      config = Riffer::Config.new
+      config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+      expect(config.evals.judge_model).must_equal "anthropic/claude-sonnet-4-20250514"
+    end
+  end
 end

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -90,7 +90,7 @@ describe Riffer::Evals::Evaluator do
   end
 
   describe "#result (protected)" do
-    it "creates a Result with the correct evaluator identifier" do
+    it "creates a Result with correct attributes" do
       klass = Class.new(Riffer::Evals::Evaluator) do
         identifier "my_evaluator"
         higher_is_better true
@@ -103,11 +103,13 @@ describe Riffer::Evals::Evaluator do
       evaluator = klass.new
       result = evaluator.evaluate(input: "test", output: "test")
 
-      expect(result).must_be_instance_of Riffer::Evals::Result
-      expect(result.evaluator).must_equal "my_evaluator"
-      expect(result.score).must_equal 0.9
-      expect(result.reason).must_equal "Good"
-      expect(result.higher_is_better).must_equal true
+      expect(result.to_h).must_equal({
+        evaluator: "my_evaluator",
+        score: 0.9,
+        reason: "Good",
+        metadata: {},
+        higher_is_better: true
+      })
     end
 
     it "creates a Result with higher_is_better from evaluator" do

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Evaluator do
+  let(:evaluator_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      identifier "test_evaluator"
+      description "A test evaluator"
+      higher_is_better true
+    end
+  end
+
+  let(:lower_is_better_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      identifier "toxicity"
+      description "Detects toxicity"
+      higher_is_better false
+    end
+  end
+
+  describe ".identifier" do
+    it "returns the set identifier" do
+      expect(evaluator_class.identifier).must_equal "test_evaluator"
+    end
+
+    it "generates identifier from class name when not set" do
+      anon_class = Class.new(Riffer::Evals::Evaluator)
+      # Anonymous classes don't have a name, so this returns nil
+      expect(anon_class.identifier).must_be_nil
+    end
+
+    it "strips _evaluator suffix from generated identifier" do
+      # Create a named class to test
+      eval <<~RUBY
+        class TestNamedEvaluator < Riffer::Evals::Evaluator
+        end
+      RUBY
+
+      expect(TestNamedEvaluator.identifier).must_equal "test_named"
+
+      Object.send(:remove_const, :TestNamedEvaluator)
+    end
+  end
+
+  describe ".description" do
+    it "returns the set description" do
+      expect(evaluator_class.description).must_equal "A test evaluator"
+    end
+
+    it "returns nil when not set" do
+      anon_class = Class.new(Riffer::Evals::Evaluator)
+      expect(anon_class.description).must_be_nil
+    end
+  end
+
+  describe ".higher_is_better" do
+    it "returns true when set to true" do
+      expect(evaluator_class.higher_is_better).must_equal true
+    end
+
+    it "returns false when set to false" do
+      expect(lower_is_better_class.higher_is_better).must_equal false
+    end
+
+    it "defaults to true when not set" do
+      anon_class = Class.new(Riffer::Evals::Evaluator)
+      expect(anon_class.higher_is_better).must_equal true
+    end
+  end
+
+  describe ".judge_model" do
+    it "returns the set judge model" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        judge_model "anthropic/claude-sonnet-4-20250514"
+      end
+      expect(klass.judge_model).must_equal "anthropic/claude-sonnet-4-20250514"
+    end
+
+    it "returns nil when not set" do
+      expect(evaluator_class.judge_model).must_be_nil
+    end
+  end
+
+  describe "#evaluate" do
+    it "raises NotImplementedError when not implemented" do
+      evaluator = evaluator_class.new
+      expect { evaluator.evaluate(input: "test", output: "test") }.must_raise(NotImplementedError)
+    end
+  end
+
+  describe "#result (protected)" do
+    it "creates a Result with the correct evaluator identifier" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        identifier "my_evaluator"
+        higher_is_better true
+
+        def evaluate(input:, output:, context: nil)
+          result(score: 0.9, reason: "Good")
+        end
+      end
+
+      evaluator = klass.new
+      result = evaluator.evaluate(input: "test", output: "test")
+
+      expect(result).must_be_instance_of Riffer::Evals::Result
+      expect(result.evaluator).must_equal "my_evaluator"
+      expect(result.score).must_equal 0.9
+      expect(result.reason).must_equal "Good"
+      expect(result.higher_is_better).must_equal true
+    end
+
+    it "creates a Result with higher_is_better from evaluator" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        identifier "toxicity"
+        higher_is_better false
+
+        def evaluate(input:, output:, context: nil)
+          result(score: 0.1, reason: "Low toxicity")
+        end
+      end
+
+      evaluator = klass.new
+      result = evaluator.evaluate(input: "test", output: "test")
+
+      expect(result.higher_is_better).must_equal false
+    end
+  end
+end

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -32,7 +32,7 @@ describe Riffer::Evals::Evaluator do
 
     it "strips _evaluator suffix from generated identifier" do
       # Create a named class to test
-      eval <<~RUBY
+      eval <<~RUBY, binding, __FILE__, __LINE__ + 1
         class TestNamedEvaluator < Riffer::Evals::Evaluator
         end
       RUBY

--- a/test/riffer/evals/evaluators/answer_relevancy_test.rb
+++ b/test/riffer/evals/evaluators/answer_relevancy_test.rb
@@ -34,7 +34,7 @@ describe Riffer::Evals::Evaluators::AnswerRelevancy do
 
       evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
       provider = evaluator.send(:judge).send(:provider_instance)
-      provider.stub_response('{"score": 0.85, "reason": "Relevant response."}')
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.85, reason: "Relevant response."}}])
 
       result = evaluator.evaluate(
         input: "What is the capital of France?",

--- a/test/riffer/evals/evaluators/answer_relevancy_test.rb
+++ b/test/riffer/evals/evaluators/answer_relevancy_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Evaluators::AnswerRelevancy do
+  describe "class configuration" do
+    it "has identifier set to answer_relevancy" do
+      expect(Riffer::Evals::Evaluators::AnswerRelevancy.identifier).must_equal "answer_relevancy"
+    end
+
+    it "has a description" do
+      expect(Riffer::Evals::Evaluators::AnswerRelevancy.description).wont_be_nil
+    end
+
+    it "has higher_is_better set to true" do
+      expect(Riffer::Evals::Evaluators::AnswerRelevancy.higher_is_better).must_equal true
+    end
+  end
+
+  describe "registry" do
+    it "is registered in the evaluators registry" do
+      evaluator_class = Riffer::Evals::Evaluators::Registry.find("answer_relevancy")
+      expect(evaluator_class).must_equal Riffer::Evals::Evaluators::AnswerRelevancy
+    end
+  end
+
+  describe "#evaluate" do
+    it "requires judge_model to be configured" do
+      # Ensure no judge model is configured
+      original_judge_model = Riffer.config.evals.judge_model
+      Riffer.config.evals.judge_model = nil
+
+      evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
+
+      error = expect {
+        evaluator.evaluate(input: "What is Ruby?", output: "Ruby is a language.")
+      }.must_raise(Riffer::ArgumentError)
+
+      expect(error.message).must_match(/No judge model configured/)
+
+      Riffer.config.evals.judge_model = original_judge_model
+    end
+
+    # Integration tests with VCR would go here for real API calls
+    # describe "with VCR" do
+    #   it "evaluates relevant response" do
+    #     VCR.use_cassette("answer_relevancy_relevant") do
+    #       Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
+    #       evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
+    #
+    #       result = evaluator.evaluate(
+    #         input: "What is the capital of France?",
+    #         output: "The capital of France is Paris."
+    #       )
+    #
+    #       expect(result.score).must_be :>=, 0.8
+    #     end
+    #   end
+    # end
+  end
+
+  describe "SYSTEM_PROMPT" do
+    it "includes scoring criteria" do
+      prompt = Riffer::Evals::Evaluators::AnswerRelevancy::SYSTEM_PROMPT
+      expect(prompt).must_include "score"
+      expect(prompt).must_include "JSON"
+    end
+  end
+end

--- a/test/riffer/evals/evaluators/answer_relevancy_test.rb
+++ b/test/riffer/evals/evaluators/answer_relevancy_test.rb
@@ -3,30 +3,15 @@
 require "test_helper"
 
 describe Riffer::Evals::Evaluators::AnswerRelevancy do
-  describe "class configuration" do
-    it "has identifier set to answer_relevancy" do
-      expect(Riffer::Evals::Evaluators::AnswerRelevancy.identifier).must_equal "answer_relevancy"
-    end
-
-    it "has a description" do
-      expect(Riffer::Evals::Evaluators::AnswerRelevancy.description).wont_be_nil
-    end
-
-    it "has higher_is_better set to true" do
-      expect(Riffer::Evals::Evaluators::AnswerRelevancy.higher_is_better).must_equal true
-    end
-  end
-
-  describe "registry" do
-    it "is registered in the evaluators registry" do
-      evaluator_class = Riffer::Evals::Evaluators::Registry.find("answer_relevancy")
+  describe "repository" do
+    it "is registered in the evaluators repository" do
+      evaluator_class = Riffer::Evals::Evaluators::Repository.find(:answer_relevancy)
       expect(evaluator_class).must_equal Riffer::Evals::Evaluators::AnswerRelevancy
     end
   end
 
   describe "#evaluate" do
     it "requires judge_model to be configured" do
-      # Ensure no judge model is configured
       original_judge_model = Riffer.config.evals.judge_model
       Riffer.config.evals.judge_model = nil
 
@@ -40,30 +25,25 @@ describe Riffer::Evals::Evaluators::AnswerRelevancy do
 
       Riffer.config.evals.judge_model = original_judge_model
     end
-
-    # Integration tests with VCR would go here for real API calls
-    # describe "with VCR" do
-    #   it "evaluates relevant response" do
-    #     VCR.use_cassette("answer_relevancy_relevant") do
-    #       Riffer.config.evals.judge_model = "anthropic/claude-sonnet-4-20250514"
-    #       evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
-    #
-    #       result = evaluator.evaluate(
-    #         input: "What is the capital of France?",
-    #         output: "The capital of France is Paris."
-    #       )
-    #
-    #       expect(result.score).must_be :>=, 0.8
-    #     end
-    #   end
-    # end
   end
 
-  describe "SYSTEM_PROMPT" do
-    it "includes scoring criteria" do
-      prompt = Riffer::Evals::Evaluators::AnswerRelevancy::SYSTEM_PROMPT
-      expect(prompt).must_include "score"
-      expect(prompt).must_include "JSON"
+  describe "integration with test provider" do
+    it "evaluates and returns a result" do
+      original = Riffer.config.evals.judge_model
+      Riffer.config.evals.judge_model = "test/test-model"
+
+      evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
+      provider = evaluator.send(:judge).send(:provider_instance)
+      provider.stub_response('{"score": 0.85, "reason": "Relevant response."}')
+
+      result = evaluator.evaluate(
+        input: "What is the capital of France?",
+        output: "The capital of France is Paris."
+      )
+
+      expect(result.score).must_equal 0.85
+
+      Riffer.config.evals.judge_model = original
     end
   end
 end

--- a/test/riffer/evals/judge/evaluation_tool_test.rb
+++ b/test/riffer/evals/judge/evaluation_tool_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Judge::EvaluationTool do
+  describe ".identifier" do
+    it "has the correct identifier" do
+      expect(Riffer::Evals::Judge::EvaluationTool.identifier).must_equal "evaluation"
+    end
+  end
+
+  describe ".description" do
+    it "has a description" do
+      expect(Riffer::Evals::Judge::EvaluationTool.description).wont_be_nil
+    end
+  end
+
+  describe ".parameters_schema" do
+    it "requires score as a number" do
+      schema = Riffer::Evals::Judge::EvaluationTool.parameters_schema
+      expect(schema[:properties]["score"][:type]).must_equal "number"
+      expect(schema[:required]).must_include "score"
+    end
+
+    it "requires reason as a string" do
+      schema = Riffer::Evals::Judge::EvaluationTool.parameters_schema
+      expect(schema[:properties]["reason"][:type]).must_equal "string"
+      expect(schema[:required]).must_include "reason"
+    end
+  end
+
+  describe "#call" do
+    it "returns a JSON response with score and reason" do
+      tool = Riffer::Evals::Judge::EvaluationTool.new
+      response = tool.call(context: nil, score: 0.85, reason: "Good response.")
+
+      expect(response).must_be_instance_of Riffer::Tools::Response
+      parsed = JSON.parse(response.content)
+      expect(parsed["score"]).must_equal 0.85
+      expect(parsed["reason"]).must_equal "Good response."
+    end
+  end
+end

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Judge do
+  describe "#initialize" do
+    it "sets the model" do
+      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+      expect(judge.model).must_equal "test/eval-model"
+    end
+  end
+
+  describe "#evaluate" do
+    it "calls the provider and parses response" do
+      # Use VCR for real API integration tests
+      # For unit tests, we verify the Judge correctly configures itself
+      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+      expect(judge.model).must_equal "test/eval-model"
+    end
+  end
+end

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -14,7 +14,7 @@ describe Riffer::Evals::Judge do
     it "evaluates with system_prompt and user_prompt" do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
       provider = judge.send(:provider_instance)
-      provider.stub_response('{"score": 0.85, "reason": "Good response."}')
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.85, reason: "Good response."}}])
 
       result = judge.evaluate(system_prompt: "You are a judge.", user_prompt: "Evaluate this.")
 
@@ -24,7 +24,7 @@ describe Riffer::Evals::Judge do
     it "evaluates with messages array" do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
       provider = judge.send(:provider_instance)
-      provider.stub_response('{"score": 0.9, "reason": "Excellent."}')
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.9, reason: "Excellent."}}])
 
       messages = [
         {role: "system", content: "You are a judge."},

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -11,11 +11,48 @@ describe Riffer::Evals::Judge do
   end
 
   describe "#evaluate" do
-    it "calls the provider and parses response" do
-      # Use VCR for real API integration tests
-      # For unit tests, we verify the Judge correctly configures itself
+    it "evaluates with system_prompt and user_prompt" do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
-      expect(judge.model).must_equal "test/eval-model"
+      provider = judge.send(:provider_instance)
+      provider.stub_response('{"score": 0.85, "reason": "Good response."}')
+
+      result = judge.evaluate(system_prompt: "You are a judge.", user_prompt: "Evaluate this.")
+
+      expect(result).must_equal({score: 0.85, reason: "Good response."})
+    end
+
+    it "evaluates with messages array" do
+      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+      provider = judge.send(:provider_instance)
+      provider.stub_response('{"score": 0.9, "reason": "Excellent."}')
+
+      messages = [
+        {role: "system", content: "You are a judge."},
+        {role: "user", content: "Evaluate this."}
+      ]
+      result = judge.evaluate(messages: messages)
+
+      expect(result).must_equal({score: 0.9, reason: "Excellent."})
+    end
+
+    it "raises error when both messages and system_prompt/user_prompt provided" do
+      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+
+      error = expect {
+        judge.evaluate(messages: [], system_prompt: "test")
+      }.must_raise(Riffer::ArgumentError)
+
+      expect(error.message).must_equal "cannot provide both messages and system_prompt/user_prompt"
+    end
+
+    it "raises error when user_prompt is missing" do
+      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+
+      error = expect {
+        judge.evaluate(system_prompt: "test")
+      }.must_raise(Riffer::ArgumentError)
+
+      expect(error.message).must_equal "user_prompt is required when messages is not provided"
     end
   end
 end

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -8,6 +8,14 @@ describe Riffer::Evals::Judge do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
       expect(judge.model).must_equal "test/eval-model"
     end
+
+    it "raises error for invalid model string" do
+      error = expect {
+        Riffer::Evals::Judge.new(model: "invalid-format")
+      }.must_raise(Riffer::ArgumentError)
+
+      expect(error.message).must_match(/Invalid model string: invalid-format/)
+    end
   end
 
   describe "#evaluate" do

--- a/test/riffer/evals/metric_test.rb
+++ b/test/riffer/evals/metric_test.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Metric do
+  describe "#initialize" do
+    it "sets the evaluator_identifier" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "answer_relevancy")
+      expect(metric.evaluator_identifier).must_equal "answer_relevancy"
+    end
+
+    it "converts evaluator_identifier to string" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: :answer_relevancy)
+      expect(metric.evaluator_identifier).must_equal "answer_relevancy"
+    end
+
+    it "sets min as a float" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: "0.8")
+      expect(metric.min).must_equal 0.8
+    end
+
+    it "sets max as a float" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: "0.2")
+      expect(metric.max).must_equal 0.2
+    end
+
+    it "sets weight as a float" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", weight: 2)
+      expect(metric.weight).must_equal 2.0
+    end
+
+    it "defaults weight to 1.0" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test")
+      expect(metric.weight).must_equal 1.0
+    end
+  end
+
+  describe "#evaluator_class" do
+    it "looks up the evaluator from the registry" do
+      # Reference the class first to trigger Zeitwerk autoload and registration
+      evaluator_class = Riffer::Evals::Evaluators::AnswerRelevancy
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "answer_relevancy")
+      expect(metric.evaluator_class).must_equal evaluator_class
+    end
+
+    it "returns nil for unknown evaluator" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "unknown_evaluator")
+      expect(metric.evaluator_class).must_be_nil
+    end
+  end
+
+  describe "#passes?" do
+    it "passes when no thresholds set" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test")
+      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.5)
+      expect(metric.passes?(result)).must_equal true
+    end
+
+    it "passes when score meets min threshold" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.85)
+      expect(metric.passes?(result)).must_equal true
+    end
+
+    it "fails when score below min threshold" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.7)
+      expect(metric.passes?(result)).must_equal false
+    end
+
+    it "passes when score meets max threshold" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: 0.2)
+      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.1)
+      expect(metric.passes?(result)).must_equal true
+    end
+
+    it "fails when score above max threshold" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: 0.2)
+      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.3)
+      expect(metric.passes?(result)).must_equal false
+    end
+
+    it "checks both min and max thresholds" do
+      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.4, max: 0.6)
+      result_pass = Riffer::Evals::Result.new(evaluator: "test", score: 0.5)
+      result_fail_low = Riffer::Evals::Result.new(evaluator: "test", score: 0.3)
+      result_fail_high = Riffer::Evals::Result.new(evaluator: "test", score: 0.7)
+
+      expect(metric.passes?(result_pass)).must_equal true
+      expect(metric.passes?(result_fail_low)).must_equal false
+      expect(metric.passes?(result_fail_high)).must_equal false
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation" do
+      metric = Riffer::Evals::Metric.new(
+        evaluator_identifier: "test",
+        min: 0.8,
+        max: nil,
+        weight: 1.5
+      )
+
+      hash = metric.to_h
+      expect(hash[:evaluator_identifier]).must_equal "test"
+      expect(hash[:min]).must_equal 0.8
+      expect(hash[:max]).must_be_nil
+      expect(hash[:weight]).must_equal 1.5
+    end
+  end
+end

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -73,7 +73,7 @@ describe Riffer::Evals::Profile do
       Riffer::Providers::Repository.register("test", Riffer::Providers::Test) unless Riffer::Providers::Repository.find("test")
     end
 
-    it "adds eval method when included in Agent" do
+    it "adds run_eval method when included in Agent" do
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
@@ -89,7 +89,7 @@ describe Riffer::Evals::Profile do
 
       agent_class.include(profile_module)
 
-      expect(agent_class.respond_to?(:eval)).must_equal true
+      expect(agent_class.respond_to?(:run_eval)).must_equal true
     end
 
     it "runs evaluation when eval is called" do
@@ -109,7 +109,7 @@ describe Riffer::Evals::Profile do
       agent_class.include(profile_module)
 
       # The test provider returns "Test response" by default
-      result = agent_class.eval(input: "What is Ruby?")
+      result = agent_class.run_eval(input: "What is Ruby?")
 
       expect(result).must_be_instance_of Riffer::Evals::RunResult
       expect(result.input).must_equal "What is Ruby?"

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -19,15 +19,11 @@ describe Riffer::Evals::Profile do
   end
 
   before do
-    Riffer::Evals::Evaluators::Registry.register("profile_test_evaluator", profile_evaluator_class)
+    Riffer::Evals::Evaluators::Repository.register(:profile_test_evaluator, profile_evaluator_class)
   end
 
   after do
-    Riffer::Evals::Evaluators::Registry.clear
-    Riffer::Evals::Evaluators::Registry.register(
-      "answer_relevancy",
-      Riffer::Evals::Evaluators::AnswerRelevancy
-    )
+    Riffer::Evals::Evaluators::Repository.clear
   end
 
   describe "ai_evals DSL" do

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Profile do
+  # Create a simple evaluator for testing
+  let(:profile_evaluator_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      identifier "profile_test_evaluator"
+      description "Test evaluator for profile tests"
+      higher_is_better true
+
+      def evaluate(input:, output:, context: nil)
+        # Simple scoring based on output containing the word from input
+        score = output.downcase.include?(input.downcase.split.first) ? 0.9 : 0.5
+        result(score: score, reason: "Test evaluation")
+      end
+    end
+  end
+
+  before do
+    Riffer::Evals::Evaluators::Registry.register("profile_test_evaluator", profile_evaluator_class)
+  end
+
+  after do
+    Riffer::Evals::Evaluators::Registry.clear
+    Riffer::Evals::Evaluators::Registry.register(
+      "answer_relevancy",
+      Riffer::Evals::Evaluators::AnswerRelevancy
+    )
+  end
+
+  describe "ai_evals DSL" do
+    it "defines metrics" do
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric :profile_test_evaluator, min: 0.8
+        end
+      end
+
+      expect(profile_module.eval_metrics.length).must_equal 1
+      expect(profile_module.eval_metrics.first.evaluator_identifier).must_equal "profile_test_evaluator"
+      expect(profile_module.eval_metrics.first.min).must_equal 0.8
+    end
+
+    it "supports multiple metrics" do
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric :profile_test_evaluator, min: 0.85
+          metric :profile_test_evaluator, max: 0.10
+        end
+      end
+
+      expect(profile_module.eval_metrics.length).must_equal 2
+    end
+
+    it "supports weight option" do
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric :profile_test_evaluator, min: 0.8, weight: 2.0
+        end
+      end
+
+      expect(profile_module.eval_metrics.first.weight).must_equal 2.0
+    end
+  end
+
+  describe "Agent integration" do
+    before do
+      # Ensure test provider is registered
+      Riffer::Providers::Repository.register("test", Riffer::Providers::Test) unless Riffer::Providers::Repository.find("test")
+    end
+
+    it "adds eval method when included in Agent" do
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric :profile_test_evaluator, min: 0.8
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "test/test-model"
+        instructions "You are a helpful assistant."
+      end
+
+      agent_class.include(profile_module)
+
+      expect(agent_class.respond_to?(:eval)).must_equal true
+    end
+
+    it "runs evaluation when eval is called" do
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric :profile_test_evaluator, min: 0.8
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "test/test-model"
+        instructions "You are a helpful assistant."
+      end
+
+      agent_class.include(profile_module)
+
+      # The test provider returns "Test response" by default
+      result = agent_class.eval(input: "What is Ruby?")
+
+      expect(result).must_be_instance_of Riffer::Evals::RunResult
+      expect(result.input).must_equal "What is Ruby?"
+      expect(result.output).must_equal "Test response"
+    end
+  end
+
+  describe "Builder" do
+    it "creates metrics with correct options" do
+      builder = Riffer::Evals::Profile::Builder.new
+      builder.metric(:test, min: 0.7, max: 0.95, weight: 1.5)
+
+      metric = builder.metrics.first
+      expect(metric.evaluator_identifier).must_equal "test"
+      expect(metric.min).must_equal 0.7
+      expect(metric.max).must_equal 0.95
+      expect(metric.weight).must_equal 1.5
+    end
+  end
+end

--- a/test/riffer/evals/result_test.rb
+++ b/test/riffer/evals/result_test.rb
@@ -43,6 +43,32 @@ describe Riffer::Evals::Result do
       result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
       expect(result.higher_is_better).must_equal true
     end
+
+    it "raises an error if score is below 0" do
+      error = expect do
+        Riffer::Evals::Result.new(evaluator: "test_eval", score: -0.1)
+      end.must_raise Riffer::ArgumentError
+
+      expect(error.message).must_match(/score must be between 0.0 and 1.0/)
+    end
+
+    it "raises an error if score is above 1" do
+      error = expect do
+        Riffer::Evals::Result.new(evaluator: "test_eval", score: 1.5)
+      end.must_raise Riffer::ArgumentError
+
+      expect(error.message).must_match(/score must be between 0.0 and 1.0/)
+    end
+
+    it "allows score of exactly 0" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0)
+      expect(result.score).must_equal 0.0
+    end
+
+    it "allows score of exactly 1" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 1)
+      expect(result.score).must_equal 1.0
+    end
   end
 
   describe "#to_h" do

--- a/test/riffer/evals/result_test.rb
+++ b/test/riffer/evals/result_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Result do
+  describe "#initialize" do
+    it "sets the evaluator" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      expect(result.evaluator).must_equal "test_eval"
+    end
+
+    it "sets the score as a float" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: "0.85")
+      expect(result.score).must_equal 0.85
+    end
+
+    it "sets the reason" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, reason: "Good response")
+      expect(result.reason).must_equal "Good response"
+    end
+
+    it "defaults reason to nil" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      expect(result.reason).must_be_nil
+    end
+
+    it "sets metadata" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, metadata: {key: "value"})
+      expect(result.metadata).must_equal({key: "value"})
+    end
+
+    it "defaults metadata to empty hash" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      expect(result.metadata).must_equal({})
+    end
+
+    it "sets higher_is_better" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, higher_is_better: false)
+      expect(result.higher_is_better).must_equal false
+    end
+
+    it "defaults higher_is_better to true" do
+      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      expect(result.higher_is_better).must_equal true
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation" do
+      result = Riffer::Evals::Result.new(
+        evaluator: "test_eval",
+        score: 0.85,
+        reason: "Good",
+        metadata: {key: "value"},
+        higher_is_better: true
+      )
+
+      hash = result.to_h
+      expect(hash[:evaluator]).must_equal "test_eval"
+      expect(hash[:score]).must_equal 0.85
+      expect(hash[:reason]).must_equal "Good"
+      expect(hash[:metadata]).must_equal({key: "value"})
+      expect(hash[:higher_is_better]).must_equal true
+    end
+  end
+end

--- a/test/riffer/evals/run_result_test.rb
+++ b/test/riffer/evals/run_result_test.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::RunResult do
+  let(:passing_result) do
+    Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.9, higher_is_better: true)
+  end
+
+  let(:failing_result) do
+    Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.6, higher_is_better: true)
+  end
+
+  let(:toxicity_result) do
+    Riffer::Evals::Result.new(evaluator: "toxicity", score: 0.1, higher_is_better: false)
+  end
+
+  let(:passing_metric) do
+    Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", min: 0.8)
+  end
+
+  let(:failing_metric) do
+    Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", min: 0.8)
+  end
+
+  let(:toxicity_metric) do
+    Riffer::Evals::Metric.new(evaluator_identifier: "toxicity", max: 0.2)
+  end
+
+  describe "#initialize" do
+    it "sets all attributes" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "question",
+        output: "answer",
+        context: {key: "value"},
+        results: [passing_result],
+        metrics: [passing_metric]
+      )
+
+      expect(run_result.input).must_equal "question"
+      expect(run_result.output).must_equal "answer"
+      expect(run_result.context).must_equal({key: "value"})
+      expect(run_result.results).must_equal [passing_result]
+      expect(run_result.metrics).must_equal [passing_metric]
+    end
+  end
+
+  describe "#passed?" do
+    it "returns true when all metrics pass" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [passing_result],
+        metrics: [passing_metric]
+      )
+
+      expect(run_result.passed?).must_equal true
+    end
+
+    it "returns false when any metric fails" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [failing_result],
+        metrics: [failing_metric]
+      )
+
+      expect(run_result.passed?).must_equal false
+    end
+
+    it "handles mixed results" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [passing_result, failing_result],
+        metrics: [passing_metric, failing_metric]
+      )
+
+      expect(run_result.passed?).must_equal false
+    end
+  end
+
+  describe "#failures" do
+    it "returns empty array when all pass" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [passing_result],
+        metrics: [passing_metric]
+      )
+
+      expect(run_result.failures).must_be_empty
+    end
+
+    it "returns failing results" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [failing_result],
+        metrics: [failing_metric]
+      )
+
+      expect(run_result.failures).must_equal [failing_result]
+    end
+
+    it "filters to only failing results" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [passing_result, failing_result],
+        metrics: [passing_metric, failing_metric]
+      )
+
+      expect(run_result.failures.length).must_equal 1
+      expect(run_result.failures.first).must_equal failing_result
+    end
+  end
+
+  describe "#aggregate_score" do
+    it "returns 0.0 for empty results" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [],
+        metrics: []
+      )
+
+      expect(run_result.aggregate_score).must_equal 0.0
+    end
+
+    it "returns the score for single result" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [passing_result],
+        metrics: [passing_metric]
+      )
+
+      expect(run_result.aggregate_score).must_equal 0.9
+    end
+
+    it "calculates weighted average" do
+      metric1 = Riffer::Evals::Metric.new(evaluator_identifier: "a", weight: 2.0)
+      metric2 = Riffer::Evals::Metric.new(evaluator_identifier: "b", weight: 1.0)
+
+      result1 = Riffer::Evals::Result.new(evaluator: "a", score: 0.9, higher_is_better: true)
+      result2 = Riffer::Evals::Result.new(evaluator: "b", score: 0.6, higher_is_better: true)
+
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [result1, result2],
+        metrics: [metric1, metric2]
+      )
+
+      # (0.9 * 2.0 + 0.6 * 1.0) / (2.0 + 1.0) = 2.4 / 3.0 = 0.8
+      expect(run_result.aggregate_score).must_be_close_to 0.8, 0.0001
+    end
+
+    it "normalizes lower_is_better scores" do
+      # For toxicity (lower is better), a score of 0.1 should become 0.9 for aggregation
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [toxicity_result],
+        metrics: [toxicity_metric]
+      )
+
+      # Toxicity score of 0.1, higher_is_better=false
+      # Normalized: 1.0 - 0.1 = 0.9
+      expect(run_result.aggregate_score).must_equal 0.9
+    end
+
+    it "combines higher_is_better and lower_is_better scores" do
+      metric1 = Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", weight: 1.0)
+      metric2 = Riffer::Evals::Metric.new(evaluator_identifier: "toxicity", weight: 1.0)
+
+      result1 = Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.8, higher_is_better: true)
+      result2 = Riffer::Evals::Result.new(evaluator: "toxicity", score: 0.2, higher_is_better: false)
+
+      run_result = Riffer::Evals::RunResult.new(
+        input: "test",
+        output: "test",
+        context: nil,
+        results: [result1, result2],
+        metrics: [metric1, metric2]
+      )
+
+      # relevancy: 0.8 (already normalized)
+      # toxicity: 1.0 - 0.2 = 0.8 (inverted)
+      # Average: (0.8 + 0.8) / 2 = 0.8
+      expect(run_result.aggregate_score).must_equal 0.8
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash representation" do
+      run_result = Riffer::Evals::RunResult.new(
+        input: "question",
+        output: "answer",
+        context: {key: "value"},
+        results: [passing_result],
+        metrics: [passing_metric]
+      )
+
+      hash = run_result.to_h
+      expect(hash[:input]).must_equal "question"
+      expect(hash[:output]).must_equal "answer"
+      expect(hash[:context]).must_equal({key: "value"})
+      expect(hash[:passed]).must_equal true
+      expect(hash[:aggregate_score]).must_equal 0.9
+      expect(hash[:results].length).must_equal 1
+    end
+  end
+end

--- a/test/riffer/evals/runner_test.rb
+++ b/test/riffer/evals/runner_test.rb
@@ -19,17 +19,11 @@ describe Riffer::Evals::Runner do
   end
 
   before do
-    Riffer::Evals::Evaluators::Registry.register("runner_test_evaluator", runner_evaluator_class)
+    Riffer::Evals::Evaluators::Repository.register(:runner_test_evaluator, runner_evaluator_class)
   end
 
   after do
-    # Clean up the registry
-    Riffer::Evals::Evaluators::Registry.clear
-    # Re-register built-in evaluators
-    Riffer::Evals::Evaluators::Registry.register(
-      "answer_relevancy",
-      Riffer::Evals::Evaluators::AnswerRelevancy
-    )
+    Riffer::Evals::Evaluators::Repository.clear
   end
 
   describe "#initialize" do
@@ -79,7 +73,7 @@ describe Riffer::Evals::Runner do
           result(score: score, reason: "From context")
         end
       end
-      Riffer::Evals::Evaluators::Registry.register("context_evaluator", context_evaluator_class)
+      Riffer::Evals::Evaluators::Repository.register(:context_evaluator, context_evaluator_class)
 
       metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "context_evaluator")]
       runner = Riffer::Evals::Runner.new(metrics: metrics)

--- a/test/riffer/evals/runner_test.rb
+++ b/test/riffer/evals/runner_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Evals::Runner do
+  # Create a simple evaluator that returns a fixed score
+  let(:runner_evaluator_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      identifier "runner_test_evaluator"
+      description "Test evaluator for runner tests"
+      higher_is_better true
+
+      def evaluate(input:, output:, context: nil)
+        # Return a score based on output length
+        score = [output.length / 100.0, 1.0].min
+        result(score: score, reason: "Based on output length")
+      end
+    end
+  end
+
+  before do
+    Riffer::Evals::Evaluators::Registry.register("runner_test_evaluator", runner_evaluator_class)
+  end
+
+  after do
+    # Clean up the registry
+    Riffer::Evals::Evaluators::Registry.clear
+    # Re-register built-in evaluators
+    Riffer::Evals::Evaluators::Registry.register(
+      "answer_relevancy",
+      Riffer::Evals::Evaluators::AnswerRelevancy
+    )
+  end
+
+  describe "#initialize" do
+    it "sets the metrics" do
+      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator")]
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+      expect(runner.metrics).must_equal metrics
+    end
+  end
+
+  describe "#run" do
+    it "returns a RunResult" do
+      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.5)]
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+
+      result = runner.run(
+        input: "What is Ruby?",
+        output: "Ruby is a programming language designed for programmer happiness. It was created by Yukihiro Matsumoto.",
+        context: nil
+      )
+
+      expect(result).must_be_instance_of Riffer::Evals::RunResult
+    end
+
+    it "runs all evaluators" do
+      metrics = [
+        Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.5),
+        Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.3)
+      ]
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+
+      result = runner.run(
+        input: "test",
+        output: "This is a test output with enough length to score reasonably well in our test evaluator.",
+        context: nil
+      )
+
+      expect(result.results.length).must_equal 2
+    end
+
+    it "passes context to evaluators" do
+      context_evaluator_class = Class.new(Riffer::Evals::Evaluator) do
+        identifier "context_evaluator"
+
+        def evaluate(input:, output:, context: nil)
+          score = context&.dig(:expected_score) || 0.5
+          result(score: score, reason: "From context")
+        end
+      end
+      Riffer::Evals::Evaluators::Registry.register("context_evaluator", context_evaluator_class)
+
+      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "context_evaluator")]
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+
+      result = runner.run(
+        input: "test",
+        output: "test output",
+        context: {expected_score: 0.95}
+      )
+
+      expect(result.results.first.score).must_equal 0.95
+    end
+
+    it "raises error for unknown evaluator" do
+      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "unknown_evaluator")]
+      runner = Riffer::Evals::Runner.new(metrics: metrics)
+
+      expect {
+        runner.run(input: "test", output: "test", context: nil)
+      }.must_raise(Riffer::ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add a new evals framework for measuring agent output quality using LLM-as-judge evaluations
- Follows riffer's existing DSL patterns (Agent, Tool) with a similar API surface
- Integrates with the provider infrastructure for judge model calls

### Key Components

| Component | Description |
|-----------|-------------|
| `Riffer::Evals::Evaluator` | Base class with DSL (identifier, description, higher_is_better, judge_model) |
| `Riffer::Evals::Profile` | Module providing `ai_evals` DSL for defining eval metrics |
| `Riffer::Evals::Metric` | Threshold configuration (min/max/weight) |
| `Riffer::Evals::Judge` | LLM-as-judge executor supporting both system/user prompts and messages array |
| `Riffer::Evals::Runner` | Orchestrates running multiple evaluators |
| `Riffer::Evals::Result` | Individual evaluation result |
| `Riffer::Evals::RunResult` | Complete eval run with passed?, failures, aggregate_score |
| `Riffer::Evals::Evaluators::Repository` | Registry for built-in and custom evaluators |

### Usage Example

```ruby
# Configure judge model
Riffer.config.evals.judge_model = "anthropic/claude-opus-4-5-20251101"

# Define eval profile
module QualityEvals
  include Riffer::Evals::Profile

  ai_evals do
    metric :answer_relevancy, min: 0.85
  end
end

# Include in agent
class MyAgent < Riffer::Agent
  include QualityEvals
  model "anthropic/claude-haiku-4-5-20251001"
end

# Run evals
result = MyAgent.eval(input: "What is Ruby?")
result.passed?         # => true/false
result.aggregate_score # => 0.91
```

### Built-in Evaluators

- `answer_relevancy` - Evaluates how well a response addresses the input question

### Design Highlights

- **Repository pattern** for evaluators: built-in evaluators are always available via `BUILT_IN` constant; custom evaluators registered separately and `clear` only resets custom registrations
- **Judge flexibility**: supports both `system_prompt:/user_prompt:` and `messages:` array interfaces with validation
- **Weighted scoring**: aggregate scores normalize all results to "higher is better" with configurable weights

## Test plan

- [x] Unit tests for all components (Result, Metric, Evaluator, Runner, RunResult, Profile, Judge)
- [x] Integration tests using test provider with stub_response
- [x] Test for answer_relevancy evaluator
- [x] Config tests for evals.judge_model
- [x] All 537 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)