### PR TITLE
fix: widen run_eval input type to accept String or messages

### DIFF
--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -117,6 +117,15 @@ result = MyAgent.run_eval(
   input: "What is the capital of France?",
   context: { ground_truth: "Paris" }  # Optional context
 )
+
+# You can also pass a messages array as input
+result = MyAgent.run_eval(
+  input: [
+    { role: "user", content: "What is Ruby?" },
+    { role: "assistant", content: "Ruby is a programming language." },
+    { role: "user", content: "What makes it special?" }
+  ]
+)
 ```
 
 ### RunResult Object

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -53,7 +53,7 @@ class Riffer::Evals::Evaluator
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
   def evaluate(input:, output:, context: nil)
     raise NotImplementedError, "#{self.class} must implement #evaluate"
   end

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -80,7 +80,7 @@ module Riffer::Evals::Profile
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    #: (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
     def run_eval(input:, context: nil, tool_context: nil)
       profile = @eval_profile
       raise Riffer::ArgumentError, "No eval profile configured" unless profile

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -19,7 +19,7 @@
 #
 class Riffer::Evals::RunResult
   # The input that was evaluated.
-  attr_reader :input #: String
+  attr_reader :input #: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]
 
   # The output that was evaluated.
   attr_reader :output #: String
@@ -35,7 +35,7 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  #: (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
   def initialize(input:, output:, context:, results:, metrics:)
     @input = input
     @output = output

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -26,7 +26,7 @@ class Riffer::Evals::Runner
 
   # Runs all evaluators and collects results.
   #
-  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   def run(input:, output:, context: nil)
     results = metrics.map do |metric|
       evaluator = metric.evaluator_class.new

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -40,8 +40,8 @@ class Riffer::Evals::Evaluator
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
-  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-  def evaluate: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
 
   # Returns a Judge instance configured for this evaluator.
   #

--- a/sig/generated/riffer/evals/profile.rbs
+++ b/sig/generated/riffer/evals/profile.rbs
@@ -53,7 +53,7 @@ module Riffer::Evals::Profile
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    # : (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-    def run_eval: (input: String, ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    def run_eval: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   end
 end

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -17,7 +17,7 @@
 #   run_result.failures         # => [result1] (results that failed thresholds)
 class Riffer::Evals::RunResult
   # The input that was evaluated.
-  attr_reader input: String
+  attr_reader input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]
 
   # The output that was evaluated.
   attr_reader output: String
@@ -33,8 +33,8 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  # : (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
-  def initialize: (input: String, output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  def initialize: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
 
   # Checks if all metrics passed their thresholds.
   #

--- a/sig/generated/riffer/evals/runner.rbs
+++ b/sig/generated/riffer/evals/runner.rbs
@@ -22,6 +22,6 @@ class Riffer::Evals::Runner
 
   # Runs all evaluators and collects results.
   #
-  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-  def run: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  def run: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
 end

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -111,6 +111,43 @@ describe Riffer::Evals::Profile do
       expect(result.input).must_equal "What is Ruby?"
       expect(result.output).must_equal "Test response"
     end
+
+    it "accepts a messages array as input" do
+      evaluator = Class.new(Riffer::Evals::Evaluator) do
+        higher_is_better true
+
+        def evaluate(input:, output:, context: nil)
+          result(score: 0.9, reason: "Test evaluation")
+        end
+      end
+
+      profile_module = Module.new do
+        include Riffer::Evals::Profile
+
+        ai_evals do
+          metric evaluator, min: 0.8
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "test/test-model"
+        instructions "You are a helpful assistant."
+      end
+
+      agent_class.include(profile_module)
+
+      messages = [
+        {role: "user", content: "What is Ruby?"},
+        {role: "assistant", content: "Ruby is a programming language."},
+        {role: "user", content: "What makes it special?"}
+      ]
+
+      result = agent_class.run_eval(input: messages)
+
+      expect(result).must_be_instance_of Riffer::Evals::RunResult
+      expect(result.input).must_equal messages
+      expect(result.output).must_equal "Test response"
+    end
   end
 
   describe "Builder" do


### PR DESCRIPTION
## Summary
- Updated RBS inline type annotations for `input:` from `String` to `String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]` across the entire eval chain (`run_eval`, `Runner#run`, `Evaluator#evaluate`, `RunResult`)
- Regenerated `sig/generated/` RBS files to match
- Added messages array example to `docs/08_EVALS.md`
- Added test coverage for passing a messages array to `run_eval`

## Test plan
- [x] `bundle exec rake` — 785 tests pass, lint clean
- [x] `bundle exec rake rbs:generate` — no drift between inline annotations and generated `.rbs` files
- [x] RBS type checking passes (`steep check` — no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)