### PR TITLE
chore: add .gitattributes to hide generated RBS files in GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sig/generated/** linguist-generated=true


### PR DESCRIPTION
This pull request adds a new rule to the `.gitattributes` file to mark all files under the `sig/generated/` directory as generated code. This helps tools like GitHub Linguist correctly identify and possibly hide generated files in diffs and statistics.