### PR TITLE
feat: add structured output support for agents

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -4,7 +4,7 @@
 
 ### Agent (`lib/riffer/agent.rb`)
 
-Base class for AI agents. Subclass and use DSL methods `model` and `instructions` to configure. Orchestrates message flow, LLM calls, and tool execution via a generate/stream loop.
+Base class for AI agents. Subclass and use DSL methods `model`, `instructions`, and `structured_output` to configure. Orchestrates message flow, LLM calls, tool execution, and structured output parsing via a generate/stream loop.
 
 ```ruby
 class EchoAgent < Riffer::Agent
@@ -82,7 +82,12 @@ lib/
     agent.rb             # Agent class
     messages.rb          # Messages namespace/module
     providers.rb         # Providers namespace/module
+    param.rb             # Single parameter definition (shared by tools and structured output)
+    params.rb            # Parameter collection with DSL and validation
+    structured_output.rb # Structured output schema wrapper
     stream_events.rb     # Stream events namespace/module
+    structured_output/
+      result.rb          # Parse/validation result object
     helpers/
       class_name_converter.rb  # Class name conversion utilities
       dependencies.rb          # Dependency management

--- a/.agents/providers.md
+++ b/.agents/providers.md
@@ -85,6 +85,81 @@ class Riffer::Providers::YourProvider < Riffer::Providers::Base
 end
 ```
 
+## Structured Output
+
+When structured output is configured, the agent passes a `Riffer::StructuredOutput` instance via `options[:structured_output]`. Providers must extract it from options (and exclude it from the splat) and convert it to their SDK-specific format.
+
+### Extracting from options
+
+All providers follow the same pattern:
+
+```ruby
+def build_request_params(messages, model, options)
+  structured_output = options[:structured_output]
+
+  params = {
+    # ...
+    **options.except(:tools, :structured_output)
+  }
+
+  # Convert to provider-specific format (see below)
+end
+```
+
+### Provider-specific formats
+
+**OpenAI** — uses `params[:text][:format]`:
+
+```ruby
+if structured_output
+  params[:text] = {
+    format: {
+      type: "json_schema",
+      name: "response",
+      schema: structured_output.json_schema,
+      strict: true
+    }
+  }
+end
+```
+
+**Anthropic** — uses `params[:output_config]`:
+
+```ruby
+if structured_output
+  params[:output_config] = {
+    format: {
+      type: "json_schema",
+      schema: structured_output.json_schema
+    }
+  }
+end
+```
+
+**Amazon Bedrock** — uses `params[:output_config][:text_format]` with stringified schema:
+
+```ruby
+if structured_output
+  params[:output_config] = {
+    text_format: {
+      type: "json_schema",
+      structure: {
+        json_schema: {
+          schema: structured_output.json_schema.to_json,
+          name: "response"
+        }
+      }
+    }
+  }
+end
+```
+
+### Key details
+
+- `structured_output.json_schema` returns a Hash with `type`, `properties`, `required`, and `additionalProperties` keys
+- Bedrock requires the schema as a JSON string (`.to_json`), others use the Hash directly
+- The agent handles parsing and validation of the response — providers only need to pass the schema to the SDK
+
 ## Shared Utilities
 
 The base class provides `parse_tool_arguments` for converting tool call arguments from JSON strings to hashes:

--- a/docs/01_OVERVIEW.md
+++ b/docs/01_OVERVIEW.md
@@ -44,7 +44,10 @@ Agents can return structured JSON responses that conform to a schema. The respon
 ```ruby
 class SentimentAgent < Riffer::Agent
   model 'openai/gpt-4o'
-  structured_output sentiment: String, score: Float
+  structured_output do
+    required :sentiment, String
+    required :score, Float
+  end
 end
 
 response = SentimentAgent.generate('Analyze: "I love this!"')

--- a/docs/01_OVERVIEW.md
+++ b/docs/01_OVERVIEW.md
@@ -37,6 +37,22 @@ end
 
 See [Tools](04_TOOLS.md) for details.
 
+### Structured Output
+
+Agents can return structured JSON responses that conform to a schema. The response is automatically parsed and validated:
+
+```ruby
+class SentimentAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  structured_output sentiment: String, score: Float
+end
+
+response = SentimentAgent.generate('Analyze: "I love this!"')
+response.object  # => {sentiment: "positive", score: 0.95}
+```
+
+See the [structured output section in Agents](03_AGENTS.md#structured_output) for details.
+
 ### Provider
 
 Providers are adapters that connect to LLM services. Riffer supports:

--- a/docs/01_OVERVIEW.md
+++ b/docs/01_OVERVIEW.md
@@ -51,7 +51,7 @@ class SentimentAgent < Riffer::Agent
 end
 
 response = SentimentAgent.generate('Analyze: "I love this!"')
-response.object  # => {sentiment: "positive", score: 0.95}
+response.structured_output  # => {sentiment: "positive", score: 0.95}
 ```
 
 See the [structured output section in Agents](03_AGENTS.md#structured_output) for details.

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -204,7 +204,7 @@ response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
 
 ### stream
 
-Streams a response as an Enumerator. Raises `Riffer::ArgumentError` if structured output is configured:
+Streams a response as an Enumerator:
 
 ```ruby
 # Class method (recommended for simple calls)

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -147,7 +147,7 @@ class SentimentAgent < Riffer::Agent
 end
 ```
 
-The LLM response is automatically parsed and validated against the schema. Access the result via `response.object`.
+The LLM response is automatically parsed and validated against the schema. Access the result via `response.structured_output`.
 
 Structured output is not compatible with streaming — calling `stream` on an agent with structured output configured raises `Riffer::ArgumentError`.
 
@@ -388,7 +388,7 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 | Attribute          | Type                        | Description                                        |
 | ------------------ | --------------------------- | -------------------------------------------------- |
 | `content`          | `String`                    | The response text                                  |
-| `object`           | `Hash` / `nil`              | Parsed and validated structured output (see below) |
+| `structured_output` | `Hash` / `nil`              | Parsed and validated structured output (see below) |
 | `blocked?`         | `Boolean`                   | `true` if a guardrail tripwire fired               |
 | `tripwire`         | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request    |
 | `modified?`        | `Boolean`                   | `true` if a guardrail modified the content         |
@@ -396,14 +396,14 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 | `interrupted?`     | `Boolean`                   | `true` if the loop was interrupted                 |
 | `interrupt_reason` | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
 
-### response.object
+### response.structured_output
 
-When structured output is configured, the LLM response is parsed as JSON and validated against the schema. The validated result is available as `response.object`:
+When structured output is configured, the LLM response is parsed as JSON and validated against the schema. The validated result is available as `response.structured_output`:
 
 ```ruby
 response = SentimentAgent.generate('Analyze: "I love this!"')
-response.content  # => raw JSON string from the LLM
-response.object   # => {sentiment: "positive", score: 0.95}
+response.content            # => raw JSON string from the LLM
+response.structured_output  # => {sentiment: "positive", score: 0.95}
 ```
 
 Returns `nil` when structured output is not configured or when validation fails.

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -131,6 +131,33 @@ class MyAgent < Riffer::Agent
 end
 ```
 
+### structured_output
+
+Configures the agent to return structured JSON responses conforming to a schema. Accepts a Hash shorthand or a `Riffer::Params` instance:
+
+```ruby
+# Hash shorthand — all fields are required
+class SentimentAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  instructions 'Analyze the sentiment of the given text.'
+  structured_output sentiment: String, score: Float
+end
+
+# Riffer::Params — supports optional fields, descriptions, and enums
+class AnalysisAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  structured_output Riffer::Params.build {
+    required :sentiment, String, description: "positive, negative, or neutral"
+    required :score, Float, description: "Confidence score between 0 and 1"
+    optional :explanation, String, description: "Brief explanation"
+  }
+end
+```
+
+The LLM response is automatically parsed and validated against the schema. Access the result via `response.object`.
+
+Structured output is not compatible with streaming — calling `stream` on an agent with structured output configured raises `Riffer::ArgumentError`.
+
 ### guardrail
 
 Registers guardrails for pre/post processing of messages. Pass the guardrail class and any options:
@@ -180,11 +207,22 @@ response = MyAgent.generate([
 
 # With tool context
 response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
+
+# With structured output (per-call)
+response = MyAgent.generate(
+  'Analyze: "I love this!"',
+  structured_output: {sentiment: String, score: Float}
+)
+response.object  # => {sentiment: "positive", score: 0.95}
+
+# With class-level structured output
+response = SentimentAgent.generate('Analyze: "I love this!"')
+response.object  # => {sentiment: "positive", score: 0.95}
 ```
 
 ### stream
 
-Streams a response as an Enumerator:
+Streams a response as an Enumerator. Raises `Riffer::ArgumentError` if structured output is configured (class-level or per-call):
 
 ```ruby
 # Class method (recommended for simple calls)
@@ -360,6 +398,33 @@ end
 ```
 
 Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` object with accumulated totals.
+
+## Response Attributes
+
+`Riffer::Agent::Response` is returned by `generate` and `resume`:
+
+| Attribute          | Type                       | Description                                             |
+| ------------------ | -------------------------- | ------------------------------------------------------- |
+| `content`          | `String`                   | The response text                                       |
+| `object`           | `Hash` / `nil`             | Parsed and validated structured output (see below)      |
+| `blocked?`         | `Boolean`                  | `true` if a guardrail tripwire fired                    |
+| `tripwire`         | `Tripwire` / `nil`         | The guardrail tripwire that blocked the request         |
+| `modified?`        | `Boolean`                  | `true` if a guardrail modified the content              |
+| `modifications`    | `Array`                    | List of guardrail modifications applied                 |
+| `interrupted?`     | `Boolean`                  | `true` if the loop was interrupted                      |
+| `interrupt_reason` | `String` / `Symbol` / `nil`| The reason passed to `throw :riffer_interrupt`          |
+
+### response.object
+
+When structured output is configured (class-level or per-call), the LLM response is parsed as JSON and validated against the schema. The validated result is available as `response.object`:
+
+```ruby
+response = SentimentAgent.generate('Analyze: "I love this!"')
+response.content  # => raw JSON string from the LLM
+response.object   # => {sentiment: "positive", score: 0.95}
+```
+
+Returns `nil` when structured output is not configured or when validation fails.
 
 ## Class Methods
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -201,24 +201,14 @@ response = MyAgent.generate([
 # With tool context
 response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
 
-# With structured output (per-call)
-params = Riffer::Params.new
-params.required(:sentiment, String)
-params.required(:score, Float)
-response = MyAgent.generate(
-  'Analyze: "I love this!"',
-  structured_output: params
-)
-response.object  # => {sentiment: "positive", score: 0.95}
-
-# With class-level structured output
+# With structured output (class-level)
 response = SentimentAgent.generate('Analyze: "I love this!"')
 response.object  # => {sentiment: "positive", score: 0.95}
 ```
 
 ### stream
 
-Streams a response as an Enumerator. Raises `Riffer::ArgumentError` if structured output is configured (class-level or per-call):
+Streams a response as an Enumerator. Raises `Riffer::ArgumentError` if structured output is configured:
 
 ```ruby
 # Class method (recommended for simple calls)
@@ -412,7 +402,7 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 ### response.object
 
-When structured output is configured (class-level or per-call), the LLM response is parsed as JSON and validated against the schema. The validated result is available as `response.object`:
+When structured output is configured, the LLM response is parsed as JSON and validated against the schema. The validated result is available as `response.object`:
 
 ```ruby
 response = SentimentAgent.generate('Analyze: "I love this!"')

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -133,19 +133,12 @@ end
 
 ### structured_output
 
-Configures the agent to return structured JSON responses conforming to a schema. Accepts a Hash shorthand, a `Riffer::Params` instance, or a block DSL:
+Configures the agent to return structured JSON responses conforming to a schema. Accepts a `Riffer::Params` instance or a block DSL:
 
 ```ruby
-# Hash shorthand — all fields are required
 class SentimentAgent < Riffer::Agent
   model 'openai/gpt-4o'
   instructions 'Analyze the sentiment of the given text.'
-  structured_output sentiment: String, score: Float
-end
-
-# Block DSL — supports optional fields, descriptions, and enums
-class AnalysisAgent < Riffer::Agent
-  model 'openai/gpt-4o'
   structured_output do
     required :sentiment, String, description: "positive, negative, or neutral"
     required :score, Float, description: "Confidence score between 0 and 1"
@@ -209,9 +202,12 @@ response = MyAgent.generate([
 response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
 
 # With structured output (per-call)
+params = Riffer::Params.new
+params.required(:sentiment, String)
+params.required(:score, Float)
 response = MyAgent.generate(
   'Analyze: "I love this!"',
-  structured_output: {sentiment: String, score: Float}
+  structured_output: params
 )
 response.object  # => {sentiment: "positive", score: 0.95}
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -133,7 +133,7 @@ end
 
 ### structured_output
 
-Configures the agent to return structured JSON responses conforming to a schema. Accepts a Hash shorthand or a `Riffer::Params` instance:
+Configures the agent to return structured JSON responses conforming to a schema. Accepts a Hash shorthand, a `Riffer::Params` instance, or a block DSL:
 
 ```ruby
 # Hash shorthand — all fields are required
@@ -143,14 +143,14 @@ class SentimentAgent < Riffer::Agent
   structured_output sentiment: String, score: Float
 end
 
-# Riffer::Params — supports optional fields, descriptions, and enums
+# Block DSL — supports optional fields, descriptions, and enums
 class AnalysisAgent < Riffer::Agent
   model 'openai/gpt-4o'
-  structured_output Riffer::Params.build {
+  structured_output do
     required :sentiment, String, description: "positive, negative, or neutral"
     required :score, Float, description: "Confidence score between 0 and 1"
     optional :explanation, String, description: "Brief explanation"
-  }
+  end
 end
 ```
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -200,10 +200,6 @@ response = MyAgent.generate([
 
 # With tool context
 response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
-
-# With structured output (class-level)
-response = SentimentAgent.generate('Analyze: "I love this!"')
-response.object  # => {sentiment: "positive", score: 0.95}
 ```
 
 ### stream
@@ -389,16 +385,16 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 `Riffer::Agent::Response` is returned by `generate` and `resume`:
 
-| Attribute          | Type                       | Description                                             |
-| ------------------ | -------------------------- | ------------------------------------------------------- |
-| `content`          | `String`                   | The response text                                       |
-| `object`           | `Hash` / `nil`             | Parsed and validated structured output (see below)      |
-| `blocked?`         | `Boolean`                  | `true` if a guardrail tripwire fired                    |
-| `tripwire`         | `Tripwire` / `nil`         | The guardrail tripwire that blocked the request         |
-| `modified?`        | `Boolean`                  | `true` if a guardrail modified the content              |
-| `modifications`    | `Array`                    | List of guardrail modifications applied                 |
-| `interrupted?`     | `Boolean`                  | `true` if the loop was interrupted                      |
-| `interrupt_reason` | `String` / `Symbol` / `nil`| The reason passed to `throw :riffer_interrupt`          |
+| Attribute          | Type                        | Description                                        |
+| ------------------ | --------------------------- | -------------------------------------------------- |
+| `content`          | `String`                    | The response text                                  |
+| `object`           | `Hash` / `nil`              | Parsed and validated structured output (see below) |
+| `blocked?`         | `Boolean`                   | `true` if a guardrail tripwire fired               |
+| `tripwire`         | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request    |
+| `modified?`        | `Boolean`                   | `true` if a guardrail modified the content         |
+| `modifications`    | `Array`                     | List of guardrail modifications applied            |
+| `interrupted?`     | `Boolean`                   | `true` if the loop was interrupted                 |
+| `interrupt_reason` | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
 
 ### response.object
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -75,18 +75,18 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+),
-  # a Riffer::Params instance, or a block evaluated against a new Params.
+  # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
-  #: (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
-  def self.structured_output(schema = nil, &block)
+  #: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
+  def self.structured_output(params = nil, &block)
     if block
       @structured_output = Riffer::Params.new
       @structured_output.instance_eval(&block)
