### PR TITLE
fix: correct RBS inline annotations and remove ivar declarations

### DIFF
--- a/.agents/code-style.md
+++ b/.agents/code-style.md
@@ -15,10 +15,6 @@ All Ruby files in `lib/` must include:
 # rbs_inline: enabled
 ```
 
-## Class Methods
-
-Use `def self.method_name` instead of `class << self` (rbs-inline does not support singleton class blocks).
-
 ## Error Handling
 
 Define custom errors as subclasses of `Riffer::Error`:

--- a/.agents/rbs-inline.md
+++ b/.agents/rbs-inline.md
@@ -13,20 +13,75 @@ Every `lib/**/*.rb` file must include the `rbs_inline: enabled` comment on line 
 
 ## Annotation Syntax
 
-Two prefixes are used:
-
-- **`#:`** — standalone lines above methods or at the class level (params, return types, instance variables)
-- **`#:`** — inline on the same line as code (attributes, constants)
+The **`#:`** prefix is used — standalone lines above methods (type signatures) or inline on the same line (attributes, constants).
 
 ### Method Parameters and Return Types
 
-Use `#:` on standalone lines above the method:
+Use a single `#:` line above the method with the RBS method signature:
 
 ```ruby
-#: name: String -- the user name
-#: age: Integer
-#: return: bool
+#: (String, Integer) -> bool
 def valid?(name, age)
+```
+
+#### Parameter Mapping
+
+| Ruby param                   | RBS signature            |
+| ---------------------------- | ------------------------ |
+| `def foo(x)`                 | `(Type)`                 |
+| `def foo(x = nil)`           | `(?Type?)`               |
+| `def foo(x = val)`           | `(?Type)`                |
+| `def foo(x:)`                | `(x: Type)`              |
+| `def foo(x: nil)`            | `(?x: Type?)`            |
+| `def foo(x: val)`            | `(?x: Type)`             |
+| `def foo(*args)`             | `(*untyped)`             |
+| `def foo(**kwargs)`          | `(**untyped)`            |
+| `def foo(&block)` (required) | `() { (Type) -> void }`  |
+| `def foo(&block)` (optional) | `() ?{ (Type) -> void }` |
+| `def foo(...)`               | `(*untyped, **untyped)`  |
+
+#### Examples
+
+```ruby
+# No parameters
+#: () -> String
+def name
+
+# Positional parameters
+#: (String, Integer) -> bool
+def valid?(name, age)
+
+# Optional positional parameter
+#: (?String?) -> String
+def self.identifier(value = nil)
+
+# Required keyword parameters
+#: (input: String, output: String) -> Riffer::Evals::Result
+def evaluate(input:, output:)
+
+# Mixed keyword parameters (required + optional)
+#: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+def evaluate(input:, output:, context: nil)
+
+# Positional + keyword parameters
+#: (String, ?tool_context: Hash[Symbol, untyped]?) -> String
+def generate(prompt, tool_context: nil)
+
+# Splat/double-splat
+#: (**untyped) -> void
+def initialize(**options)
+
+# Forward arguments
+#: (*untyped, **untyped) -> String
+def self.generate(...)
+
+# Block parameter (required)
+#: () { (Riffer::Messages::Base) -> void } -> self
+def on_message(&block)
+
+# Block parameter (optional)
+#: () ?{ (Riffer::Config) -> void } -> void
+def configure(&block)
 ```
 
 ### Attributes
@@ -43,22 +98,6 @@ VERSION = "1.0.0" #: String
 DEFAULTS = {}.freeze #: Hash[Symbol, untyped]
 ```
 
-### Instance Variables
-
-Use `#:` on standalone lines at the class level:
-
-```ruby
-#: @name: String
-#: @cache: Hash[String, untyped]
-```
-
-### Class Instance Variables
-
-```ruby
-#: self.@identifier: String?
-#: self.@model: String?
-```
-
 ## Common Type Patterns
 
 | Pattern                   | Meaning                     |
@@ -72,10 +111,6 @@ Use `#:` on standalone lines at the class level:
 | `bool`                    | Boolean (true or false)     |
 | `untyped`                 | Any type                    |
 | `void`                    | No meaningful return        |
-
-## Class Methods
-
-Class methods must use `def self.method_name` syntax. `class << self` blocks are **not supported** by rbs-inline.
 
 ## Workflow
 

--- a/.agents/rdoc.md
+++ b/.agents/rdoc.md
@@ -4,14 +4,15 @@ Use RDoc prose comments for public API descriptions and RBS inline annotations f
 
 ## Parameters and Return Types
 
-Use `#:` annotations for parameter types and return types on standalone lines above methods:
+Describe parameters in the RDoc prose comment. Use a single `#:` line for the RBS method signature (see [rbs-inline.md](rbs-inline.md) for the full type annotation syntax):
 
 ```ruby
 # Creates a new agent.
 #
-#: name: String -- the agent name
-#: options: Hash[Symbol, untyped] -- optional configuration
-#: return: void
+# +name+ - the agent name.
+# +options+ - optional configuration.
+#
+#: (String, ?options: Hash[Symbol, untyped]) -> void
 def initialize(name, options: {})
 ```
 

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -27,7 +27,7 @@ module Riffer
   # Raised when tool execution times out.
   class TimeoutError < Error; end
 
-  #: return: Riffer::Config
+  #: () -> Riffer::Config
   def self.config
     @config ||= Config.new
   end
@@ -38,13 +38,12 @@ module Riffer
   #     config.openai.api_key = ENV['OPENAI_API_KEY']
   #   end
   #
-  #: &block: (Riffer::Config) -> void
-  #: return: void
+  #: () ?{ (Riffer::Config) -> void } -> void
   def self.configure(&block)
     yield config if block_given?
   end
 
-  #: return: String
+  #: () -> String
   def self.version
     VERSION
   end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -23,28 +23,9 @@ class Riffer::Agent
   extend Riffer::Helpers::ClassNameConverter
   extend Riffer::Helpers::Validations
 
-  #: self.@identifier: String?
-  #: self.@model: String?
-  #: self.@instructions: String?
-  #: self.@provider_options: Hash[Symbol, untyped]?
-  #: self.@model_options: Hash[Symbol, untyped]?
-  #: self.@tools_config: (Array[singleton(Riffer::Tool)] | Proc)?
-
-  #: @messages: Array[Riffer::Messages::Base]
-  #: @message_callbacks: Array[^(Riffer::Messages::Base) -> void]
-  #: @token_usage: Riffer::TokenUsage?
-  #: @model_string: String
-  #: @instructions_text: String?
-  #: @provider_name: String
-  #: @model_name: String
-  #: @tool_context: Hash[Symbol, untyped]?
-  #: @resolved_tools: Array[singleton(Riffer::Tool)]?
-  #: @provider_instance: Riffer::Providers::Base?
-
   # Gets or sets the agent identifier.
   #
-  #: value: String? -- the identifier to set, or nil to get
-  #: return: String
+  #: (?String?) -> String
   def self.identifier(value = nil)
     return @identifier || class_name_to_path(name) if value.nil?
     @identifier = value.to_s
@@ -52,8 +33,7 @@ class Riffer::Agent
 
   # Gets or sets the model string (e.g., "openai/gpt-4o").
   #
-  #: model_string: String? -- the model string to set, or nil to get
-  #: return: String?
+  #: (?String?) -> String?
   def self.model(model_string = nil)
     return @model if model_string.nil?
     validate_is_string!(model_string, "model")
@@ -62,8 +42,7 @@ class Riffer::Agent
 
   # Gets or sets the agent instructions.
   #
-  #: instructions_text: String? -- the instructions to set, or nil to get
-  #: return: String?
+  #: (?String?) -> String?
   def self.instructions(instructions_text = nil)
     return @instructions if instructions_text.nil?
     validate_is_string!(instructions_text, "instructions")
@@ -72,8 +51,7 @@ class Riffer::Agent
 
   # Gets or sets provider options passed to the provider client.
   #
-  #: options: Hash[Symbol, untyped]? -- the options to set, or nil to get
-  #: return: Hash[Symbol, untyped]
+  #: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.provider_options(options = nil)
     return @provider_options || {} if options.nil?
     @provider_options = options
@@ -81,8 +59,7 @@ class Riffer::Agent
 
   # Gets or sets model options passed to generate_text/stream_text.
   #
-  #: options: Hash[Symbol, untyped]? -- the options to set, or nil to get
-  #: return: Hash[Symbol, untyped]
+  #: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.model_options(options = nil)
     return @model_options || {} if options.nil?
     @model_options = options
@@ -90,8 +67,7 @@ class Riffer::Agent
 
   # Gets or sets the tools used by this agent.
   #
-  #: tools_or_lambda: (Array[singleton(Riffer::Tool)] | Proc)? -- tools array or lambda returning tools
-  #: return: (Array[singleton(Riffer::Tool)] | Proc)?
+  #: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools(tools_or_lambda = nil)
     return @tools_config if tools_or_lambda.nil?
     @tools_config = tools_or_lambda
@@ -99,15 +75,14 @@ class Riffer::Agent
 
   # Finds an agent class by identifier.
   #
-  #: identifier: String -- the identifier to search for
-  #: return: singleton(Riffer::Agent)?
+  #: (String) -> singleton(Riffer::Agent)?
   def self.find(identifier)
     subclasses.find { |agent_class| agent_class.identifier == identifier.to_s }
   end
 
   # Returns all agent subclasses.
   #
-  #: return: Array[singleton(Riffer::Agent)]
+  #: () -> Array[singleton(Riffer::Agent)]
   def self.all
     subclasses
   end
@@ -116,9 +91,7 @@ class Riffer::Agent
   #
   # See #generate for parameters and return value.
   #
-  #: *args: untyped
-  #: **kwargs: untyped
-  #: return: String
+  #: (*untyped, **untyped) -> String
   def self.generate(...)
     new.generate(...)
   end
@@ -127,9 +100,7 @@ class Riffer::Agent
   #
   # See #stream for parameters and return value.
   #
-  #: *args: untyped
-  #: **kwargs: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def self.stream(...)
     new.stream(...)
   end
@@ -145,7 +116,7 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
-  #: return: void
+  #: () -> void
   def initialize
     @messages = []
     @message_callbacks = []
@@ -163,9 +134,7 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  #: prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  #: tool_context: Hash[Symbol, untyped]? -- optional context object passed to all tool calls
-  #: return: String
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> String
   def generate(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
@@ -186,9 +155,7 @@ class Riffer::Agent
 
   # Streams a response from the agent.
   #
-  #: prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  #: tool_context: Hash[Symbol, untyped]? -- optional context object passed to all tool calls
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
@@ -245,8 +212,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if no block is given.
   #
-  #: &block: (Riffer::Messages::Base) -> void
-  #: return: self
+  #: () { (Riffer::Messages::Base) -> void } -> self
   def on_message(&block)
     raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
     @message_callbacks << block
@@ -255,23 +221,20 @@ class Riffer::Agent
 
   private
 
-  #: message: Riffer::Messages::Base
-  #: return: void
+  #: (Riffer::Messages::Base) -> void
   def add_message(message)
     @messages << message
     @message_callbacks.each { |callback| callback.call(message) }
   end
 
-  #: usage: Riffer::TokenUsage?
-  #: return: void
+  #: (Riffer::TokenUsage?) -> void
   def track_token_usage(usage)
     return unless usage
 
     @token_usage = @token_usage ? @token_usage + usage : usage
   end
 
-  #: prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  #: return: void
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])) -> void
   def initialize_messages(prompt_or_messages)
     @messages = []
     @messages << Riffer::Messages::System.new(@instructions_text) if @instructions_text
@@ -285,7 +248,7 @@ class Riffer::Agent
     end
   end
 
-  #: return: Riffer::Messages::Assistant
+  #: () -> Riffer::Messages::Assistant
   def call_llm
     provider_instance.generate_text(
       messages: @messages,
@@ -295,7 +258,7 @@ class Riffer::Agent
     )
   end
 
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream
     provider_instance.stream_text(
       messages: @messages,
@@ -305,7 +268,7 @@ class Riffer::Agent
     )
   end
 
-  #: return: Riffer::Providers::Base
+  #: () -> Riffer::Providers::Base
   def provider_instance
     @provider_instance ||= begin
       provider_class = Riffer::Providers::Repository.find(@provider_name)
@@ -314,14 +277,12 @@ class Riffer::Agent
     end
   end
 
-  #: response: Riffer::Messages::Assistant
-  #: return: bool
+  #: (Riffer::Messages::Assistant) -> bool
   def has_tool_calls?(response)
     response.is_a?(Riffer::Messages::Assistant) && !response.tool_calls.empty?
   end
 
-  #: response: Riffer::Messages::Assistant
-  #: return: void
+  #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
     response.tool_calls.each do |tool_call|
       result = execute_tool_call(tool_call)
@@ -335,8 +296,7 @@ class Riffer::Agent
     end
   end
 
-  #: tool_call: Riffer::Messages::Assistant::ToolCall
-  #: return: Riffer::Tools::Response
+  #: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
   def execute_tool_call(tool_call)
     tool_class = find_tool_class(tool_call.name)
 
@@ -361,7 +321,7 @@ class Riffer::Agent
     end
   end
 
-  #: return: Array[singleton(Riffer::Tool)]
+  #: () -> Array[singleton(Riffer::Tool)]
   def resolved_tools
     @resolved_tools ||= begin
       config = self.class.uses_tools
@@ -375,14 +335,12 @@ class Riffer::Agent
     end
   end
 
-  #: name: String
-  #: return: singleton(Riffer::Tool)?
+  #: (String) -> singleton(Riffer::Tool)?
   def find_tool_class(name)
     resolved_tools.find { |tool_class| tool_class.name == name }
   end
 
-  #: arguments: (String | Hash[String, untyped])?
-  #: return: Hash[Symbol, untyped]
+  #: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
 
@@ -390,7 +348,7 @@ class Riffer::Agent
     args.transform_keys(&:to_sym)
   end
 
-  #: return: String
+  #: () -> String
   def extract_final_response
     last_assistant_message = @messages.reverse.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
     last_assistant_message&.content || ""

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -32,7 +32,7 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader :evals #: Riffer::Config::Evals
 
-  #: return: void
+  #: () -> void
   def initialize
     @amazon_bedrock = AmazonBedrock.new
     @anthropic = Anthropic.new

--- a/lib/riffer/core.rb
+++ b/lib/riffer/core.rb
@@ -7,13 +7,10 @@ require "logger"
 #
 # Handles logging and configuration for the framework.
 class Riffer::Core
-  #: @logger: Logger
-  #: @storage_registry: Hash[String, untyped]
-
   # The logger instance for Riffer.
   attr_reader :logger #: Logger
 
-  #: return: void
+  #: () -> void
   def initialize
     @logger = Logger.new($stdout)
     @logger.level = Logger::INFO
@@ -22,8 +19,7 @@ class Riffer::Core
 
   # Yields self for configuration.
   #
