### PR TITLE
fix: add --comment flag to claude code review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"
           use_sticky_comment: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Summary
- Add the `--comment` flag to the code-review plugin prompt in the Claude Code review workflow
- Without this flag, the review plugin does not post comments on PRs

## Test plan
- Open a PR and verify the Claude Code review action posts review comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)