-    elsif schema.nil?
+    elsif params.nil?
       @structured_output
     else
-      @structured_output = schema
+      raise Riffer::ArgumentError, "structured_output must be a Riffer::Params" unless params.is_a?(Riffer::Params)
+      @structured_output = params
     end
   end
 
@@ -208,7 +208,7 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
   def generate(prompt_or_messages, tool_context: nil, structured_output: nil)
     @tool_context = tool_context
     @resolved_tools = nil
@@ -230,7 +230,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream(prompt_or_messages, tool_context: nil, structured_output: nil)
     resolved = structured_output || self.class.structured_output
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if resolved
@@ -641,10 +641,10 @@ class Riffer::Agent
     [processed_response, tripwire, modifications]
   end
 
-  #: ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
-  def resolve_structured_output(call_level_schema)
-    schema = call_level_schema || self.class.structured_output
-    schema ? Riffer::StructuredOutput.new(schema) : nil
+  #: (Riffer::Params?) -> Riffer::StructuredOutput?
+  def resolve_structured_output(call_level_params)
+    params = call_level_params || self.class.structured_output
+    params ? Riffer::StructuredOutput.new(params) : nil
   end
 
   #: () -> Hash[Symbol, untyped]

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -73,6 +73,17 @@ class Riffer::Agent
     @model_options = options
   end
 
+  # Gets or sets the structured output schema for this agent.
+  #
+  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+)
+  # or a Riffer::Params instance.
+  #
+  #: (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
+  def self.structured_output(schema = nil)
+    return @structured_output if schema.nil?
+    @structured_output = schema
+  end
+
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #
   # Defaults to DEFAULT_MAX_STEPS (16). Set to +Float::INFINITY+ for
@@ -191,12 +202,13 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, tool_context: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
+  def generate(prompt_or_messages, tool_context: nil, structured_output: nil)
     @tool_context = tool_context
     @resolved_tools = nil
     clear_resolved_model
     @interrupted = false
+    @structured_output = resolve_structured_output(structured_output)
     initialize_messages(prompt_or_messages)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
@@ -210,8 +222,13 @@ class Riffer::Agent
 
   # Streams a response from the agent.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, tool_context: nil)
+  # Raises Riffer::ArgumentError if structured output is configured.
+  #
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt_or_messages, tool_context: nil, structured_output: nil)
+    resolved = structured_output || self.class.structured_output
+    raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if resolved
+
     @tool_context = tool_context
     @resolved_tools = nil
     clear_resolved_model
@@ -298,13 +315,17 @@ class Riffer::Agent
         execute_tool_calls(processed_response)
       end
 
-      return build_response(extract_final_response, modifications: all_modifications)
+      content = extract_final_response
+      object = parse_structured_content(content)
+      return build_response(content, modifications: all_modifications, object: object)
     end
 
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
     @interrupted = true
-    build_response(extract_final_response, modifications: all_modifications, interrupted: true, interrupt_reason: reason)
+    content = extract_final_response
+    object = parse_structured_content(content)
+    build_response(content, modifications: all_modifications, interrupted: true, interrupt_reason: reason, object: object)
   end
 
   #: (Riffer::Messages::Base) -> void
@@ -422,7 +443,7 @@ class Riffer::Agent
       messages: @messages,
       model: @model_name,
       tools: resolved_tools,
-      **self.class.model_options
+      **merged_model_options
     )
   end
 
@@ -614,8 +635,28 @@ class Riffer::Agent
     [processed_response, tripwire, modifications]
   end
 
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Response
-  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil)
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason)
+  #: ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
+  def resolve_structured_output(call_level_schema)
+    schema = call_level_schema || self.class.structured_output
+    schema ? Riffer::StructuredOutput.new(schema) : nil
+  end
+
+  #: () -> Hash[Symbol, untyped]
+  def merged_model_options
+    opts = self.class.model_options.dup
+    opts[:structured_output] = @structured_output if @structured_output
+    opts
+  end
+
+  #: (String) -> Hash[Symbol, untyped]?
+  def parse_structured_content(content)
+    return nil unless @structured_output
+    result = @structured_output.parse_and_validate(content)
+    result.object
+  end
+
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, object: nil)
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, object: object)
   end
 end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -321,16 +321,16 @@ class Riffer::Agent
       end
 
       content = extract_final_response
-      object = parse_structured_content(content)
-      return build_response(content, modifications: all_modifications, object: object)
+      structured_output = parse_structured_content(content)
+      return build_response(content, modifications: all_modifications, structured_output: structured_output)
     end
 
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
     @interrupted = true
     content = extract_final_response
-    object = parse_structured_content(content)
-    build_response(content, modifications: all_modifications, interrupted: true, interrupt_reason: reason, object: object)
+    structured_output = parse_structured_content(content)
+    build_response(content, modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: structured_output)
   end
 
   #: (Riffer::Messages::Base) -> void
@@ -660,8 +660,8 @@ class Riffer::Agent
     result.object
   end
 
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, object: nil)
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, object: object)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output)
   end
 end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -75,13 +75,19 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+)
-  # or a Riffer::Params instance.
+  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+),
+  # a Riffer::Params instance, or a block evaluated against a new Params.
   #
-  #: (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
-  def self.structured_output(schema = nil)
-    return @structured_output if schema.nil?
-    @structured_output = schema
+  #: (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
+  def self.structured_output(schema = nil, &block)
+    if block
+      @structured_output = Riffer::Params.new
+      @structured_output.instance_eval(&block)
+    elsif schema.nil?
+      @structured_output
+    else
+      @structured_output = schema
+    end
   end
 
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -208,13 +208,13 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, tool_context: nil, structured_output: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate(prompt_or_messages, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
     clear_resolved_model
     @interrupted = false
-    @structured_output = resolve_structured_output(structured_output)
+    @structured_output = resolve_structured_output
     initialize_messages(prompt_or_messages)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
@@ -230,10 +230,9 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, tool_context: nil, structured_output: nil)
-    resolved = structured_output || self.class.structured_output
-    raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if resolved
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt_or_messages, tool_context: nil)
+    raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @tool_context = tool_context
     @resolved_tools = nil
@@ -641,9 +640,9 @@ class Riffer::Agent
     [processed_response, tripwire, modifications]
   end
 
-  #: (Riffer::Params?) -> Riffer::StructuredOutput?
-  def resolve_structured_output(call_level_params)
-    params = call_level_params || self.class.structured_output
+  #: () -> Riffer::StructuredOutput?
+  def resolve_structured_output
+    params = self.class.structured_output
     params ? Riffer::StructuredOutput.new(params) : nil
   end
 

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -25,8 +25,8 @@ class Riffer::Agent::Response
   # The reason provided with the interrupt, if any.
   attr_reader :interrupt_reason #: (String | Symbol)?
 
-  # The parsed structured output object, if structured output was configured.
-  attr_reader :object #: Hash[Symbol, untyped]?
+  # The parsed structured output, if structured output was configured.
+  attr_reader :structured_output #: Hash[Symbol, untyped]?
 
   # Creates a new response.
   #
@@ -35,16 +35,16 @@ class Riffer::Agent::Response
   # +modifications+ - guardrail modifications applied during processing.
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
-  # +object+ - parsed structured output object when structured output is configured.
+  # +structured_output+ - parsed structured output when structured output is configured.
   #
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, object: nil)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
     @content = content
     @tripwire = tripwire
     @modifications = modifications
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
-    @object = object
+    @structured_output = structured_output
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -25,6 +25,9 @@ class Riffer::Agent::Response
   # The reason provided with the interrupt, if any.
   attr_reader :interrupt_reason #: (String | Symbol)?
 
+  # The parsed structured output object, if structured output was configured.
+  attr_reader :object #: Hash[Symbol, untyped]?
+
   # Creates a new response.
   #
   # +content+ - the response content.