-  #: &block: (Riffer::Core) -> void
-  #: return: void
+  #: () ?{ (Riffer::Core) -> void } -> void
   def configure(&block)
     yield self if block_given?
   end

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -24,20 +24,12 @@
 #   end
 #
 class Riffer::Evals::Evaluator
-  #: self.@identifier: String?
-  #: self.@description: String?
-  #: self.@higher_is_better: bool?
-  #: self.@judge_model: String?
-
-  #: @judge: Riffer::Evals::Judge?
-
   class << self
     include Riffer::Helpers::ClassNameConverter
 
     # Gets or sets the evaluator identifier.
     #
-    #: value: String? -- the identifier to set, or nil to get
-    #: return: String
+    #: (?String?) -> String
     def identifier(value = nil)
       return @identifier || class_name_to_identifier(name) if value.nil?
       @identifier = value.to_s
@@ -45,8 +37,7 @@ class Riffer::Evals::Evaluator
 
     # Gets or sets the evaluator description.
     #
-    #: value: String? -- the description to set, or nil to get
-    #: return: String?
+    #: (?String?) -> String?
     def description(value = nil)
       return @description if value.nil?
       @description = value.to_s
@@ -54,8 +45,7 @@ class Riffer::Evals::Evaluator
 
     # Gets or sets whether higher scores are better.
     #
-    #: value: bool? -- the value to set, or nil to get
-    #: return: bool
+    #: (?bool?) -> bool
     def higher_is_better(value = nil)
       return @higher_is_better.nil? || @higher_is_better if value.nil?
       @higher_is_better = value
@@ -63,8 +53,7 @@ class Riffer::Evals::Evaluator
 
     # Gets or sets the judge model for LLM-as-judge evaluations.
     #
-    #: value: String? -- the model to set (provider/model format), or nil to get
-    #: return: String?
+    #: (?String?) -> String?
     def judge_model(value = nil)
       return @judge_model if value.nil?
       @judge_model = value.to_s
@@ -72,8 +61,7 @@ class Riffer::Evals::Evaluator
 
     private
 
-    #: name: String?
-    #: return: String?
+    #: (String?) -> String?
     def class_name_to_identifier(name)
       return nil if name.nil?
       class_name = name.split("::").last
@@ -86,10 +74,7 @@ class Riffer::Evals::Evaluator
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  #: input: String -- the input that was given to the agent
-  #: output: String -- the output produced by the agent
-  #: context: Hash[Symbol, untyped]? -- optional context (e.g., ground_truth)
-  #: return: Riffer::Evals::Result
+  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
   def evaluate(input:, output:, context: nil)
     raise NotImplementedError, "#{self.class} must implement #evaluate"
   end
@@ -98,7 +83,7 @@ class Riffer::Evals::Evaluator
 
   # Returns a Judge instance configured for this evaluator.
   #
-  #: return: Riffer::Evals::Judge
+  #: () -> Riffer::Evals::Judge
   def judge
     @judge ||= begin
       model = self.class.judge_model || Riffer.config.evals.judge_model
@@ -109,10 +94,7 @@ class Riffer::Evals::Evaluator
 
   # Helper to build a Result object.
   #
-  #: score: Float -- the evaluation score (0.0 to 1.0)
-  #: reason: String? -- optional explanation
-  #: metadata: Hash[Symbol, untyped] -- optional additional data
-  #: return: Riffer::Evals::Result
+  #: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
   def result(score:, reason: nil, metadata: {})
     Riffer::Evals::Result.new(
       evaluator: self.class.identifier,

--- a/lib/riffer/evals/evaluators.rb
+++ b/lib/riffer/evals/evaluators.rb
@@ -23,24 +23,19 @@ module Riffer::Evals::Evaluators
       answer_relevancy: -> { Riffer::Evals::Evaluators::AnswerRelevancy }
     }.freeze #: Hash[Symbol, ^() -> singleton(Riffer::Evals::Evaluator)]
 
-    #: self.@custom: Hash[Symbol, ^() -> singleton(Riffer::Evals::Evaluator)]
-
     @custom = {}
 
     class << self
       # Registers a custom evaluator class with an identifier.
       #
-      #: identifier: (String | Symbol) -- the identifier to register
-      #: evaluator_class: singleton(Riffer::Evals::Evaluator) -- the evaluator class
-      #: return: void
+      #: ((String | Symbol), singleton(Riffer::Evals::Evaluator)) -> void
       def register(identifier, evaluator_class)
         @custom[identifier.to_sym] = -> { evaluator_class }
       end
 
       # Finds an evaluator class by identifier.
       #
-      #: identifier: (String | Symbol) -- the identifier to look up
-      #: return: singleton(Riffer::Evals::Evaluator)?
+      #: ((String | Symbol)) -> singleton(Riffer::Evals::Evaluator)?
       def find(identifier)
         id = identifier.to_sym
         (@custom[id] || BUILT_IN[id])&.call
@@ -48,14 +43,14 @@ module Riffer::Evals::Evaluators
 
       # Returns all registered evaluators (built-in and custom).
       #
-      #: return: Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
+      #: () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
       def all
         BUILT_IN.merge(@custom).transform_values(&:call)
       end
 
       # Clears custom registrations (for testing). Built-ins remain.
       #
-      #: return: void
+      #: () -> void
       def clear
         @custom = {}
       end

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -38,10 +38,7 @@ class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
       - 0.0 = Completely irrelevant
   PROMPT
 
-  #: input: String -- the input that was given to the agent
-  #: output: String -- the output produced by the agent
-  #: context: Hash[Symbol, untyped]? -- optional context
-  #: return: Riffer::Evals::Result
+  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
   def evaluate(input:, output:, context: nil)
     user_prompt = build_user_prompt(input: input, output: output)
     evaluation = judge.evaluate(system_prompt: SYSTEM_PROMPT, user_prompt: user_prompt)
@@ -50,9 +47,7 @@ class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
 
   private
 
-  #: input: String
-  #: output: String
-  #: return: String
+  #: (input: String, output: String) -> String
   def build_user_prompt(input:, output:)
     <<~PROMPT
       Input/Question:

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -28,28 +28,18 @@ class Riffer::Evals::Judge
       required :reason, String, description: "Brief explanation for the score"
     end
 
-    #: context: Hash[Symbol, untyped]?
-    #: score: Float
-    #: reason: String
-    #: return: Riffer::Tools::Response
+    #: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
     def call(context:, score:, reason:)
       json({score: score, reason: reason})
     end
   end
-
-  #: @provider_options: Hash[Symbol, untyped]
-  #: @provider_instance: Riffer::Providers::Base?
-  #: @provider_name: String?
-  #: @model_name: String?
 
   # The model string (provider/model format).
   attr_reader :model #: String
 
   # Initializes a new judge.
   #
-  #: model: String -- the model to use (provider/model format)
-  #: provider_options: Hash[Symbol, untyped] -- options passed to the provider
-  #: return: void
+  #: (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
   def initialize(model:, provider_options: {})
     provider_name, model_name = model.split("/", 2)
     unless [provider_name, model_name].all? { |part| part.is_a?(String) && !part.strip.empty? }
@@ -65,10 +55,7 @@ class Riffer::Evals::Judge
   # Raises Riffer::ArgumentError if both messages and system_prompt/user_prompt are provided,
   # or if user_prompt is missing when messages is not provided.
   #
-  #: messages: Array[Hash[Symbol, untyped]]? -- array of message hashes
-  #: system_prompt: String? -- the system prompt for the judge
-  #: user_prompt: String? -- the user prompt containing the evaluation request
-  #: return: Hash[Symbol, untyped]
+  #: (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
   def evaluate(messages: nil, system_prompt: nil, user_prompt: nil)
     response = if messages
       raise Riffer::ArgumentError, "cannot provide both messages and system_prompt/user_prompt" if system_prompt || user_prompt
@@ -83,7 +70,7 @@ class Riffer::Evals::Judge
 
   private
 
-  #: return: Riffer::Providers::Base
+  #: () -> Riffer::Providers::Base
   def provider_instance
     @provider_instance ||= begin
       provider_class = Riffer::Providers::Repository.find(provider_name)
@@ -92,18 +79,17 @@ class Riffer::Evals::Judge
     end
   end
 
-  #: return: String
+  #: () -> String
   def provider_name
     @provider_name ||= @model.split("/", 2).first
   end
 
-  #: return: String
+  #: () -> String
   def model_name
     @model_name ||= @model.split("/", 2).last
   end
 
-  #: response: Riffer::Messages::Assistant
-  #: return: Hash[Symbol, untyped]
+  #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def parse_tool_response(response)
     tool_call = response.tool_calls.first
     raise Riffer::Error, "Invalid judge response: no tool call found" unless tool_call

--- a/lib/riffer/evals/metric.rb
+++ b/lib/riffer/evals/metric.rb
@@ -28,11 +28,7 @@ class Riffer::Evals::Metric
 
   # Initializes a new metric.
   #
-  #: evaluator_identifier: String -- the evaluator to use
-  #: min: Float? -- minimum score threshold
-  #: max: Float? -- maximum score threshold
-  #: weight: Float -- weight for aggregation (default: 1.0)
-  #: return: void
+  #: (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
   def initialize(evaluator_identifier:, min: nil, max: nil, weight: 1.0)
     @evaluator_identifier = evaluator_identifier.to_s
     @min = min&.to_f
@@ -42,15 +38,14 @@ class Riffer::Evals::Metric
 
   # Returns the evaluator class for this metric.
   #
-  #: return: singleton(Riffer::Evals::Evaluator)?
+  #: () -> singleton(Riffer::Evals::Evaluator)?
   def evaluator_class
     Riffer::Evals::Evaluators::Repository.find(evaluator_identifier)
   end
 
   # Checks if a result passes this metric's thresholds.
   #
-  #: result: Riffer::Evals::Result -- the evaluation result to check
-  #: return: bool
+  #: (Riffer::Evals::Result) -> bool
   def passes?(result)
     return false if min && result.score < min
     return false if max && result.score > max
@@ -59,7 +54,7 @@ class Riffer::Evals::Metric
 
   # Returns a hash representation of the metric.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {
       evaluator_identifier: evaluator_identifier,

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -24,8 +24,7 @@
 #   result.passed?  # => true/false
 #
 module Riffer::Evals::Profile
-  #: base: Module
-  #: return: void
+  #: (Module) -> void
   def self.included(base)
     base.extend(ClassMethods)
 
@@ -43,18 +42,14 @@ module Riffer::Evals::Profile
     # The configured metrics.
     attr_reader :metrics #: Array[Riffer::Evals::Metric]
 
-    #: return: void
+    #: () -> void
     def initialize
       @metrics = []
     end
 
     # Defines a metric with thresholds.
     #
