### PR TITLE
feat: support dynamic model selection via lambda

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -65,7 +65,7 @@ On resume, `execute_pending_tool_calls` detects tool calls from the last assista
 
 ## Key Patterns
 
-- Model strings use `provider/model` format (e.g., `openai/gpt-4`)
+- Model config accepts a `provider/model` string (e.g., `openai/gpt-4`) or a Proc/lambda that returns one
 - Configuration via `Riffer.configure { |c| c.openai.api_key = "..." }`
 - Providers use `depends_on` helper for runtime dependency checking
 - Zeitwerk for autoloading - file structure must match module/class names

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -29,6 +29,26 @@ class MyAgent < Riffer::Agent
 end
 ```
 
+Models can also be resolved dynamically with a lambda:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model -> { "anthropic/claude-sonnet-4-20250514" }
+end
+```
+
+When the lambda accepts a parameter, it receives the `tool_context`:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model ->(ctx) {
+    ctx&.dig(:premium) ? "anthropic/claude-sonnet-4-20250514" : "anthropic/claude-haiku-4-5-20251001"
+  }
+end
+```
+
+The lambda is re-evaluated on each `generate` or `stream` call, so the model can change between calls based on runtime context.
+
 ### instructions
 
 Sets system instructions for the agent:

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -34,13 +34,18 @@ class Riffer::Agent
     @identifier = value.to_s
   end
 
-  # Gets or sets the model string (e.g., "openai/gpt-4o").
+  # Gets or sets the model string (e.g., "openai/gpt-4o") or Proc.
   #
-  #: (?String?) -> String?
-  def self.model(model_string = nil)
-    return @model if model_string.nil?
-    validate_is_string!(model_string, "model")
-    @model = model_string
+  #: (?(String | Proc)?) -> (String | Proc)?
+  def self.model(model_string_or_proc = nil)
+    return @model if model_string_or_proc.nil?
+
+    if model_string_or_proc.is_a?(Proc)
+      @model = model_string_or_proc
+    else
+      validate_is_string!(model_string_or_proc, "model")
+      @model = model_string_or_proc
+    end
   end
 
   # Gets or sets the agent instructions.
@@ -173,15 +178,15 @@ class Riffer::Agent
     @message_callbacks = []
     @token_usage = nil
     @interrupted = false
-    @model_string = self.class.model
+    @model_config = self.class.model
     @instructions_text = self.class.instructions
 
-    provider_name, model_name = @model_string.split("/", 2)
-
-    raise Riffer::ArgumentError, "Invalid model string: #{@model_string}" unless [provider_name, model_name].all? { |part| part.is_a?(String) && !part.strip.empty? }
-
-    @provider_name = provider_name
-    @model_name = model_name
+    if @model_config.is_a?(Proc)
+      @provider_name = nil
+      @model_name = nil
+    else
+      parse_model_string!(@model_config)
+    end
   end
 
   # Generates a response from the agent.
@@ -190,6 +195,8 @@ class Riffer::Agent
   def generate(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
+    @resolved_model = nil
+    @provider_instance = nil if @model_config.is_a?(Proc)
     @interrupted = false
     initialize_messages(prompt_or_messages)
 
@@ -208,6 +215,8 @@ class Riffer::Agent
   def stream(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
+    @resolved_model = nil
+    @provider_instance = nil if @model_config.is_a?(Proc)
     @interrupted = false
     initialize_messages(prompt_or_messages)
 
@@ -333,6 +342,8 @@ class Riffer::Agent
     @tool_context = tool_context if tool_context
     @interrupted = false
     @resolved_tools = nil
+    @resolved_model = nil
+    @provider_instance = nil if @model_config.is_a?(Proc)
   end
 
   #: (Enumerator::Yielder, ?resume: bool) -> void
@@ -409,6 +420,7 @@ class Riffer::Agent
 
   #: () -> Riffer::Messages::Assistant
   def call_llm
+    resolved_model
     provider_instance.generate_text(
       messages: @messages,
       model: @model_name,
@@ -419,6 +431,7 @@ class Riffer::Agent
 
   #: () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream
+    resolved_model
     provider_instance.stream_text(
       messages: @messages,
       model: @model_name,
@@ -515,6 +528,29 @@ class Riffer::Agent
       Riffer::Tools::Response.error(e.message, type: :validation_error)
     rescue => e
       Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+    end
+  end
+
+  #: (untyped) -> void
+  def parse_model_string!(model_string)
+    raise Riffer::ArgumentError, "Invalid model string: #{model_string}" unless model_string.is_a?(String)
+    provider_name, model_name = model_string.split("/", 2)
+    raise Riffer::ArgumentError, "Invalid model string: #{model_string}" unless [provider_name, model_name].all? { |part| part.is_a?(String) && !part.strip.empty? }
+    @provider_name = provider_name
+    @model_name = model_name
+  end
+
+  #: () -> String
+  def resolved_model
+    @resolved_model ||= begin
+      config = @model_config
+      if config.is_a?(Proc)
+        model_string = (config.arity == 0) ? config.call : config.call(@tool_context)
+        parse_model_string!(model_string)
+        model_string
+      else
+        config
+      end
     end
   end
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -195,8 +195,7 @@ class Riffer::Agent
   def generate(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
-    @resolved_model = nil
-    @provider_instance = nil if @model_config.is_a?(Proc)
+    clear_resolved_model
     @interrupted = false
     initialize_messages(prompt_or_messages)
 
@@ -215,8 +214,7 @@ class Riffer::Agent
   def stream(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
-    @resolved_model = nil
-    @provider_instance = nil if @model_config.is_a?(Proc)
+    clear_resolved_model
     @interrupted = false
     initialize_messages(prompt_or_messages)
 
@@ -342,8 +340,7 @@ class Riffer::Agent
     @tool_context = tool_context if tool_context
     @interrupted = false
     @resolved_tools = nil
-    @resolved_model = nil
-    @provider_instance = nil if @model_config.is_a?(Proc)
+    clear_resolved_model
   end
 
   #: (Enumerator::Yielder, ?resume: bool) -> void
@@ -420,7 +417,7 @@ class Riffer::Agent
 
   #: () -> Riffer::Messages::Assistant
   def call_llm
-    resolved_model
+    resolve_model
     provider_instance.generate_text(
       messages: @messages,
       model: @model_name,
@@ -431,7 +428,7 @@ class Riffer::Agent
 
   #: () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream
-    resolved_model
+    resolve_model
     provider_instance.stream_text(
       messages: @messages,
       model: @model_name,
@@ -540,17 +537,22 @@ class Riffer::Agent
     @model_name = model_name
   end
 
+  #: () -> void
+  def clear_resolved_model
+    @resolved_model = nil
+    @provider_instance = nil if @model_config.is_a?(Proc)
+  end
+
+  attr_reader :resolved_model #: String?
+
   #: () -> String
-  def resolved_model
-    @resolved_model ||= begin
-      config = @model_config
-      if config.is_a?(Proc)
-        model_string = (config.arity == 0) ? config.call : config.call(@tool_context)
-        parse_model_string!(model_string)
-        model_string
-      else
-        config
-      end
+  def resolve_model
+    @resolved_model ||= if @model_config.is_a?(Proc)
+      model_string = (@model_config.arity == 0) ? @model_config.call : @model_config.call(@tool_context)
+      parse_model_string!(model_string)
+      model_string
+    else
+      @model_config
     end
   end
 

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -205,8 +205,13 @@ class Riffer::Agent
   # : (untyped) -> void
   def parse_model_string!: (untyped) -> void
 
+  # : () -> void
+  def clear_resolved_model: () -> void
+
+  attr_reader resolved_model: String?
+
   # : () -> String
-  def resolved_model: () -> String
+  def resolve_model: () -> String
 
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -30,10 +30,10 @@ class Riffer::Agent
   # : (?String?) -> String
   def self.identifier: (?String?) -> String
 
-  # Gets or sets the model string (e.g., "openai/gpt-4o").
+  # Gets or sets the model string (e.g., "openai/gpt-4o") or Proc.
   #
-  # : (?String?) -> String?
-  def self.model: (?String?) -> String?
+  # : (?(String | Proc)?) -> (String | Proc)?
+  def self.model: (?(String | Proc)?) -> (String | Proc)?
 
   # Gets or sets the agent instructions.
   #
@@ -201,6 +201,12 @@ class Riffer::Agent
 
   # : (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
   def execute_tool_call: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+
+  # : (untyped) -> void
+  def parse_model_string!: (untyped) -> void
+
+  # : () -> String
+  def resolved_model: () -> String
 
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -40,6 +40,13 @@ describe Riffer::Agent do
       error = expect { agent_class.model("   ") }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/model cannot be empty/)
     end
+
+    it "accepts a Proc" do
+      agent = Class.new(Riffer::Agent) do
+        model -> { "test/riffer-1" }
+      end
+      expect(agent.model).must_be_instance_of Proc
+    end
   end
 
   describe ".instructions" do
@@ -748,6 +755,135 @@ describe Riffer::Agent do
         uses_tools -> { [tool_class] }
       end
       expect(agent.uses_tools).must_be_instance_of Proc
+    end
+  end
+
+  describe "dynamic model selection" do
+    it "resolves lambda for generate" do
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { "test/riffer-1" }
+      end
+
+      result = dynamic_agent_class.generate("Hello")
+      expect(result).must_be_instance_of Riffer::Agent::Response
+    end
+
+    it "resolves lambda for stream" do
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { "test/riffer-1" }
+      end
+
+      events = dynamic_agent_class.stream("Hello").to_a
+      expect(events).wont_be_empty
+    end
+
+    it "passes tool_context to lambda with arity 1" do
+      received_context = nil
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model ->(ctx) {
+          received_context = ctx
+          "test/riffer-1"
+        }
+      end
+
+      dynamic_agent_class.generate("Hello", tool_context: {premium: true})
+      expect(received_context).must_equal({premium: true})
+    end
+
+    it "calls lambda with no args when arity is 0" do
+      called = false
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> {
+          called = true
+          "test/riffer-1"
+        }
+      end
+
+      dynamic_agent_class.generate("Hello")
+      expect(called).must_equal true
+    end
+
+    it "uses resolved model for provider lookup" do
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { "test/riffer-1" }
+      end
+
+      agent = dynamic_agent_class.new
+      agent.generate("Hello")
+      provider = agent.send(:provider_instance)
+      expect(provider).must_be_instance_of Riffer::Providers::Test
+    end
+
+    it "re-evaluates lambda for each generate call" do
+      call_count = 0
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> {
+          call_count += 1
+          "test/riffer-1"
+        }
+      end
+
+      agent = dynamic_agent_class.new
+      agent.generate("Hello")
+      agent.generate("Hello again")
+      expect(call_count).must_equal 2
+    end
+
+    it "can change model between calls based on tool_context" do
+      models_used = []
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model ->(ctx) {
+          model = ctx&.dig(:premium) ? "test/riffer-premium" : "test/riffer-basic"
+          models_used << model
+          model
+        }
+      end
+
+      agent = dynamic_agent_class.new
+      agent.generate("Hello", tool_context: {premium: false})
+      agent.generate("Hello", tool_context: {premium: true})
+      expect(models_used).must_equal ["test/riffer-basic", "test/riffer-premium"]
+    end
+
+    it "passes resolved model name to provider" do
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { "test/my-model" }
+      end
+
+      agent = dynamic_agent_class.new
+      agent.generate("Hello")
+      provider = agent.send(:provider_instance)
+      expect(provider.calls.last[:model]).must_equal "my-model"
+    end
+
+    it "raises on invalid lambda return without slash" do
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { "invalid-format" }
+      end
+
+      agent = dynamic_agent_class.new
+      error = expect { agent.generate("Hello") }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Invalid model string: invalid-format/)
+    end
+
+    it "raises on nil lambda return" do
+      value = nil
+      dynamic_agent_class = Class.new(Riffer::Agent) do
+        model -> { value }
+      end
+
+      agent = dynamic_agent_class.new
+      error = expect { agent.generate("Hello") }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Invalid model string/)
+    end
+
+    it "static string still works" do
+      static_agent_class = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+      end
+
+      result = static_agent_class.generate("Hello")
+      expect(result).must_be_instance_of Riffer::Agent::Response
     end
   end
 


### PR DESCRIPTION
## Summary

- Allow the `model` DSL on `Riffer::Agent` to accept a `Proc`/lambda in addition to a static string
- The lambda is re-evaluated on each `generate`/`stream` call, enabling runtime model selection based on `tool_context`
- Supports arity-0 lambdas (no args) and arity-1 lambdas (receives `tool_context`)
- Follows the same pattern already established by `uses_tools` lambda support
- Updates docs (`03_AGENTS.md`) and architecture guide (`.agents/architecture.md`)
- Rename `resolved_model` method to `resolve_model` with `attr_reader` for the cached value
- Extract `clear_resolved_model` helper to DRY up repeated reset logic
- Remove unnecessary local variable indirection in `resolve_model`

## Test plan

- [x] All 809 existing tests pass (`bundle exec rake test`)
- [x] No lint violations (`bundle exec rake standard`)
- [x] Type checking passes (`bundle exec steep check`)
- [x] New tests cover: lambda resolution for generate/stream, tool_context passing (arity 0 & 1), provider lookup, re-evaluation across calls, model switching between calls, model name forwarding to provider, invalid returns (no slash, nil), static string regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)