@@ -32,14 +35,16 @@ class Riffer::Agent::Response
   # +modifications+ - guardrail modifications applied during processing.
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
+  # +object+ - parsed structured output object when structured output is configured.
   #
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, object: nil)
     @content = content
     @tripwire = tripwire
     @modifications = modifications
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
+    @object = object
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/param.rb
+++ b/lib/riffer/param.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Riffer::Tools::Param represents a single parameter definition for a tool.
+# Riffer::Param represents a single parameter definition.
 #
 # Handles type validation and JSON Schema generation for individual parameters.
-class Riffer::Tools::Param
+class Riffer::Param
   # Maps Ruby types to JSON Schema type strings
   TYPE_MAPPINGS = {
     String => "string",

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -1,17 +1,29 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Riffer::Tools::Params provides a DSL for defining tool parameters.
+# Riffer::Params provides a DSL for defining parameters.
 #
-# Used within a Tool's +params+ block to define required and optional parameters.
+# Used within a Tool's +params+ block to define required and optional parameters,
+# and by StructuredOutput to define response schemas.
 #
 #   params do
 #     required :city, String, description: "The city name"
 #     optional :units, String, default: "celsius", enum: ["celsius", "fahrenheit"]
 #   end
 #
-class Riffer::Tools::Params
-  attr_reader :parameters #: Array[Riffer::Tools::Param]
+class Riffer::Params
+  attr_reader :parameters #: Array[Riffer::Param]
+
+  # Builds a Params from shorthand Hash where all keys are required.
+  #
+  #   Riffer::Params.from_hash(sentiment: String, score: Float)
+  #
+  #: (Hash[Symbol, Class]) -> Riffer::Params
+  def self.from_hash(hash)
+    params = new
+    hash.each { |name, type| params.required(name, type) }
+    params
+  end
 
   #: () -> void
   def initialize
@@ -22,7 +34,7 @@ class Riffer::Tools::Params
   #
   #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?) -> void
   def required(name, type, description: nil, enum: nil)
-    @parameters << Riffer::Tools::Param.new(
+    @parameters << Riffer::Param.new(
       name: name,
       type: type,
       required: true,
@@ -35,7 +47,7 @@ class Riffer::Tools::Params
   #
   #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped) -> void
   def optional(name, type, description: nil, enum: nil, default: nil)
-    @parameters << Riffer::Tools::Param.new(
+    @parameters << Riffer::Param.new(
       name: name,
       type: type,
       required: false,

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -14,17 +14,6 @@
 class Riffer::Params
   attr_reader :parameters #: Array[Riffer::Param]
 
-  # Builds a Params from shorthand Hash where all keys are required.
-  #
-  #   Riffer::Params.from_hash(sentiment: String, score: Float)
-  #
-  #: (Hash[Symbol, Class]) -> Riffer::Params
-  def self.from_hash(hash)
-    params = new
-    hash.each { |name, type| params.required(name, type) }
-    params
-  end
-
   #: () -> void
   def initialize
     @parameters = []

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -34,17 +34,32 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   def build_request_params(messages, model, options)
     partitioned_messages = partition_messages(messages)
     tools = options[:tools]
+    structured_output = options[:structured_output]
 
     params = {
       model_id: model,
       system: partitioned_messages[:system],
       messages: partitioned_messages[:conversation],
-      **options.except(:tools)
+      **options.except(:tools, :structured_output)
     }
 
     if tools && !tools.empty?
       params[:tool_config] = {
         tools: tools.map { |t| convert_tool_to_bedrock_format(t) }
+      }
+    end
+
+    if structured_output
+      params[:output_config] = {
+        text_format: {
+          type: "json_schema",
+          structure: {
+            json_schema: {
+              schema: structured_output.json_schema.to_json,
+              name: "response"
+            }
+          }
+        }
       }
     end
 

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -24,6 +24,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   def build_request_params(messages, model, options)
     partitioned_messages = partition_messages(messages)
     tools = options[:tools]
+    structured_output = options[:structured_output]
 
     max_tokens = options.fetch(:max_tokens, 4096)
 
@@ -31,13 +32,22 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       model: model,
       messages: partitioned_messages[:conversation],
       max_tokens: max_tokens,
-      **options.except(:tools, :max_tokens)
+      **options.except(:tools, :max_tokens, :structured_output)
     }
 
     params[:system] = partitioned_messages[:system] if partitioned_messages[:system]
 
     if tools && !tools.empty?
       params[:tools] = tools.map { |t| convert_tool_to_anthropic_format(t) }
+    end
+
+    if structured_output
+      params[:output_config] = {
+        format: {
+          type: "json_schema",
+          schema: structured_output.json_schema
+        }
+      }
     end
 
     params

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -21,6 +21,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
   def build_request_params(messages, model, options)
     reasoning = options[:reasoning]
     tools = options[:tools]
+    structured_output = options[:structured_output]
 
     params = {
       input: convert_messages_to_openai_format(messages),
@@ -29,11 +30,22 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
         effort: reasoning,
         summary: "auto"
       },
-      **options.except(:reasoning, :tools)
+      **options.except(:reasoning, :tools, :structured_output)
     }
 
     if tools && !tools.empty?
       params[:tools] = tools.map { |t| convert_tool_to_openai_format(t) }
+    end
+
+    if structured_output
+      params[:text] = {
+        format: {
+          type: "json_schema",
+          name: "response",
+          schema: structured_output.json_schema,
+          strict: true
+        }
+      }
     end
 
     params.compact

--- a/lib/riffer/structured_output.rb
+++ b/lib/riffer/structured_output.rb
@@ -3,12 +3,12 @@
 
 require "json"
 
-# Riffer::StructuredOutput normalizes schema input and provides parse/validate
-# for structured JSON responses from LLM providers.
+# Riffer::StructuredOutput provides parse/validate for structured JSON
+# responses from LLM providers.
 #
-# Accepts either a Hash shorthand or a Params instance as schema.
-#
-#   so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+#   params = Riffer::Params.new
+#   params.required(:sentiment, String)
+#   so = Riffer::StructuredOutput.new(params)
 #   result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
 #   result.object  #=> {sentiment: "positive", score: 0.9}
 #
@@ -16,9 +16,9 @@ class Riffer::StructuredOutput
   attr_reader :params #: Riffer::Params
   attr_reader :json_schema #: Hash[Symbol, untyped]
 
-  #: ((Hash[Symbol, Class] | Riffer::Params)) -> void
-  def initialize(schema)
-    @params = schema.is_a?(Riffer::Params) ? schema : Riffer::Params.from_hash(schema)
+  #: (Riffer::Params) -> void
+  def initialize(params)
+    @params = params
     @json_schema = @params.to_json_schema
   end
 

--- a/lib/riffer/structured_output.rb
+++ b/lib/riffer/structured_output.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "json"
+
+# Riffer::StructuredOutput normalizes schema input and provides parse/validate
+# for structured JSON responses from LLM providers.
+#
+# Accepts either a Hash shorthand or a Params instance as schema.
+#
+#   so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+#   result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
+#   result.object  #=> {sentiment: "positive", score: 0.9}
+#
+class Riffer::StructuredOutput
+  attr_reader :params #: Riffer::Params
+  attr_reader :json_schema #: Hash[Symbol, untyped]
+
+  #: ((Hash[Symbol, Class] | Riffer::Params)) -> void
+  def initialize(schema)
+    @params = schema.is_a?(Riffer::Params) ? schema : Riffer::Params.from_hash(schema)
+    @json_schema = @params.to_json_schema
+  end
+
+  # Parses a JSON string and validates it against the schema.
+  #
+  # Returns a Result with the validated object on success, or an error message on failure.
+  #
+  #: (String) -> Riffer::StructuredOutput::Result
+  def parse_and_validate(json_string)
+    parsed = JSON.parse(json_string)
+    validated = @params.validate(parsed.transform_keys(&:to_sym))
+    Result.new(object: validated)
+  rescue JSON::ParserError => e
+    Result.new(error: "JSON parse error: #{e.message}")
+  rescue Riffer::ValidationError => e
+    Result.new(error: "Validation error: #{e.message}")
+  end
+end

--- a/lib/riffer/structured_output/result.rb
+++ b/lib/riffer/structured_output/result.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Wraps the result of structured output parsing and validation.
+#
+# On success, +object+ contains the validated Hash and +error+ is nil.
+# On failure, +error+ contains the error message and +object+ is nil.
+#
+#   result = structured_output.parse_and_validate(json_string)
+#   if result.success?
+#     result.object  #=> {sentiment: "positive", score: 0.9}
+#   else
+#     result.error   #=> "JSON parse error: ..."
+#   end
+#
+class Riffer::StructuredOutput::Result
+  attr_reader :object #: Hash[Symbol, untyped]?
+  attr_reader :error #: String?
+
+  #: (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
+  def initialize(object: nil, error: nil)
+    @object = object
+    @error = error
+  end
+
+  # Returns true when parsing and validation succeeded.
+  #
+  #: () -> bool
+  def success? = @error.nil?
+
+  # Returns true when parsing or validation failed.
+  #
+  #: () -> bool
+  def failure? = !success?
+end

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -65,10 +65,10 @@ class Riffer::Tool
 
   # Defines parameters using the Params DSL.
   #
-  #: () ?{ () -> void } -> Riffer::Tools::Params?
+  #: () ?{ () -> void } -> Riffer::Params?
   def self.params(&block)
     return @params_builder if block.nil?
-    @params_builder = Riffer::Tools::Params.new
+    @params_builder = Riffer::Params.new
     @params_builder.instance_eval(&block)
   end
 

--- a/lib/riffer/tools.rb
+++ b/lib/riffer/tools.rb
@@ -4,8 +4,6 @@
 # Namespace for tool-related classes in the Riffer framework.
 #
 # Contains:
-# - Riffer::Tools::Param - Individual parameter definition
-# - Riffer::Tools::Params - DSL for defining tool parameters
 # - Riffer::Tools::Response - Required return type for tool execution
 module Riffer::Tools
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -52,11 +52,10 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+),
-  # a Riffer::Params instance, or a block evaluated against a new Params.
+  # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
-  # : (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
-  def self.structured_output: (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
+  # : (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
+  def self.structured_output: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
 
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #
@@ -128,15 +127,15 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Resumes an agent loop.
   #
@@ -241,8 +240,8 @@ class Riffer::Agent
   # : (Riffer::Messages::Assistant) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_after_guardrails: (Riffer::Messages::Assistant) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
-  # : ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
-  def resolve_structured_output: ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
+  # : (Riffer::Params?) -> Riffer::StructuredOutput?
+  def resolve_structured_output: (Riffer::Params?) -> Riffer::StructuredOutput?
 
   # : () -> Hash[Symbol, untyped]
   def merged_model_options: () -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -50,6 +50,14 @@ class Riffer::Agent
   # : (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.model_options: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
 
+  # Gets or sets the structured output schema for this agent.
+  #
+  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+)
+  # or a Riffer::Params instance.
+  #
+  # : (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
+  def self.structured_output: (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
+
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #
   # Defaults to DEFAULT_MAX_STEPS (16). Set to +Float::INFINITY+ for
@@ -120,13 +128,15 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # Raises Riffer::ArgumentError if structured output is configured.
+  #
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: (Hash[Symbol, Class] | Riffer::Params)?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Resumes an agent loop.
   #
@@ -231,6 +241,15 @@ class Riffer::Agent
   # : (Riffer::Messages::Assistant) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_after_guardrails: (Riffer::Messages::Assistant) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Response
-  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Response
+  # : ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
+  def resolve_structured_output: ((Hash[Symbol, Class] | Riffer::Params)?) -> Riffer::StructuredOutput?
+
+  # : () -> Hash[Symbol, untyped]
+  def merged_model_options: () -> Hash[Symbol, untyped]
+
+  # : (String) -> Hash[Symbol, untyped]?
+  def parse_structured_content: (String) -> Hash[Symbol, untyped]?
+
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -249,6 +249,6 @@ class Riffer::Agent
   # : (String) -> Hash[Symbol, untyped]?
   def parse_structured_content: (String) -> Hash[Symbol, untyped]?
 
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -127,15 +127,15 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?, ?structured_output: Riffer::Params?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Resumes an agent loop.
   #
@@ -240,8 +240,8 @@ class Riffer::Agent
   # : (Riffer::Messages::Assistant) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_after_guardrails: (Riffer::Messages::Assistant) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
-  # : (Riffer::Params?) -> Riffer::StructuredOutput?
-  def resolve_structured_output: (Riffer::Params?) -> Riffer::StructuredOutput?
+  # : () -> Riffer::StructuredOutput?
+  def resolve_structured_output: () -> Riffer::StructuredOutput?
 
   # : () -> Hash[Symbol, untyped]
   def merged_model_options: () -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -52,11 +52,11 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+)
-  # or a Riffer::Params instance.
+  # Accepts a Hash shorthand (e.g., +{sentiment: String, score: Float}+),
+  # a Riffer::Params instance, or a block evaluated against a new Params.
   #
-  # : (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
-  def self.structured_output: (?(Hash[Symbol, Class] | Riffer::Params)?) -> (Hash[Symbol, Class] | Riffer::Params)?
+  # : (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
+  def self.structured_output: (?(Hash[Symbol, Class] | Riffer::Params)?) ?{ () -> void } -> (Hash[Symbol, Class] | Riffer::Params)?
 
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -24,6 +24,9 @@ class Riffer::Agent::Response
   # The reason provided with the interrupt, if any.
   attr_reader interrupt_reason: (String | Symbol)?
 
+  # The parsed structured output object, if structured output was configured.
+  attr_reader object: Hash[Symbol, untyped]?
+
   # Creates a new response.
   #
   # +content+ - the response content.
@@ -31,9 +34,10 @@ class Riffer::Agent::Response
   # +modifications+ - guardrail modifications applied during processing.
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
+  # +object+ - parsed structured output object when structured output is configured.
   #
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -24,8 +24,8 @@ class Riffer::Agent::Response
   # The reason provided with the interrupt, if any.
   attr_reader interrupt_reason: (String | Symbol)?
 
-  # The parsed structured output object, if structured output was configured.
-  attr_reader object: Hash[Symbol, untyped]?
+  # The parsed structured output, if structured output was configured.
+  attr_reader structured_output: Hash[Symbol, untyped]?
 
   # Creates a new response.
   #
@@ -34,10 +34,10 @@ class Riffer::Agent::Response
   # +modifications+ - guardrail modifications applied during processing.
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
-  # +object+ - parsed structured output object when structured output is configured.
+  # +structured_output+ - parsed structured output when structured output is configured.
   #
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?object: Hash[Symbol, untyped]?) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/param.rbs
+++ b/sig/generated/riffer/param.rbs
@@ -1,9 +1,9 @@
-# Generated from lib/riffer/tools/param.rb with RBS::Inline
+# Generated from lib/riffer/param.rb with RBS::Inline
 
-# Riffer::Tools::Param represents a single parameter definition for a tool.
+# Riffer::Param represents a single parameter definition.
 #
 # Handles type validation and JSON Schema generation for individual parameters.
-class Riffer::Tools::Param
+class Riffer::Param
   # Maps Ruby types to JSON Schema type strings
   TYPE_MAPPINGS: Hash[Class, String]
 

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -12,13 +12,6 @@
 class Riffer::Params
   attr_reader parameters: Array[Riffer::Param]
 
-  # Builds a Params from shorthand Hash where all keys are required.
-  #
-  #   Riffer::Params.from_hash(sentiment: String, score: Float)
-  #
-  # : (Hash[Symbol, Class]) -> Riffer::Params
-  def self.from_hash: (Hash[Symbol, Class]) -> Riffer::Params
-
   # : () -> void
   def initialize: () -> void
 

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -1,15 +1,23 @@
-# Generated from lib/riffer/tools/params.rb with RBS::Inline
+# Generated from lib/riffer/params.rb with RBS::Inline
 
-# Riffer::Tools::Params provides a DSL for defining tool parameters.
+# Riffer::Params provides a DSL for defining parameters.
 #
-# Used within a Tool's +params+ block to define required and optional parameters.
+# Used within a Tool's +params+ block to define required and optional parameters,
+# and by StructuredOutput to define response schemas.
 #
 #   params do
 #     required :city, String, description: "The city name"
 #     optional :units, String, default: "celsius", enum: ["celsius", "fahrenheit"]
 #   end
-class Riffer::Tools::Params
-  attr_reader parameters: Array[Riffer::Tools::Param]
+class Riffer::Params
+  attr_reader parameters: Array[Riffer::Param]
+
+  # Builds a Params from shorthand Hash where all keys are required.
+  #
+  #   Riffer::Params.from_hash(sentiment: String, score: Float)
+  #
+  # : (Hash[Symbol, Class]) -> Riffer::Params
+  def self.from_hash: (Hash[Symbol, Class]) -> Riffer::Params
 
   # : () -> void
   def initialize: () -> void

--- a/sig/generated/riffer/structured_output.rbs
+++ b/sig/generated/riffer/structured_output.rbs
@@ -1,0 +1,25 @@
+# Generated from lib/riffer/structured_output.rb with RBS::Inline
+
+# Riffer::StructuredOutput normalizes schema input and provides parse/validate
+# for structured JSON responses from LLM providers.
+#
+# Accepts either a Hash shorthand or a Params instance as schema.
+#
+#   so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+#   result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
+#   result.object  #=> {sentiment: "positive", score: 0.9}
+class Riffer::StructuredOutput
+  attr_reader params: Riffer::Params
+
+  attr_reader json_schema: Hash[Symbol, untyped]
+
+  # : ((Hash[Symbol, Class] | Riffer::Params)) -> void
+  def initialize: (Hash[Symbol, Class] | Riffer::Params) -> void
+
+  # Parses a JSON string and validates it against the schema.
+  #
+  # Returns a Result with the validated object on success, or an error message on failure.
+  #
+  # : (String) -> Riffer::StructuredOutput::Result
+  def parse_and_validate: (String) -> Riffer::StructuredOutput::Result
+end

--- a/sig/generated/riffer/structured_output.rbs
+++ b/sig/generated/riffer/structured_output.rbs
@@ -1,11 +1,11 @@
 # Generated from lib/riffer/structured_output.rb with RBS::Inline
 
-# Riffer::StructuredOutput normalizes schema input and provides parse/validate
-# for structured JSON responses from LLM providers.
+# Riffer::StructuredOutput provides parse/validate for structured JSON
+# responses from LLM providers.
 #
-# Accepts either a Hash shorthand or a Params instance as schema.
-#
-#   so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+#   params = Riffer::Params.new
+#   params.required(:sentiment, String)
+#   so = Riffer::StructuredOutput.new(params)
 #   result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
 #   result.object  #=> {sentiment: "positive", score: 0.9}
 class Riffer::StructuredOutput
@@ -13,8 +13,8 @@ class Riffer::StructuredOutput
 
   attr_reader json_schema: Hash[Symbol, untyped]
 
-  # : ((Hash[Symbol, Class] | Riffer::Params)) -> void
-  def initialize: (Hash[Symbol, Class] | Riffer::Params) -> void
+  # : (Riffer::Params) -> void
+  def initialize: (Riffer::Params) -> void
 
   # Parses a JSON string and validates it against the schema.
   #

--- a/sig/generated/riffer/structured_output/result.rbs
+++ b/sig/generated/riffer/structured_output/result.rbs
@@ -1,0 +1,31 @@
+# Generated from lib/riffer/structured_output/result.rb with RBS::Inline
+
+# Wraps the result of structured output parsing and validation.
+#
+# On success, +object+ contains the validated Hash and +error+ is nil.
+# On failure, +error+ contains the error message and +object+ is nil.
+#
+#   result = structured_output.parse_and_validate(json_string)
+#   if result.success?
+#     result.object  #=> {sentiment: "positive", score: 0.9}
+#   else
+#     result.error   #=> "JSON parse error: ..."
+#   end
+class Riffer::StructuredOutput::Result
+  attr_reader object: Hash[Symbol, untyped]?
+
+  attr_reader error: String?
+
+  # : (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
+  def initialize: (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
+
+  # Returns true when parsing and validation succeeded.
+  #
+  # : () -> bool
+  def success?: () -> bool
+
+  # Returns true when parsing or validation failed.
+  #
+  # : () -> bool
+  def failure?: () -> bool
+end

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -49,8 +49,8 @@ class Riffer::Tool
 
   # Defines parameters using the Params DSL.
   #
-  # : () ?{ () -> void } -> Riffer::Tools::Params?
-  def self.params: () ?{ () -> void } -> Riffer::Tools::Params?
+  # : () ?{ () -> void } -> Riffer::Params?
+  def self.params: () ?{ () -> void } -> Riffer::Params?
 
   # Returns the JSON Schema for the tool's parameters.
   #

--- a/sig/generated/riffer/tools.rbs
+++ b/sig/generated/riffer/tools.rbs
@@ -3,8 +3,6 @@
 # Namespace for tool-related classes in the Riffer framework.
 #
 # Contains:
-# - Riffer::Tools::Param - Individual parameter definition
-# - Riffer::Tools::Params - DSL for defining tool parameters
 # - Riffer::Tools::Response - Required return type for tool execution
 module Riffer::Tools
 end

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"Analyze the sentiment
+        of the following text: ''I love this product, it is amazing!''"}]}],"system":[],"outputConfig":{"textFormat":{"type":"json_schema","structure":{"jsonSchema":{"schema":"{\"type\":\"object\",\"properties\":{\"sentiment\":{\"type\":\"string\"},\"score\":{\"type\":\"number\"}},\"required\":[\"sentiment\",\"score\"],\"additionalProperties\":false}","name":"response"}}}}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 852bc9d1-98f3-488a-9e95-10cfd891a308
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.242.0 ua/2.1 api/bedrock_runtime#1.73.0 os/macos#25 md/arm64
+        lang/ruby#3.4.8 md/3.4.8 m/Z,b,D
+      Content-Length:
+      - '436'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Feb 2026 23:53:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '358'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 9115c625-562c-4c4c-8195-938d24ed690c
+    body:
+      encoding: UTF-8
+      string: '{"metrics":{"latencyMs":2061},"output":{"message":{"content":[{"text":"{\"sentiment\":\"positive\",\"score\":0.95}"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,"inputTokens":189,"outputTokens":14,"serverToolUsage":{},"totalTokens":203}}'
+  recorded_at: Thu, 19 Feb 2026 23:53:05 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json.yml
@@ -1,0 +1,103 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Analyze
+        the sentiment of the following text: ''I love this product, it is amazing!''"}],"max_tokens":4096,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"sentiment":{"type":"string"},"score":{"type":"number"}},"required":["sentiment","score"],"additionalProperties":false}}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Anthropic::Client/Ruby 1.19.0
+      Host:
+      - api.anthropic.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 1.19.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Anthropic-Version:
+      - '2023-06-01'
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '389'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Feb 2026 23:45:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2026-02-19T23:45:48Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2026-02-19T23:45:49Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '4000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '3999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2026-02-19T23:45:47Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2026-02-19T23:45:48Z'
+      Request-Id:
+      - req_011CYJKR4bTZmANrr3kVjTXy
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 448f7295-c0ce-49f3-9599-c18ee47b4fc1
+      Server:
+      - cloudflare
+      X-Envoy-Upstream-Service-Time:
+      - '1886'
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Cf-Ray:
+      - 9d09a3cd7cf22afc-YVR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_01CBpmFyPzpWSusc1nsLb5mQ","type":"message","role":"assistant","content":[{"type":"text","text":"{\"sentiment\":
+        \"positive\", \"score\": 0.95}"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":189,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":17,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: Thu, 19 Feb 2026 23:45:49 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json.yml
@@ -1,0 +1,191 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"input":[{"role":"user","content":"Analyze the sentiment of the following
+        text: ''I love this product, it is amazing!''"}],"model":"gpt-5-nano","text":{"format":{"type":"json_schema","name":"response","schema":{"type":"object","properties":{"sentiment":{"type":"string"},"score":{"type":"number"}},"required":["sentiment","score"],"additionalProperties":false},"strict":true}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - OpenAI::Client/Ruby 0.49.0
+      Host:
+      - api.openai.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 0.49.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '376'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Feb 2026 23:45:46 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '180000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '179999730'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - team-c58089d6-6de8-4174-9362-b238cecaf04f
+      Openai-Project:
+      - proj_bAqiRfh7TFWmykwzXG5BVsrE
+      X-Request-Id:
+      - req_f663b7289dd795b390a40be0a8ea3c32
+      Openai-Processing-Ms:
+      - '3705'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ES5zX6kymK8v0s9b0_P8Zw2nYAisI5RBT2bCP1TUIFU-1771544742.8093166-1.0.1.1-Lfva4Uce4jOoY1ytQGelvm5rEsLmB.HpvP4kGZocAcWHhh1WpsLazHsQ_sDTCw.c7PlWAJ_IrIQaHKynHYrs.E_MIABPyLgoAbrDtN5Lp3ibQ3AiyApVuXH5LMA60vpg;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Fri, 20 Feb 2026
+        00:15:46 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Ray:
+      - 9d09a3b28c88803b-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_09e119552f605860016997a0a71a3c81958f0cf7dcc8c7b97f",
+          "object": "response",
+          "created_at": 1771544743,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1771544746,
+          "error": null,
+          "frequency_penalty": 0.0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-5-nano-2025-08-07",
+          "output": [
+            {
+              "id": "rs_09e119552f605860016997a0a77b04819597e324b0a851d37a",
+              "type": "reasoning",
+              "summary": []
+            },
+            {
+              "id": "msg_09e119552f605860016997a0aa95e88195834b6da372a90e35",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\"sentiment\":\"positive\",\"score\":0.95}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0.0,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "prompt_cache_retention": null,
+          "reasoning": {
+            "effort": "medium",
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": false,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "description": null,
+              "name": "response",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "sentiment": {
+                    "type": "string"
+                  },
+                  "score": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sentiment",
+                  "score"
+                ],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 53,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 488,
+            "output_tokens_details": {
+              "reasoning_tokens": 448
+            },
+            "total_tokens": 541
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Thu, 19 Feb 2026 23:45:46 GMT
+recorded_with: VCR 6.4.0

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -76,15 +76,15 @@ describe Riffer::Agent::Response do
     end
   end
 
-  describe "#object" do
+  describe "#structured_output" do
     it "defaults to nil" do
       response = Riffer::Agent::Response.new("Hello!")
-      expect(response.object).must_be_nil
+      expect(response.structured_output).must_be_nil
     end
 
-    it "stores the object" do
-      response = Riffer::Agent::Response.new("Hello!", object: {sentiment: "positive", score: 0.9})
-      expect(response.object).must_equal({sentiment: "positive", score: 0.9})
+    it "stores the structured output" do
+      response = Riffer::Agent::Response.new("Hello!", structured_output: {sentiment: "positive", score: 0.9})
+      expect(response.structured_output).must_equal({sentiment: "positive", score: 0.9})
     end
   end
 

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -76,6 +76,18 @@ describe Riffer::Agent::Response do
     end
   end
 
+  describe "#object" do
+    it "defaults to nil" do
+      response = Riffer::Agent::Response.new("Hello!")
+      expect(response.object).must_be_nil
+    end
+
+    it "stores the object" do
+      response = Riffer::Agent::Response.new("Hello!", object: {sentiment: "positive", score: 0.9})
+      expect(response.object).must_equal({sentiment: "positive", score: 0.9})
+    end
+  end
+
   describe "#interrupted?" do
     it "returns false by default" do
       response = Riffer::Agent::Response.new("Hello!")

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -591,14 +591,6 @@ describe Riffer::Agent do
       expect(agent_class.structured_output).must_be_nil
     end
 
-    it "stores Hash schema" do
-      klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
-        structured_output sentiment: String, score: Float
-      end
-      expect(klass.structured_output).must_equal({sentiment: String, score: Float})
-    end
-
     it "stores Params instance" do
       params = Riffer::Params.new
       params.required(:sentiment, String)
@@ -620,13 +612,24 @@ describe Riffer::Agent do
       expect(klass.structured_output).must_be_instance_of Riffer::Params
       expect(klass.structured_output.parameters.size).must_equal 2
     end
+
+    it "raises ArgumentError for non-Params argument" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+      end
+      error = expect { klass.structured_output({sentiment: String}) }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/structured_output must be a Riffer::Params/)
+    end
   end
 
   describe "#generate with structured_output" do
     it "returns Response with parsed object from class-level schema" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String, score: Float
+        structured_output do
+          required :sentiment, String
+          required :score, Float
+        end
       end
 
       agent = klass.new
@@ -638,32 +641,43 @@ describe Riffer::Agent do
     end
 
     it "returns Response with parsed object from kwarg" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      params.required(:score, Float)
+
       agent = agent_class.new
       provider = agent.send(:provider_instance)
       provider.stub_response('{"sentiment":"positive","score":0.9}')
 
-      result = agent.generate("Analyze sentiment", structured_output: {sentiment: String, score: Float})
+      result = agent.generate("Analyze sentiment", structured_output: params)
       expect(result.object).must_equal({sentiment: "positive", score: 0.9})
     end
 
     it "per-call kwarg overrides class-level default" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String
+        structured_output do
+          required :sentiment, String
+        end
       end
+
+      mood_params = Riffer::Params.new
+      mood_params.required(:mood, String)
 
       agent = klass.new
       provider = agent.send(:provider_instance)
       provider.stub_response('{"mood":"happy"}')
 
-      result = agent.generate("Analyze", structured_output: {mood: String})
+      result = agent.generate("Analyze", structured_output: mood_params)
       expect(result.object).must_equal({mood: "happy"})
     end
 
     it "sets object to nil when LLM returns invalid JSON" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String
+        structured_output do
+          required :sentiment, String
+        end
       end
 
       agent = klass.new
@@ -677,7 +691,9 @@ describe Riffer::Agent do
     it "preserves raw content when object parsing fails" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String
+        structured_output do
+          required :sentiment, String
+        end
       end
 
       agent = klass.new
@@ -688,7 +704,7 @@ describe Riffer::Agent do
       expect(result.content).must_equal "This is not JSON"
     end
 
-    it "works with Params instance schema" do
+    it "works with Params instance kwarg" do
       params = Riffer::Params.new
       params.required(:sentiment, String)
 
@@ -703,7 +719,9 @@ describe Riffer::Agent do
     it "passes structured_output to provider" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String
+        structured_output do
+          required :sentiment, String
+        end
       end
 
       agent = klass.new
@@ -732,7 +750,9 @@ describe Riffer::Agent do
     it "raises ArgumentError when class-level structured_output is configured" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
-        structured_output sentiment: String
+        structured_output do
+          required :sentiment, String
+        end
       end
 
       agent = klass.new
@@ -741,8 +761,11 @@ describe Riffer::Agent do
     end
 
     it "raises ArgumentError when kwarg structured_output is provided" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+
       agent = agent_class.new
-      error = expect { agent.stream("Hello", structured_output: {sentiment: String}) }.must_raise(Riffer::ArgumentError)
+      error = expect { agent.stream("Hello", structured_output: params) }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/Structured output is not supported with streaming/)
     end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -640,38 +640,6 @@ describe Riffer::Agent do
       expect(result.object).must_equal({sentiment: "positive", score: 0.9})
     end
 
-    it "returns Response with parsed object from kwarg" do
-      params = Riffer::Params.new
-      params.required(:sentiment, String)
-      params.required(:score, Float)
-
-      agent = agent_class.new
-      provider = agent.send(:provider_instance)
-      provider.stub_response('{"sentiment":"positive","score":0.9}')
-
-      result = agent.generate("Analyze sentiment", structured_output: params)
-      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
-    end
-
-    it "per-call kwarg overrides class-level default" do
-      klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
-        structured_output do
-          required :sentiment, String
-        end
-      end
-
-      mood_params = Riffer::Params.new
-      mood_params.required(:mood, String)
-
-      agent = klass.new
-      provider = agent.send(:provider_instance)
-      provider.stub_response('{"mood":"happy"}')
-
-      result = agent.generate("Analyze", structured_output: mood_params)
-      expect(result.object).must_equal({mood: "happy"})
-    end
-
     it "sets object to nil when LLM returns invalid JSON" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
@@ -704,15 +672,20 @@ describe Riffer::Agent do
       expect(result.content).must_equal "This is not JSON"
     end
 
-    it "works with Params instance kwarg" do
+    it "works with Params instance at class level" do
       params = Riffer::Params.new
       params.required(:sentiment, String)
 
-      agent = agent_class.new
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output params
+      end
+
+      agent = klass.new
       provider = agent.send(:provider_instance)
       provider.stub_response('{"sentiment":"positive"}')
 
-      result = agent.generate("Analyze", structured_output: params)
+      result = agent.generate("Analyze")
       expect(result.object).must_equal({sentiment: "positive"})
     end
 
@@ -757,15 +730,6 @@ describe Riffer::Agent do
 
       agent = klass.new
       error = expect { agent.stream("Hello") }.must_raise(Riffer::ArgumentError)
-      expect(error.message).must_match(/Structured output is not supported with streaming/)
-    end
-
-    it "raises ArgumentError when kwarg structured_output is provided" do
-      params = Riffer::Params.new
-      params.required(:sentiment, String)
-
-      agent = agent_class.new
-      error = expect { agent.stream("Hello", structured_output: params) }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/Structured output is not supported with streaming/)
     end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -689,29 +689,6 @@ describe Riffer::Agent do
       expect(result.object).must_equal({sentiment: "positive"})
     end
 
-    it "passes structured_output to provider" do
-      klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
-        structured_output do
-          required :sentiment, String
-        end
-      end
-
-      agent = klass.new
-      provider = agent.send(:provider_instance)
-      provider.stub_response('{"sentiment":"positive"}')
-
-      agent.generate("Analyze sentiment")
-      expect(provider.calls.last[:structured_output]).must_be_instance_of Riffer::StructuredOutput
-    end
-
-    it "does not pass structured_output when not configured" do
-      agent = agent_class.new
-      provider = agent.send(:provider_instance)
-      agent.generate("Hello")
-      expect(provider.calls.last.key?(:structured_output)).must_equal false
-    end
-
     it "returns nil object when structured_output is not configured" do
       agent = agent_class.new
       result = agent.generate("Hello")

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -623,7 +623,7 @@ describe Riffer::Agent do
   end
 
   describe "#generate with structured_output" do
-    it "returns Response with parsed object from class-level schema" do
+    it "returns Response with parsed structured_output from class-level schema" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
         structured_output do
@@ -637,10 +637,10 @@ describe Riffer::Agent do
       provider.stub_response('{"sentiment":"positive","score":0.9}')
 
       result = agent.generate("Analyze sentiment")
-      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+      expect(result.structured_output).must_equal({sentiment: "positive", score: 0.9})
     end
 
-    it "sets object to nil when LLM returns invalid JSON" do
+    it "sets structured_output to nil when LLM returns invalid JSON" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
         structured_output do
@@ -653,10 +653,10 @@ describe Riffer::Agent do
       provider.stub_response("This is not JSON")
 
       result = agent.generate("Analyze sentiment")
-      expect(result.object).must_be_nil
+      expect(result.structured_output).must_be_nil
     end
 
-    it "preserves raw content when object parsing fails" do
+    it "preserves raw content when structured_output parsing fails" do
       klass = Class.new(Riffer::Agent) do
         model "test/riffer-1"
         structured_output do
@@ -686,13 +686,13 @@ describe Riffer::Agent do
       provider.stub_response('{"sentiment":"positive"}')
 
       result = agent.generate("Analyze")
-      expect(result.object).must_equal({sentiment: "positive"})
+      expect(result.structured_output).must_equal({sentiment: "positive"})
     end
 
-    it "returns nil object when structured_output is not configured" do
+    it "returns nil structured_output when structured_output is not configured" do
       agent = agent_class.new
       result = agent.generate("Hello")
-      expect(result.object).must_be_nil
+      expect(result.structured_output).must_be_nil
     end
   end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -608,6 +608,18 @@ describe Riffer::Agent do
       klass.structured_output(params)
       expect(klass.structured_output).must_equal params
     end
+
+    it "stores Params from block DSL" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output do
+          required :sentiment, String, description: "The sentiment"
+          optional :score, Float
+        end
+      end
+      expect(klass.structured_output).must_be_instance_of Riffer::Params
+      expect(klass.structured_output.parameters.size).must_equal 2
+    end
   end
 
   describe "#generate with structured_output" do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -586,6 +586,161 @@ describe Riffer::Agent do
     end
   end
 
+  describe ".structured_output" do
+    it "returns nil when not set" do
+      expect(agent_class.structured_output).must_be_nil
+    end
+
+    it "stores Hash schema" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String, score: Float
+      end
+      expect(klass.structured_output).must_equal({sentiment: String, score: Float})
+    end
+
+    it "stores Params instance" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+      end
+      klass.structured_output(params)
+      expect(klass.structured_output).must_equal params
+    end
+  end
+
+  describe "#generate with structured_output" do
+    it "returns Response with parsed object from class-level schema" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String, score: Float
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"sentiment":"positive","score":0.9}')
+
+      result = agent.generate("Analyze sentiment")
+      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+    end
+
+    it "returns Response with parsed object from kwarg" do
+      agent = agent_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"sentiment":"positive","score":0.9}')
+
+      result = agent.generate("Analyze sentiment", structured_output: {sentiment: String, score: Float})
+      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+    end
+
+    it "per-call kwarg overrides class-level default" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"mood":"happy"}')
+
+      result = agent.generate("Analyze", structured_output: {mood: String})
+      expect(result.object).must_equal({mood: "happy"})
+    end
+
+    it "sets object to nil when LLM returns invalid JSON" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("This is not JSON")
+
+      result = agent.generate("Analyze sentiment")
+      expect(result.object).must_be_nil
+    end
+
+    it "preserves raw content when object parsing fails" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("This is not JSON")
+
+      result = agent.generate("Analyze sentiment")
+      expect(result.content).must_equal "This is not JSON"
+    end
+
+    it "works with Params instance schema" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+
+      agent = agent_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"sentiment":"positive"}')
+
+      result = agent.generate("Analyze", structured_output: params)
+      expect(result.object).must_equal({sentiment: "positive"})
+    end
+
+    it "passes structured_output to provider" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"sentiment":"positive"}')
+
+      agent.generate("Analyze sentiment")
+      expect(provider.calls.last[:structured_output]).must_be_instance_of Riffer::StructuredOutput
+    end
+
+    it "does not pass structured_output when not configured" do
+      agent = agent_class.new
+      provider = agent.send(:provider_instance)
+      agent.generate("Hello")
+      expect(provider.calls.last.key?(:structured_output)).must_equal false
+    end
+
+    it "returns nil object when structured_output is not configured" do
+      agent = agent_class.new
+      result = agent.generate("Hello")
+      expect(result.object).must_be_nil
+    end
+  end
+
+  describe "#stream with structured_output" do
+    it "raises ArgumentError when class-level structured_output is configured" do
+      klass = Class.new(Riffer::Agent) do
+        model "test/riffer-1"
+        structured_output sentiment: String
+      end
+
+      agent = klass.new
+      error = expect { agent.stream("Hello") }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Structured output is not supported with streaming/)
+    end
+
+    it "raises ArgumentError when kwarg structured_output is provided" do
+      agent = agent_class.new
+      error = expect { agent.stream("Hello", structured_output: {sentiment: String}) }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Structured output is not supported with streaming/)
+    end
+
+    it "works normally without structured_output" do
+      agent = agent_class.new
+      result = agent.stream("Hello")
+      expect(result).must_be_instance_of Enumerator
+    end
+  end
+
   describe "instructions validation" do
     it "raises error when instructions is empty string" do
       error = expect do