-    #: identifier: (Symbol | String) -- the evaluator identifier
-    #: min: Float? -- minimum score threshold
-    #: max: Float? -- maximum score threshold
-    #: weight: Float -- weight for aggregation (default: 1.0)
-    #: return: void
+    #: ((Symbol | String), ?min: Float?, ?max: Float?, ?weight: Float) -> void
     def metric(identifier, min: nil, max: nil, weight: 1.0)
       metrics << Riffer::Evals::Metric.new(
         evaluator_identifier: identifier,
@@ -68,8 +63,7 @@ module Riffer::Evals::Profile
   module ClassMethods
     # Defines the eval metrics for this profile.
     #
-    #: &block: () -> void
-    #: return: void
+    #: () { () -> void } -> void
     def ai_evals(&block)
       builder = Builder.new
       builder.instance_eval(&block)
@@ -78,7 +72,7 @@ module Riffer::Evals::Profile
 
     # Returns the configured metrics.
     #
-    #: return: Array[Riffer::Evals::Metric]
+    #: () -> Array[Riffer::Evals::Metric]
     def eval_metrics
       @eval_metrics || []
     end
@@ -87,10 +81,7 @@ module Riffer::Evals::Profile
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    #: input: String -- the input to send to the agent
-    #: context: Hash[Symbol, untyped]? -- optional context for evaluation
-    #: tool_context: Hash[Symbol, untyped]? -- optional context passed to tools during generation
-    #: return: Riffer::Evals::RunResult
+    #: (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
     def run_eval(input:, context: nil, tool_context: nil)
       profile = @eval_profile
       raise Riffer::ArgumentError, "No eval profile configured" unless profile

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -36,12 +36,7 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
-  #: evaluator: String -- the evaluator identifier
-  #: score: Float -- the score (0.0 to 1.0)
-  #: reason: String? -- optional explanation
-  #: metadata: Hash[Symbol, untyped] -- optional additional data
-  #: higher_is_better: bool -- whether higher is better (default: true)
-  #: return: void
+  #: (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
   def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
     @evaluator = evaluator
     @score = score.to_f
@@ -53,7 +48,7 @@ class Riffer::Evals::Result
 
   # Returns a hash representation of the result.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {
       evaluator: evaluator,
@@ -66,7 +61,7 @@ class Riffer::Evals::Result
 
   private
 
-  #: return: void
+  #: () -> void
   def validate_score!
     return if score.is_a?(Numeric) && score >= 0.0 && score <= 1.0
 

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -18,8 +18,6 @@
 #   run_result.failures         # => [result1] (results that failed thresholds)
 #
 class Riffer::Evals::RunResult
-  #: @failures: Array[Riffer::Evals::Result]?
-
   # The input that was evaluated.
   attr_reader :input #: String
 
@@ -37,12 +35,7 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  #: input: String -- the input that was evaluated
-  #: output: String -- the output that was evaluated
-  #: context: Hash[Symbol, untyped]? -- the evaluation context
-  #: results: Array[Riffer::Evals::Result] -- individual results
-  #: metrics: Array[Riffer::Evals::Metric] -- the metrics evaluated
-  #: return: void
+  #: (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
   def initialize(input:, output:, context:, results:, metrics:)
     @input = input
     @output = output
@@ -53,14 +46,14 @@ class Riffer::Evals::RunResult
 
   # Checks if all metrics passed their thresholds.
   #
-  #: return: bool
+  #: () -> bool
   def passed?
     failures.empty?
   end
 
   # Returns results that failed their metric thresholds.
   #
-  #: return: Array[Riffer::Evals::Result]
+  #: () -> Array[Riffer::Evals::Result]
   def failures
     @failures ||= results.select.with_index do |result, index|
       metric = metrics[index]
@@ -74,7 +67,7 @@ class Riffer::Evals::RunResult
   # For evaluators where lower is better (e.g., toxicity), the score is
   # inverted (1 - score) before aggregation.
   #
-  #: return: Float
+  #: () -> Float
   def aggregate_score
     return 0.0 if results.empty?
 
@@ -92,7 +85,7 @@ class Riffer::Evals::RunResult
 
   # Returns a hash representation of the run result.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {
       input: input,

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -19,18 +19,14 @@ class Riffer::Evals::Runner
 
   # Initializes a new runner.
   #
-  #: metrics: Array[Riffer::Evals::Metric] -- the metrics to evaluate
-  #: return: void
+  #: (metrics: Array[Riffer::Evals::Metric]) -> void
   def initialize(metrics:)
     @metrics = metrics
   end
 
   # Runs all evaluators and collects results.
   #
-  #: input: String -- the input given to the agent
-  #: output: String -- the output produced by the agent
-  #: context: Hash[Symbol, untyped]? -- optional context (e.g., ground_truth)
-  #: return: Riffer::Evals::RunResult
+  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   def run(input:, output:, context: nil)
     results = metrics.map do |metric|
       evaluator_class = metric.evaluator_class

--- a/lib/riffer/helpers/class_name_converter.rb
+++ b/lib/riffer/helpers/class_name_converter.rb
@@ -7,9 +7,7 @@ module Riffer::Helpers::ClassNameConverter
 
   # Converts a class name to snake_case identifier format.
   #
-  #: class_name: String -- the class name (e.g., "Riffer::Agent")
-  #: separator: String -- the separator to use for namespaces (default: "/")
-  #: return: String
+  #: (String, ?separator: String) -> String
   def class_name_to_path(class_name, separator: DEFAULT_SEPARATOR)
     class_name
       .to_s

--- a/lib/riffer/helpers/dependencies.rb
+++ b/lib/riffer/helpers/dependencies.rb
@@ -19,9 +19,7 @@ module Riffer::Helpers::Dependencies
   # Raises LoadError if the gem is not installed.
   # Raises VersionError if the gem version does not satisfy requirements.
   #
-  #: gem_name: String -- the gem name
-  #: req: (bool | String) -- true to require the gem, false to skip, or String to require a different lib
-  #: return: true
+  #: (String, ?req: (bool | String)) -> true
   def depends_on(gem_name, req: true)
     gem(gem_name)
 

--- a/lib/riffer/helpers/validations.rb
+++ b/lib/riffer/helpers/validations.rb
@@ -7,9 +7,7 @@ module Riffer::Helpers::Validations
   #
   # Raises Riffer::ArgumentError if the value is not a string or is empty.
   #
-  #: value: untyped -- the value to validate
-  #: name: String -- the name of the value for error messages
-  #: return: true
+  #: (untyped, ?String) -> true
   def validate_is_string!(value, name = "value")
     raise Riffer::ArgumentError, "#{name} must be a String" unless value.is_a?(String)
     raise Riffer::ArgumentError, "#{name} cannot be empty" if value.strip.empty?

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -19,24 +19,21 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # Token usage data for this response.
   attr_reader :token_usage #: Riffer::TokenUsage?
 
-  #: content: String
-  #: tool_calls: Array[Riffer::Messages::Assistant::ToolCall] -- optional tool calls
-  #: token_usage: Riffer::TokenUsage? -- optional token usage data
-  #: return: void
+  #: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?) -> void
   def initialize(content, tool_calls: [], token_usage: nil)
     super(content)
     @tool_calls = tool_calls
     @token_usage = token_usage
   end
 
-  #: return: Symbol
+  #: () -> Symbol
   def role
     :assistant
   end
 
   # Converts the message to a hash.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}
     hash[:tool_calls] = tool_calls.map(&:to_h) unless tool_calls.empty?

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -8,15 +8,14 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader :content #: String
 
-  #: content: String
-  #: return: void
+  #: (String) -> void
   def initialize(content)
     @content = content
   end
 
   # Converts the message to a hash.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: role, content: content}
   end
@@ -25,7 +24,7 @@ class Riffer::Messages::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  #: return: Symbol
+  #: () -> Symbol
   def role
     raise NotImplementedError, "Subclasses must implement #role"
   end

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -9,8 +9,7 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
-  #: msg: (Hash[Symbol | String, untyped] | Riffer::Messages::Base)
-  #: return: Riffer::Messages::Base
+  #: ((Hash[Symbol | String, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
   def convert_to_message_object(msg)
     return msg if msg.is_a?(Riffer::Messages::Base)
 
@@ -23,8 +22,7 @@ module Riffer::Messages::Converter
 
   private
 
-  #: hash: Hash[Symbol | String, untyped]
-  #: return: Riffer::Messages::Base
+  #: (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
   def convert_hash_to_message(hash)
     role = hash[:role] || hash["role"]
     content = hash[:content] || hash["content"]

--- a/lib/riffer/messages/system.rb
+++ b/lib/riffer/messages/system.rb
@@ -8,7 +8,7 @@
 #   msg.content  # => "You are a helpful assistant."
 #
 class Riffer::Messages::System < Riffer::Messages::Base
-  #: return: Symbol
+  #: () -> Symbol
   def role
     :system
   end

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -25,12 +25,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
   attr_reader :error_type #: Symbol?
 
-  #: content: String -- the tool execution result
-  #: tool_call_id: String -- the ID of the tool call
-  #: name: String -- the tool name
-  #: error: String? -- optional error message
-  #: error_type: Symbol? -- optional error type
-  #: return: void
+  #: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
   def initialize(content, tool_call_id:, name:, error: nil, error_type: nil)
     super(content)
     @tool_call_id = tool_call_id
@@ -41,19 +36,19 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
 
   # Returns true if the tool execution resulted in an error.
   #
-  #: return: bool
+  #: () -> bool
   def error?
     !@error.nil?
   end
 
-  #: return: Symbol
+  #: () -> Symbol
   def role
     :tool
   end
 
   # Converts the message to a hash.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content, tool_call_id: tool_call_id, name: name}
     if error?

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -8,7 +8,7 @@
 #   msg.content  # => "Hello!"
 #
 class Riffer::Messages::User < Riffer::Messages::Base
-  #: return: Symbol
+  #: () -> Symbol
   def role
     :user
   end

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -9,14 +9,9 @@ require "json"
 #
 # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/BedrockRuntime/Client.html
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
-  #: @client: Aws::BedrockRuntime::Client
-
   # Initializes the Amazon Bedrock provider.
   #
-  #: api_token: String? -- Bearer token for API authentication
-  #: region: String? -- AWS region
-  #: **options: untyped
-  #: return: void
+  #: (?api_token: String?, ?region: String?, **untyped) -> void
   def initialize(api_token: nil, region: nil, **options)
     depends_on "aws-sdk-bedrockruntime"
 
@@ -37,10 +32,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
 
   private
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
   def perform_generate_text(messages, model:, **options)
     partitioned_messages = partition_messages(messages)
     tools = options[:tools]
@@ -62,10 +54,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     extract_assistant_message(response, extract_token_usage(response))
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def perform_stream_text(messages, model:, **options)
     Enumerator.new do |yielder|
       partitioned_messages = partition_messages(messages)
@@ -150,8 +139,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     end
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: return: Hash[Symbol, untyped]
+  #: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages(messages)
     system_prompts = []
     conversation_messages = []
@@ -175,9 +163,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     }
   end
 
-  #: conversation_messages: Array[Hash[Symbol, untyped]]
-  #: message: Riffer::Messages::Tool
-  #: return: void
+  #: (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
   def append_tool_result(conversation_messages, message)
     tool_result = {
       tool_result: {
@@ -194,8 +180,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     end
   end
 
-  #: message: Riffer::Messages::Assistant
-  #: return: Hash[Symbol, untyped]
+  #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_bedrock_format(message)
     content = []
     content << {text: message.content} if message.content && !message.content.empty?
@@ -213,15 +198,13 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     {role: "assistant", content: content}
   end
 
-  #: arguments: (String | Hash[String, untyped])?
-  #: return: Hash[String, untyped]
+  #: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
     arguments.is_a?(String) ? JSON.parse(arguments) : arguments
   end
 
-  #: response: Aws::BedrockRuntime::Types::ConverseResponse
-  #: return: Riffer::TokenUsage?
+  #: (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
     return nil unless usage
@@ -234,9 +217,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     )
   end
 
-  #: response: Aws::BedrockRuntime::Types::ConverseResponse
-  #: token_usage: Riffer::TokenUsage?
-  #: return: Riffer::Messages::Assistant
+  #: (Aws::BedrockRuntime::Types::ConverseResponse, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
   def extract_assistant_message(response, token_usage = nil)
     output = response.output
     raise Riffer::Error, "No output returned from Bedrock API" if output.nil? || output.message.nil?
@@ -267,8 +248,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     Riffer::Messages::Assistant.new(text_content, tool_calls: tool_calls, token_usage: token_usage)
   end
 
-  #: tool: singleton(Riffer::Tool)
-  #: return: Hash[Symbol, untyped]
+  #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_bedrock_format(tool)
     {
       tool_spec: {

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -9,13 +9,9 @@ require "json"
 #
 # See https://github.com/anthropics/anthropic-sdk-ruby
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
-  #: @client: Anthropic::Client
-
   # Initializes the Anthropic provider.
   #
-  #: api_key: String? -- Anthropic API key
-  #: **options: untyped
-  #: return: void
+  #: (?api_key: String?, **untyped) -> void
   def initialize(api_key: nil, **options)
     depends_on "anthropic"
 
@@ -26,10 +22,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
   private
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
   def perform_generate_text(messages, model:, **options)
     partitioned_messages = partition_messages(messages)
     tools = options[:tools]
@@ -53,10 +46,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     extract_assistant_message(response, extract_token_usage(response))
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def perform_stream_text(messages, model:, **options)
     Enumerator.new do |yielder|
       partitioned_messages = partition_messages(messages)
@@ -143,8 +133,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     end
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: return: Hash[Symbol, untyped]
+  #: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages(messages)
     system_prompts = []
     conversation_messages = []
@@ -175,8 +164,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     }
   end
 
-  #: message: Riffer::Messages::Assistant
-  #: return: Hash[Symbol, untyped]
+  #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_anthropic_format(message)
     content = []
     content << {type: "text", text: message.content} if message.content && !message.content.empty?
@@ -193,15 +181,13 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     {role: "assistant", content: content}
   end
 
-  #: arguments: (String | Hash[String, untyped])?
-  #: return: Hash[String, untyped]
+  #: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
     arguments.is_a?(String) ? JSON.parse(arguments) : arguments
   end
 
-  #: response: Anthropic::Models::Message
-  #: return: Riffer::TokenUsage?
+  #: (Anthropic::Models::Message) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
     return nil unless usage
@@ -214,9 +200,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     )
   end
 
-  #: response: Anthropic::Models::Message
-  #: token_usage: Riffer::TokenUsage?
-  #: return: Riffer::Messages::Assistant
+  #: (Anthropic::Models::Message, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
   def extract_assistant_message(response, token_usage = nil)
     content_blocks = response.content
     raise Riffer::Error, "No content returned from Anthropic API" if content_blocks.nil? || content_blocks.empty?
@@ -246,8 +230,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     Riffer::Messages::Assistant.new(text_content, tool_calls: tool_calls, token_usage: token_usage)
   end
 
-  #: tool: singleton(Riffer::Tool)
-  #: return: Hash[Symbol, untyped]
+  #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_anthropic_format(tool)
     {
       name: tool.name,

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -10,12 +10,7 @@ class Riffer::Providers::Base
 
   # Generates text using the provider.
   #
-  #: prompt: String? -- the user prompt (required when messages is not provided)
-  #: system: String? -- an optional system message
-  #: messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]? -- optional messages array
-  #: model: String? -- optional model string to override the configured model
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Riffer::Messages::Assistant
   def generate_text(prompt: nil, system: nil, messages: nil, model: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
     normalized_messages = normalize_messages(prompt: prompt, system: system, messages: messages)
@@ -25,12 +20,7 @@ class Riffer::Providers::Base
 
   # Streams text from the provider.
   #
-  #: prompt: String? -- the user prompt (required when messages is not provided)
-  #: system: String? -- an optional system message
-  #: messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]? -- optional messages array
-  #: model: String? -- optional model string to override the configured model
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream_text(prompt: nil, system: nil, messages: nil, model: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
     normalized_messages = normalize_messages(prompt: prompt, system: system, messages: messages)
@@ -40,26 +30,17 @@ class Riffer::Providers::Base
 
   private
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String?
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
   def perform_generate_text(messages, model: nil, **options)
     raise NotImplementedError, "Subclasses must implement #perform_generate_text"
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String?
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def perform_stream_text(messages, model: nil, **options)
     raise NotImplementedError, "Subclasses must implement #perform_stream_text"
   end
 
-  #: prompt: String?
-  #: system: String?
-  #: messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?
-  #: return: void
+  #: (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
   def validate_input!(prompt:, system:, messages:)
     if messages.nil?
       raise Riffer::ArgumentError, "prompt is required when messages is not provided" if prompt.nil?
@@ -69,10 +50,7 @@ class Riffer::Providers::Base
     end
   end
 
-  #: prompt: String?
-  #: system: String?
-  #: messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?
-  #: return: Array[Riffer::Messages::Base]
+  #: (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?) -> Array[Riffer::Messages::Base]
   def normalize_messages(prompt:, system:, messages:)
     if messages
       return messages.map { |msg| convert_to_message_object(msg) }
@@ -84,8 +62,7 @@ class Riffer::Providers::Base
     result
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: return: void
+  #: (Array[Riffer::Messages::Base]) -> void
   def validate_normalized_messages!(messages)
     has_user = messages.any? { |msg| msg.is_a?(Riffer::Messages::User) }
     raise Riffer::ArgumentError, "messages must include at least one user message" unless has_user

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -5,12 +5,9 @@
 #
 # Requires the +openai+ gem to be installed.
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
-  #: @client: OpenAI::Client
-
   # Initializes the OpenAI provider.
   #
-  #: **options: untyped
-  #: return: void
+  #: (**untyped) -> void
   def initialize(**options)
     depends_on "openai"
 
@@ -20,10 +17,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
 
   private
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
   def perform_generate_text(messages, model:, **options)
     params = build_request_params(messages, model, options)
     response = @client.responses.create(params)
@@ -31,10 +25,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     extract_assistant_message(response.output, extract_token_usage(response))
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def perform_stream_text(messages, model:, **options)
     Enumerator.new do |yielder|
       params = build_request_params(messages, model, options)
@@ -44,10 +35,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String
-  #: options: Hash[Symbol, untyped]
-  #: return: Hash[Symbol, untyped]
+  #: (Array[Riffer::Messages::Base], String, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     reasoning = options[:reasoning]
     tools = options[:tools]
@@ -69,8 +57,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     params.compact
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: return: Array[Hash[Symbol, untyped]]
+  #: (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
   def convert_messages_to_openai_format(messages)
     messages.flat_map do |message|
       case message
@@ -90,8 +77,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
-  #: message: Riffer::Messages::Assistant
-  #: return: (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
+  #: (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
   def convert_assistant_to_openai_format(message)
     if message.tool_calls.empty?
       {role: "assistant", content: message.content}
@@ -111,8 +97,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
-  #: response: OpenAI::Models::Responses::Response
-  #: return: Riffer::TokenUsage?
+  #: (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
     return nil unless usage
@@ -123,9 +108,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     )
   end
 
-  #: output_items: Array[OpenAI::Models::Responses::response_output_item]
-  #: token_usage: Riffer::TokenUsage?
-  #: return: Riffer::Messages::Assistant
+  #: (Array[OpenAI::Models::Responses::response_output_item], ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
   def extract_assistant_message(output_items, token_usage = nil)
     text_content = ""
     tool_calls = []
@@ -152,9 +135,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     Riffer::Messages::Assistant.new(text_content, tool_calls: tool_calls, token_usage: token_usage)
   end
 
-  #: stream: OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event]
-  #: yielder: Enumerator::Yielder
-  #: return: void
+  #: (OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event], Enumerator::Yielder) -> void
   def process_stream_events(stream, yielder)
     tool_info = {}
 
@@ -168,9 +149,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
-  #: event: OpenAI::Models::Responses::response_stream_event
-  #: tool_info: Hash[String, Hash[Symbol, untyped]]
-  #: return: void
+  #: (OpenAI::Models::Responses::response_stream_event, Hash[String, Hash[Symbol, untyped]]) -> void
   def track_tool_info(event, tool_info)
     return unless event.type == :"response.output_item.added"
     return unless event.item&.type == :function_call
@@ -181,9 +160,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     }
   end
 
-  #: event: OpenAI::Models::Responses::response_stream_event
-  #: tool_info: Hash[String, Hash[Symbol, untyped]]
-  #: return: Riffer::StreamEvents::Base?
+  #: (OpenAI::Models::Responses::response_stream_event, ?Hash[String, Hash[Symbol, untyped]]) -> Riffer::StreamEvents::Base?
   def convert_event(event, tool_info = {})
     case event.type
     when :"response.output_text.delta"
@@ -222,8 +199,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
-  #: tool: singleton(Riffer::Tool)
-  #: return: Hash[Symbol, untyped]
+  #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_openai_format(tool)
     {
       type: "function",

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -13,8 +13,7 @@ class Riffer::Providers::Repository
 
   # Finds a provider class by identifier.
   #
-  #: identifier: (String | Symbol) -- the identifier to search for
-  #: return: singleton(Riffer::Providers::Base)?
+  #: ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def self.find(identifier)
     REPO.fetch(identifier.to_sym, nil)&.call
   end

--- a/lib/riffer/providers/test.rb
+++ b/lib/riffer/providers/test.rb
@@ -5,17 +5,12 @@
 #
 # No external gems required.
 class Riffer::Providers::Test < Riffer::Providers::Base
-  #: @responses: Array[Hash[Symbol, untyped]]
-  #: @current_index: Integer
-  #: @stubbed_responses: Array[Hash[Symbol, untyped]]
-
   # Array of recorded method calls for assertions.
   attr_reader :calls #: Array[Hash[Symbol, untyped]]
 
   # Initializes the test provider.
   #
-  #: **options: untyped
-  #: return: void
+  #: (**untyped) -> void
   def initialize(**options)
     @responses = options[:responses] || []
     @current_index = 0
@@ -31,10 +26,7 @@ class Riffer::Providers::Test < Riffer::Providers::Base
   #   provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
   #   provider.stub_response("Final response", token_usage: Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 5))
   #
-  #: content: String -- the response content
-  #: tool_calls: Array[Hash[Symbol, untyped]] -- optional tool calls to include
-  #: token_usage: Riffer::TokenUsage? -- optional token usage data to include
-  #: return: void
+  #: (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
   def stub_response(content, tool_calls: [], token_usage: nil)
     formatted_tool_calls = tool_calls.map.with_index do |tc, idx|
       Riffer::Messages::Assistant::ToolCall.new(
@@ -49,14 +41,14 @@ class Riffer::Providers::Test < Riffer::Providers::Base
 
   # Clears all stubbed responses.
   #
-  #: return: void
+  #: () -> void
   def clear_stubs
     @stubbed_responses = []
   end
 
   private
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def next_response
     if @stubbed_responses.any?
       @stubbed_responses.shift
@@ -69,10 +61,7 @@ class Riffer::Providers::Test < Riffer::Providers::Base
     end
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String?
-  #: **options: untyped
-  #: return: Riffer::Messages::Assistant
+  #: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
   def perform_generate_text(messages, model: nil, **options)
     @calls << {messages: messages.map(&:to_h), model: model, **options}
     response = next_response
@@ -88,10 +77,7 @@ class Riffer::Providers::Test < Riffer::Providers::Base
     end
   end
 
-  #: messages: Array[Riffer::Messages::Base]
-  #: model: String?
-  #: **options: untyped
-  #: return: Enumerator[Riffer::StreamEvents::Base, void]
+  #: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def perform_stream_text(messages, model: nil, **options)
     @calls << {messages: messages.map(&:to_h), model: model, **options}
     response = next_response

--- a/lib/riffer/stream_events/base.rb
+++ b/lib/riffer/stream_events/base.rb
@@ -8,8 +8,7 @@ class Riffer::StreamEvents::Base
   # The message role (typically :assistant).
   attr_reader :role #: Symbol
 
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (?role: Symbol) -> void
   def initialize(role: :assistant)
     @role = role
   end
@@ -18,7 +17,7 @@ class Riffer::StreamEvents::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     raise NotImplementedError, "Subclasses must implement #to_h"
   end

--- a/lib/riffer/stream_events/reasoning_delta.rb
+++ b/lib/riffer/stream_events/reasoning_delta.rb
@@ -9,15 +9,13 @@ class Riffer::StreamEvents::ReasoningDelta < Riffer::StreamEvents::Base
   # The incremental reasoning content.
   attr_reader :content #: String
 
-  #: content: String -- the incremental reasoning content
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}
   end

--- a/lib/riffer/stream_events/reasoning_done.rb
+++ b/lib/riffer/stream_events/reasoning_done.rb
@@ -9,15 +9,13 @@ class Riffer::StreamEvents::ReasoningDone < Riffer::StreamEvents::Base
   # The complete reasoning content.
   attr_reader :content #: String
 
-  #: content: String -- the complete reasoning content
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}
   end

--- a/lib/riffer/stream_events/text_delta.rb
+++ b/lib/riffer/stream_events/text_delta.rb
@@ -8,15 +8,13 @@ class Riffer::StreamEvents::TextDelta < Riffer::StreamEvents::Base
   # The incremental text content.
   attr_reader :content #: String
 
-  #: content: String -- the incremental text content
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}
   end

--- a/lib/riffer/stream_events/text_done.rb
+++ b/lib/riffer/stream_events/text_done.rb
@@ -8,15 +8,13 @@ class Riffer::StreamEvents::TextDone < Riffer::StreamEvents::Base
   # The complete text content.
   attr_reader :content #: String
 
-  #: content: String -- the complete text content
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}
   end

