### PR TITLE
chore: skip claude code review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- By default the Claude Code Review action will not review PRs from bots but results in a failure. This prevents a CI failure.
- Add `if: github.actor != 'dependabot[bot]'` condition to the `claude-review` job in the Claude Code Review workflow
- Prevents unnecessary code reviews on automated Dependabot dependency bump PRs

## Test plan
- Open a Dependabot PR (or re-run an existing one) and confirm the Claude Code Review workflow is skipped
- Open a non-Dependabot PR and confirm the review still runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)