--- a/test/riffer/param_test.rb
+++ b/test/riffer/param_test.rb
@@ -2,141 +2,141 @@
 
 require "test_helper"
 
-describe Riffer::Tools::Param do
+describe Riffer::Param do
   describe "#initialize" do
     it "sets the name as a symbol" do
-      param = Riffer::Tools::Param.new(name: "city", type: String, required: true)
+      param = Riffer::Param.new(name: "city", type: String, required: true)
       expect(param.name).must_equal :city
     end
 
     it "sets the type" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.type).must_equal String
     end
 
     it "sets required flag" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.required).must_equal true
     end
 
     it "sets description" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true, description: "The city name")
+      param = Riffer::Param.new(name: :city, type: String, required: true, description: "The city name")
       expect(param.description).must_equal "The city name"
     end
 
     it "sets enum" do
-      param = Riffer::Tools::Param.new(name: :unit, type: String, required: true, enum: ["celsius", "fahrenheit"])
+      param = Riffer::Param.new(name: :unit, type: String, required: true, enum: ["celsius", "fahrenheit"])
       expect(param.enum).must_equal ["celsius", "fahrenheit"]
     end
 
     it "sets default" do
-      param = Riffer::Tools::Param.new(name: :unit, type: String, required: false, default: "celsius")
+      param = Riffer::Param.new(name: :unit, type: String, required: false, default: "celsius")
       expect(param.default).must_equal "celsius"
     end
   end
 
   describe "#valid_type?" do
     it "returns true for valid string type" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.valid_type?("Toronto")).must_equal true
     end
 
     it "returns false for invalid string type" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.valid_type?(123)).must_equal false
     end
 
     it "returns true for valid integer type" do