--- a/lib/riffer/stream_events/token_usage_done.rb
+++ b/lib/riffer/stream_events/token_usage_done.rb
@@ -13,15 +13,13 @@ class Riffer::StreamEvents::TokenUsageDone < Riffer::StreamEvents::Base
   # The token usage data for this response.
   attr_reader :token_usage #: Riffer::TokenUsage
 
-  #: token_usage: Riffer::TokenUsage -- the token usage data
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
   def initialize(token_usage:, role: :assistant)
     super(role: role)
     @token_usage = token_usage
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, token_usage: @token_usage.to_h}
   end

--- a/lib/riffer/stream_events/tool_call_delta.rb
+++ b/lib/riffer/stream_events/tool_call_delta.rb
@@ -14,11 +14,7 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
   # The incremental arguments JSON fragment.
   attr_reader :arguments_delta #: String
 
-  #: item_id: String -- the tool call item identifier
-  #: arguments_delta: String -- the incremental arguments JSON fragment
-  #: name: String? -- the tool name (may only be present in first delta)
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
   def initialize(item_id:, arguments_delta:, name: nil, role: :assistant)
     super(role: role)
     @item_id = item_id
@@ -26,7 +22,7 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
     @arguments_delta = arguments_delta
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, item_id: @item_id, name: @name, arguments_delta: @arguments_delta}.compact
   end

--- a/lib/riffer/stream_events/tool_call_done.rb
+++ b/lib/riffer/stream_events/tool_call_done.rb
@@ -17,12 +17,7 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
   # The complete arguments JSON string.
   attr_reader :arguments #: String
 
-  #: item_id: String -- the tool call item identifier
-  #: call_id: String -- the call identifier for response matching
-  #: name: String -- the tool name
-  #: arguments: String -- the complete arguments JSON string
-  #: role: Symbol -- the message role (defaults to :assistant)
-  #: return: void
+  #: (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
   def initialize(item_id:, call_id:, name:, arguments:, role: :assistant)
     super(role: role)
     @item_id = item_id
@@ -31,7 +26,7 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
     @arguments = arguments
   end
 
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, item_id: @item_id, call_id: @call_id, name: @name, arguments: @arguments}
   end

--- a/lib/riffer/token_usage.rb
+++ b/lib/riffer/token_usage.rb
@@ -23,11 +23,7 @@ class Riffer::TokenUsage
   # Number of tokens read from cache (Anthropic-specific).
   attr_reader :cache_read_tokens #: Integer?
 
-  #: input_tokens: Integer
-  #: output_tokens: Integer
-  #: cache_creation_tokens: Integer? -- tokens written to cache
-  #: cache_read_tokens: Integer? -- tokens read from cache
-  #: return: void
+  #: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
   def initialize(input_tokens:, output_tokens:, cache_creation_tokens: nil, cache_read_tokens: nil)
     @input_tokens = input_tokens
     @output_tokens = output_tokens
@@ -37,15 +33,14 @@ class Riffer::TokenUsage
 
   # Returns the total number of tokens (input + output).
   #
-  #: return: Integer
+  #: () -> Integer
   def total_tokens
     input_tokens + output_tokens
   end
 
   # Combines two TokenUsage objects for cumulative tracking.
   #
