### PR TITLE
fix: add RBS annotations and fix test provider web search docs

### DIFF
--- a/docs_providers/05_TEST_PROVIDER.md
+++ b/docs_providers/05_TEST_PROVIDER.md
@@ -145,22 +145,19 @@ text_done = events.find { |e| e.is_a?(Riffer::StreamEvents::TextDone) }
 
 ## Web Search
 
-The test provider emits web search events when the stubbed response includes `web_search`:
+The test provider emits web search events when `web_search: true` is passed to the stream call:
 
 ```ruby
-provider.stub_response("Here are the latest results.", web_search: {
-  query: "Ruby 3.4 release",
-  sources: [{title: "Ruby Releases", url: "https://www.ruby-lang.org/en/news/"}]
-})
+provider.stub_response("Here are the latest results.")
 
 events = []
-agent.stream("What's new in Ruby?").each { |e| events << e }
+agent.stream("What's new in Ruby?", web_search: true).each { |e| events << e }
 
 # Events include WebSearchStatus and WebSearchDone before text events
 search_deltas = events.select { |e| e.is_a?(Riffer::StreamEvents::WebSearchStatus) }
 search_done = events.find { |e| e.is_a?(Riffer::StreamEvents::WebSearchDone) }
-search_done.query    # => "Ruby 3.4 release"
-search_done.sources  # => [{title: "Ruby Releases", url: "https://www.ruby-lang.org/en/news/"}]
+search_done.query    # => "test search query"
+search_done.sources  # => [{title: "Example", url: "https://example.com"}]
 ```
 
 ## Initial Responses

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -7,7 +7,7 @@
 #
 # See https://github.com/anthropics/anthropic-sdk-ruby
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
-  WEB_SEARCH_TOOL_TYPE = "web_search_20250305"
+  WEB_SEARCH_TOOL_TYPE = "web_search_20250305" #: String
 
   # Initializes the Anthropic provider.
   #

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -5,7 +5,7 @@
 #
 # Requires the +openai+ gem to be installed.
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
-  WEB_SEARCH_TOOL_TYPE = "web_search_preview"
+  WEB_SEARCH_TOOL_TYPE = "web_search_preview" #: String
 
   # Initializes the OpenAI provider.
   #

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -6,7 +6,7 @@
 #
 # See https://github.com/anthropics/anthropic-sdk-ruby
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
-  WEB_SEARCH_TOOL_TYPE: ::String
+  WEB_SEARCH_TOOL_TYPE: String
 
   # Initializes the Anthropic provider.
   #

--- a/sig/generated/riffer/providers/open_ai.rbs
+++ b/sig/generated/riffer/providers/open_ai.rbs
@@ -4,7 +4,7 @@
 #
 # Requires the +openai+ gem to be installed.
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
-  WEB_SEARCH_TOOL_TYPE: ::String
+  WEB_SEARCH_TOOL_TYPE: String
 
   # Initializes the OpenAI provider.
   #


### PR DESCRIPTION
## Summary
PR #126 added web_search support for OpenAI and Anthropic providers. A post-merge code review found two issues: missing RBS type annotations on new constants and an incorrect example in the test provider docs.

- Add missing `#: String` RBS type annotations to `WEB_SEARCH_TOOL_TYPE` constants in Anthropic and OpenAI providers
- Fix incorrect web search example in test provider docs — `web_search` is passed to the `stream` call, not `stub_response`
- Regenerate RBS signatures to reflect the new annotations

## Test plan
- [x] `bundle exec rake` — all 902 tests pass, linting clean
- [x] `bundle exec rake rbs:generate` — RBS signatures regenerated
- [x] Steep type checking passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)