-      param = Riffer::Tools::Param.new(name: :count, type: Integer, required: true)
+      param = Riffer::Param.new(name: :count, type: Integer, required: true)
       expect(param.valid_type?(42)).must_equal true
     end
 
     it "returns true for valid float type" do
-      param = Riffer::Tools::Param.new(name: :amount, type: Float, required: true)
+      param = Riffer::Param.new(name: :amount, type: Float, required: true)
       expect(param.valid_type?(3.14)).must_equal true
     end
 
     it "returns true for true boolean value" do
-      param = Riffer::Tools::Param.new(name: :enabled, type: TrueClass, required: true)
+      param = Riffer::Param.new(name: :enabled, type: TrueClass, required: true)
       expect(param.valid_type?(true)).must_equal true
     end
 
     it "returns true for false boolean value" do
-      param = Riffer::Tools::Param.new(name: :enabled, type: TrueClass, required: true)
+      param = Riffer::Param.new(name: :enabled, type: TrueClass, required: true)
       expect(param.valid_type?(false)).must_equal true
     end
 
     it "returns true for nil on optional params" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: false)
+      param = Riffer::Param.new(name: :city, type: String, required: false)
       expect(param.valid_type?(nil)).must_equal true
     end
 
     it "returns true for valid array type" do
-      param = Riffer::Tools::Param.new(name: :items, type: Array, required: true)
+      param = Riffer::Param.new(name: :items, type: Array, required: true)
       expect(param.valid_type?([1, 2, 3])).must_equal true
     end
 
     it "returns true for valid hash type" do