-  #: other: Riffer::TokenUsage
-  #: return: Riffer::TokenUsage
+  #: (Riffer::TokenUsage) -> Riffer::TokenUsage
   def +(other)
     Riffer::TokenUsage.new(
       input_tokens: input_tokens + other.input_tokens,
@@ -59,7 +54,7 @@ class Riffer::TokenUsage
   #
   # Cache tokens are omitted if nil.
   #
-  #: return: Hash[Symbol, Integer]
+  #: () -> Hash[Symbol, Integer]
   def to_h
     hash = {input_tokens: input_tokens, output_tokens: output_tokens}
     hash[:cache_creation_tokens] = cache_creation_tokens if cache_creation_tokens
@@ -69,9 +64,7 @@ class Riffer::TokenUsage
 
   private
 
-  #: a: Integer?
-  #: b: Integer?
-  #: return: Integer?
+  #: (Integer?, Integer?) -> Integer?
   def add_nullable(a, b)
     return nil if a.nil? && b.nil?
     (a || 0) + (b || 0)

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -31,15 +31,9 @@ class Riffer::Tool
 
   extend Riffer::Helpers::ClassNameConverter
 
-  #: self.@description: String?
-  #: self.@identifier: String?
-  #: self.@timeout: Float?
-  #: self.@params_builder: Riffer::Tools::Params?
-
   # Gets or sets the tool description.
   #
-  #: value: String? -- the description to set, or nil to get
-  #: return: String?
+  #: (?String?) -> String?
   def self.description(value = nil)
     return @description if value.nil?
     @description = value.to_s
@@ -47,8 +41,7 @@ class Riffer::Tool
 
   # Gets or sets the tool identifier/name.
   #
-  #: value: String? -- the identifier to set, or nil to get
-  #: return: String
+  #: (?String?) -> String
   def self.identifier(value = nil)
     return @identifier || class_name_to_path(Module.instance_method(:name).bind_call(self), separator: TOOL_SEPARATOR) if value.nil?
     @identifier = value.to_s
@@ -56,8 +49,7 @@ class Riffer::Tool
 
   # Alias for identifier - used by providers.
   #
-  #: value: String? -- the name to set, or nil to get
-  #: return: String
+  #: (?String?) -> String
   def self.name(value = nil)
     return identifier(value) unless value.nil?
     identifier
@@ -65,8 +57,7 @@ class Riffer::Tool
 
   # Gets or sets the tool timeout in seconds.
   #
-  #: value: (Integer | Float)? -- the timeout to set in seconds, or nil to get
-  #: return: (Integer | Float)
+  #: (?(Integer | Float)?) -> (Integer | Float)
   def self.timeout(value = nil)
     return @timeout || DEFAULT_TIMEOUT if value.nil?
     @timeout = value.to_f
@@ -74,8 +65,7 @@ class Riffer::Tool
 
   # Defines parameters using the Params DSL.
   #
-  #: &block: () -> void
-  #: return: Riffer::Tools::Params?
+  #: () ?{ () -> void } -> Riffer::Tools::Params?
   def self.params(&block)
     return @params_builder if block.nil?
     @params_builder = Riffer::Tools::Params.new
@@ -84,7 +74,7 @@ class Riffer::Tool
 
   # Returns the JSON Schema for the tool's parameters.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def self.parameters_schema
     @params_builder&.to_json_schema || empty_schema
   end
@@ -98,34 +88,28 @@ class Riffer::Tool
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  #: context: Hash[Symbol, untyped]? -- optional context passed from the agent
-  #: **kwargs: untyped
-  #: return: Riffer::Tools::Response
+  #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call(context:, **kwargs)
     raise NotImplementedError, "#{self.class} must implement #call"
   end
 
   # Creates a text response. Shorthand for Riffer::Tools::Response.text.
   #
-  #: result: untyped -- the tool result (converted via to_s)
-  #: return: Riffer::Tools::Response
+  #: (untyped) -> Riffer::Tools::Response
   def text(result)
     Riffer::Tools::Response.text(result)
   end
 
   # Creates a JSON response. Shorthand for Riffer::Tools::Response.json.
   #
-  #: result: untyped -- the tool result (converted via JSON.generate)
-  #: return: Riffer::Tools::Response
+  #: (untyped) -> Riffer::Tools::Response
   def json(result)
     Riffer::Tools::Response.json(result)
   end
 
   # Creates an error response. Shorthand for Riffer::Tools::Response.error.
   #
-  #: message: String -- the error message
-  #: type: Symbol -- the error type (default: :execution_error)
-  #: return: Riffer::Tools::Response
+  #: (String, ?type: Symbol) -> Riffer::Tools::Response
   def error(message, type: :execution_error)
     Riffer::Tools::Response.error(message, type: type)
   end
@@ -136,9 +120,7 @@ class Riffer::Tool
   # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
   # Raises Riffer::Error if the tool does not return a Response object.
   #
-  #: context: Hash[Symbol, untyped]? -- context passed from the agent
-  #: **kwargs: untyped
-  #: return: Riffer::Tools::Response
+  #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params
     validated_args = params_builder ? params_builder.validate(kwargs) : kwargs

--- a/lib/riffer/tools/param.rb
+++ b/lib/riffer/tools/param.rb
@@ -23,13 +23,7 @@ class Riffer::Tools::Param
   attr_reader :enum #: Array[untyped]?
   attr_reader :default #: untyped
 
-  #: name: Symbol -- the parameter name
-  #: type: Class -- the expected Ruby type
-  #: required: bool -- whether the parameter is required
-  #: description: String? -- optional description for the parameter
-  #: enum: Array[untyped]? -- optional list of allowed values
-  #: default: untyped -- optional default value for optional parameters
-  #: return: void
+  #: (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
   def initialize(name:, type:, required:, description: nil, enum: nil, default: nil)
     @name = name.to_sym
     @type = type
@@ -41,8 +35,7 @@ class Riffer::Tools::Param
 
   # Validates that a value matches the expected type.
   #
-  #: value: untyped
-  #: return: bool
+  #: (untyped) -> bool
   def valid_type?(value)
     return true if value.nil? && !required
 
@@ -55,14 +48,14 @@ class Riffer::Tools::Param
 
   # Returns the JSON Schema type name for this parameter.
   #
-  #: return: String
+  #: () -> String
   def type_name
     TYPE_MAPPINGS[type] || type.to_s.downcase
   end
 
   # Converts this parameter to JSON Schema format.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_json_schema
     schema = {type: type_name}
     schema[:description] = description if description

--- a/lib/riffer/tools/params.rb
+++ b/lib/riffer/tools/params.rb
@@ -13,18 +13,14 @@
 class Riffer::Tools::Params
   attr_reader :parameters #: Array[Riffer::Tools::Param]
 
-  #: return: void
+  #: () -> void
   def initialize
     @parameters = []
   end
 
   # Defines a required parameter.
   #
-  #: name: Symbol -- the parameter name
-  #: type: Class -- the expected Ruby type
-  #: description: String? -- optional description
-  #: enum: Array[untyped]? -- optional list of allowed values
-  #: return: void
+  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?) -> void
   def required(name, type, description: nil, enum: nil)
     @parameters << Riffer::Tools::Param.new(
       name: name,
@@ -37,12 +33,7 @@ class Riffer::Tools::Params
 
   # Defines an optional parameter.
   #
-  #: name: Symbol -- the parameter name
-  #: type: Class -- the expected Ruby type
-  #: description: String? -- optional description
-  #: enum: Array[untyped]? -- optional list of allowed values
-  #: default: untyped -- default value when not provided
-  #: return: void
+  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
   def optional(name, type, description: nil, enum: nil, default: nil)
     @parameters << Riffer::Tools::Param.new(
       name: name,
@@ -58,8 +49,7 @@ class Riffer::Tools::Params
   #
   # Raises Riffer::ValidationError if validation fails.
   #
-  #: arguments: Hash[Symbol, untyped]
-  #: return: Hash[Symbol, untyped]
+  #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def validate(arguments)
     validated = {}
     errors = []
@@ -97,7 +87,7 @@ class Riffer::Tools::Params
 
   # Converts all parameters to JSON Schema format.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_json_schema
     properties = {}
     required_params = []

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -28,9 +28,7 @@ class Riffer::Tools::Response
   #
   # Raises Riffer::ArgumentError if format is invalid.
   #
-  #: result: untyped -- the tool result
-  #: format: Symbol -- the format (:text or :json; default: :text)
-  #: return: Riffer::Tools::Response
+  #: (untyped, ?format: Symbol) -> Riffer::Tools::Response
   def self.success(result, format: :text)
     unless VALID_FORMATS.include?(format)
       raise Riffer::ArgumentError, "Invalid format: #{format}. Must be one of: #{VALID_FORMATS.join(", ")}"
@@ -42,49 +40,41 @@ class Riffer::Tools::Response
 
   # Creates a success response with text format.
   #
-  #: result: untyped -- the tool result (converted via to_s)
-  #: return: Riffer::Tools::Response
+  #: (untyped) -> Riffer::Tools::Response
   def self.text(result)
     success(result, format: :text)
   end
 
   # Creates a success response with JSON format.
   #
-  #: result: untyped -- the tool result (converted via to_json)
-  #: return: Riffer::Tools::Response
+  #: (untyped) -> Riffer::Tools::Response
   def self.json(result)
     success(result, format: :json)
   end
 
   # Creates an error response.
   #
-  #: message: String -- the error message
-  #: type: Symbol -- the error type (default: :execution_error)
-  #: return: Riffer::Tools::Response
+  #: (String, ?type: Symbol) -> Riffer::Tools::Response
   def self.error(message, type: :execution_error)
     new(content: message, success: false, error_message: message, error_type: type)
   end
 
-  #: return: bool
+  #: () -> bool
   def success? = @success
 
-  #: return: bool
+  #: () -> bool
   def error? = !@success
 
   # Returns a hash representation of the response.
   #
-  #: return: Hash[Symbol, untyped]
+  #: () -> Hash[Symbol, untyped]
   def to_h
     {content: @content, error: @error_message, error_type: @error_type}
   end
 
   private
 
-  #: content: String
-  #: success: bool
-  #: error_message: String?
-  #: error_type: Symbol?
-  #: return: void
+  #: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
   def initialize(content:, success:, error_message: nil, error_type: nil)
     @content = content
     @success = success

--- a/sig/generated/riffer.rbs
+++ b/sig/generated/riffer.rbs
@@ -17,8 +17,8 @@ module Riffer
   class TimeoutError < Error
   end
 
-  # : return: Riffer::Config
-  def self.config: () -> untyped
+  # : () -> Riffer::Config
+  def self.config: () -> Riffer::Config
 
   # Yields the configuration for block-based setup.
   #
@@ -26,10 +26,9 @@ module Riffer
   #     config.openai.api_key = ENV['OPENAI_API_KEY']
   #   end
   #
-  # : &block: (Riffer::Config) -> void
-  # : return: void
-  def self.configure: () ?{ (?) -> untyped } -> untyped
+  # : () ?{ (Riffer::Config) -> void } -> void
+  def self.configure: () ?{ (Riffer::Config) -> void } -> void
 
-  # : return: String
-  def self.version: () -> untyped
+  # : () -> String
+  def self.version: () -> String
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -23,68 +23,57 @@ class Riffer::Agent
 
   # Gets or sets the agent identifier.
   #
-  # : value: String? -- the identifier to set, or nil to get
-  # : return: String
-  def self.identifier: (?untyped value) -> untyped
+  # : (?String?) -> String
+  def self.identifier: (?String?) -> String
 
   # Gets or sets the model string (e.g., "openai/gpt-4o").
   #
-  # : model_string: String? -- the model string to set, or nil to get
-  # : return: String?
-  def self.model: (?untyped model_string) -> untyped
+  # : (?String?) -> String?
+  def self.model: (?String?) -> String?
 
   # Gets or sets the agent instructions.
   #
-  # : instructions_text: String? -- the instructions to set, or nil to get
-  # : return: String?
-  def self.instructions: (?untyped instructions_text) -> untyped
+  # : (?String?) -> String?
+  def self.instructions: (?String?) -> String?
 
   # Gets or sets provider options passed to the provider client.
   #
-  # : options: Hash[Symbol, untyped]? -- the options to set, or nil to get
-  # : return: Hash[Symbol, untyped]
-  def self.provider_options: (?untyped options) -> untyped
+  # : (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
+  def self.provider_options: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
 
   # Gets or sets model options passed to generate_text/stream_text.
   #
-  # : options: Hash[Symbol, untyped]? -- the options to set, or nil to get
-  # : return: Hash[Symbol, untyped]
-  def self.model_options: (?untyped options) -> untyped
+  # : (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
+  def self.model_options: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
 
   # Gets or sets the tools used by this agent.
   #
-  # : tools_or_lambda: (Array[singleton(Riffer::Tool)] | Proc)? -- tools array or lambda returning tools
-  # : return: (Array[singleton(Riffer::Tool)] | Proc)?
-  def self.uses_tools: (?untyped tools_or_lambda) -> untyped
+  # : (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
+  def self.uses_tools: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
 
   # Finds an agent class by identifier.
   #
-  # : identifier: String -- the identifier to search for
-  # : return: singleton(Riffer::Agent)?
-  def self.find: (untyped identifier) -> untyped
+  # : (String) -> singleton(Riffer::Agent)?
+  def self.find: (String) -> singleton(Riffer::Agent)?
 
   # Returns all agent subclasses.
   #
-  # : return: Array[singleton(Riffer::Agent)]
-  def self.all: () -> untyped
+  # : () -> Array[singleton(Riffer::Agent)]
+  def self.all: () -> Array[singleton(Riffer::Agent)]
 
   # Generates a response using a new agent instance.
   #
   # See #generate for parameters and return value.
   #
-  # : *args: untyped
-  # : **kwargs: untyped
-  # : return: String
-  def self.generate: () -> untyped
+  # : (*untyped, **untyped) -> String
+  def self.generate: (*untyped, **untyped) -> String
 
   # Streams a response using a new agent instance.
   #
   # See #stream for parameters and return value.
   #
-  # : *args: untyped
-  # : **kwargs: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def self.stream: () -> untyped
+  # : (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def self.stream: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # The message history for the agent.
   attr_reader messages: Array[Riffer::Messages::Base]
@@ -97,77 +86,64 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
-  # : return: void
-  def initialize: () -> untyped
+  # : () -> void
+  def initialize: () -> void
 
   # Generates a response from the agent.
   #
-  # : prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  # : tool_context: Hash[Symbol, untyped]? -- optional context object passed to all tool calls
-  # : return: String
-  def generate: (untyped prompt_or_messages, ?tool_context: untyped) -> untyped
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> String
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> String
 
   # Streams a response from the agent.
   #
-  # : prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  # : tool_context: Hash[Symbol, untyped]? -- optional context object passed to all tool calls
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (untyped prompt_or_messages, ?tool_context: untyped) -> untyped
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a callback to be invoked when messages are added during generation.
   #
   # Raises Riffer::ArgumentError if no block is given.
   #
-  # : &block: (Riffer::Messages::Base) -> void
-  # : return: self
-  def on_message: () ?{ (?) -> untyped } -> untyped
+  # : () { (Riffer::Messages::Base) -> void } -> self
+  def on_message: () { (Riffer::Messages::Base) -> void } -> self
 
   private
 
-  # : message: Riffer::Messages::Base
-  # : return: void
-  def add_message: (untyped message) -> untyped
+  # : (Riffer::Messages::Base) -> void
+  def add_message: (Riffer::Messages::Base) -> void
 
-  # : usage: Riffer::TokenUsage?
-  # : return: void
-  def track_token_usage: (untyped usage) -> untyped
+  # : (Riffer::TokenUsage?) -> void
+  def track_token_usage: (Riffer::TokenUsage?) -> void
 
-  # : prompt_or_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])
-  # : return: void
-  def initialize_messages: (untyped prompt_or_messages) -> untyped
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base])) -> void
+  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
 
-  # : return: Riffer::Messages::Assistant
-  def call_llm: () -> untyped
+  # : () -> Riffer::Messages::Assistant
+  def call_llm: () -> Riffer::Messages::Assistant
 
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def call_llm_stream: () -> untyped
+  # : () -> Enumerator[Riffer::StreamEvents::Base, void]
+  def call_llm_stream: () -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # : return: Riffer::Providers::Base
-  def provider_instance: () -> untyped
+  # : () -> Riffer::Providers::Base
+  def provider_instance: () -> Riffer::Providers::Base
 
-  # : response: Riffer::Messages::Assistant
-  # : return: bool
-  def has_tool_calls?: (untyped response) -> untyped
+  # : (Riffer::Messages::Assistant) -> bool
+  def has_tool_calls?: (Riffer::Messages::Assistant) -> bool
 
-  # : response: Riffer::Messages::Assistant
-  # : return: void
-  def execute_tool_calls: (untyped response) -> untyped
+  # : (Riffer::Messages::Assistant) -> void
+  def execute_tool_calls: (Riffer::Messages::Assistant) -> void
 
-  # : tool_call: Riffer::Messages::Assistant::ToolCall
-  # : return: Riffer::Tools::Response
-  def execute_tool_call: (untyped tool_call) -> untyped
+  # : (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+  def execute_tool_call: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
 
-  # : return: Array[singleton(Riffer::Tool)]
-  def resolved_tools: () -> untyped
+  # : () -> Array[singleton(Riffer::Tool)]
+  def resolved_tools: () -> Array[singleton(Riffer::Tool)]
 
-  # : name: String
-  # : return: singleton(Riffer::Tool)?
-  def find_tool_class: (untyped name) -> untyped
+  # : (String) -> singleton(Riffer::Tool)?
+  def find_tool_class: (String) -> singleton(Riffer::Tool)?
 
-  # : arguments: (String | Hash[String, untyped])?
-  # : return: Hash[Symbol, untyped]
-  def parse_tool_arguments: (untyped arguments) -> untyped
+  # : ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
 
-  # : return: String
-  def extract_final_response: () -> untyped
+  # : () -> String
+  def extract_final_response: () -> String
 end

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -55,6 +55,6 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader evals: Riffer::Config::Evals
 
-  # : return: void
-  def initialize: () -> untyped
+  # : () -> void
+  def initialize: () -> void
 end

--- a/sig/generated/riffer/core.rbs
+++ b/sig/generated/riffer/core.rbs
@@ -7,12 +7,11 @@ class Riffer::Core
   # The logger instance for Riffer.
   attr_reader logger: Logger
 
-  # : return: void
-  def initialize: () -> untyped
+  # : () -> void
+  def initialize: () -> void
 
   # Yields self for configuration.
   #
-  # : &block: (Riffer::Core) -> void
-  # : return: void
-  def configure: () ?{ (?) -> untyped } -> untyped
+  # : () ?{ (Riffer::Core) -> void } -> void
+  def configure: () ?{ (Riffer::Core) -> void } -> void
 end

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -26,52 +26,41 @@ class Riffer::Evals::Evaluator
 
   # Gets or sets the evaluator identifier.
   #
-  # : value: String? -- the identifier to set, or nil to get
-  # : return: String
-  def self.identifier: (?untyped value) -> untyped
+  # : (?String?) -> String
+  def self.identifier: (?String?) -> String
 
   # Gets or sets the evaluator description.
   #
-  # : value: String? -- the description to set, or nil to get
-  # : return: String?
-  def self.description: (?untyped value) -> untyped
+  # : (?String?) -> String?
+  def self.description: (?String?) -> String?
 
   # Gets or sets whether higher scores are better.
   #
-  # : value: bool? -- the value to set, or nil to get
-  # : return: bool
-  def self.higher_is_better: (?untyped value) -> untyped
+  # : (?bool?) -> bool
+  def self.higher_is_better: (?bool?) -> bool
 
   # Gets or sets the judge model for LLM-as-judge evaluations.
   #
-  # : value: String? -- the model to set (provider/model format), or nil to get
-  # : return: String?
-  def self.judge_model: (?untyped value) -> untyped
+  # : (?String?) -> String?
+  def self.judge_model: (?String?) -> String?
 
-  # : name: String?
-  # : return: String?
-  private def self.class_name_to_identifier: (untyped name) -> untyped
+  # : (String?) -> String?
+  private def self.class_name_to_identifier: (String?) -> String?
 
   # Evaluates an input/output pair.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  # : input: String -- the input that was given to the agent
