### PR TITLE
feat: remove identifiers from evals and guardrails

### DIFF
--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -24,7 +24,7 @@ module QualityEvals
   include Riffer::Evals::Profile
 
   ai_evals do
-    metric :answer_relevancy, min: 0.85
+    metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85
   end
 end
 
@@ -53,7 +53,7 @@ The judge model is the LLM that evaluates agent outputs. You can use any configu
 
 ## Built-in Evaluators
 
-### answer_relevancy
+### AnswerRelevancy
 
 Evaluates how well a response addresses the input question.
 
@@ -67,7 +67,7 @@ Evaluates how well a response addresses the input question.
 
 ```ruby
 ai_evals do
-  metric :answer_relevancy, min: 0.85
+  metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85
 end
 ```
 
@@ -82,7 +82,7 @@ module QualityEvals
   include Riffer::Evals::Profile
 
   ai_evals do
-    metric :answer_relevancy, min: 0.85
+    metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85
   end
 end
 ```
@@ -95,7 +95,7 @@ end
 
 ```ruby
 ai_evals do
-  metric :answer_relevancy, min: 0.85, weight: 2.0  # Weighted more heavily
+  metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85, weight: 2.0  # Weighted more heavily
 end
 ```
 
@@ -138,7 +138,7 @@ result.to_h             # => Hash representation
 Individual evaluation results:
 
 ```ruby
-result.results.first.evaluator       # => "answer_relevancy"
+result.results.first.evaluator       # => Riffer::Evals::Evaluators::AnswerRelevancy
 result.results.first.score           # => 0.92
 result.results.first.reason          # => "The response directly addresses..."
 result.results.first.higher_is_better # => true
@@ -151,7 +151,6 @@ Create evaluators by subclassing `Riffer::Evals::Evaluator`:
 ```ruby
 # app/evals/medical_accuracy_evaluator.rb
 class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
-  identifier "medical_accuracy"
   description "Evaluates medical information accuracy"
   higher_is_better true
   judge_model "anthropic/claude-opus-4-5-20251101"  # Optional override
@@ -179,20 +178,20 @@ class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
 end
 ```
 
-### Registering Custom Evaluators
+### Using Custom Evaluators
 
-Register custom evaluators in your app initialization. Built-in evaluators are always available.
+Reference your custom evaluator class directly in eval profiles:
 
 ```ruby
-# config/initializers/riffer.rb
-Riffer::Evals::Evaluators::Repository.register(:medical_accuracy, MedicalAccuracyEvaluator)
+ai_evals do
+  metric MedicalAccuracyEvaluator, min: 0.9
+end
 ```
 
 ### Evaluator DSL
 
 Class methods:
 
-- `identifier(value)` - Set the evaluator identifier (defaults to snake_case class name)
 - `description(value)` - Human-readable description
 - `higher_is_better(value)` - Whether higher scores are better (default: true)
 - `judge_model(value)` - Override the global judge model
@@ -231,7 +230,6 @@ Evaluators don't have to use LLM-as-judge:
 
 ```ruby
 class LengthEvaluator < Riffer::Evals::Evaluator
-  identifier "response_length"
   description "Checks response is within expected length"
   higher_is_better true
 
@@ -289,7 +287,7 @@ module QualityEvals
   include Riffer::Evals::Profile
 
   ai_evals do
-    metric :answer_relevancy, min: 0.85, weight: 2.0
+    metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85, weight: 2.0
   end
 end
 

--- a/docs/09_GUARDRAILS.md
+++ b/docs/09_GUARDRAILS.md
@@ -41,20 +41,6 @@ class ContentFilterGuardrail < Riffer::Guardrail
 end
 ```
 
-## Configuration Methods
-
-### identifier
-
-Sets a custom identifier (defaults to snake_case class name):
-
-```ruby
-class MyGuardrail < Riffer::Guardrail
-  identifier "my_custom_guardrail"
-end
-
-MyGuardrail.identifier  # => "my_custom_guardrail"
-```
-
 ## Processing Methods
 
 ### process_input
@@ -186,7 +172,7 @@ response = MyAgent.generate("Hello")
 if response.blocked?
   puts "Blocked: #{response.tripwire.reason}"
   puts "Phase: #{response.tripwire.phase}"
-  puts "Guardrail: #{response.tripwire.guardrail_id}"
+  puts "Guardrail: #{response.tripwire.guardrail}"
 else
   puts response.content
 end
@@ -201,7 +187,7 @@ response = MyAgent.generate("Hello")
 
 if response.modified?
   response.modifications.each do |mod|
-    puts "Guardrail: #{mod.guardrail_id}"
+    puts "Guardrail: #{mod.guardrail}"
     puts "Phase: #{mod.phase}"
     puts "Changed indices: #{mod.message_indices}"
   end
@@ -214,7 +200,7 @@ During streaming, `GuardrailModification` events are emitted when transforms occ
 MyAgent.stream("Hello").each do |event|
   case event
   when Riffer::StreamEvents::GuardrailModification
-    puts "Modified by: #{event.guardrail_id} (#{event.phase})"
+    puts "Modified by: #{event.guardrail} (#{event.phase})"
   when Riffer::StreamEvents::TextDelta
     print event.content
   end
@@ -264,8 +250,6 @@ end
 
 ```ruby
 class UnicodeNormalizer < Riffer::Guardrail
-  identifier "unicode_normalizer"
-
   def process_input(messages, context:)
     normalized = messages.map do |msg|
       if msg.respond_to?(:content) && msg.content
@@ -296,8 +280,6 @@ end
 
 ```ruby
 class TokenLimiter < Riffer::Guardrail
-  identifier "token_limiter"
-
   def initialize(limit:, strategy: :truncate)
     super()
     @limit = limit