-      param = Riffer::Tools::Param.new(name: :data, type: Hash, required: true)
+      param = Riffer::Param.new(name: :data, type: Hash, required: true)
       expect(param.valid_type?({key: "value"})).must_equal true
     end
   end
 
   describe "#type_name" do
     it "returns 'string' for String" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.type_name).must_equal "string"
     end
 
     it "returns 'integer' for Integer" do
-      param = Riffer::Tools::Param.new(name: :count, type: Integer, required: true)
+      param = Riffer::Param.new(name: :count, type: Integer, required: true)
       expect(param.type_name).must_equal "integer"
     end
 
     it "returns 'number' for Float" do
-      param = Riffer::Tools::Param.new(name: :amount, type: Float, required: true)
+      param = Riffer::Param.new(name: :amount, type: Float, required: true)
       expect(param.type_name).must_equal "number"
     end
 
     it "returns 'boolean' for TrueClass" do
-      param = Riffer::Tools::Param.new(name: :enabled, type: TrueClass, required: true)
+      param = Riffer::Param.new(name: :enabled, type: TrueClass, required: true)
       expect(param.type_name).must_equal "boolean"
     end
 
     it "returns 'array' for Array" do
-      param = Riffer::Tools::Param.new(name: :items, type: Array, required: true)
+      param = Riffer::Param.new(name: :items, type: Array, required: true)
       expect(param.type_name).must_equal "array"
     end
 
     it "returns 'object' for Hash" do
-      param = Riffer::Tools::Param.new(name: :data, type: Hash, required: true)
+      param = Riffer::Param.new(name: :data, type: Hash, required: true)
       expect(param.type_name).must_equal "object"
     end
   end
 
   describe "#to_json_schema" do
     it "returns hash with type" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.to_json_schema[:type]).must_equal "string"
     end
 
     it "includes description when set" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true, description: "The city name")
+      param = Riffer::Param.new(name: :city, type: String, required: true, description: "The city name")
       expect(param.to_json_schema[:description]).must_equal "The city name"
     end
 
     it "includes enum when set" do
-      param = Riffer::Tools::Param.new(name: :unit, type: String, required: true, enum: ["celsius", "fahrenheit"])
+      param = Riffer::Param.new(name: :unit, type: String, required: true, enum: ["celsius", "fahrenheit"])
       expect(param.to_json_schema[:enum]).must_equal ["celsius", "fahrenheit"]
     end
 
     it "excludes description when not set" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.to_json_schema.key?(:description)).must_equal false
     end
 
     it "excludes enum when not set" do
-      param = Riffer::Tools::Param.new(name: :city, type: String, required: true)
+      param = Riffer::Param.new(name: :city, type: String, required: true)
       expect(param.to_json_schema.key?(:enum)).must_equal false
     end
   end

--- a/test/riffer/params_test.rb
+++ b/test/riffer/params_test.rb
@@ -3,39 +3,6 @@
 require "test_helper"
 
 describe Riffer::Params do
-  describe ".from_hash" do
-    it "creates params with all keys as required" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      expect(params.parameters.length).must_equal 2
-    end
-
-    it "marks all params as required" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      expect(params.parameters.all?(&:required)).must_equal true
-    end
-
-    it "sets correct names" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      expect(params.parameters.map(&:name)).must_equal [:sentiment, :score]
-    end
-
-    it "sets correct types" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      expect(params.parameters.map(&:type)).must_equal [String, Float]
-    end
-
-    it "validates successfully with matching input" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      result = params.validate(sentiment: "positive", score: 0.9)
-      expect(result).must_equal({sentiment: "positive", score: 0.9})
-    end
-
-    it "raises ValidationError for missing keys" do
-      params = Riffer::Params.from_hash(sentiment: String, score: Float)
-      expect { params.validate(sentiment: "positive") }.must_raise(Riffer::ValidationError)
-    end
-  end
-
   describe "#required" do
     it "adds a parameter" do
       params = Riffer::Params.new

--- a/test/riffer/params_test.rb
+++ b/test/riffer/params_test.rb
@@ -2,40 +2,73 @@
 
 require "test_helper"
 
-describe Riffer::Tools::Params do
+describe Riffer::Params do
+  describe ".from_hash" do
+    it "creates params with all keys as required" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      expect(params.parameters.length).must_equal 2
+    end
+
+    it "marks all params as required" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      expect(params.parameters.all?(&:required)).must_equal true
+    end
+
+    it "sets correct names" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      expect(params.parameters.map(&:name)).must_equal [:sentiment, :score]
+    end
+
+    it "sets correct types" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      expect(params.parameters.map(&:type)).must_equal [String, Float]
+    end
+
+    it "validates successfully with matching input" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      result = params.validate(sentiment: "positive", score: 0.9)
+      expect(result).must_equal({sentiment: "positive", score: 0.9})
+    end
+
+    it "raises ValidationError for missing keys" do
+      params = Riffer::Params.from_hash(sentiment: String, score: Float)
+      expect { params.validate(sentiment: "positive") }.must_raise(Riffer::ValidationError)
+    end
+  end
+
   describe "#required" do
     it "adds a parameter" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect(params.parameters.length).must_equal 1
     end
 
     it "marks the parameter as required" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect(params.parameters.first.required).must_equal true
     end
 
     it "sets the parameter name" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect(params.parameters.first.name).must_equal :city
     end
 
     it "sets the parameter type" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect(params.parameters.first.type).must_equal String
     end
 
     it "sets the description" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String, description: "The city name")
       expect(params.parameters.first.description).must_equal "The city name"
     end
 
     it "sets the enum" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:unit, String, enum: ["celsius", "fahrenheit"])
       expect(params.parameters.first.enum).must_equal ["celsius", "fahrenheit"]
     end