-  # : output: String -- the output produced by the agent
-  # : context: Hash[Symbol, untyped]? -- optional context (e.g., ground_truth)
-  # : return: Riffer::Evals::Result
-  def evaluate: (input: untyped, output: untyped, ?context: untyped) -> untyped
+  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  def evaluate: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
 
   # Returns a Judge instance configured for this evaluator.
   #
-  # : return: Riffer::Evals::Judge
-  def judge: () -> untyped
+  # : () -> Riffer::Evals::Judge
+  def judge: () -> Riffer::Evals::Judge
 
   # Helper to build a Result object.
   #
-  # : score: Float -- the evaluation score (0.0 to 1.0)
-  # : reason: String? -- optional explanation
-  # : metadata: Hash[Symbol, untyped] -- optional additional data
-  # : return: Riffer::Evals::Result
-  def result: (score: untyped, ?reason: untyped, ?metadata: untyped) -> untyped
+  # : (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
+  def result: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
 end

--- a/sig/generated/riffer/evals/evaluators.rbs
+++ b/sig/generated/riffer/evals/evaluators.rbs
@@ -21,25 +21,22 @@ module Riffer::Evals::Evaluators
 
     # Registers a custom evaluator class with an identifier.
     #
-    # : identifier: (String | Symbol) -- the identifier to register
-    # : evaluator_class: singleton(Riffer::Evals::Evaluator) -- the evaluator class
-    # : return: void
-    def self.register: (untyped identifier, untyped evaluator_class) -> untyped
+    # : ((String | Symbol), singleton(Riffer::Evals::Evaluator)) -> void
+    def self.register: (String | Symbol, singleton(Riffer::Evals::Evaluator)) -> void
 
     # Finds an evaluator class by identifier.
     #
-    # : identifier: (String | Symbol) -- the identifier to look up
-    # : return: singleton(Riffer::Evals::Evaluator)?
-    def self.find: (untyped identifier) -> untyped
+    # : ((String | Symbol)) -> singleton(Riffer::Evals::Evaluator)?
+    def self.find: (String | Symbol) -> singleton(Riffer::Evals::Evaluator)?
 
     # Returns all registered evaluators (built-in and custom).
     #
-    # : return: Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
-    def self.all: () -> untyped
+    # : () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
+    def self.all: () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
 
     # Clears custom registrations (for testing). Built-ins remain.
     #
-    # : return: void
-    def self.clear: () -> untyped
+    # : () -> void
+    def self.clear: () -> void
   end
 end

--- a/sig/generated/riffer/evals/evaluators/answer_relevancy.rbs
+++ b/sig/generated/riffer/evals/evaluators/answer_relevancy.rbs
@@ -14,16 +14,11 @@
 class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
   SYSTEM_PROMPT: String
 
-  # : input: String -- the input that was given to the agent
-  # : output: String -- the output produced by the agent
-  # : context: Hash[Symbol, untyped]? -- optional context
-  # : return: Riffer::Evals::Result
-  def evaluate: (input: untyped, output: untyped, ?context: untyped) -> untyped
+  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  def evaluate: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
 
   private
 
-  # : input: String
-  # : output: String
-  # : return: String
-  def build_user_prompt: (input: untyped, output: untyped) -> untyped
+  # : (input: String, output: String) -> String
+  def build_user_prompt: (input: String, output: String) -> String
 end

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -16,11 +16,8 @@
 class Riffer::Evals::Judge
   # Internal tool for structured evaluation output.
   class EvaluationTool < Riffer::Tool
-    # : context: Hash[Symbol, untyped]?
-    # : score: Float
-    # : reason: String
-    # : return: Riffer::Tools::Response
-    def call: (context: untyped, score: untyped, reason: untyped) -> untyped
+    # : (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
+    def call: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
   end
 
   # The model string (provider/model format).
@@ -28,34 +25,28 @@ class Riffer::Evals::Judge
 
   # Initializes a new judge.
   #