@@ -339,8 +321,6 @@ end
 
 ```ruby
 class ContentPolicyFilter < Riffer::Guardrail
-  identifier "content_policy"
-
   BLOCKED_PATTERNS = [
     /pattern1/i,
     /pattern2/i

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -9,7 +9,6 @@
 # See Riffer::Evals::Evaluators.
 #
 #   class MyEvaluator < Riffer::Evals::Evaluator
-#     identifier "my_evaluator"
 #     description "Evaluates response quality"
 #     higher_is_better true
 #     judge_model "anthropic/claude-opus-4-5-20251101"
@@ -25,16 +24,6 @@
 #
 class Riffer::Evals::Evaluator
   class << self
-    include Riffer::Helpers::ClassNameConverter
-
-    # Gets or sets the evaluator identifier.
-    #
-    #: (?String?) -> String
-    def identifier(value = nil)
-      return @identifier || class_name_to_identifier(name) if value.nil?
-      @identifier = value.to_s
-    end
-
     # Gets or sets the evaluator description.
     #
     #: (?String?) -> String?
@@ -57,16 +46,6 @@ class Riffer::Evals::Evaluator
     def judge_model(value = nil)
       return @judge_model if value.nil?
       @judge_model = value.to_s
-    end
-
-    private
-
-    #: (String?) -> String?
-    def class_name_to_identifier(name)
-      return nil if name.nil?
-      class_name = name.split("::").last
-      return nil if class_name.nil?
-      class_name_to_path(class_name).sub(/_evaluator$/, "")
     end
   end
 
@@ -97,7 +76,7 @@ class Riffer::Evals::Evaluator
   #: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
   def result(score:, reason: nil, metadata: {})
     Riffer::Evals::Result.new(
-      evaluator: self.class.identifier,
+      evaluator: self.class,
       score: score,
       reason: reason,
       metadata: metadata,

--- a/lib/riffer/evals/evaluators.rb
+++ b/lib/riffer/evals/evaluators.rb
@@ -1,59 +1,6 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Namespace for built-in evaluators and the evaluator repository.
-#
-# See Riffer::Evals::Evaluators::Repository for registering custom evaluators.
+# Namespace for built-in evaluators.
 module Riffer::Evals::Evaluators
-  # Repository for looking up evaluators by identifier.
-  #
-  # Built-in evaluators are always available. Custom evaluators
-  # can be registered using Repository.register in your app initialization.
-  #
-  #   # Register a custom evaluator (config/initializers/riffer.rb)
-  #   Riffer::Evals::Evaluators::Repository.register(:my_evaluator, MyEvaluator)
-  #
-  #   # Find an evaluator
-  #   Riffer::Evals::Evaluators::Repository.find(:answer_relevancy)
-  #   # => Riffer::Evals::Evaluators::AnswerRelevancy
-  #
-  class Repository
-    # Built-in evaluators (always available).
-    BUILT_IN = {
-      answer_relevancy: -> { Riffer::Evals::Evaluators::AnswerRelevancy }
-    }.freeze #: Hash[Symbol, ^() -> singleton(Riffer::Evals::Evaluator)]
-
-    @custom = {}
-
-    class << self
-      # Registers a custom evaluator class with an identifier.
-      #
-      #: ((String | Symbol), singleton(Riffer::Evals::Evaluator)) -> void
-      def register(identifier, evaluator_class)
-        @custom[identifier.to_sym] = -> { evaluator_class }
-      end
-
-      # Finds an evaluator class by identifier.
-      #
-      #: ((String | Symbol)) -> singleton(Riffer::Evals::Evaluator)?
-      def find(identifier)
-        id = identifier.to_sym
-        (@custom[id] || BUILT_IN[id])&.call
-      end
-
-      # Returns all registered evaluators (built-in and custom).
-      #
-      #: () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
-      def all
-        BUILT_IN.merge(@custom).transform_values(&:call)
-      end
-
-      # Clears custom registrations (for testing). Built-ins remain.
-      #
-      #: () -> void
-      def clear
-        @custom = {}
-      end
-    end
-  end
 end

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -14,7 +14,6 @@
 #   result.score  # => 0.95
 #
 class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
-  identifier "answer_relevancy"
   description "Evaluates how well the response addresses the input question"
   higher_is_better true
 

--- a/lib/riffer/evals/metric.rb
+++ b/lib/riffer/evals/metric.rb
@@ -6,7 +6,7 @@
 # Metrics define which evaluator to use and what thresholds determine pass/fail.
 #
 #   metric = Riffer::Evals::Metric.new(
-#     evaluator_identifier: "answer_relevancy",
+#     evaluator_class: Riffer::Evals::Evaluators::AnswerRelevancy,
 #     min: 0.85,
 #     weight: 1.0
 #   )
@@ -14,8 +14,8 @@
 #   metric.passes?(result)  # => true/false based on thresholds
 #
 class Riffer::Evals::Metric
-  # The identifier of the evaluator to use.
-  attr_reader :evaluator_identifier #: String
+  # The evaluator class to use.
+  attr_reader :evaluator_class #: singleton(Riffer::Evals::Evaluator)
 
   # Minimum acceptable score (for higher_is_better evaluators).
   attr_reader :min #: Float?
@@ -28,19 +28,18 @@ class Riffer::Evals::Metric
 
   # Initializes a new metric.
   #
-  #: (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
-  def initialize(evaluator_identifier:, min: nil, max: nil, weight: 1.0)
-    @evaluator_identifier = evaluator_identifier.to_s
+  # Raises Riffer::ArgumentError if evaluator_class is not a subclass of Riffer::Evals::Evaluator.
+  #
+  #: (evaluator_class: singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
+  def initialize(evaluator_class:, min: nil, max: nil, weight: 1.0)
+    unless evaluator_class.is_a?(Class) && evaluator_class < Riffer::Evals::Evaluator
+      raise Riffer::ArgumentError, "evaluator_class must be a subclass of Riffer::Evals::Evaluator, got #{evaluator_class.inspect}"
+    end
+
+    @evaluator_class = evaluator_class
     @min = min&.to_f
     @max = max&.to_f
     @weight = weight.to_f
-  end
-
-  # Returns the evaluator class for this metric.
-  #
-  #: () -> singleton(Riffer::Evals::Evaluator)?
-  def evaluator_class
-    Riffer::Evals::Evaluators::Repository.find(evaluator_identifier)
   end
 
   # Checks if a result passes this metric's thresholds.
@@ -57,7 +56,7 @@ class Riffer::Evals::Metric
   #: () -> Hash[Symbol, untyped]
   def to_h
     {
-      evaluator_identifier: evaluator_identifier,
+      evaluator_class: evaluator_class,
       min: min,
       max: max,
       weight: weight

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -10,8 +10,7 @@
 #     include Riffer::Evals::Profile
 #
 #     ai_evals do
-#       metric :answer_relevancy, min: 0.85
-#       metric :hallucination, max: 0.10
+#       metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85
 #     end
 #   end
 #
@@ -49,10 +48,10 @@ module Riffer::Evals::Profile
 
     # Defines a metric with thresholds.
     #
-    #: ((Symbol | String), ?min: Float?, ?max: Float?, ?weight: Float) -> void
-    def metric(identifier, min: nil, max: nil, weight: 1.0)
+    #: (singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
+    def metric(evaluator_class, min: nil, max: nil, weight: 1.0)
       metrics << Riffer::Evals::Metric.new(
-        evaluator_identifier: identifier,
+        evaluator_class: evaluator_class,
         min: min,
         max: max,
         weight: weight

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -51,7 +51,7 @@ class Riffer::Evals::Result
   #: () -> Hash[Symbol, untyped]
   def to_h
     {
-      evaluator: evaluator.name || evaluator.inspect,
+      evaluator: evaluator.name,
       score: score,
       reason: reason,
       metadata: metadata,

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -6,19 +6,19 @@
 # Contains the score, reason, and metadata from running an evaluator.
 #
 #   result = Riffer::Evals::Result.new(
-#     evaluator: "answer_relevancy",
+#     evaluator: Riffer::Evals::Evaluators::AnswerRelevancy,
 #     score: 0.85,
 #     reason: "The response addresses the question directly.",
 #     higher_is_better: true
 #   )
 #
 #   result.score           # => 0.85
-#   result.evaluator       # => "answer_relevancy"
+#   result.evaluator       # => Riffer::Evals::Evaluators::AnswerRelevancy
 #   result.higher_is_better # => true
 #
 class Riffer::Evals::Result
-  # The identifier of the evaluator that produced this result.
-  attr_reader :evaluator #: String
+  # The evaluator class that produced this result.
+  attr_reader :evaluator #: singleton(Riffer::Evals::Evaluator)
 
   # The evaluation score (0.0 to 1.0).
   attr_reader :score #: Float
@@ -36,7 +36,7 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
-  #: (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
+  #: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
   def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
     @evaluator = evaluator
     @score = score.to_f
@@ -51,7 +51,7 @@ class Riffer::Evals::Result
   #: () -> Hash[Symbol, untyped]
   def to_h
     {
-      evaluator: evaluator,
+      evaluator: evaluator.name || evaluator.inspect,
       score: score,
       reason: reason,
       metadata: metadata,

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -29,10 +29,7 @@ class Riffer::Evals::Runner
   #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   def run(input:, output:, context: nil)
     results = metrics.map do |metric|
-      evaluator_class = metric.evaluator_class
-      raise Riffer::ArgumentError, "Evaluator not found: #{metric.evaluator_identifier}" unless evaluator_class
-
-      evaluator = evaluator_class.new
+      evaluator = metric.evaluator_class.new
       evaluator.evaluate(input: input, output: output, context: context)
     end
 

--- a/lib/riffer/guardrail.rb
+++ b/lib/riffer/guardrail.rb
@@ -6,8 +6,6 @@
 # Subclass this to create custom guardrails:
 #
 #   class MyGuardrail < Riffer::Guardrail
-#     identifier "my_guardrail"
-#
 #     def process_input(messages, context:)
 #       # Return pass(messages), transform(modified_messages), or block(reason)
 #       pass(messages)
@@ -19,29 +17,6 @@
 #     end
 #   end
 class Riffer::Guardrail
-  include Riffer::Helpers::ClassNameConverter
-
-  class << self
-    include Riffer::Helpers::ClassNameConverter
-
-    # Gets or sets the guardrail identifier.
-    #
-    # +value+ - the identifier to set, or nil to get.
-    #
-    #: (?String?) -> String
-    def identifier(value = nil)
-      return @identifier || class_name_to_path(name) if value.nil?
-      @identifier = value.to_s
-    end
-  end
-
-  # Returns the instance's identifier.
-  #
-  #: () -> String
-  def identifier
-    self.class.identifier
-  end
-
   # Processes input messages before they are sent to the LLM.
   #
   # Override this method in subclasses to implement input processing.

--- a/lib/riffer/guardrails/max_length.rb
+++ b/lib/riffer/guardrails/max_length.rb
@@ -8,8 +8,6 @@
 #   guardrail :before, with: Riffer::Guardrails::MaxLength, max: 1000
 #   guardrail :after, with: Riffer::Guardrails::MaxLength, max: 5000
 class Riffer::Guardrails::MaxLength < Riffer::Guardrail
-  identifier "riffer/guardrails/max_length"
-
   DEFAULT_MAX = 10_000 #: Integer
 
   # The maximum allowed character length.

--- a/lib/riffer/guardrails/modification.rb
+++ b/lib/riffer/guardrails/modification.rb
@@ -7,8 +7,8 @@
 # created to record which guardrail made the change, in which phase, and
 # which message indices were affected.
 class Riffer::Guardrails::Modification
-  # The identifier of the guardrail that transformed data.
-  attr_reader :guardrail_id #: String
+  # The guardrail class that transformed data.
+  attr_reader :guardrail #: singleton(Riffer::Guardrail)
 
   # The phase when the transformation occurred (:before or :after).
   attr_reader :phase #: Symbol
@@ -18,13 +18,13 @@ class Riffer::Guardrails::Modification
 
   # Creates a new modification record.
   #
-  # +guardrail_id+ - identifier of the guardrail that transformed.
+  # +guardrail+ - the guardrail class that transformed.
   # +phase+ - :before or :after.
   # +message_indices+ - indices of changed messages.
   #
-  #: (guardrail_id: String, phase: Symbol, message_indices: Array[Integer]) -> void
-  def initialize(guardrail_id:, phase:, message_indices:)
-    @guardrail_id = guardrail_id
+  #: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
+  def initialize(guardrail:, phase:, message_indices:)
+    @guardrail = guardrail
     @phase = phase
     @message_indices = message_indices
   end
@@ -33,6 +33,6 @@ class Riffer::Guardrails::Modification
   #
   #: () -> Hash[Symbol, untyped]
   def to_h
-    {guardrail_id: guardrail_id, phase: phase, message_indices: message_indices}
+    {guardrail: guardrail.name || guardrail.inspect, phase: phase, message_indices: message_indices}
   end
 end

--- a/lib/riffer/guardrails/modification.rb
+++ b/lib/riffer/guardrails/modification.rb
@@ -33,6 +33,10 @@ class Riffer::Guardrails::Modification
   #
   #: () -> Hash[Symbol, untyped]
   def to_h
-    {guardrail: guardrail.name || guardrail.inspect, phase: phase, message_indices: message_indices}
+    {
+      guardrail: guardrail.name,
+      phase: phase,
+      message_indices: message_indices
+    }
   end
 end

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -52,7 +52,7 @@ class Riffer::Guardrails::Runner
       if result.block?
         tripwire = Riffer::Guardrails::Tripwire.new(
           reason: result.data,
-          guardrail_id: guardrail.identifier,
+          guardrail: guardrail.class,
           phase: phase,
           metadata: result.metadata
         )
@@ -61,7 +61,7 @@ class Riffer::Guardrails::Runner
 
       if result.transform?
         modifications << Riffer::Guardrails::Modification.new(
-          guardrail_id: guardrail.identifier,
+          guardrail: guardrail.class,
           phase: phase,
           message_indices: detect_changed_indices(current_data, result.data)
         )

--- a/lib/riffer/guardrails/tripwire.rb
+++ b/lib/riffer/guardrails/tripwire.rb
@@ -8,7 +8,7 @@
 #
 #   tripwire = Tripwire.new(
 #     reason: "PII detected in input",
-#     guardrail_id: "pii_redactor",
+#     guardrail: PiiRedactor,
 #     phase: :before,
 #     metadata: { detected_types: [:email, :phone] }
 #   )
@@ -18,8 +18,8 @@ class Riffer::Guardrails::Tripwire
   # The reason for blocking.
   attr_reader :reason #: String
 
-  # The identifier of the guardrail that triggered the block.
-  attr_reader :guardrail_id #: String
+  # The guardrail class that triggered the block.
+  attr_reader :guardrail #: singleton(Riffer::Guardrail)
 
   # The phase when the block occurred (:before or :after).
   attr_reader :phase #: Symbol
@@ -30,18 +30,18 @@ class Riffer::Guardrails::Tripwire
   # Creates a new tripwire.
   #
   # +reason+ - the reason for blocking.
-  # +guardrail_id+ - identifier of the guardrail that blocked.
+  # +guardrail+ - the guardrail class that blocked.
   # +phase+ - :before or :after.
   # +metadata+ - optional additional information.
   #
   # Raises Riffer::ArgumentError if the phase is invalid.
   #
-  #: (reason: String, guardrail_id: String, phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
-  def initialize(reason:, guardrail_id:, phase:, metadata: nil)
+  #: (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
+  def initialize(reason:, guardrail:, phase:, metadata: nil)
     raise Riffer::ArgumentError, "Invalid phase: #{phase}" unless PHASES.include?(phase)
 
     @reason = reason
-    @guardrail_id = guardrail_id
+    @guardrail = guardrail
     @phase = phase
     @metadata = metadata
   end
@@ -52,7 +52,7 @@ class Riffer::Guardrails::Tripwire
   def to_h
     {
       reason: reason,
-      guardrail_id: guardrail_id,
+      guardrail: guardrail.name || guardrail.inspect,
       phase: phase,
       metadata: metadata
     }

--- a/lib/riffer/guardrails/tripwire.rb
+++ b/lib/riffer/guardrails/tripwire.rb
@@ -52,7 +52,7 @@ class Riffer::Guardrails::Tripwire
   def to_h
     {
       reason: reason,
-      guardrail: guardrail.name || guardrail.inspect,
+      guardrail: guardrail.name,
       phase: phase,
       metadata: metadata
     }

--- a/lib/riffer/stream_events/guardrail_modification.rb
+++ b/lib/riffer/stream_events/guardrail_modification.rb
@@ -19,10 +19,10 @@ class Riffer::StreamEvents::GuardrailModification < Riffer::StreamEvents::Base
     @modification = modification
   end
 
-  # The guardrail identifier that made the transformation.
+  # The guardrail class that made the transformation.
   #
-  #: () -> String
-  def guardrail_id = modification.guardrail_id
+  #: () -> singleton(Riffer::Guardrail)
+  def guardrail = modification.guardrail
 
   # The phase when the transformation occurred.
   #

--- a/lib/riffer/stream_events/guardrail_tripwire.rb
+++ b/lib/riffer/stream_events/guardrail_tripwire.rb
@@ -33,11 +33,11 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
     tripwire.phase
   end
 
-  # The guardrail identifier that triggered the block.
+  # The guardrail class that triggered the block.
   #
-  #: () -> String
-  def guardrail_id
-    tripwire.guardrail_id
+  #: () -> singleton(Riffer::Guardrail)
+  def guardrail
+    tripwire.guardrail
   end
 
   # Converts the event to a hash.

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -8,7 +8,6 @@
 # See Riffer::Evals::Evaluators.
 #
 #   class MyEvaluator < Riffer::Evals::Evaluator
-#     identifier "my_evaluator"
 #     description "Evaluates response quality"
 #     higher_is_better true
 #     judge_model "anthropic/claude-opus-4-5-20251101"
@@ -22,13 +21,6 @@
 #     end
 #   end
 class Riffer::Evals::Evaluator
-  include Riffer::Helpers::ClassNameConverter
-
-  # Gets or sets the evaluator identifier.
-  #
-  # : (?String?) -> String
-  def self.identifier: (?String?) -> String
-
   # Gets or sets the evaluator description.
   #
   # : (?String?) -> String?
@@ -43,9 +35,6 @@ class Riffer::Evals::Evaluator
   #
   # : (?String?) -> String?
   def self.judge_model: (?String?) -> String?
-
-  # : (String?) -> String?
-  private def self.class_name_to_identifier: (String?) -> String?
 
   # Evaluates an input/output pair.
   #

--- a/sig/generated/riffer/evals/evaluators.rbs
+++ b/sig/generated/riffer/evals/evaluators.rbs
@@ -1,42 +1,5 @@
 # Generated from lib/riffer/evals/evaluators.rb with RBS::Inline
 
-# Namespace for built-in evaluators and the evaluator repository.
-#
-# See Riffer::Evals::Evaluators::Repository for registering custom evaluators.
+# Namespace for built-in evaluators.
 module Riffer::Evals::Evaluators
-  # Repository for looking up evaluators by identifier.
-  #
-  # Built-in evaluators are always available. Custom evaluators
-  # can be registered using Repository.register in your app initialization.
-  #
-  #   # Register a custom evaluator (config/initializers/riffer.rb)
-  #   Riffer::Evals::Evaluators::Repository.register(:my_evaluator, MyEvaluator)
-  #
-  #   # Find an evaluator
-  #   Riffer::Evals::Evaluators::Repository.find(:answer_relevancy)
-  #   # => Riffer::Evals::Evaluators::AnswerRelevancy
-  class Repository
-    # Built-in evaluators (always available).
-    BUILT_IN: Hash[Symbol, ^() -> singleton(Riffer::Evals::Evaluator)]
-
-    # Registers a custom evaluator class with an identifier.
-    #
-    # : ((String | Symbol), singleton(Riffer::Evals::Evaluator)) -> void
-    def self.register: (String | Symbol, singleton(Riffer::Evals::Evaluator)) -> void
-
-    # Finds an evaluator class by identifier.
-    #
-    # : ((String | Symbol)) -> singleton(Riffer::Evals::Evaluator)?
-    def self.find: (String | Symbol) -> singleton(Riffer::Evals::Evaluator)?
-
-    # Returns all registered evaluators (built-in and custom).
-    #
-    # : () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
-    def self.all: () -> Hash[Symbol, singleton(Riffer::Evals::Evaluator)]
-
-    # Clears custom registrations (for testing). Built-ins remain.
-    #
-    # : () -> void
-    def self.clear: () -> void
-  end
 end

--- a/sig/generated/riffer/evals/metric.rbs
+++ b/sig/generated/riffer/evals/metric.rbs
@@ -5,15 +5,15 @@
 # Metrics define which evaluator to use and what thresholds determine pass/fail.
 #
 #   metric = Riffer::Evals::Metric.new(
-#     evaluator_identifier: "answer_relevancy",
+#     evaluator_class: Riffer::Evals::Evaluators::AnswerRelevancy,
 #     min: 0.85,
 #     weight: 1.0
 #   )
 #
 #   metric.passes?(result)  # => true/false based on thresholds
 class Riffer::Evals::Metric
-  # The identifier of the evaluator to use.
-  attr_reader evaluator_identifier: String
+  # The evaluator class to use.
+  attr_reader evaluator_class: singleton(Riffer::Evals::Evaluator)
 
   # Minimum acceptable score (for higher_is_better evaluators).
   attr_reader min: Float?
@@ -26,13 +26,10 @@ class Riffer::Evals::Metric
 
   # Initializes a new metric.
   #
-  # : (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
-  def initialize: (evaluator_identifier: String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
-
-  # Returns the evaluator class for this metric.
+  # Raises Riffer::ArgumentError if evaluator_class is not a subclass of Riffer::Evals::Evaluator.
   #
-  # : () -> singleton(Riffer::Evals::Evaluator)?
-  def evaluator_class: () -> singleton(Riffer::Evals::Evaluator)?
+  # : (evaluator_class: singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
+  def initialize: (evaluator_class: singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
 
   # Checks if a result passes this metric's thresholds.
   #

--- a/sig/generated/riffer/evals/profile.rbs
+++ b/sig/generated/riffer/evals/profile.rbs
@@ -9,8 +9,7 @@
 #     include Riffer::Evals::Profile
 #
 #     ai_evals do
-#       metric :answer_relevancy, min: 0.85
-#       metric :hallucination, max: 0.10
+#       metric Riffer::Evals::Evaluators::AnswerRelevancy, min: 0.85
 #     end
 #   end
 #
@@ -35,8 +34,8 @@ module Riffer::Evals::Profile
 
     # Defines a metric with thresholds.
     #
-    # : ((Symbol | String), ?min: Float?, ?max: Float?, ?weight: Float) -> void
-    def metric: (Symbol | String, ?min: Float?, ?max: Float?, ?weight: Float) -> void
+    # : (singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
+    def metric: (singleton(Riffer::Evals::Evaluator), ?min: Float?, ?max: Float?, ?weight: Float) -> void
   end
 
   module ClassMethods

--- a/sig/generated/riffer/evals/result.rbs
+++ b/sig/generated/riffer/evals/result.rbs
@@ -5,18 +5,18 @@
 # Contains the score, reason, and metadata from running an evaluator.
 #
 #   result = Riffer::Evals::Result.new(
-#     evaluator: "answer_relevancy",
+#     evaluator: Riffer::Evals::Evaluators::AnswerRelevancy,
 #     score: 0.85,
 #     reason: "The response addresses the question directly.",
 #     higher_is_better: true
 #   )
 #
 #   result.score           # => 0.85
-#   result.evaluator       # => "answer_relevancy"
+#   result.evaluator       # => Riffer::Evals::Evaluators::AnswerRelevancy
 #   result.higher_is_better # => true
 class Riffer::Evals::Result
-  # The identifier of the evaluator that produced this result.
-  attr_reader evaluator: String
+  # The evaluator class that produced this result.
+  attr_reader evaluator: singleton(Riffer::Evals::Evaluator)
 
   # The evaluation score (0.0 to 1.0).
   attr_reader score: Float
@@ -34,8 +34,8 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
-  # : (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
-  def initialize: (evaluator: String, score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
+  # : (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
+  def initialize: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
 
   # Returns a hash representation of the result.
   #

--- a/sig/generated/riffer/guardrail.rbs
+++ b/sig/generated/riffer/guardrail.rbs
@@ -5,8 +5,6 @@
 # Subclass this to create custom guardrails:
 #
 #   class MyGuardrail < Riffer::Guardrail
-#     identifier "my_guardrail"
-#
 #     def process_input(messages, context:)
 #       # Return pass(messages), transform(modified_messages), or block(reason)
 #       pass(messages)
@@ -18,22 +16,6 @@
 #     end
 #   end
 class Riffer::Guardrail
-  include Riffer::Helpers::ClassNameConverter
-
-  include Riffer::Helpers::ClassNameConverter
-
-  # Gets or sets the guardrail identifier.
-  #
-  # +value+ - the identifier to set, or nil to get.
-  #
-  # : (?String?) -> String
-  def self.identifier: (?String?) -> String
-
-  # Returns the instance's identifier.
-  #
-  # : () -> String
-  def identifier: () -> String
-
   # Processes input messages before they are sent to the LLM.
   #
   # Override this method in subclasses to implement input processing.

--- a/sig/generated/riffer/guardrails/modification.rbs
+++ b/sig/generated/riffer/guardrails/modification.rbs
@@ -6,8 +6,8 @@
 # created to record which guardrail made the change, in which phase, and
 # which message indices were affected.
 class Riffer::Guardrails::Modification
-  # The identifier of the guardrail that transformed data.
-  attr_reader guardrail_id: String
+  # The guardrail class that transformed data.
+  attr_reader guardrail: singleton(Riffer::Guardrail)
 
   # The phase when the transformation occurred (:before or :after).
   attr_reader phase: Symbol
@@ -17,12 +17,12 @@ class Riffer::Guardrails::Modification
 
   # Creates a new modification record.
   #
-  # +guardrail_id+ - identifier of the guardrail that transformed.
+  # +guardrail+ - the guardrail class that transformed.
   # +phase+ - :before or :after.
   # +message_indices+ - indices of changed messages.
   #
-  # : (guardrail_id: String, phase: Symbol, message_indices: Array[Integer]) -> void
-  def initialize: (guardrail_id: String, phase: Symbol, message_indices: Array[Integer]) -> void
+  # : (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
+  def initialize: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
 
   # Converts the modification to a hash.
   #

--- a/sig/generated/riffer/guardrails/tripwire.rbs
+++ b/sig/generated/riffer/guardrails/tripwire.rbs
@@ -7,7 +7,7 @@
 #
 #   tripwire = Tripwire.new(
 #     reason: "PII detected in input",
-#     guardrail_id: "pii_redactor",
+#     guardrail: PiiRedactor,
 #     phase: :before,
 #     metadata: { detected_types: [:email, :phone] }
 #   )
@@ -17,8 +17,8 @@ class Riffer::Guardrails::Tripwire
   # The reason for blocking.
   attr_reader reason: String
 
-  # The identifier of the guardrail that triggered the block.
-  attr_reader guardrail_id: String
+  # The guardrail class that triggered the block.
+  attr_reader guardrail: singleton(Riffer::Guardrail)
 
   # The phase when the block occurred (:before or :after).
   attr_reader phase: Symbol
@@ -29,14 +29,14 @@ class Riffer::Guardrails::Tripwire
   # Creates a new tripwire.
   #
   # +reason+ - the reason for blocking.
-  # +guardrail_id+ - identifier of the guardrail that blocked.
+  # +guardrail+ - the guardrail class that blocked.
   # +phase+ - :before or :after.
   # +metadata+ - optional additional information.
   #
   # Raises Riffer::ArgumentError if the phase is invalid.
   #
-  # : (reason: String, guardrail_id: String, phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
-  def initialize: (reason: String, guardrail_id: String, phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
+  # : (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
+  def initialize: (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
 
   # Converts the tripwire to a hash.
   #

--- a/sig/generated/riffer/stream_events/guardrail_modification.rbs
+++ b/sig/generated/riffer/stream_events/guardrail_modification.rbs
@@ -15,10 +15,10 @@ class Riffer::StreamEvents::GuardrailModification < Riffer::StreamEvents::Base
   # : (Riffer::Guardrails::Modification, ?role: Symbol) -> void
   def initialize: (Riffer::Guardrails::Modification, ?role: Symbol) -> void
 
-  # The guardrail identifier that made the transformation.
+  # The guardrail class that made the transformation.
   #
-  # : () -> String
-  def guardrail_id: () -> String
+  # : () -> singleton(Riffer::Guardrail)
+  def guardrail: () -> singleton(Riffer::Guardrail)
 
   # The phase when the transformation occurred.
   #

--- a/sig/generated/riffer/stream_events/guardrail_tripwire.rbs
+++ b/sig/generated/riffer/stream_events/guardrail_tripwire.rbs
@@ -25,10 +25,10 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
   # : () -> Symbol
   def phase: () -> Symbol
 
-  # The guardrail identifier that triggered the block.
+  # The guardrail class that triggered the block.
   #
-  # : () -> String
-  def guardrail_id: () -> String
+  # : () -> singleton(Riffer::Guardrail)
+  def guardrail: () -> singleton(Riffer::Guardrail)
 
   # Converts the event to a hash.
   #

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -17,7 +17,7 @@ describe Riffer::Agent::Response do
     it "stores the tripwire" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "test",
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       response = Riffer::Agent::Response.new("", tripwire: tripwire)
@@ -33,7 +33,7 @@ describe Riffer::Agent::Response do
 
     it "returns provided modifications" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "test",
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [0]
       )
@@ -50,7 +50,7 @@ describe Riffer::Agent::Response do
 
     it "returns true when modifications present" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "test",
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [0]
       )
@@ -68,7 +68,7 @@ describe Riffer::Agent::Response do
     it "returns true when tripwire present" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "test",
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       response = Riffer::Agent::Response.new("", tripwire: tripwire)

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1469,15 +1469,11 @@ describe Riffer::Agent do
 
   describe ".guardrail" do
     let(:pass_guardrail_class) do
-      Class.new(Riffer::Guardrail) do
-        identifier "pass_guardrail"
-      end
+      Class.new(Riffer::Guardrail)
     end
 
     let(:block_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "block_guardrail"
-
         def process_input(messages, context:)
           block("Input blocked")
         end
@@ -1562,8 +1558,6 @@ describe Riffer::Agent do
   describe "#generate with guardrails" do
     let(:transform_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "transform_guardrail"
-
         def process_input(messages, context:)
           transform(messages.map { |m|
             case m
@@ -1583,8 +1577,6 @@ describe Riffer::Agent do
 
     let(:block_input_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "block_input_guardrail"
-
         def process_input(messages, context:)
           block("Input blocked", metadata: {reason: "test"})
         end
@@ -1593,8 +1585,6 @@ describe Riffer::Agent do
 
     let(:block_output_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "block_output_guardrail"
-
         def process_output(response, messages:, context:)
           block("Output blocked", metadata: {reason: "test"})
         end
@@ -1641,9 +1631,9 @@ describe Riffer::Agent do
         expect(result.tripwire.phase).must_equal :before
       end
 
-      it "has tripwire with guardrail_id" do
+      it "has tripwire with guardrail" do
         result = agent_with_blocking_input.generate("Hello")
-        expect(result.tripwire.guardrail_id).must_equal "block_input_guardrail"
+        expect(result.tripwire.guardrail).must_equal block_input_guardrail_class
       end
 
       it "has tripwire with metadata" do
@@ -1715,10 +1705,10 @@ describe Riffer::Agent do
         expect(result.modified?).must_equal true
       end
 
-      it "response has modifications with correct guardrail_id" do
+      it "response has modifications with correct guardrail" do
         result = agent_with_transform.generate("Hello")
-        ids = result.modifications.map(&:guardrail_id)
-        expect(ids).must_include "transform_guardrail"
+        guardrails = result.modifications.map(&:guardrail)
+        expect(guardrails).must_include transform_guardrail_class
       end
 
       it "after phase modifications have remapped message indices" do
@@ -1745,8 +1735,6 @@ describe Riffer::Agent do
   describe "#stream with guardrails" do
     let(:block_input_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "block_input_guardrail"
-
         def process_input(messages, context:)
           block("Input blocked")
         end
@@ -1755,8 +1743,6 @@ describe Riffer::Agent do
 
     let(:block_output_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "block_output_guardrail"
-
         def process_output(response, messages:, context:)
           block("Output blocked")
         end
@@ -1824,8 +1810,6 @@ describe Riffer::Agent do
     describe "with transform guardrails" do
       let(:transform_guardrail_class) do
         Class.new(Riffer::Guardrail) do
-          identifier "stream_transform_guardrail"
-
           def process_input(messages, context:)
             transform(messages.map { |m|
               case m
@@ -1854,10 +1838,10 @@ describe Riffer::Agent do
         expect(mod_events).wont_be_empty
       end
 
-      it "GuardrailModification event has correct guardrail_id" do
+      it "GuardrailModification event has correct guardrail" do
         events = agent_with_stream_transform.stream("Hello").to_a
         mod_event = events.find { |e| e.is_a?(Riffer::StreamEvents::GuardrailModification) }
-        expect(mod_event.guardrail_id).must_equal "stream_transform_guardrail"
+        expect(mod_event.guardrail).must_equal transform_guardrail_class
       end
     end
   end

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -5,7 +5,6 @@ require "test_helper"
 describe Riffer::Evals::Evaluator do
   let(:evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      identifier "test_evaluator"
       description "A test evaluator"
       higher_is_better true
     end
@@ -13,33 +12,8 @@ describe Riffer::Evals::Evaluator do
 
   let(:lower_is_better_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      identifier "toxicity"
       description "Detects toxicity"
       higher_is_better false
-    end
-  end
-
-  describe ".identifier" do
-    it "returns the set identifier" do
-      expect(evaluator_class.identifier).must_equal "test_evaluator"
-    end
-
-    it "generates identifier from class name when not set" do
-      anon_class = Class.new(Riffer::Evals::Evaluator)
-      # Anonymous classes don't have a name, so this returns nil
-      expect(anon_class.identifier).must_be_nil
-    end
-
-    it "strips _evaluator suffix from generated identifier" do
-      # Create a named class to test
-      eval <<~RUBY, binding, __FILE__, __LINE__ + 1
-        class TestNamedEvaluator < Riffer::Evals::Evaluator
-        end
-      RUBY
-
-      expect(TestNamedEvaluator.identifier).must_equal "test_named"
-
-      Object.send(:remove_const, :TestNamedEvaluator)
     end
   end
 
@@ -92,7 +66,6 @@ describe Riffer::Evals::Evaluator do
   describe "#result (protected)" do
     it "creates a Result with correct attributes" do
       klass = Class.new(Riffer::Evals::Evaluator) do
-        identifier "my_evaluator"
         higher_is_better true
 
         def evaluate(input:, output:, context: nil)
@@ -103,18 +76,15 @@ describe Riffer::Evals::Evaluator do
       evaluator = klass.new
       result = evaluator.evaluate(input: "test", output: "test")
 
-      expect(result.to_h).must_equal({
-        evaluator: "my_evaluator",
-        score: 0.9,
-        reason: "Good",
-        metadata: {},
-        higher_is_better: true
-      })
+      expect(result.evaluator).must_equal klass
+      expect(result.score).must_equal 0.9
+      expect(result.reason).must_equal "Good"
+      expect(result.metadata).must_equal({})
+      expect(result.higher_is_better).must_equal true
     end
 
     it "creates a Result with higher_is_better from evaluator" do
       klass = Class.new(Riffer::Evals::Evaluator) do
-        identifier "toxicity"
         higher_is_better false
 
         def evaluate(input:, output:, context: nil)

--- a/test/riffer/evals/evaluators/answer_relevancy_test.rb
+++ b/test/riffer/evals/evaluators/answer_relevancy_test.rb
@@ -3,13 +3,6 @@
 require "test_helper"
 
 describe Riffer::Evals::Evaluators::AnswerRelevancy do
-  describe "repository" do
-    it "is registered in the evaluators repository" do
-      evaluator_class = Riffer::Evals::Evaluators::Repository.find(:answer_relevancy)
-      expect(evaluator_class).must_equal Riffer::Evals::Evaluators::AnswerRelevancy
-    end
-  end
-
   describe "#evaluate" do
     it "requires judge_model to be configured" do
       original_judge_model = Riffer.config.evals.judge_model

--- a/test/riffer/evals/metric_test.rb
+++ b/test/riffer/evals/metric_test.rb
@@ -3,88 +3,95 @@
 require "test_helper"
 
 describe Riffer::Evals::Metric do
+  let(:stub_evaluator_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      description "Test evaluator"
+      higher_is_better true
+    end
+  end
+
   describe "#initialize" do
-    it "sets the evaluator_identifier" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "answer_relevancy")
-      expect(metric.evaluator_identifier).must_equal "answer_relevancy"
+    it "sets the evaluator_class" do
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class)
+      expect(metric.evaluator_class).must_equal stub_evaluator_class
     end
 
-    it "converts evaluator_identifier to string" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: :answer_relevancy)
-      expect(metric.evaluator_identifier).must_equal "answer_relevancy"
+    it "raises error for non-evaluator class" do
+      expect {
+        Riffer::Evals::Metric.new(evaluator_class: String)
+      }.must_raise(Riffer::ArgumentError)
+    end
+
+    it "raises error for non-class" do
+      expect {
+        Riffer::Evals::Metric.new(evaluator_class: "answer_relevancy")
+      }.must_raise(Riffer::ArgumentError)
     end
 
     it "sets min as a float" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: "0.8")
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, min: "0.8")
       expect(metric.min).must_equal 0.8
     end
 
     it "sets max as a float" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: "0.2")
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, max: "0.2")
       expect(metric.max).must_equal 0.2
     end
 
     it "sets weight as a float" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", weight: 2)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, weight: 2)
       expect(metric.weight).must_equal 2.0
     end
 
     it "defaults weight to 1.0" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test")
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class)
       expect(metric.weight).must_equal 1.0
     end
   end
 
   describe "#evaluator_class" do
-    it "looks up the evaluator from the registry" do
-      # Reference the class first to trigger Zeitwerk autoload and registration
-      evaluator_class = Riffer::Evals::Evaluators::AnswerRelevancy
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "answer_relevancy")
-      expect(metric.evaluator_class).must_equal evaluator_class
-    end
-
-    it "returns nil for unknown evaluator" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "unknown_evaluator")
-      expect(metric.evaluator_class).must_be_nil
+    it "returns the evaluator class" do
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class)
+      expect(metric.evaluator_class).must_equal stub_evaluator_class
     end
   end
 
   describe "#passes?" do
     it "passes when no thresholds set" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test")
-      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.5)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.5)
       expect(metric.passes?(result)).must_equal true
     end
 
     it "passes when score meets min threshold" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.8)
-      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.85)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, min: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.85)
       expect(metric.passes?(result)).must_equal true
     end
 
     it "fails when score below min threshold" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.8)
-      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.7)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, min: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.7)
       expect(metric.passes?(result)).must_equal false
     end
 
     it "passes when score meets max threshold" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: 0.2)
-      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.1)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, max: 0.2)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.1)
       expect(metric.passes?(result)).must_equal true
     end
 
     it "fails when score above max threshold" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", max: 0.2)
-      result = Riffer::Evals::Result.new(evaluator: "test", score: 0.3)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, max: 0.2)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.3)
       expect(metric.passes?(result)).must_equal false
     end
 
     it "checks both min and max thresholds" do
-      metric = Riffer::Evals::Metric.new(evaluator_identifier: "test", min: 0.4, max: 0.6)
-      result_pass = Riffer::Evals::Result.new(evaluator: "test", score: 0.5)
-      result_fail_low = Riffer::Evals::Result.new(evaluator: "test", score: 0.3)
-      result_fail_high = Riffer::Evals::Result.new(evaluator: "test", score: 0.7)
+      metric = Riffer::Evals::Metric.new(evaluator_class: stub_evaluator_class, min: 0.4, max: 0.6)
+      result_pass = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.5)
+      result_fail_low = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.3)
+      result_fail_high = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.7)
 
       expect(metric.passes?(result_pass)).must_equal true
       expect(metric.passes?(result_fail_low)).must_equal false
@@ -95,14 +102,14 @@ describe Riffer::Evals::Metric do
   describe "#to_h" do
     it "returns a hash representation" do
       metric = Riffer::Evals::Metric.new(
-        evaluator_identifier: "test",
+        evaluator_class: stub_evaluator_class,
         min: 0.8,
         max: nil,
         weight: 1.5
       )
 
       hash = metric.to_h
-      expect(hash[:evaluator_identifier]).must_equal "test"
+      expect(hash[:evaluator_class]).must_equal stub_evaluator_class
       expect(hash[:min]).must_equal 0.8
       expect(hash[:max]).must_be_nil
       expect(hash[:weight]).must_equal 1.5

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -6,7 +6,6 @@ describe Riffer::Evals::Profile do
   # Create a simple evaluator for testing
   let(:profile_evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      identifier "profile_test_evaluator"
       description "Test evaluator for profile tests"
       higher_is_better true
 
@@ -18,36 +17,30 @@ describe Riffer::Evals::Profile do
     end
   end
 
-  before do
-    Riffer::Evals::Evaluators::Repository.register(:profile_test_evaluator, profile_evaluator_class)
-  end
-
-  after do
-    Riffer::Evals::Evaluators::Repository.clear
-  end
-
   describe "ai_evals DSL" do
     it "defines metrics" do
+      evaluator = profile_evaluator_class
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
         ai_evals do
-          metric :profile_test_evaluator, min: 0.8
+          metric evaluator, min: 0.8
         end
       end
 
       expect(profile_module.eval_metrics.length).must_equal 1
-      expect(profile_module.eval_metrics.first.evaluator_identifier).must_equal "profile_test_evaluator"
+      expect(profile_module.eval_metrics.first.evaluator_class).must_equal profile_evaluator_class
       expect(profile_module.eval_metrics.first.min).must_equal 0.8
     end
 
     it "supports multiple metrics" do
+      evaluator = profile_evaluator_class
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
         ai_evals do
-          metric :profile_test_evaluator, min: 0.85
-          metric :profile_test_evaluator, max: 0.10
+          metric evaluator, min: 0.85
+          metric evaluator, max: 0.10
         end
       end
 
@@ -55,11 +48,12 @@ describe Riffer::Evals::Profile do
     end
 
     it "supports weight option" do
+      evaluator = profile_evaluator_class
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
         ai_evals do
-          metric :profile_test_evaluator, min: 0.8, weight: 2.0
+          metric evaluator, min: 0.8, weight: 2.0
         end
       end
 
@@ -74,11 +68,12 @@ describe Riffer::Evals::Profile do
     end
 
     it "adds run_eval method when included in Agent" do
+      evaluator = profile_evaluator_class
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
         ai_evals do
-          metric :profile_test_evaluator, min: 0.8
+          metric evaluator, min: 0.8
         end
       end
 
@@ -93,11 +88,12 @@ describe Riffer::Evals::Profile do
     end
 
     it "runs evaluation when eval is called" do
+      evaluator = profile_evaluator_class
       profile_module = Module.new do
         include Riffer::Evals::Profile
 
         ai_evals do
-          metric :profile_test_evaluator, min: 0.8
+          metric evaluator, min: 0.8
         end
       end
 
@@ -120,10 +116,10 @@ describe Riffer::Evals::Profile do
   describe "Builder" do
     it "creates metrics with correct options" do
       builder = Riffer::Evals::Profile::Builder.new
-      builder.metric(:test, min: 0.7, max: 0.95, weight: 1.5)
+      builder.metric(profile_evaluator_class, min: 0.7, max: 0.95, weight: 1.5)
 
       metric = builder.metrics.first
-      expect(metric.evaluator_identifier).must_equal "test"
+      expect(metric.evaluator_class).must_equal profile_evaluator_class
       expect(metric.min).must_equal 0.7
       expect(metric.max).must_equal 0.95
       expect(metric.weight).must_equal 1.5

--- a/test/riffer/evals/result_test.rb
+++ b/test/riffer/evals/result_test.rb
@@ -3,50 +3,56 @@
 require "test_helper"
 
 describe Riffer::Evals::Result do
+  let(:stub_evaluator_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      description "Test evaluator"
+    end
+  end
+
   describe "#initialize" do
     it "sets the evaluator" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
-      expect(result.evaluator).must_equal "test_eval"
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
+      expect(result.evaluator).must_equal stub_evaluator_class
     end
 
     it "sets the score as a float" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: "0.85")
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: "0.85")
       expect(result.score).must_equal 0.85
     end
 
     it "sets the reason" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, reason: "Good response")
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, reason: "Good response")
       expect(result.reason).must_equal "Good response"
     end
 
     it "defaults reason to nil" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
       expect(result.reason).must_be_nil
     end
 
     it "sets metadata" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, metadata: {key: "value"})
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, metadata: {key: "value"})
       expect(result.metadata).must_equal({key: "value"})
     end
 
     it "defaults metadata to empty hash" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
       expect(result.metadata).must_equal({})
     end
 
     it "sets higher_is_better" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8, higher_is_better: false)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, higher_is_better: false)
       expect(result.higher_is_better).must_equal false
     end
 
     it "defaults higher_is_better to true" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
       expect(result.higher_is_better).must_equal true
     end
 
     it "raises an error if score is below 0" do
       error = expect do
-        Riffer::Evals::Result.new(evaluator: "test_eval", score: -0.1)
+        Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: -0.1)
       end.must_raise Riffer::ArgumentError
 
       expect(error.message).must_match(/score must be between 0.0 and 1.0/)
@@ -54,19 +60,19 @@ describe Riffer::Evals::Result do
 
     it "raises an error if score is above 1" do
       error = expect do
-        Riffer::Evals::Result.new(evaluator: "test_eval", score: 1.5)
+        Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 1.5)
       end.must_raise Riffer::ArgumentError
 
       expect(error.message).must_match(/score must be between 0.0 and 1.0/)
     end
 
     it "allows score of exactly 0" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 0)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0)
       expect(result.score).must_equal 0.0
     end
 
     it "allows score of exactly 1" do
-      result = Riffer::Evals::Result.new(evaluator: "test_eval", score: 1)
+      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 1)
       expect(result.score).must_equal 1.0
     end
   end
@@ -74,7 +80,7 @@ describe Riffer::Evals::Result do
   describe "#to_h" do
     it "returns a hash representation" do
       result = Riffer::Evals::Result.new(
-        evaluator: "test_eval",
+        evaluator: stub_evaluator_class,
         score: 0.85,
         reason: "Good",
         metadata: {key: "value"},
@@ -82,7 +88,8 @@ describe Riffer::Evals::Result do
       )
 
       hash = result.to_h
-      expect(hash[:evaluator]).must_equal "test_eval"
+      expect(hash[:evaluator]).must_be_kind_of String
+      expect(hash[:evaluator]).wont_be_empty
       expect(hash[:score]).must_equal 0.85
       expect(hash[:reason]).must_equal "Good"
       expect(hash[:metadata]).must_equal({key: "value"})

--- a/test/riffer/evals/result_test.rb
+++ b/test/riffer/evals/result_test.rb
@@ -3,56 +3,50 @@
 require "test_helper"
 
 describe Riffer::Evals::Result do
-  let(:stub_evaluator_class) do
-    Class.new(Riffer::Evals::Evaluator) do
-      description "Test evaluator"
-    end
-  end
-
   describe "#initialize" do
     it "sets the evaluator" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
-      expect(result.evaluator).must_equal stub_evaluator_class
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8)
+      expect(result.evaluator).must_equal Riffer::Evals::Evaluator
     end
 
     it "sets the score as a float" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: "0.85")
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: "0.85")
       expect(result.score).must_equal 0.85
     end
 
     it "sets the reason" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, reason: "Good response")
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8, reason: "Good response")
       expect(result.reason).must_equal "Good response"
     end
 
     it "defaults reason to nil" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8)
       expect(result.reason).must_be_nil
     end
 
     it "sets metadata" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, metadata: {key: "value"})
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8, metadata: {key: "value"})
       expect(result.metadata).must_equal({key: "value"})
     end
 
     it "defaults metadata to empty hash" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8)
       expect(result.metadata).must_equal({})
     end
 
     it "sets higher_is_better" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8, higher_is_better: false)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8, higher_is_better: false)
       expect(result.higher_is_better).must_equal false
     end
 
     it "defaults higher_is_better to true" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0.8)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8)
       expect(result.higher_is_better).must_equal true
     end
 
     it "raises an error if score is below 0" do
       error = expect do
-        Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: -0.1)
+        Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: -0.1)
       end.must_raise Riffer::ArgumentError
 
       expect(error.message).must_match(/score must be between 0.0 and 1.0/)
@@ -60,19 +54,19 @@ describe Riffer::Evals::Result do
 
     it "raises an error if score is above 1" do
       error = expect do
-        Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 1.5)
+        Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 1.5)
       end.must_raise Riffer::ArgumentError
 
       expect(error.message).must_match(/score must be between 0.0 and 1.0/)
     end
 
     it "allows score of exactly 0" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 0)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0)
       expect(result.score).must_equal 0.0
     end
 
     it "allows score of exactly 1" do
-      result = Riffer::Evals::Result.new(evaluator: stub_evaluator_class, score: 1)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 1)
       expect(result.score).must_equal 1.0
     end
   end
@@ -80,7 +74,7 @@ describe Riffer::Evals::Result do
   describe "#to_h" do
     it "returns a hash representation" do
       result = Riffer::Evals::Result.new(
-        evaluator: stub_evaluator_class,
+        evaluator: Riffer::Evals::Evaluator,
         score: 0.85,
         reason: "Good",
         metadata: {key: "value"},

--- a/test/riffer/evals/run_result_test.rb
+++ b/test/riffer/evals/run_result_test.rb
@@ -3,28 +3,40 @@
 require "test_helper"
 
 describe Riffer::Evals::RunResult do
+  let(:relevancy_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      higher_is_better true
+    end
+  end
+
+  let(:toxicity_class) do
+    Class.new(Riffer::Evals::Evaluator) do
+      higher_is_better false
+    end
+  end
+
   let(:passing_result) do
-    Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.9, higher_is_better: true)
+    Riffer::Evals::Result.new(evaluator: relevancy_class, score: 0.9, higher_is_better: true)
   end
 
   let(:failing_result) do
-    Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.6, higher_is_better: true)
+    Riffer::Evals::Result.new(evaluator: relevancy_class, score: 0.6, higher_is_better: true)
   end
 
   let(:toxicity_result) do
-    Riffer::Evals::Result.new(evaluator: "toxicity", score: 0.1, higher_is_better: false)
+    Riffer::Evals::Result.new(evaluator: toxicity_class, score: 0.1, higher_is_better: false)
   end
 
   let(:passing_metric) do
-    Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", min: 0.8)
+    Riffer::Evals::Metric.new(evaluator_class: relevancy_class, min: 0.8)
   end
 
   let(:failing_metric) do
-    Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", min: 0.8)
+    Riffer::Evals::Metric.new(evaluator_class: relevancy_class, min: 0.8)
   end
 
   let(:toxicity_metric) do
-    Riffer::Evals::Metric.new(evaluator_identifier: "toxicity", max: 0.2)
+    Riffer::Evals::Metric.new(evaluator_class: toxicity_class, max: 0.2)
   end
 
   describe "#initialize" do
@@ -148,11 +160,14 @@ describe Riffer::Evals::RunResult do
     end
 
     it "calculates weighted average" do
-      metric1 = Riffer::Evals::Metric.new(evaluator_identifier: "a", weight: 2.0)
-      metric2 = Riffer::Evals::Metric.new(evaluator_identifier: "b", weight: 1.0)
+      a_class = Class.new(Riffer::Evals::Evaluator) { higher_is_better true }
+      b_class = Class.new(Riffer::Evals::Evaluator) { higher_is_better true }
 
-      result1 = Riffer::Evals::Result.new(evaluator: "a", score: 0.9, higher_is_better: true)
-      result2 = Riffer::Evals::Result.new(evaluator: "b", score: 0.6, higher_is_better: true)
+      metric1 = Riffer::Evals::Metric.new(evaluator_class: a_class, weight: 2.0)
+      metric2 = Riffer::Evals::Metric.new(evaluator_class: b_class, weight: 1.0)
+
+      result1 = Riffer::Evals::Result.new(evaluator: a_class, score: 0.9, higher_is_better: true)
+      result2 = Riffer::Evals::Result.new(evaluator: b_class, score: 0.6, higher_is_better: true)
 
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
@@ -182,11 +197,11 @@ describe Riffer::Evals::RunResult do
     end
 
     it "combines higher_is_better and lower_is_better scores" do
-      metric1 = Riffer::Evals::Metric.new(evaluator_identifier: "relevancy", weight: 1.0)
-      metric2 = Riffer::Evals::Metric.new(evaluator_identifier: "toxicity", weight: 1.0)
+      metric1 = Riffer::Evals::Metric.new(evaluator_class: relevancy_class, weight: 1.0)
+      metric2 = Riffer::Evals::Metric.new(evaluator_class: toxicity_class, weight: 1.0)
 
-      result1 = Riffer::Evals::Result.new(evaluator: "relevancy", score: 0.8, higher_is_better: true)
-      result2 = Riffer::Evals::Result.new(evaluator: "toxicity", score: 0.2, higher_is_better: false)
+      result1 = Riffer::Evals::Result.new(evaluator: relevancy_class, score: 0.8, higher_is_better: true)
+      result2 = Riffer::Evals::Result.new(evaluator: toxicity_class, score: 0.2, higher_is_better: false)
 
       run_result = Riffer::Evals::RunResult.new(
         input: "test",

--- a/test/riffer/evals/runner_test.rb
+++ b/test/riffer/evals/runner_test.rb
@@ -6,7 +6,6 @@ describe Riffer::Evals::Runner do
   # Create a simple evaluator that returns a fixed score
   let(:runner_evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      identifier "runner_test_evaluator"
       description "Test evaluator for runner tests"
       higher_is_better true
 
@@ -18,17 +17,9 @@ describe Riffer::Evals::Runner do
     end
   end
 
-  before do
-    Riffer::Evals::Evaluators::Repository.register(:runner_test_evaluator, runner_evaluator_class)
-  end
-
-  after do
-    Riffer::Evals::Evaluators::Repository.clear
-  end
-
   describe "#initialize" do
     it "sets the metrics" do
-      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator")]
+      metrics = [Riffer::Evals::Metric.new(evaluator_class: runner_evaluator_class)]
       runner = Riffer::Evals::Runner.new(metrics: metrics)
       expect(runner.metrics).must_equal metrics
     end
@@ -36,7 +27,7 @@ describe Riffer::Evals::Runner do
 
   describe "#run" do
     it "returns a RunResult" do
-      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.5)]
+      metrics = [Riffer::Evals::Metric.new(evaluator_class: runner_evaluator_class, min: 0.5)]
       runner = Riffer::Evals::Runner.new(metrics: metrics)
 
       result = runner.run(
@@ -50,8 +41,8 @@ describe Riffer::Evals::Runner do
 
     it "runs all evaluators" do
       metrics = [
-        Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.5),
-        Riffer::Evals::Metric.new(evaluator_identifier: "runner_test_evaluator", min: 0.3)
+        Riffer::Evals::Metric.new(evaluator_class: runner_evaluator_class, min: 0.5),
+        Riffer::Evals::Metric.new(evaluator_class: runner_evaluator_class, min: 0.3)
       ]
       runner = Riffer::Evals::Runner.new(metrics: metrics)
 
@@ -66,16 +57,13 @@ describe Riffer::Evals::Runner do
 
     it "passes context to evaluators" do
       context_evaluator_class = Class.new(Riffer::Evals::Evaluator) do
-        identifier "context_evaluator"
-
         def evaluate(input:, output:, context: nil)
           score = context&.dig(:expected_score) || 0.5
           result(score: score, reason: "From context")
         end
       end
-      Riffer::Evals::Evaluators::Repository.register(:context_evaluator, context_evaluator_class)
 
-      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "context_evaluator")]
+      metrics = [Riffer::Evals::Metric.new(evaluator_class: context_evaluator_class)]
       runner = Riffer::Evals::Runner.new(metrics: metrics)
 
       result = runner.run(
@@ -85,15 +73,6 @@ describe Riffer::Evals::Runner do
       )
 
       expect(result.results.first.score).must_equal 0.95
-    end
-
-    it "raises error for unknown evaluator" do
-      metrics = [Riffer::Evals::Metric.new(evaluator_identifier: "unknown_evaluator")]
-      runner = Riffer::Evals::Runner.new(metrics: metrics)
-
-      expect {
-        runner.run(input: "test", output: "test", context: nil)
-      }.must_raise(Riffer::ArgumentError)
     end
   end
 end

--- a/test/riffer/guardrail_test.rb
+++ b/test/riffer/guardrail_test.rb
@@ -3,36 +3,6 @@
 require "test_helper"
 
 describe Riffer::Guardrail do
-  describe ".identifier" do
-    it "defaults to snake_case class name" do
-      expect(Riffer::Guardrail.identifier).must_equal "riffer/guardrail"
-    end
-
-    it "can be set explicitly" do
-      guardrail_class = Class.new(Riffer::Guardrail) do
-        identifier "custom_guardrail"
-      end
-      expect(guardrail_class.identifier).must_equal "custom_guardrail"
-    end
-
-    it "converts non-string identifiers to string" do
-      guardrail_class = Class.new(Riffer::Guardrail) do
-        identifier :my_guardrail
-      end
-      expect(guardrail_class.identifier).must_equal "my_guardrail"
-    end
-  end
-
-  describe "#identifier" do
-    it "returns the class identifier" do
-      guardrail_class = Class.new(Riffer::Guardrail) do
-        identifier "instance_guardrail"
-      end
-      guardrail = guardrail_class.new
-      expect(guardrail.identifier).must_equal "instance_guardrail"
-    end
-  end
-
   describe "#process_input" do
     it "returns pass by default" do
       guardrail = Riffer::Guardrail.new
@@ -68,8 +38,6 @@ describe Riffer::Guardrail do
   describe "custom guardrail" do
     let(:custom_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "custom_transformer"
-
         def process_input(messages, context:)
           transform(messages.map { |m| Riffer::Messages::User.new(m.content.upcase) })
         end

--- a/test/riffer/guardrails/max_length_test.rb
+++ b/test/riffer/guardrails/max_length_test.rb
@@ -15,12 +15,6 @@ describe Riffer::Guardrails::MaxLength do
     end
   end
 
-  describe ".identifier" do
-    it "has default identifier" do
-      expect(Riffer::Guardrails::MaxLength.identifier).must_equal "riffer/guardrails/max_length"
-    end
-  end
-
   describe "#process_input" do
     it "passes messages under the limit" do
       guardrail = Riffer::Guardrails::MaxLength.new(max: 100)

--- a/test/riffer/guardrails/modification_test.rb
+++ b/test/riffer/guardrails/modification_test.rb
@@ -3,21 +3,23 @@
 require "test_helper"
 
 describe Riffer::Guardrails::Modification do
-  describe "#guardrail_id" do
-    it "returns the guardrail identifier" do
+  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
+
+  describe "#guardrail" do
+    it "returns the guardrail class" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :before,
         message_indices: [0, 1]
       )
-      expect(modification.guardrail_id).must_equal "pii_redactor"
+      expect(modification.guardrail).must_equal stub_guardrail_class
     end
   end
 
   describe "#phase" do
     it "returns the phase" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "normalizer",
+        guardrail: stub_guardrail_class,
         phase: :after,
         message_indices: [0]
       )
@@ -28,7 +30,7 @@ describe Riffer::Guardrails::Modification do
   describe "#message_indices" do
     it "returns the message indices" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "normalizer",
+        guardrail: stub_guardrail_class,
         phase: :before,
         message_indices: [1, 3]
       )
@@ -37,18 +39,19 @@ describe Riffer::Guardrails::Modification do
   end
 
   describe "#to_h" do
-    it "returns a hash with guardrail_id" do
+    it "returns a hash with guardrail as string" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :before,
         message_indices: [0]
       )
-      expect(modification.to_h[:guardrail_id]).must_equal "pii_redactor"
+      expect(modification.to_h[:guardrail]).must_be_kind_of String
+      expect(modification.to_h[:guardrail]).wont_be_empty
     end
 
     it "returns a hash with phase" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :after,
         message_indices: [0]
       )
@@ -57,7 +60,7 @@ describe Riffer::Guardrails::Modification do
 
     it "returns a hash with message_indices" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :before,
         message_indices: [0, 2]
       )

--- a/test/riffer/guardrails/modification_test.rb
+++ b/test/riffer/guardrails/modification_test.rb
@@ -3,23 +3,21 @@
 require "test_helper"
 
 describe Riffer::Guardrails::Modification do
-  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
-
   describe "#guardrail" do
     it "returns the guardrail class" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [0, 1]
       )
-      expect(modification.guardrail).must_equal stub_guardrail_class
+      expect(modification.guardrail).must_equal Riffer::Guardrail
     end
   end
 
   describe "#phase" do
     it "returns the phase" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :after,
         message_indices: [0]
       )
@@ -30,7 +28,7 @@ describe Riffer::Guardrails::Modification do
   describe "#message_indices" do
     it "returns the message indices" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [1, 3]
       )
@@ -41,7 +39,7 @@ describe Riffer::Guardrails::Modification do
   describe "#to_h" do
     it "returns a hash with guardrail as string" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [0]
       )
@@ -51,7 +49,7 @@ describe Riffer::Guardrails::Modification do
 
     it "returns a hash with phase" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :after,
         message_indices: [0]
       )
@@ -60,7 +58,7 @@ describe Riffer::Guardrails::Modification do
 
     it "returns a hash with message_indices" do
       modification = Riffer::Guardrails::Modification.new(
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         message_indices: [0, 2]
       )

--- a/test/riffer/guardrails/runner_test.rb
+++ b/test/riffer/guardrails/runner_test.rb
@@ -5,8 +5,6 @@ require "test_helper"
 describe Riffer::Guardrails::Runner do
   let(:pass_guardrail_class) do
     Class.new(Riffer::Guardrail) do
-      identifier "pass_guardrail"
-
       def process_input(messages, context:)
         pass(messages)
       end
@@ -19,8 +17,6 @@ describe Riffer::Guardrails::Runner do
 
   let(:transform_guardrail_class) do
     Class.new(Riffer::Guardrail) do
-      identifier "transform_guardrail"
-
       def process_input(messages, context:)
         transform(messages.map { |m|
           Riffer::Messages::User.new("[transformed] #{m.content}")
@@ -35,8 +31,6 @@ describe Riffer::Guardrails::Runner do
 
   let(:block_guardrail_class) do
     Class.new(Riffer::Guardrail) do
-      identifier "block_guardrail"
-
       def process_input(messages, context:)
         block("Input blocked", metadata: {phase: :before})
       end
@@ -101,11 +95,11 @@ describe Riffer::Guardrails::Runner do
       expect(tripwire.phase).must_equal :before
     end
 
-    it "tripwire has correct guardrail_id" do
+    it "tripwire has correct guardrail" do
       runner = Riffer::Guardrails::Runner.new([config_for(block_guardrail_class)], phase: :before)
       messages = [Riffer::Messages::User.new("Hello")]
       _data, tripwire, _modifications = runner.run(messages)
-      expect(tripwire.guardrail_id).must_equal "block_guardrail"
+      expect(tripwire.guardrail).must_equal block_guardrail_class
     end
 
     it "tripwire has correct metadata" do
@@ -167,7 +161,7 @@ describe Riffer::Guardrails::Runner do
       runner = Riffer::Guardrails::Runner.new(configs, phase: :before)
       messages = [Riffer::Messages::User.new("Hello")]
       _data, tripwire, _modifications = runner.run(messages)
-      expect(tripwire.guardrail_id).must_equal "block_guardrail"
+      expect(tripwire.guardrail).must_equal block_guardrail_class
     end
 
     it "returns original data when blocked" do
@@ -181,8 +175,6 @@ describe Riffer::Guardrails::Runner do
   describe "context passing" do
     let(:context_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "context_guardrail"
-
         def process_input(messages, context:)
           if context && context[:block]
             block("Context says block")
@@ -211,8 +203,6 @@ describe Riffer::Guardrails::Runner do
   describe "guardrail options" do
     let(:options_guardrail_class) do
       Class.new(Riffer::Guardrail) do
-        identifier "options_guardrail"
-
         attr_reader :prefix
 
         def initialize(prefix: "[default]")
@@ -258,11 +248,11 @@ describe Riffer::Guardrails::Runner do
       expect(modifications.length).must_equal 1
     end
 
-    it "modification has correct guardrail_id" do
+    it "modification has correct guardrail" do
       runner = Riffer::Guardrails::Runner.new([config_for(transform_guardrail_class)], phase: :before)
       messages = [Riffer::Messages::User.new("Hello")]
       _data, _tripwire, modifications = runner.run(messages)
-      expect(modifications.first.guardrail_id).must_equal "transform_guardrail"
+      expect(modifications.first.guardrail).must_equal transform_guardrail_class
     end
 
     it "modification has correct phase" do
@@ -298,8 +288,6 @@ describe Riffer::Guardrails::Runner do
 
     it "detects correct indices when only some messages change" do
       selective_guardrail_class = Class.new(Riffer::Guardrail) do
-        identifier "selective_guardrail"
-
         def process_input(messages, context:)
           transformed = messages.map.with_index { |m, i|
             (i == 1) ? Riffer::Messages::User.new("[changed] #{m.content}") : m

--- a/test/riffer/guardrails/tripwire_test.rb
+++ b/test/riffer/guardrails/tripwire_test.rb
@@ -3,29 +3,31 @@
 require "test_helper"
 
 describe Riffer::Guardrails::Tripwire do
+  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
+
   describe "#initialize" do
     it "creates a tripwire with required attributes" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "PII detected",
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :before
       )
       expect(tripwire.reason).must_equal "PII detected"
     end
 
-    it "stores the guardrail_id" do
+    it "stores the guardrail" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "my_guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before
       )
-      expect(tripwire.guardrail_id).must_equal "my_guardrail"
+      expect(tripwire.guardrail).must_equal stub_guardrail_class
     end
 
     it "stores the phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :after
       )
       expect(tripwire.phase).must_equal :after
@@ -34,7 +36,7 @@ describe Riffer::Guardrails::Tripwire do
     it "accepts before phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before
       )
       expect(tripwire.phase).must_equal :before
@@ -43,7 +45,7 @@ describe Riffer::Guardrails::Tripwire do
     it "accepts after phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :after
       )
       expect(tripwire.phase).must_equal :after
@@ -53,7 +55,7 @@ describe Riffer::Guardrails::Tripwire do
       error = expect do
         Riffer::Guardrails::Tripwire.new(
           reason: "blocked",
-          guardrail_id: "guardrail",
+          guardrail: stub_guardrail_class,
           phase: :invalid
         )
       end.must_raise(Riffer::ArgumentError)
@@ -63,7 +65,7 @@ describe Riffer::Guardrails::Tripwire do
     it "stores metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before,
         metadata: {detected: [:email]}
       )
@@ -73,7 +75,7 @@ describe Riffer::Guardrails::Tripwire do
     it "allows nil metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before
       )
       expect(tripwire.metadata).must_be_nil
@@ -84,7 +86,7 @@ describe Riffer::Guardrails::Tripwire do
     it "returns a hash representation" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "PII detected",
-        guardrail_id: "pii_redactor",
+        guardrail: stub_guardrail_class,
         phase: :before,
         metadata: {types: [:email]}
       )
@@ -92,19 +94,20 @@ describe Riffer::Guardrails::Tripwire do
       expect(hash[:reason]).must_equal "PII detected"
     end
 
-    it "includes guardrail_id" do
+    it "includes guardrail as string" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "my_guardrail",
+        guardrail: stub_guardrail_class,
         phase: :after
       )
-      expect(tripwire.to_h[:guardrail_id]).must_equal "my_guardrail"
+      expect(tripwire.to_h[:guardrail]).must_be_kind_of String
+      expect(tripwire.to_h[:guardrail]).wont_be_empty
     end
 
     it "includes phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before
       )
       expect(tripwire.to_h[:phase]).must_equal :before
@@ -113,7 +116,7 @@ describe Riffer::Guardrails::Tripwire do
     it "includes metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail_id: "guardrail",
+        guardrail: stub_guardrail_class,
         phase: :before,
         metadata: {key: "value"}
       )

--- a/test/riffer/guardrails/tripwire_test.rb
+++ b/test/riffer/guardrails/tripwire_test.rb
@@ -3,13 +3,11 @@
 require "test_helper"
 
 describe Riffer::Guardrails::Tripwire do
-  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
-
   describe "#initialize" do
     it "creates a tripwire with required attributes" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "PII detected",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       expect(tripwire.reason).must_equal "PII detected"
@@ -18,16 +16,16 @@ describe Riffer::Guardrails::Tripwire do
     it "stores the guardrail" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
-      expect(tripwire.guardrail).must_equal stub_guardrail_class
+      expect(tripwire.guardrail).must_equal Riffer::Guardrail
     end
 
     it "stores the phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :after
       )
       expect(tripwire.phase).must_equal :after
@@ -36,7 +34,7 @@ describe Riffer::Guardrails::Tripwire do
     it "accepts before phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       expect(tripwire.phase).must_equal :before
@@ -45,7 +43,7 @@ describe Riffer::Guardrails::Tripwire do
     it "accepts after phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :after
       )
       expect(tripwire.phase).must_equal :after
@@ -55,7 +53,7 @@ describe Riffer::Guardrails::Tripwire do
       error = expect do
         Riffer::Guardrails::Tripwire.new(
           reason: "blocked",
-          guardrail: stub_guardrail_class,
+          guardrail: Riffer::Guardrail,
           phase: :invalid
         )
       end.must_raise(Riffer::ArgumentError)
@@ -65,7 +63,7 @@ describe Riffer::Guardrails::Tripwire do
     it "stores metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         metadata: {detected: [:email]}
       )
@@ -75,7 +73,7 @@ describe Riffer::Guardrails::Tripwire do
     it "allows nil metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       expect(tripwire.metadata).must_be_nil
@@ -86,7 +84,7 @@ describe Riffer::Guardrails::Tripwire do
     it "returns a hash representation" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "PII detected",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         metadata: {types: [:email]}
       )
@@ -97,7 +95,7 @@ describe Riffer::Guardrails::Tripwire do
     it "includes guardrail as string" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :after
       )
       expect(tripwire.to_h[:guardrail]).must_be_kind_of String
@@ -107,7 +105,7 @@ describe Riffer::Guardrails::Tripwire do
     it "includes phase" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before
       )
       expect(tripwire.to_h[:phase]).must_equal :before
@@ -116,7 +114,7 @@ describe Riffer::Guardrails::Tripwire do
     it "includes metadata" do
       tripwire = Riffer::Guardrails::Tripwire.new(
         reason: "blocked",
-        guardrail: stub_guardrail_class,
+        guardrail: Riffer::Guardrail,
         phase: :before,
         metadata: {key: "value"}
       )

--- a/test/riffer/stream_events/guardrail_modification_test.rb
+++ b/test/riffer/stream_events/guardrail_modification_test.rb
@@ -3,9 +3,11 @@
 require "test_helper"
 
 describe Riffer::StreamEvents::GuardrailModification do
+  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
+
   let(:modification) do
     Riffer::Guardrails::Modification.new(
-      guardrail_id: "pii_redactor",
+      guardrail: stub_guardrail_class,
       phase: :before,
       message_indices: [0, 1]
     )
@@ -18,10 +20,10 @@ describe Riffer::StreamEvents::GuardrailModification do
     end
   end
 
-  describe "#guardrail_id" do
+  describe "#guardrail" do
     it "delegates to modification" do
       event = Riffer::StreamEvents::GuardrailModification.new(modification)
-      expect(event.guardrail_id).must_equal "pii_redactor"
+      expect(event.guardrail).must_equal stub_guardrail_class
     end
   end
 
@@ -59,7 +61,8 @@ describe Riffer::StreamEvents::GuardrailModification do
 
     it "includes modification hash" do
       event = Riffer::StreamEvents::GuardrailModification.new(modification)
-      expect(event.to_h[:modification][:guardrail_id]).must_equal "pii_redactor"
+      expect(event.to_h[:modification][:guardrail]).must_be_kind_of String
+      expect(event.to_h[:modification][:guardrail]).wont_be_empty
     end
 
     it "includes phase in modification hash" do

--- a/test/riffer/stream_events/guardrail_modification_test.rb
+++ b/test/riffer/stream_events/guardrail_modification_test.rb
@@ -3,11 +3,9 @@
 require "test_helper"
 
 describe Riffer::StreamEvents::GuardrailModification do
-  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
-
   let(:modification) do
     Riffer::Guardrails::Modification.new(
-      guardrail: stub_guardrail_class,
+      guardrail: Riffer::Guardrail,
       phase: :before,
       message_indices: [0, 1]
     )
@@ -23,7 +21,7 @@ describe Riffer::StreamEvents::GuardrailModification do
   describe "#guardrail" do
     it "delegates to modification" do
       event = Riffer::StreamEvents::GuardrailModification.new(modification)
-      expect(event.guardrail).must_equal stub_guardrail_class
+      expect(event.guardrail).must_equal Riffer::Guardrail
     end
   end
 

--- a/test/riffer/stream_events/guardrail_tripwire_test.rb
+++ b/test/riffer/stream_events/guardrail_tripwire_test.rb
@@ -3,12 +3,10 @@
 require "test_helper"
 
 describe Riffer::StreamEvents::GuardrailTripwire do
-  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
-
   let(:guardrails_tripwire) do
     Riffer::Guardrails::Tripwire.new(
       reason: "PII detected",
-      guardrail: stub_guardrail_class,
+      guardrail: Riffer::Guardrail,
       phase: :before,
       metadata: {types: [:email]}
     )
@@ -48,7 +46,7 @@ describe Riffer::StreamEvents::GuardrailTripwire do
   describe "#guardrail" do
     it "returns the guardrail class" do
       event = Riffer::StreamEvents::GuardrailTripwire.new(guardrails_tripwire)
-      expect(event.guardrail).must_equal stub_guardrail_class
+      expect(event.guardrail).must_equal Riffer::Guardrail
     end
   end
 

--- a/test/riffer/stream_events/guardrail_tripwire_test.rb
+++ b/test/riffer/stream_events/guardrail_tripwire_test.rb
@@ -3,10 +3,12 @@
 require "test_helper"
 
 describe Riffer::StreamEvents::GuardrailTripwire do
+  let(:stub_guardrail_class) { Class.new(Riffer::Guardrail) }
+
   let(:guardrails_tripwire) do
     Riffer::Guardrails::Tripwire.new(
       reason: "PII detected",
-      guardrail_id: "pii_redactor",
+      guardrail: stub_guardrail_class,
       phase: :before,
       metadata: {types: [:email]}
     )
@@ -43,10 +45,10 @@ describe Riffer::StreamEvents::GuardrailTripwire do
     end
   end
 
-  describe "#guardrail_id" do
-    it "returns the guardrail identifier" do
+  describe "#guardrail" do
+    it "returns the guardrail class" do
       event = Riffer::StreamEvents::GuardrailTripwire.new(guardrails_tripwire)
-      expect(event.guardrail_id).must_equal "pii_redactor"
+      expect(event.guardrail).must_equal stub_guardrail_class
     end
   end
 
@@ -61,9 +63,10 @@ describe Riffer::StreamEvents::GuardrailTripwire do
       expect(event.to_h[:tripwire][:reason]).must_equal "PII detected"
     end
 
-    it "includes guardrail_id in tripwire" do
+    it "includes guardrail as string in tripwire" do
       event = Riffer::StreamEvents::GuardrailTripwire.new(guardrails_tripwire)
-      expect(event.to_h[:tripwire][:guardrail_id]).must_equal "pii_redactor"
+      expect(event.to_h[:tripwire][:guardrail]).must_be_kind_of String
+      expect(event.to_h[:tripwire][:guardrail]).wont_be_empty
     end
 
     it "includes phase in tripwire" do


### PR DESCRIPTION
## Summary
- Replace string-based identifier lookup with direct class references in both evals and guardrails subsystems
- Remove `Evaluators::Repository` — metrics now store `evaluator_class` (a class reference) directly instead of resolving via `evaluator_identifier` (a string)
- Remove `identifier` class/instance methods from `Guardrail` — `Tripwire` and `Modification` now store the guardrail class directly instead of a string `guardrail_id`
- Update Profile DSL to accept classes instead of symbols: `metric MyEvaluator, min: 0.85` instead of `metric :my_evaluator, min: 0.85`

## Test plan
- [x] `bundle exec rake` (tests + lint + type check) passes — 749 tests, 0 failures
- [x] RBS type signatures regenerated and verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)