@@ -43,19 +76,19 @@ describe Riffer::Tools::Params do
 
   describe "#optional" do
     it "adds a parameter" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.optional(:units, String)
       expect(params.parameters.length).must_equal 1
     end
 
     it "marks the parameter as not required" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.optional(:units, String)
       expect(params.parameters.first.required).must_equal false
     end
 
     it "sets the default value" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.optional(:units, String, default: "celsius")
       expect(params.parameters.first.default).must_equal "celsius"
     end
@@ -63,67 +96,67 @@ describe Riffer::Tools::Params do
 
   describe "#validate" do
     it "returns validated arguments for valid input" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       result = params.validate({city: "Toronto"})
       expect(result).must_equal({city: "Toronto"})
     end
 
     it "raises ValidationError for missing required param" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect { params.validate({}) }.must_raise(Riffer::ValidationError)
     end
 
     it "includes param name in missing required error" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       error = expect { params.validate({}) }.must_raise(Riffer::ValidationError)
       expect(error.message).must_match(/city is required/)
     end
 
     it "raises ValidationError for wrong type" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       expect { params.validate({city: 123}) }.must_raise(Riffer::ValidationError)
     end
 
     it "includes param name in wrong type error" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       error = expect { params.validate({city: 123}) }.must_raise(Riffer::ValidationError)
       expect(error.message).must_match(/city must be a string/)
     end
 
     it "raises ValidationError for enum violation" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:unit, String, enum: ["celsius", "fahrenheit"])
       expect { params.validate({unit: "kelvin"}) }.must_raise(Riffer::ValidationError)
     end
 
     it "includes allowed values in enum violation error" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:unit, String, enum: ["celsius", "fahrenheit"])
       error = expect { params.validate({unit: "kelvin"}) }.must_raise(Riffer::ValidationError)
       expect(error.message).must_match(/must be one of/)
     end
 
     it "applies default for missing optional param" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.optional(:units, String, default: "celsius")
       result = params.validate({})
       expect(result[:units]).must_equal "celsius"
     end
 
     it "uses provided value over default" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.optional(:units, String, default: "celsius")
       result = params.validate({units: "fahrenheit"})
       expect(result[:units]).must_equal "fahrenheit"
     end
 
     it "includes first missing param in multiple errors" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       params.required(:country, String)
       error = expect { params.validate({}) }.must_raise(Riffer::ValidationError)
@@ -131,7 +164,7 @@ describe Riffer::Tools::Params do
     end
 
     it "includes second missing param in multiple errors" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       params.required(:country, String)
       error = expect { params.validate({}) }.must_raise(Riffer::ValidationError)
@@ -141,12 +174,12 @@ describe Riffer::Tools::Params do
 
   describe "#to_json_schema" do
     it "returns object type" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       expect(params.to_json_schema[:type]).must_equal "object"
     end
 
     it "includes properties for each parameter" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       params.optional(:units, String)
       schema = params.to_json_schema
@@ -154,7 +187,7 @@ describe Riffer::Tools::Params do
     end
 
     it "includes required array" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       params.required(:city, String)
       params.optional(:units, String)
       schema = params.to_json_schema
@@ -162,18 +195,18 @@ describe Riffer::Tools::Params do
     end
 
     it "sets additionalProperties to false" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       expect(params.to_json_schema[:additionalProperties]).must_equal false
     end
 
     it "returns empty properties for no params" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       schema = params.to_json_schema
       expect(schema[:properties]).must_equal({})
     end
 
     it "returns empty required array for no params" do
-      params = Riffer::Tools::Params.new
+      params = Riffer::Params.new
       schema = params.to_json_schema
       expect(schema[:required]).must_equal([])
     end

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -120,7 +120,10 @@ describe Riffer::Providers::AmazonBedrock do
       it "returns an Assistant message" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -133,7 +136,10 @@ describe Riffer::Providers::AmazonBedrock do
       it "returns non-empty content" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -146,7 +152,10 @@ describe Riffer::Providers::AmazonBedrock do
       it "returns valid JSON content" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -159,7 +168,10 @@ describe Riffer::Providers::AmazonBedrock do
       it "includes sentiment key" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -173,7 +185,10 @@ describe Riffer::Providers::AmazonBedrock do
       it "includes score key" do
         VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -290,7 +305,10 @@ describe Riffer::Providers::AmazonBedrock do
   describe "structured output" do
     it "includes output_config.text_format in request params" do
       provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      params.required(:score, Float)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
@@ -300,7 +318,9 @@ describe Riffer::Providers::AmazonBedrock do
 
     it "includes json_schema structure with name" do
       provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
@@ -310,7 +330,9 @@ describe Riffer::Providers::AmazonBedrock do
 
     it "serializes schema as JSON string" do
       provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
@@ -332,7 +354,9 @@ describe Riffer::Providers::AmazonBedrock do
 
     it "does not pass structured_output through to API params" do
       provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -219,6 +219,60 @@ describe Riffer::Providers::AmazonBedrock do
     end
   end
 
+  describe "structured output" do
+    it "includes output_config.text_format in request params" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
+
+      expect(params[:output_config][:text_format][:type]).must_equal "json_schema"
+    end
+
+    it "includes json_schema structure with name" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
+
+      expect(params[:output_config][:text_format][:structure][:json_schema][:name]).must_equal "response"
+    end
+
+    it "serializes schema as JSON string" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
+
+      schema_json = params[:output_config][:text_format][:structure][:json_schema][:schema]
+      expect(schema_json).must_be_instance_of String
+      parsed = JSON.parse(schema_json)
+      expect(parsed["type"]).must_equal "object"
+    end
+
+    it "does not include output_config when not configured" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {})
+
+      expect(params.key?(:output_config)).must_equal false
+    end
+
+    it "does not pass structured_output through to API params" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "anthropic.claude-3-haiku-20240307-v1:0", {structured_output: structured_output})
+
+      expect(params.key?(:structured_output)).must_equal false
+    end
+  end
+
   describe "tool calling" do
     let(:weather_tool) do
       Class.new(Riffer::Tool) do

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -116,6 +116,74 @@ describe Riffer::Providers::AmazonBedrock do
         end
       end
     end
+    describe "structured output" do
+      it "returns an Assistant message" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: structured_output
+          )
+          expect(result).must_be_instance_of Riffer::Messages::Assistant
+        end
+      end
+
+      it "returns non-empty content" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: structured_output
+          )
+          expect(result.content).wont_be_empty
+        end
+      end
+
+      it "returns valid JSON content" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: structured_output
+          )
+          JSON.parse(result.content)
+        end
+      end
+
+      it "includes sentiment key" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("sentiment")).must_equal true
+        end
+      end
+
+      it "includes score key" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("score")).must_equal true
+        end
+      end
+    end
   end
 
   describe "#stream_text" do

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -96,7 +96,10 @@ describe Riffer::Providers::Anthropic do
       it "returns an Assistant message" do
         VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "claude-haiku-4-5-20251001",
@@ -109,7 +112,10 @@ describe Riffer::Providers::Anthropic do
       it "returns non-empty content" do
         VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "claude-haiku-4-5-20251001",
@@ -122,7 +128,10 @@ describe Riffer::Providers::Anthropic do
       it "returns valid JSON content" do
         VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "claude-haiku-4-5-20251001",
@@ -135,7 +144,10 @@ describe Riffer::Providers::Anthropic do
       it "includes sentiment key" do
         VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "claude-haiku-4-5-20251001",
@@ -149,7 +161,10 @@ describe Riffer::Providers::Anthropic do
       it "includes score key" do
         VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "claude-haiku-4-5-20251001",
@@ -227,7 +242,10 @@ describe Riffer::Providers::Anthropic do
   describe "structured output" do
     it "includes output_config.format in request params" do
       provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      params.required(:score, Float)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})
@@ -237,7 +255,9 @@ describe Riffer::Providers::Anthropic do
 
     it "includes json_schema in format" do
       provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})
@@ -256,7 +276,9 @@ describe Riffer::Providers::Anthropic do
 
     it "does not pass structured_output through to API params" do
       provider = Riffer::Providers::Anthropic.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -92,6 +92,74 @@ describe Riffer::Providers::Anthropic do
         end
       end
     end
+    describe "structured output" do
+      it "returns an Assistant message" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: structured_output
+          )
+          expect(result).must_be_instance_of Riffer::Messages::Assistant
+        end
+      end
+
+      it "returns non-empty content" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: structured_output
+          )
+          expect(result.content).wont_be_empty
+        end
+      end
+
+      it "returns valid JSON content" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: structured_output
+          )
+          JSON.parse(result.content)
+        end
+      end
+
+      it "includes sentiment key" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("sentiment")).must_equal true
+        end
+      end
+
+      it "includes score key" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("score")).must_equal true
+        end
+      end
+    end
   end
 
   describe "#stream_text" do

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -156,6 +156,47 @@ describe Riffer::Providers::Anthropic do
     end
   end
 
+  describe "structured output" do
+    it "includes output_config.format in request params" do
+      provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})
+
+      expect(params[:output_config][:format][:type]).must_equal "json_schema"
+    end
+
+    it "includes json_schema in format" do
+      provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})
+
+      expect(params[:output_config][:format][:schema][:type]).must_equal "object"
+    end
+
+    it "does not include output_config when not configured" do
+      provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+      messages = [Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {})
+
+      expect(params.key?(:output_config)).must_equal false
+    end
+
+    it "does not pass structured_output through to API params" do
+      provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "claude-haiku-4-5-20251001", {structured_output: structured_output})
+
+      expect(params.key?(:structured_output)).must_equal false
+    end
+  end
+
   describe "tool calling" do
     let(:weather_tool) do
       Class.new(Riffer::Tool) do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -103,6 +103,75 @@ describe Riffer::Providers::OpenAI do
       end
     end
 
+    describe "structured output" do
+      it "returns an Assistant message" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "gpt-5-nano",
+            structured_output: structured_output
+          )
+          expect(result).must_be_instance_of Riffer::Messages::Assistant
+        end
+      end
+
+      it "returns non-empty content" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "gpt-5-nano",
+            structured_output: structured_output
+          )
+          expect(result.content).wont_be_empty
+        end
+      end
+
+      it "returns valid JSON content" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "gpt-5-nano",
+            structured_output: structured_output
+          )
+          JSON.parse(result.content)
+        end
+      end
+
+      it "includes sentiment key" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "gpt-5-nano",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("sentiment")).must_equal true
+        end
+      end
+
+      it "includes score key" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          result = provider.generate_text(
+            prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
+            model: "gpt-5-nano",
+            structured_output: structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed.key?("score")).must_equal true
+        end
+      end
+    end
+
     describe "without reasoning parameter" do
       it "does not include reasoning in request params" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/without_reasoning_parameter/does_not_include_reasoning") do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -248,6 +248,67 @@ describe Riffer::Providers::OpenAI do
     end
   end
 