-  # : model: String -- the model to use (provider/model format)
-  # : provider_options: Hash[Symbol, untyped] -- options passed to the provider
-  # : return: void
-  def initialize: (model: untyped, ?provider_options: untyped) -> untyped
+  # : (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
+  def initialize: (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
 
   # Evaluates using the configured LLM.
   #
   # Raises Riffer::ArgumentError if both messages and system_prompt/user_prompt are provided,
   # or if user_prompt is missing when messages is not provided.
   #
-  # : messages: Array[Hash[Symbol, untyped]]? -- array of message hashes
-  # : system_prompt: String? -- the system prompt for the judge
-  # : user_prompt: String? -- the user prompt containing the evaluation request
-  # : return: Hash[Symbol, untyped]
-  def evaluate: (?messages: untyped, ?system_prompt: untyped, ?user_prompt: untyped) -> untyped
+  # : (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
+  def evaluate: (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
 
   private
 
-  # : return: Riffer::Providers::Base
-  def provider_instance: () -> untyped
+  # : () -> Riffer::Providers::Base
+  def provider_instance: () -> Riffer::Providers::Base
 
-  # : return: String
-  def provider_name: () -> untyped
+  # : () -> String
+  def provider_name: () -> String
 
-  # : return: String
-  def model_name: () -> untyped
+  # : () -> String
+  def model_name: () -> String
 
-  # : response: Riffer::Messages::Assistant
-  # : return: Hash[Symbol, untyped]
-  def parse_tool_response: (untyped response) -> untyped
+  # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
+  def parse_tool_response: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/evals/metric.rbs
+++ b/sig/generated/riffer/evals/metric.rbs
@@ -26,26 +26,21 @@ class Riffer::Evals::Metric
 
   # Initializes a new metric.
   #
-  # : evaluator_identifier: String -- the evaluator to use
-  # : min: Float? -- minimum score threshold
-  # : max: Float? -- maximum score threshold
-  # : weight: Float -- weight for aggregation (default: 1.0)
-  # : return: void
-  def initialize: (evaluator_identifier: untyped, ?min: untyped, ?max: untyped, ?weight: untyped) -> untyped
+  # : (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
+  def initialize: (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
 
   # Returns the evaluator class for this metric.
   #
-  # : return: singleton(Riffer::Evals::Evaluator)?
-  def evaluator_class: () -> untyped
+  # : () -> singleton(Riffer::Evals::Evaluator)?
+  def evaluator_class: () -> singleton(Riffer::Evals::Evaluator)?
 
   # Checks if a result passes this metric's thresholds.
   #
-  # : result: Riffer::Evals::Result -- the evaluation result to check
-  # : return: bool
-  def passes?: (untyped result) -> untyped
+  # : (Riffer::Evals::Result) -> bool
+  def passes?: (Riffer::Evals::Result) -> bool
 
   # Returns a hash representation of the metric.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/evals/profile.rbs
+++ b/sig/generated/riffer/evals/profile.rbs
@@ -22,48 +22,39 @@
 #   result = MyAgent.run_eval(input: "What is Ruby?")
 #   result.passed?  # => true/false
 module Riffer::Evals::Profile
-  # : base: Module
-  # : return: void
-  def self.included: (untyped base) -> untyped
+  # : (Module) -> void
+  def self.included: (Module) -> void
 
   # DSL builder for configuring metrics within ai_evals block.
   class Builder
     # The configured metrics.
     attr_reader metrics: Array[Riffer::Evals::Metric]
 
-    # : return: void
-    def initialize: () -> untyped
+    # : () -> void
+    def initialize: () -> void
 
     # Defines a metric with thresholds.
     #
-    # : identifier: (Symbol | String) -- the evaluator identifier
-    # : min: Float? -- minimum score threshold
-    # : max: Float? -- maximum score threshold
-    # : weight: Float -- weight for aggregation (default: 1.0)
-    # : return: void
-    def metric: (untyped identifier, ?min: untyped, ?max: untyped, ?weight: untyped) -> untyped
+    # : ((Symbol | String), ?min: Float?, ?max: Float?, ?weight: Float) -> void
+    def metric: (Symbol | String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
   end
 
   module ClassMethods
     # Defines the eval metrics for this profile.
     #
-    # : &block: () -> void
-    # : return: void
-    def ai_evals: () ?{ (?) -> untyped } -> untyped
+    # : () { () -> void } -> void
+    def ai_evals: () { () -> void } -> void
 
     # Returns the configured metrics.
     #
-    # : return: Array[Riffer::Evals::Metric]
-    def eval_metrics: () -> untyped
+    # : () -> Array[Riffer::Evals::Metric]
+    def eval_metrics: () -> Array[Riffer::Evals::Metric]
   end
 
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    # : input: String -- the input to send to the agent
-    # : context: Hash[Symbol, untyped]? -- optional context for evaluation
-    # : tool_context: Hash[Symbol, untyped]? -- optional context passed to tools during generation
-    # : return: Riffer::Evals::RunResult
-    def run_eval: (input: untyped, ?context: untyped, ?tool_context: untyped) -> untyped
+    # : (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    def run_eval: (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   end
 end

--- a/sig/generated/riffer/evals/result.rbs
+++ b/sig/generated/riffer/evals/result.rbs
@@ -34,21 +34,16 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
-  # : evaluator: String -- the evaluator identifier
-  # : score: Float -- the score (0.0 to 1.0)
-  # : reason: String? -- optional explanation
-  # : metadata: Hash[Symbol, untyped] -- optional additional data
-  # : higher_is_better: bool -- whether higher is better (default: true)
-  # : return: void
-  def initialize: (evaluator: untyped, score: untyped, ?reason: untyped, ?metadata: untyped, ?higher_is_better: untyped) -> untyped
+  # : (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
+  def initialize: (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
 
   # Returns a hash representation of the result.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 
   private
 
-  # : return: void
-  def validate_score!: () -> untyped
+  # : () -> void
+  def validate_score!: () -> void
 end

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -33,23 +33,18 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  # : input: String -- the input that was evaluated
-  # : output: String -- the output that was evaluated
-  # : context: Hash[Symbol, untyped]? -- the evaluation context
-  # : results: Array[Riffer::Evals::Result] -- individual results
-  # : metrics: Array[Riffer::Evals::Metric] -- the metrics evaluated
-  # : return: void
-  def initialize: (input: untyped, output: untyped, context: untyped, results: untyped, metrics: untyped) -> untyped
+  # : (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  def initialize: (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
 
   # Checks if all metrics passed their thresholds.
   #
-  # : return: bool
-  def passed?: () -> untyped
+  # : () -> bool
+  def passed?: () -> bool
 
   # Returns results that failed their metric thresholds.
   #
-  # : return: Array[Riffer::Evals::Result]
-  def failures: () -> untyped
+  # : () -> Array[Riffer::Evals::Result]
+  def failures: () -> Array[Riffer::Evals::Result]
 
   # Calculates the weighted aggregate score.
   #
@@ -57,11 +52,11 @@ class Riffer::Evals::RunResult
   # For evaluators where lower is better (e.g., toxicity), the score is
   # inverted (1 - score) before aggregation.
   #
-  # : return: Float
-  def aggregate_score: () -> untyped
+  # : () -> Float
+  def aggregate_score: () -> Float
 
   # Returns a hash representation of the run result.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/evals/runner.rbs
+++ b/sig/generated/riffer/evals/runner.rbs
@@ -17,15 +17,11 @@ class Riffer::Evals::Runner
 
   # Initializes a new runner.
   #
-  # : metrics: Array[Riffer::Evals::Metric] -- the metrics to evaluate
-  # : return: void
-  def initialize: (metrics: untyped) -> untyped
+  # : (metrics: Array[Riffer::Evals::Metric]) -> void
+  def initialize: (metrics: Array[Riffer::Evals::Metric]) -> void
 
   # Runs all evaluators and collects results.
   #
-  # : input: String -- the input given to the agent
-  # : output: String -- the output produced by the agent
-  # : context: Hash[Symbol, untyped]? -- optional context (e.g., ground_truth)
-  # : return: Riffer::Evals::RunResult
-  def run: (input: untyped, output: untyped, ?context: untyped) -> untyped
+  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  def run: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
 end

--- a/sig/generated/riffer/helpers/class_name_converter.rbs
+++ b/sig/generated/riffer/helpers/class_name_converter.rbs
@@ -6,8 +6,6 @@ module Riffer::Helpers::ClassNameConverter
 
   # Converts a class name to snake_case identifier format.
   #
-  # : class_name: String -- the class name (e.g., "Riffer::Agent")
-  # : separator: String -- the separator to use for namespaces (default: "/")
-  # : return: String
-  def class_name_to_path: (untyped class_name, ?separator: untyped) -> untyped
+  # : (String, ?separator: String) -> String
+  def class_name_to_path: (String, ?separator: String) -> String
 end

--- a/sig/generated/riffer/helpers/dependencies.rbs
+++ b/sig/generated/riffer/helpers/dependencies.rbs
@@ -20,8 +20,6 @@ module Riffer::Helpers::Dependencies
   # Raises LoadError if the gem is not installed.
   # Raises VersionError if the gem version does not satisfy requirements.
   #
-  # : gem_name: String -- the gem name
-  # : req: (bool | String) -- true to require the gem, false to skip, or String to require a different lib
-  # : return: true
-  def depends_on: (untyped gem_name, ?req: untyped) -> untyped
+  # : (String, ?req: (bool | String)) -> true
+  def depends_on: (String, ?req: bool | String) -> true
 end

--- a/sig/generated/riffer/helpers/validations.rbs
+++ b/sig/generated/riffer/helpers/validations.rbs
@@ -6,8 +6,6 @@ module Riffer::Helpers::Validations
   #
   # Raises Riffer::ArgumentError if the value is not a string or is empty.
   #
-  # : value: untyped -- the value to validate
-  # : name: String -- the name of the value for error messages
-  # : return: true
-  def validate_is_string!: (untyped value, ?untyped name) -> untyped
+  # : (untyped, ?String) -> true
+  def validate_is_string!: (untyped, ?String) -> true
 end

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -28,17 +28,14 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # Token usage data for this response.
   attr_reader token_usage: Riffer::TokenUsage?
 
-  # : content: String
-  # : tool_calls: Array[Riffer::Messages::Assistant::ToolCall] -- optional tool calls
-  # : token_usage: Riffer::TokenUsage? -- optional token usage data
-  # : return: void
-  def initialize: (untyped content, ?tool_calls: untyped, ?token_usage: untyped) -> untyped
+  # : (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?) -> void
+  def initialize: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?) -> void
 
-  # : return: Symbol
-  def role: () -> untyped
+  # : () -> Symbol
+  def role: () -> Symbol
 
   # Converts the message to a hash.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/messages/base.rbs
+++ b/sig/generated/riffer/messages/base.rbs
@@ -7,19 +7,18 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader content: String
 
-  # : content: String
-  # : return: void
-  def initialize: (untyped content) -> untyped
+  # : (String) -> void
+  def initialize: (String) -> void
 
   # Converts the message to a hash.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 
   # Returns the message role.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  # : return: Symbol
-  def role: () -> untyped
+  # : () -> Symbol
+  def role: () -> Symbol
 end

--- a/sig/generated/riffer/messages/converter.rbs
+++ b/sig/generated/riffer/messages/converter.rbs
@@ -8,13 +8,11 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
-  # : msg: (Hash[Symbol | String, untyped] | Riffer::Messages::Base)
-  # : return: Riffer::Messages::Base
-  def convert_to_message_object: (untyped msg) -> untyped
+  # : ((Hash[Symbol | String, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
+  def convert_to_message_object: (Hash[Symbol | String, untyped] | Riffer::Messages::Base) -> Riffer::Messages::Base
 
   private
 
-  # : hash: Hash[Symbol | String, untyped]
-  # : return: Riffer::Messages::Base
-  def convert_hash_to_message: (untyped hash) -> untyped
+  # : (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
+  def convert_hash_to_message: (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
 end

--- a/sig/generated/riffer/messages/system.rbs
+++ b/sig/generated/riffer/messages/system.rbs
@@ -6,6 +6,6 @@
 #   msg.role     # => :system
 #   msg.content  # => "You are a helpful assistant."
 class Riffer::Messages::System < Riffer::Messages::Base
-  # : return: Symbol
-  def role: () -> untyped
+  # : () -> Symbol
+  def role: () -> Symbol
 end

--- a/sig/generated/riffer/messages/tool.rbs
+++ b/sig/generated/riffer/messages/tool.rbs
@@ -23,24 +23,19 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
   attr_reader error_type: Symbol?
 
-  # : content: String -- the tool execution result
-  # : tool_call_id: String -- the ID of the tool call
-  # : name: String -- the tool name
-  # : error: String? -- optional error message
-  # : error_type: Symbol? -- optional error type
-  # : return: void
-  def initialize: (untyped content, tool_call_id: untyped, name: untyped, ?error: untyped, ?error_type: untyped) -> untyped
+  # : (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
+  def initialize: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
 
   # Returns true if the tool execution resulted in an error.
   #
-  # : return: bool
-  def error?: () -> untyped
+  # : () -> bool
+  def error?: () -> bool
 
-  # : return: Symbol
-  def role: () -> untyped
+  # : () -> Symbol
+  def role: () -> Symbol
 
   # Converts the message to a hash.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/messages/user.rbs
+++ b/sig/generated/riffer/messages/user.rbs
@@ -6,6 +6,6 @@
 #   msg.role     # => :user
 #   msg.content  # => "Hello!"
 class Riffer::Messages::User < Riffer::Messages::Base
-  # : return: Symbol
-  def role: () -> untyped
+  # : () -> Symbol
+  def role: () -> Symbol
 end

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -8,53 +8,35 @@
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # Initializes the Amazon Bedrock provider.
   #
-  # : api_token: String? -- Bearer token for API authentication
-  # : region: String? -- AWS region
-  # : **options: untyped
-  # : return: void
-  def initialize: (?api_token: untyped, ?region: untyped, **untyped options) -> untyped
+  # : (?api_token: String?, ?region: String?, **untyped) -> void
+  def initialize: (?api_token: String?, ?region: String?, **untyped) -> void
 
   private
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def perform_generate_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
+  def perform_generate_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def perform_stream_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def perform_stream_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : return: Hash[Symbol, untyped]
-  def partition_messages: (untyped messages) -> untyped
+  # : (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
+  def partition_messages: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
 
-  # : conversation_messages: Array[Hash[Symbol, untyped]]
-  # : message: Riffer::Messages::Tool
-  # : return: void
-  def append_tool_result: (untyped conversation_messages, untyped message) -> untyped
+  # : (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
+  def append_tool_result: (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
 
-  # : message: Riffer::Messages::Assistant
-  # : return: Hash[Symbol, untyped]
-  def convert_assistant_to_bedrock_format: (untyped message) -> untyped
+  # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
+  def convert_assistant_to_bedrock_format: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 
-  # : arguments: (String | Hash[String, untyped])?
-  # : return: Hash[String, untyped]
-  def parse_tool_arguments: (untyped arguments) -> untyped
+  # : ((String | Hash[String, untyped])?) -> Hash[String, untyped]
+  def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
 
-  # : response: Aws::BedrockRuntime::Types::ConverseResponse
-  # : return: Riffer::TokenUsage?
-  def extract_token_usage: (untyped response) -> untyped
+  # : (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
+  def extract_token_usage: (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
 
-  # : response: Aws::BedrockRuntime::Types::ConverseResponse
-  # : token_usage: Riffer::TokenUsage?
-  # : return: Riffer::Messages::Assistant
-  def extract_assistant_message: (untyped response, ?untyped token_usage) -> untyped
+  # : (Aws::BedrockRuntime::Types::ConverseResponse, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
+  def extract_assistant_message: (Aws::BedrockRuntime::Types::ConverseResponse, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
 
-  # : tool: singleton(Riffer::Tool)
-  # : return: Hash[Symbol, untyped]
-  def convert_tool_to_bedrock_format: (untyped tool) -> untyped
+  # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
+  def convert_tool_to_bedrock_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -8,47 +8,32 @@
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
   # Initializes the Anthropic provider.
   #
-  # : api_key: String? -- Anthropic API key
-  # : **options: untyped
-  # : return: void
-  def initialize: (?api_key: untyped, **untyped options) -> untyped
+  # : (?api_key: String?, **untyped) -> void
+  def initialize: (?api_key: String?, **untyped) -> void
 
   private
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def perform_generate_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
+  def perform_generate_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def perform_stream_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def perform_stream_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : return: Hash[Symbol, untyped]
-  def partition_messages: (untyped messages) -> untyped
+  # : (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
+  def partition_messages: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
 
-  # : message: Riffer::Messages::Assistant
-  # : return: Hash[Symbol, untyped]
-  def convert_assistant_to_anthropic_format: (untyped message) -> untyped
+  # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
+  def convert_assistant_to_anthropic_format: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 
-  # : arguments: (String | Hash[String, untyped])?
-  # : return: Hash[String, untyped]
-  def parse_tool_arguments: (untyped arguments) -> untyped
+  # : ((String | Hash[String, untyped])?) -> Hash[String, untyped]
+  def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
 
-  # : response: Anthropic::Models::Message
-  # : return: Riffer::TokenUsage?
-  def extract_token_usage: (untyped response) -> untyped
+  # : (Anthropic::Models::Message) -> Riffer::TokenUsage?
+  def extract_token_usage: (Anthropic::Models::Message) -> Riffer::TokenUsage?
 
-  # : response: Anthropic::Models::Message
-  # : token_usage: Riffer::TokenUsage?
-  # : return: Riffer::Messages::Assistant
-  def extract_assistant_message: (untyped response, ?untyped token_usage) -> untyped
+  # : (Anthropic::Models::Message, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
+  def extract_assistant_message: (Anthropic::Models::Message, ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
 
-  # : tool: singleton(Riffer::Tool)
-  # : return: Hash[Symbol, untyped]
-  def convert_tool_to_anthropic_format: (untyped tool) -> untyped
+  # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
+  def convert_tool_to_anthropic_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -10,51 +10,28 @@ class Riffer::Providers::Base
 
   # Generates text using the provider.
   #
-  # : prompt: String? -- the user prompt (required when messages is not provided)
-  # : system: String? -- an optional system message
-  # : messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]? -- optional messages array
-  # : model: String? -- optional model string to override the configured model
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def generate_text: (?prompt: untyped, ?system: untyped, ?messages: untyped, ?model: untyped, **untyped options) -> untyped
+  # : (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Riffer::Messages::Assistant
+  def generate_text: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Riffer::Messages::Assistant
 
   # Streams text from the provider.
   #
-  # : prompt: String? -- the user prompt (required when messages is not provided)
-  # : system: String? -- an optional system message
-  # : messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]? -- optional messages array
-  # : model: String? -- optional model string to override the configured model
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def stream_text: (?prompt: untyped, ?system: untyped, ?messages: untyped, ?model: untyped, **untyped options) -> untyped
+  # : (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream_text: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   private
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String?
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def perform_generate_text: (untyped messages, ?model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
+  def perform_generate_text: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String?
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def perform_stream_text: (untyped messages, ?model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def perform_stream_text: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # : prompt: String?
-  # : system: String?
-  # : messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?
-  # : return: void
-  def validate_input!: (prompt: untyped, system: untyped, messages: untyped) -> untyped
+  # : (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
+  def validate_input!: (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
 
-  # : prompt: String?
-  # : system: String?
-  # : messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?
-  # : return: Array[Riffer::Messages::Base]
-  def normalize_messages: (prompt: untyped, system: untyped, messages: untyped) -> untyped
+  # : (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?) -> Array[Riffer::Messages::Base]
+  def normalize_messages: (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?) -> Array[Riffer::Messages::Base]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : return: void
-  def validate_normalized_messages!: (untyped messages) -> untyped
+  # : (Array[Riffer::Messages::Base]) -> void
+  def validate_normalized_messages!: (Array[Riffer::Messages::Base]) -> void
 end

--- a/sig/generated/riffer/providers/open_ai.rbs
+++ b/sig/generated/riffer/providers/open_ai.rbs
@@ -6,63 +6,41 @@
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
   # Initializes the OpenAI provider.
   #
-  # : **options: untyped
-  # : return: void
-  def initialize: (**untyped options) -> untyped
+  # : (**untyped) -> void
+  def initialize: (**untyped) -> void
 
   private
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def perform_generate_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
+  def perform_generate_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Riffer::Messages::Assistant
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def perform_stream_text: (untyped messages, model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def perform_stream_text: (Array[Riffer::Messages::Base], model: String, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String
-  # : options: Hash[Symbol, untyped]
-  # : return: Hash[Symbol, untyped]
-  def build_request_params: (untyped messages, untyped model, untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], String, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def build_request_params: (Array[Riffer::Messages::Base], String, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : return: Array[Hash[Symbol, untyped]]
-  def convert_messages_to_openai_format: (untyped messages) -> untyped
+  # : (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
+  def convert_messages_to_openai_format: (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
 
-  # : message: Riffer::Messages::Assistant
-  # : return: (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
-  def convert_assistant_to_openai_format: (untyped message) -> untyped
+  # : (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
+  def convert_assistant_to_openai_format: (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
 
-  # : response: OpenAI::Models::Responses::Response
-  # : return: Riffer::TokenUsage?
-  def extract_token_usage: (untyped response) -> untyped
+  # : (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
+  def extract_token_usage: (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
 
-  # : output_items: Array[OpenAI::Models::Responses::response_output_item]
-  # : token_usage: Riffer::TokenUsage?
-  # : return: Riffer::Messages::Assistant
-  def extract_assistant_message: (untyped output_items, ?untyped token_usage) -> untyped
+  # : (Array[OpenAI::Models::Responses::response_output_item], ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
+  def extract_assistant_message: (Array[OpenAI::Models::Responses::response_output_item], ?Riffer::TokenUsage?) -> Riffer::Messages::Assistant
 
-  # : stream: OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event]
-  # : yielder: Enumerator::Yielder
-  # : return: void
-  def process_stream_events: (untyped stream, untyped yielder) -> untyped
+  # : (OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event], Enumerator::Yielder) -> void
+  def process_stream_events: (OpenAI::Internal::Stream[OpenAI::Models::Responses::response_stream_event], Enumerator::Yielder) -> void
 
-  # : event: OpenAI::Models::Responses::response_stream_event
-  # : tool_info: Hash[String, Hash[Symbol, untyped]]
-  # : return: void
-  def track_tool_info: (untyped event, untyped tool_info) -> untyped
+  # : (OpenAI::Models::Responses::response_stream_event, Hash[String, Hash[Symbol, untyped]]) -> void
+  def track_tool_info: (OpenAI::Models::Responses::response_stream_event, Hash[String, Hash[Symbol, untyped]]) -> void
 
-  # : event: OpenAI::Models::Responses::response_stream_event
-  # : tool_info: Hash[String, Hash[Symbol, untyped]]
-  # : return: Riffer::StreamEvents::Base?
-  def convert_event: (untyped event, ?untyped tool_info) -> untyped
+  # : (OpenAI::Models::Responses::response_stream_event, ?Hash[String, Hash[Symbol, untyped]]) -> Riffer::StreamEvents::Base?
+  def convert_event: (OpenAI::Models::Responses::response_stream_event, ?Hash[String, Hash[Symbol, untyped]]) -> Riffer::StreamEvents::Base?
 
-  # : tool: singleton(Riffer::Tool)
-  # : return: Hash[Symbol, untyped]
-  def convert_tool_to_openai_format: (untyped tool) -> untyped
+  # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
+  def convert_tool_to_openai_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/repository.rbs
+++ b/sig/generated/riffer/providers/repository.rbs
@@ -7,7 +7,6 @@ class Riffer::Providers::Repository
 
   # Finds a provider class by identifier.
   #
-  # : identifier: (String | Symbol) -- the identifier to search for
-  # : return: singleton(Riffer::Providers::Base)?
-  def self.find: (untyped identifier) -> untyped
+  # : ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
+  def self.find: (String | Symbol) -> singleton(Riffer::Providers::Base)?
 end

--- a/sig/generated/riffer/providers/test.rbs
+++ b/sig/generated/riffer/providers/test.rbs
@@ -9,9 +9,8 @@ class Riffer::Providers::Test < Riffer::Providers::Base
 
   # Initializes the test provider.
   #
-  # : **options: untyped
-  # : return: void
-  def initialize: (**untyped options) -> untyped
+  # : (**untyped) -> void
+  def initialize: (**untyped) -> void
 
   # Stubs the next response from the provider.
   #
@@ -21,31 +20,22 @@ class Riffer::Providers::Test < Riffer::Providers::Base
   #   provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
   #   provider.stub_response("Final response", token_usage: Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 5))
   #
-  # : content: String -- the response content
-  # : tool_calls: Array[Hash[Symbol, untyped]] -- optional tool calls to include
-  # : token_usage: Riffer::TokenUsage? -- optional token usage data to include
-  # : return: void
-  def stub_response: (untyped content, ?tool_calls: untyped, ?token_usage: untyped) -> untyped
+  # : (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
+  def stub_response: (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
 
   # Clears all stubbed responses.
   #
-  # : return: void
-  def clear_stubs: () -> untyped
+  # : () -> void
+  def clear_stubs: () -> void
 
   private
 
-  # : return: Hash[Symbol, untyped]
-  def next_response: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def next_response: () -> Hash[Symbol, untyped]
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String?
-  # : **options: untyped
-  # : return: Riffer::Messages::Assistant
-  def perform_generate_text: (untyped messages, ?model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
+  def perform_generate_text: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Riffer::Messages::Assistant
 
-  # : messages: Array[Riffer::Messages::Base]
-  # : model: String?
-  # : **options: untyped
-  # : return: Enumerator[Riffer::StreamEvents::Base, void]
-  def perform_stream_text: (untyped messages, ?model: untyped, **untyped options) -> untyped
+  # : (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def perform_stream_text: (Array[Riffer::Messages::Base], ?model: String?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 end

--- a/sig/generated/riffer/stream_events/base.rbs
+++ b/sig/generated/riffer/stream_events/base.rbs
@@ -7,14 +7,13 @@ class Riffer::StreamEvents::Base
   # The message role (typically :assistant).
   attr_reader role: Symbol
 
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (?role: untyped) -> untyped
+  # : (?role: Symbol) -> void
+  def initialize: (?role: Symbol) -> void
 
   # Converts the event to a hash.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/reasoning_delta.rbs
+++ b/sig/generated/riffer/stream_events/reasoning_delta.rbs
@@ -8,11 +8,9 @@ class Riffer::StreamEvents::ReasoningDelta < Riffer::StreamEvents::Base
   # The incremental reasoning content.
   attr_reader content: String
 
-  # : content: String -- the incremental reasoning content
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (untyped content, ?role: untyped) -> untyped
+  # : (String, ?role: Symbol) -> void
+  def initialize: (String, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/reasoning_done.rbs
+++ b/sig/generated/riffer/stream_events/reasoning_done.rbs
@@ -8,11 +8,9 @@ class Riffer::StreamEvents::ReasoningDone < Riffer::StreamEvents::Base
   # The complete reasoning content.
   attr_reader content: String
 
-  # : content: String -- the complete reasoning content
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (untyped content, ?role: untyped) -> untyped
+  # : (String, ?role: Symbol) -> void
+  def initialize: (String, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/text_delta.rbs
+++ b/sig/generated/riffer/stream_events/text_delta.rbs
@@ -7,11 +7,9 @@ class Riffer::StreamEvents::TextDelta < Riffer::StreamEvents::Base
   # The incremental text content.
   attr_reader content: String
 
-  # : content: String -- the incremental text content
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (untyped content, ?role: untyped) -> untyped
+  # : (String, ?role: Symbol) -> void
+  def initialize: (String, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/text_done.rbs
+++ b/sig/generated/riffer/stream_events/text_done.rbs
@@ -7,11 +7,9 @@ class Riffer::StreamEvents::TextDone < Riffer::StreamEvents::Base
   # The complete text content.
   attr_reader content: String
 
-  # : content: String -- the complete text content
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (untyped content, ?role: untyped) -> untyped
+  # : (String, ?role: Symbol) -> void
+  def initialize: (String, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/token_usage_done.rbs
+++ b/sig/generated/riffer/stream_events/token_usage_done.rbs
@@ -11,11 +11,9 @@ class Riffer::StreamEvents::TokenUsageDone < Riffer::StreamEvents::Base
   # The token usage data for this response.
   attr_reader token_usage: Riffer::TokenUsage
 
-  # : token_usage: Riffer::TokenUsage -- the token usage data
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (token_usage: untyped, ?role: untyped) -> untyped
+  # : (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
+  def initialize: (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/tool_call_delta.rbs
+++ b/sig/generated/riffer/stream_events/tool_call_delta.rbs
@@ -13,13 +13,9 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
   # The incremental arguments JSON fragment.
   attr_reader arguments_delta: String
 
-  # : item_id: String -- the tool call item identifier
-  # : arguments_delta: String -- the incremental arguments JSON fragment
-  # : name: String? -- the tool name (may only be present in first delta)
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (item_id: untyped, arguments_delta: untyped, ?name: untyped, ?role: untyped) -> untyped
+  # : (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
+  def initialize: (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/tool_call_done.rbs
+++ b/sig/generated/riffer/stream_events/tool_call_done.rbs
@@ -16,14 +16,9 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
   # The complete arguments JSON string.
   attr_reader arguments: String
 
-  # : item_id: String -- the tool call item identifier
-  # : call_id: String -- the call identifier for response matching
-  # : name: String -- the tool name
-  # : arguments: String -- the complete arguments JSON string
-  # : role: Symbol -- the message role (defaults to :assistant)
-  # : return: void
-  def initialize: (item_id: untyped, call_id: untyped, name: untyped, arguments: untyped, ?role: untyped) -> untyped
+  # : (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
+  def initialize: (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
 
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/token_usage.rbs
+++ b/sig/generated/riffer/token_usage.rbs
@@ -21,35 +21,28 @@ class Riffer::TokenUsage
   # Number of tokens read from cache (Anthropic-specific).
   attr_reader cache_read_tokens: Integer?
 
-  # : input_tokens: Integer
-  # : output_tokens: Integer
-  # : cache_creation_tokens: Integer? -- tokens written to cache
-  # : cache_read_tokens: Integer? -- tokens read from cache
-  # : return: void
-  def initialize: (input_tokens: untyped, output_tokens: untyped, ?cache_creation_tokens: untyped, ?cache_read_tokens: untyped) -> untyped
+  # : (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
+  def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
 
   # Returns the total number of tokens (input + output).
   #
-  # : return: Integer
-  def total_tokens: () -> untyped
+  # : () -> Integer
+  def total_tokens: () -> Integer
 
   # Combines two TokenUsage objects for cumulative tracking.
   #
-  # : other: Riffer::TokenUsage
-  # : return: Riffer::TokenUsage
-  def +: (untyped other) -> untyped
+  # : (Riffer::TokenUsage) -> Riffer::TokenUsage
+  def +: (Riffer::TokenUsage) -> Riffer::TokenUsage
 
   # Converts the token usage to a hash representation.
   #
   # Cache tokens are omitted if nil.
   #
-  # : return: Hash[Symbol, Integer]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, Integer]
+  def to_h: () -> Hash[Symbol, Integer]
 
   private
 
-  # : a: Integer?
-  # : b: Integer?
-  # : return: Integer?
-  def add_nullable: (untyped a, untyped b) -> untyped
+  # : (Integer?, Integer?) -> Integer?
+  def add_nullable: (Integer?, Integer?) -> Integer?
 end

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -29,38 +29,33 @@ class Riffer::Tool
 
   # Gets or sets the tool description.
   #
-  # : value: String? -- the description to set, or nil to get
-  # : return: String?
-  def self.description: (?untyped value) -> untyped
+  # : (?String?) -> String?
+  def self.description: (?String?) -> String?
 
   # Gets or sets the tool identifier/name.
   #
-  # : value: String? -- the identifier to set, or nil to get
-  # : return: String
-  def self.identifier: (?untyped value) -> untyped
+  # : (?String?) -> String
+  def self.identifier: (?String?) -> String
 
   # Alias for identifier - used by providers.
   #
-  # : value: String? -- the name to set, or nil to get
-  # : return: String
-  def self.name: (?untyped value) -> untyped
+  # : (?String?) -> String
+  def self.name: (?String?) -> String
 
   # Gets or sets the tool timeout in seconds.
   #
-  # : value: (Integer | Float)? -- the timeout to set in seconds, or nil to get
-  # : return: (Integer | Float)
-  def self.timeout: (?untyped value) -> untyped
+  # : (?(Integer | Float)?) -> (Integer | Float)
+  def self.timeout: (?(Integer | Float)?) -> (Integer | Float)
 
   # Defines parameters using the Params DSL.
   #
-  # : &block: () -> void
-  # : return: Riffer::Tools::Params?
-  def self.params: () ?{ (?) -> untyped } -> untyped
+  # : () ?{ () -> void } -> Riffer::Tools::Params?
+  def self.params: () ?{ () -> void } -> Riffer::Tools::Params?
 
   # Returns the JSON Schema for the tool's parameters.
   #
-  # : return: Hash[Symbol, untyped]
-  def self.parameters_schema: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def self.parameters_schema: () -> Hash[Symbol, untyped]
 
   def self.empty_schema: () -> untyped
 
@@ -68,29 +63,23 @@ class Riffer::Tool
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  # : context: Hash[Symbol, untyped]? -- optional context passed from the agent
-  # : **kwargs: untyped
-  # : return: Riffer::Tools::Response
-  def call: (context: untyped, **untyped kwargs) -> untyped
+  # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  def call: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
 
   # Creates a text response. Shorthand for Riffer::Tools::Response.text.
   #
-  # : result: untyped -- the tool result (converted via to_s)
-  # : return: Riffer::Tools::Response
-  def text: (untyped result) -> untyped
+  # : (untyped) -> Riffer::Tools::Response
+  def text: (untyped) -> Riffer::Tools::Response
 
   # Creates a JSON response. Shorthand for Riffer::Tools::Response.json.
   #
-  # : result: untyped -- the tool result (converted via JSON.generate)
-  # : return: Riffer::Tools::Response
-  def json: (untyped result) -> untyped
+  # : (untyped) -> Riffer::Tools::Response
+  def json: (untyped) -> Riffer::Tools::Response
 
   # Creates an error response. Shorthand for Riffer::Tools::Response.error.
   #
-  # : message: String -- the error message
-  # : type: Symbol -- the error type (default: :execution_error)
-  # : return: Riffer::Tools::Response
-  def error: (untyped message, ?type: untyped) -> untyped
+  # : (String, ?type: Symbol) -> Riffer::Tools::Response
+  def error: (String, ?type: Symbol) -> Riffer::Tools::Response
 
   # Executes the tool with validation and timeout (used by Agent).
   #
@@ -98,8 +87,6 @@ class Riffer::Tool
   # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
   # Raises Riffer::Error if the tool does not return a Response object.
   #
-  # : context: Hash[Symbol, untyped]? -- context passed from the agent
-  # : **kwargs: untyped
-  # : return: Riffer::Tools::Response
-  def call_with_validation: (context: untyped, **untyped kwargs) -> untyped
+  # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  def call_with_validation: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
 end

--- a/sig/generated/riffer/tools/param.rbs
+++ b/sig/generated/riffer/tools/param.rbs
@@ -19,28 +19,21 @@ class Riffer::Tools::Param
 
   attr_reader default: untyped
 
-  # : name: Symbol -- the parameter name
-  # : type: Class -- the expected Ruby type
-  # : required: bool -- whether the parameter is required
-  # : description: String? -- optional description for the parameter
-  # : enum: Array[untyped]? -- optional list of allowed values
-  # : default: untyped -- optional default value for optional parameters
-  # : return: void
-  def initialize: (name: untyped, type: untyped, required: untyped, ?description: untyped, ?enum: untyped, ?default: untyped) -> untyped
+  # : (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
+  def initialize: (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
 
   # Validates that a value matches the expected type.
   #
-  # : value: untyped
-  # : return: bool
-  def valid_type?: (untyped value) -> untyped
+  # : (untyped) -> bool
+  def valid_type?: (untyped) -> bool
 
   # Returns the JSON Schema type name for this parameter.
   #
-  # : return: String
-  def type_name: () -> untyped
+  # : () -> String
+  def type_name: () -> String
 
   # Converts this parameter to JSON Schema format.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_json_schema: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_json_schema: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/tools/params.rbs
+++ b/sig/generated/riffer/tools/params.rbs
@@ -11,38 +11,28 @@
 class Riffer::Tools::Params
   attr_reader parameters: Array[Riffer::Tools::Param]
 
-  # : return: void
-  def initialize: () -> untyped
+  # : () -> void
+  def initialize: () -> void
 
   # Defines a required parameter.
   #
-  # : name: Symbol -- the parameter name
-  # : type: Class -- the expected Ruby type
-  # : description: String? -- optional description
-  # : enum: Array[untyped]? -- optional list of allowed values
-  # : return: void
-  def required: (untyped name, untyped type, ?description: untyped, ?enum: untyped) -> untyped
+  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?) -> void
+  def required: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?) -> void
 
   # Defines an optional parameter.
   #
-  # : name: Symbol -- the parameter name
-  # : type: Class -- the expected Ruby type
-  # : description: String? -- optional description
-  # : enum: Array[untyped]? -- optional list of allowed values
-  # : default: untyped -- default value when not provided
-  # : return: void
-  def optional: (untyped name, untyped type, ?description: untyped, ?enum: untyped, ?default: untyped) -> untyped
+  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
+  def optional: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
 
   # Validates arguments against parameter definitions.
   #
   # Raises Riffer::ValidationError if validation fails.
   #
-  # : arguments: Hash[Symbol, untyped]
-  # : return: Hash[Symbol, untyped]
-  def validate: (untyped arguments) -> untyped
+  # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def validate: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
   # Converts all parameters to JSON Schema format.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_json_schema: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_json_schema: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/tools/response.rbs
+++ b/sig/generated/riffer/tools/response.rbs
@@ -26,47 +26,37 @@ class Riffer::Tools::Response
   #
   # Raises Riffer::ArgumentError if format is invalid.
   #
-  # : result: untyped -- the tool result
-  # : format: Symbol -- the format (:text or :json; default: :text)
-  # : return: Riffer::Tools::Response
-  def self.success: (untyped result, ?format: untyped) -> untyped
+  # : (untyped, ?format: Symbol) -> Riffer::Tools::Response
+  def self.success: (untyped, ?format: Symbol) -> Riffer::Tools::Response
 
   # Creates a success response with text format.
   #
-  # : result: untyped -- the tool result (converted via to_s)
-  # : return: Riffer::Tools::Response
-  def self.text: (untyped result) -> untyped
+  # : (untyped) -> Riffer::Tools::Response
+  def self.text: (untyped) -> Riffer::Tools::Response
 
   # Creates a success response with JSON format.
   #
-  # : result: untyped -- the tool result (converted via to_json)
-  # : return: Riffer::Tools::Response
-  def self.json: (untyped result) -> untyped
+  # : (untyped) -> Riffer::Tools::Response
+  def self.json: (untyped) -> Riffer::Tools::Response
 
   # Creates an error response.
   #
-  # : message: String -- the error message
-  # : type: Symbol -- the error type (default: :execution_error)
-  # : return: Riffer::Tools::Response
-  def self.error: (untyped message, ?type: untyped) -> untyped
+  # : (String, ?type: Symbol) -> Riffer::Tools::Response
+  def self.error: (String, ?type: Symbol) -> Riffer::Tools::Response
 
-  # : return: bool
-  def success?: () -> untyped
+  # : () -> bool
+  def success?: () -> bool
 
-  # : return: bool
-  def error?: () -> untyped
+  # : () -> bool
+  def error?: () -> bool
 
   # Returns a hash representation of the response.
   #
-  # : return: Hash[Symbol, untyped]
-  def to_h: () -> untyped
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
 
   private
 
-  # : content: String
-  # : success: bool
-  # : error_message: String?
-  # : error_type: Symbol?
-  # : return: void
-  def initialize: (content: untyped, success: untyped, ?error_message: untyped, ?error_type: untyped) -> untyped
+  # : (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
+  def initialize: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
 end


### PR DESCRIPTION
## Summary

- Update RBS inline annotations across all `lib/` files to use proper method signature syntax (`#: (Type) -> ReturnType`) instead of the incorrect per-parameter format
- Remove internal instance variable type declarations (`# @rbs @var` / `# @rbs self.@var`) from 11 files — these aren't part of the public API since consumers interact through `attr_reader` which already has inline type annotations
- Update `.agents/rbs-inline.md` and `.agents/code-style.md` to reflect the corrected annotation style

## Test plan

- [x] `bundle exec rake rbs:generate` — regenerated RBS files successfully
- [x] `bundle exec rake` — 599 tests pass, no Steep type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)