+  describe "structured output" do
+    it "includes text.format in request params" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
+
+      expect(params[:text][:format][:type]).must_equal "json_schema"
+    end
+
+    it "sets schema name to response" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
+
+      expect(params[:text][:format][:name]).must_equal "response"
+    end
+
+    it "sets strict to true" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
+
+      expect(params[:text][:format][:strict]).must_equal true
+    end
+
+    it "includes json_schema in format" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
+
+      expect(params[:text][:format][:schema][:type]).must_equal "object"
+    end
+
+    it "does not include text.format when not configured" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      messages = [Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {})
+
+      expect(params[:text]).must_be_nil
+    end
+
+    it "does not pass structured_output through to API params" do
+      provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      messages = [Riffer::Messages::User.new("Analyze")]
+
+      params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
+
+      expect(params.key?(:structured_output)).must_equal false
+    end
+  end
+
   describe "tool calling" do
     let(:weather_tool) do
       Class.new(Riffer::Tool) do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -107,7 +107,10 @@ describe Riffer::Providers::OpenAI do
       it "returns an Assistant message" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "gpt-5-nano",
@@ -120,7 +123,10 @@ describe Riffer::Providers::OpenAI do
       it "returns non-empty content" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "gpt-5-nano",
@@ -133,7 +139,10 @@ describe Riffer::Providers::OpenAI do
       it "returns valid JSON content" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "gpt-5-nano",
@@ -146,7 +155,10 @@ describe Riffer::Providers::OpenAI do
       it "includes sentiment key" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "gpt-5-nano",
@@ -160,7 +172,10 @@ describe Riffer::Providers::OpenAI do
       it "includes score key" do
         VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output/returns_structured_json") do
           provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-          structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+          params = Riffer::Params.new
+          params.required(:sentiment, String)
+          params.required(:score, Float)
+          structured_output = Riffer::StructuredOutput.new(params)
           result = provider.generate_text(
             prompt: "Analyze the sentiment of the following text: 'I love this product, it is amazing!'",
             model: "gpt-5-nano",
@@ -320,7 +335,10 @@ describe Riffer::Providers::OpenAI do
   describe "structured output" do
     it "includes text.format in request params" do
       provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      params.required(:score, Float)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
@@ -330,7 +348,9 @@ describe Riffer::Providers::OpenAI do
 
     it "sets schema name to response" do
       provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
@@ -340,7 +360,9 @@ describe Riffer::Providers::OpenAI do
 
     it "sets strict to true" do
       provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
@@ -350,7 +372,9 @@ describe Riffer::Providers::OpenAI do
 
     it "includes json_schema in format" do
       provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})
@@ -369,7 +393,9 @@ describe Riffer::Providers::OpenAI do
 
     it "does not pass structured_output through to API params" do
       provider = Riffer::Providers::OpenAI.new(api_key: api_key)
-      structured_output = Riffer::StructuredOutput.new(sentiment: String)
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      structured_output = Riffer::StructuredOutput.new(params)
       messages = [Riffer::Messages::User.new("Analyze")]
 
       params = provider.send(:build_request_params, messages, "gpt-5-nano", {structured_output: structured_output})

--- a/test/riffer/structured_output/result_test.rb
+++ b/test/riffer/structured_output/result_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::StructuredOutput::Result do
+  describe "#success?" do
+    it "returns true when no error" do
+      result = Riffer::StructuredOutput::Result.new(object: {sentiment: "positive"})
+      expect(result.success?).must_equal true
+    end
+
+    it "returns false when error present" do
+      result = Riffer::StructuredOutput::Result.new(error: "something went wrong")
+      expect(result.success?).must_equal false
+    end
+  end
+
+  describe "#failure?" do
+    it "returns false when no error" do
+      result = Riffer::StructuredOutput::Result.new(object: {sentiment: "positive"})
+      expect(result.failure?).must_equal false
+    end
+
+    it "returns true when error present" do
+      result = Riffer::StructuredOutput::Result.new(error: "something went wrong")
+      expect(result.failure?).must_equal true
+    end
+  end
+
+  describe "#object" do
+    it "returns the validated object" do
+      result = Riffer::StructuredOutput::Result.new(object: {sentiment: "positive", score: 0.9})
+      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+    end
+
+    it "returns nil on failure" do
+      result = Riffer::StructuredOutput::Result.new(error: "something went wrong")
+      expect(result.object).must_be_nil
+    end
+  end
+
+  describe "#error" do
+    it "returns the error message" do
+      result = Riffer::StructuredOutput::Result.new(error: "parse failed")
+      expect(result.error).must_equal "parse failed"
+    end
+
+    it "returns nil on success" do
+      result = Riffer::StructuredOutput::Result.new(object: {sentiment: "positive"})
+      expect(result.error).must_be_nil
+    end
+  end
+end

--- a/test/riffer/structured_output_test.rb
+++ b/test/riffer/structured_output_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::StructuredOutput do
+  describe "#initialize" do
+    it "accepts a Hash shorthand" do
+      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      expect(so.params).must_be_instance_of Riffer::Params
+    end
+
+    it "accepts a Params instance" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      so = Riffer::StructuredOutput.new(params)
+      expect(so.params).must_equal params
+    end
+
+    it "generates json_schema from Hash shorthand" do
+      so = Riffer::StructuredOutput.new(sentiment: String)
+      expect(so.json_schema[:type]).must_equal "object"
+      expect(so.json_schema[:properties].keys).must_equal ["sentiment"]
+    end
+
+    it "generates json_schema from Params instance" do
+      params = Riffer::Params.new
+      params.required(:sentiment, String)
+      so = Riffer::StructuredOutput.new(params)
+      expect(so.json_schema[:type]).must_equal "object"
+      expect(so.json_schema[:properties].keys).must_equal ["sentiment"]
+    end
+  end
+
+  describe "#parse_and_validate" do
+    it "returns successful result for valid JSON" do
+      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
+      expect(result.success?).must_equal true
+    end
+
+    it "returns validated object with symbolized keys" do
+      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
+      expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+    end
+
+    it "returns failure result for invalid JSON" do
+      so = Riffer::StructuredOutput.new(sentiment: String)
+      result = so.parse_and_validate("not json")
+      expect(result.failure?).must_equal true
+    end
+
+    it "includes JSON parse error message" do
+      so = Riffer::StructuredOutput.new(sentiment: String)
+      result = so.parse_and_validate("not json")
+      expect(result.error).must_match(/JSON parse error/)
+    end
+
+    it "returns failure result for validation errors" do
+      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      result = so.parse_and_validate('{"sentiment":"positive"}')
+      expect(result.failure?).must_equal true
+    end
+
+    it "includes validation error message" do
+      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      result = so.parse_and_validate('{"sentiment":"positive"}')
+      expect(result.error).must_match(/Validation error/)
+    end
+
+    it "returns failure result for wrong types" do
+      so = Riffer::StructuredOutput.new(sentiment: String)
+      result = so.parse_and_validate('{"sentiment":123}')
+      expect(result.failure?).must_equal true
+    end
+  end
+end

--- a/test/riffer/structured_output_test.rb
+++ b/test/riffer/structured_output_test.rb
@@ -3,29 +3,27 @@
 require "test_helper"
 
 describe Riffer::StructuredOutput do
+  let(:sentiment_params) do
+    params = Riffer::Params.new
+    params.required(:sentiment, String)
+    params
+  end
+
+  let(:sentiment_score_params) do
+    params = Riffer::Params.new
+    params.required(:sentiment, String)
+    params.required(:score, Float)
+    params
+  end
+
   describe "#initialize" do
-    it "accepts a Hash shorthand" do
-      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
-      expect(so.params).must_be_instance_of Riffer::Params
-    end
-
     it "accepts a Params instance" do
-      params = Riffer::Params.new
-      params.required(:sentiment, String)
-      so = Riffer::StructuredOutput.new(params)
-      expect(so.params).must_equal params
-    end
-
-    it "generates json_schema from Hash shorthand" do
-      so = Riffer::StructuredOutput.new(sentiment: String)
-      expect(so.json_schema[:type]).must_equal "object"
-      expect(so.json_schema[:properties].keys).must_equal ["sentiment"]
+      so = Riffer::StructuredOutput.new(sentiment_params)
+      expect(so.params).must_equal sentiment_params
     end
 
     it "generates json_schema from Params instance" do
-      params = Riffer::Params.new
-      params.required(:sentiment, String)
-      so = Riffer::StructuredOutput.new(params)
+      so = Riffer::StructuredOutput.new(sentiment_params)
       expect(so.json_schema[:type]).must_equal "object"
       expect(so.json_schema[:properties].keys).must_equal ["sentiment"]
     end
@@ -33,43 +31,43 @@ describe Riffer::StructuredOutput do
 
   describe "#parse_and_validate" do
     it "returns successful result for valid JSON" do
-      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      so = Riffer::StructuredOutput.new(sentiment_score_params)
       result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
       expect(result.success?).must_equal true
     end
 
     it "returns validated object with symbolized keys" do
-      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      so = Riffer::StructuredOutput.new(sentiment_score_params)
       result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
       expect(result.object).must_equal({sentiment: "positive", score: 0.9})
     end
 
     it "returns failure result for invalid JSON" do
-      so = Riffer::StructuredOutput.new(sentiment: String)
+      so = Riffer::StructuredOutput.new(sentiment_params)
       result = so.parse_and_validate("not json")
       expect(result.failure?).must_equal true
     end
 
     it "includes JSON parse error message" do
-      so = Riffer::StructuredOutput.new(sentiment: String)
+      so = Riffer::StructuredOutput.new(sentiment_params)
       result = so.parse_and_validate("not json")
       expect(result.error).must_match(/JSON parse error/)
     end
 
     it "returns failure result for validation errors" do
-      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      so = Riffer::StructuredOutput.new(sentiment_score_params)
       result = so.parse_and_validate('{"sentiment":"positive"}')
       expect(result.failure?).must_equal true
     end
 
     it "includes validation error message" do
-      so = Riffer::StructuredOutput.new(sentiment: String, score: Float)
+      so = Riffer::StructuredOutput.new(sentiment_score_params)
       result = so.parse_and_validate('{"sentiment":"positive"}')
       expect(result.error).must_match(/Validation error/)
     end
 
     it "returns failure result for wrong types" do
-      so = Riffer::StructuredOutput.new(sentiment: String)
+      so = Riffer::StructuredOutput.new(sentiment_params)
       result = so.parse_and_validate('{"sentiment":123}')
       expect(result.failure?).must_equal true
     end

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -70,7 +70,7 @@ describe Riffer::Tool do
 
   describe ".params" do
     it "returns the params builder" do
-      expect(weather_tool_class.params).must_be_instance_of Riffer::Tools::Params
+      expect(weather_tool_class.params).must_be_instance_of Riffer::Params
     end
 
     it "returns nil when no params defined" do


### PR DESCRIPTION
## Summary

- Move `Riffer::Tools::Params`/`Param` to top-level `Riffer::Params`/`Param` namespace since they are now shared by both Tool DSL and StructuredOutput
- Create `Riffer::StructuredOutput` with `parse_and_validate` returning a `Result` object
- Add `Riffer::StructuredOutput::Result` with `success?`/`failure?`, `object`/`error`
- Add class-level `structured_output` DSL on `Agent` (block DSL or `Riffer::Params` instance)
- Remove per-call `structured_output:` kwarg from `Agent#generate` and `Agent#stream` — structured output is now class-level only
- Remove Hash shorthand from `structured_output` — now accepts only `Riffer::Params` instances or block DSL
- Remove `Params.from_hash` (no longer needed without Hash shorthand)
- Add type guard in `Agent.structured_output` to reject non-Params arguments
- Guard `Agent#stream` against structured output (raises `Riffer::ArgumentError`)
- Add `structured_output` attribute to `Agent::Response` for parsed structured output
- Wire structured output schema through to all three providers:
  - **OpenAI**: `text.format` with `json_schema` in `build_request_params`
  - **Anthropic**: `output_config.format` with `json_schema`
  - **Bedrock**: `output_config.text_format` with `json_schema` (schema serialized as JSON string)
- Add structured output VCR integration tests for all three providers
- Remove tests that inspect private internals (`provider.calls`) — all tests now assert through the public API only
- Document structured output in `docs/03_AGENTS.md`, `docs/01_OVERVIEW.md`, `.agents/architecture.md`, and `.agents/providers.md`

## Test plan

- [x] `bundle exec rake` — 869 tests pass, 0 failures, 0 errors
- [x] `bundle exec rake standard` — no lint violations
- [x] `steep check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)