### PR TITLE
refactor: rename test provider to mock provider

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -107,7 +107,7 @@ lib/
       amazon_bedrock.rb  # Amazon Bedrock provider
       anthropic.rb       # Anthropic provider
       repository.rb      # Provider registry
-      test.rb            # Test provider
+      mock.rb            # Mock provider
     stream_events/
       base.rb            # Base stream event
       interrupt.rb       # Interrupt event

--- a/docs/01_OVERVIEW.md
+++ b/docs/01_OVERVIEW.md
@@ -62,7 +62,7 @@ Providers are adapters that connect to LLM services. Riffer supports:
 
 - **OpenAI** - GPT models via the OpenAI API
 - **Amazon Bedrock** - Claude and other models via AWS Bedrock
-- **Test** - Mock provider for testing
+- **Mock** - Mock provider for testing
 
 See [Providers](providers/01_PROVIDERS.md) for details.
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -25,7 +25,7 @@ class MyAgent < Riffer::Agent
   # or
   model 'amazon_bedrock/anthropic.claude-3-sonnet-20240229-v1:0'  # Bedrock
   # or
-  model 'test/any'                # Test provider
+  model 'mock/any'                # Mock provider
 end
 ```
 

--- a/docs_providers/01_PROVIDERS.md
+++ b/docs_providers/01_PROVIDERS.md
@@ -9,7 +9,7 @@ Providers are adapters that connect Riffer to LLM services. They implement a com
 | OpenAI         | `openai`         | `openai`                 |
 | Amazon Bedrock | `amazon_bedrock` | `aws-sdk-bedrockruntime` |
 | Anthropic      | `anthropic`      | `anthropic`              |
-| Test           | `test`           | None                     |
+| Mock           | `mock`           | None                     |
 
 ## Model String Format
 
@@ -20,7 +20,7 @@ class MyAgent < Riffer::Agent
   model 'openai/gpt-4o'              # OpenAI
   model 'amazon_bedrock/anthropic.claude-3-sonnet-20240229-v1:0'  # Bedrock
   model 'anthropic/claude-3-5-sonnet-20241022'  # Anthropic
-  model 'test/any'                   # Test provider
+  model 'mock/any'                   # Mock provider
 end
 ```
 
@@ -155,8 +155,8 @@ Riffer::Providers::Repository.find(:amazon_bedrock)
 Riffer::Providers::Repository.find(:anthropic)
 # => Riffer::Providers::Anthropic
 
-Riffer::Providers::Repository.find(:test)
-# => Riffer::Providers::Test
+Riffer::Providers::Repository.find(:mock)
+# => Riffer::Providers::Mock
 ```
 
 ## Provider-Specific Guides
@@ -164,5 +164,5 @@ Riffer::Providers::Repository.find(:test)
 - [Amazon Bedrock](02_AMAZON_BEDROCK.md) - Claude and other models via AWS
 - [Anthropic](03_ANTHROPIC.md) - Claude models via Anthropic API
 - [OpenAI](04_OPENAI.md) - GPT models
-- [Test](05_TEST_PROVIDER.md) - Mock provider for testing
+- [Mock](05_MOCK_PROVIDER.md) - Mock provider for testing
 - [Custom Providers](06_CUSTOM_PROVIDERS.md) - Creating your own provider

--- a/docs_providers/05_MOCK_PROVIDER.md
+++ b/docs_providers/05_MOCK_PROVIDER.md
@@ -1,14 +1,14 @@
-# Test Provider
+# Mock Provider
 
-The Test provider is a mock provider for testing agents without making real API calls.
+The Mock provider is a mock provider for testing agents without making real API calls.
 
 ## Usage
 
-No additional gems required. Use the `test` provider identifier:
+No additional gems required. Use the `mock` provider identifier:
 
 ```ruby
 class TestableAgent < Riffer::Agent
-  model 'test/any'  # The model name doesn't matter for test provider
+  model 'mock/any'  # The model name doesn't matter for mock provider
   instructions 'You are helpful.'
   uses_tools [MyTool]
 end
@@ -58,7 +58,7 @@ provider.stub_response("Third response")
 agent.generate("Message 1")  # => "First response"
 agent.generate("Message 2")  # => "Second response"
 agent.generate("Message 3")  # => "Third response"
-agent.generate("Message 4")  # => "Test response" (default)
+agent.generate("Message 4")  # => "Mock response" (default)
 ```
 
 ## Inspecting Calls
@@ -130,7 +130,7 @@ end
 
 ## Streaming
 
-The test provider also supports streaming:
+The mock provider also supports streaming:
 
 ```ruby
 provider.stub_response("Hello world.")
@@ -165,7 +165,7 @@ search_done.sources  # => [{title: "Example", url: "https://example.com"}]
 Pass responses during initialization:
 
 ```ruby
-provider = Riffer::Providers::Test.new(responses: [
+provider = Riffer::Providers::Mock.new(responses: [
   {content: "First"},
   {content: "Second"}
 ])
@@ -176,5 +176,5 @@ provider = Riffer::Providers::Test.new(responses: [
 When no stubs are queued and initial responses are exhausted, the provider returns:
 
 ```ruby
-{role: "assistant", content: "Test response"}
+{role: "assistant", content: "Mock response"}
 ```

--- a/lib/riffer/providers.rb
+++ b/lib/riffer/providers.rb
@@ -6,6 +6,6 @@
 # Providers connect Riffer to LLM services:
 # - Riffer::Providers::OpenAI - OpenAI GPT models
 # - Riffer::Providers::AmazonBedrock - AWS Bedrock models
-# - Riffer::Providers::Test - Mock provider for testing
+# - Riffer::Providers::Mock - Mock provider for testing
 module Riffer::Providers
 end

--- a/lib/riffer/providers/mock.rb
+++ b/lib/riffer/providers/mock.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Test provider for mocking LLM responses in tests.
+# Mock provider for mocking LLM responses in tests.
 #
 # No external gems required.
-class Riffer::Providers::Test < Riffer::Providers::Base
+class Riffer::Providers::Mock < Riffer::Providers::Base
   # Array of recorded method calls for assertions.
   attr_reader :calls #: Array[Hash[Symbol, untyped]]
 
-  # Initializes the test provider.
+  # Initializes the mock provider.
   #
   #: (**untyped) -> void
   def initialize(**options)
@@ -30,8 +30,8 @@ class Riffer::Providers::Test < Riffer::Providers::Base
   def stub_response(content, tool_calls: [], token_usage: nil)
     formatted_tool_calls = tool_calls.map.with_index do |tc, idx|
       Riffer::Messages::Assistant::ToolCall.new(
-        id: tc[:id] || "test_id_#{idx}",
-        call_id: tc[:call_id] || tc[:id] || "test_call_#{idx}",
+        id: tc[:id] || "mock_id_#{idx}",
+        call_id: tc[:call_id] || tc[:id] || "mock_call_#{idx}",
         name: tc[:name],
         arguments: tc[:arguments].is_a?(String) ? tc[:arguments] : tc[:arguments].to_json
       )
@@ -90,10 +90,10 @@ class Riffer::Providers::Test < Riffer::Providers::Base
 
     if web_search
       yielder << Riffer::StreamEvents::WebSearchStatus.new("in_progress")
-      yielder << Riffer::StreamEvents::WebSearchStatus.new("searching", query: "test search query")
+      yielder << Riffer::StreamEvents::WebSearchStatus.new("searching", query: "mock search query")
       yielder << Riffer::StreamEvents::WebSearchStatus.new("open_page", url: "https://example.com")
       yielder << Riffer::StreamEvents::WebSearchStatus.new("completed")
-      yielder << Riffer::StreamEvents::WebSearchDone.new("test search query", sources: [{title: "Example", url: "https://example.com"}])
+      yielder << Riffer::StreamEvents::WebSearchDone.new("mock search query", sources: [{title: "Example", url: "https://example.com"}])
     end
 
     unless full_content.empty?
@@ -130,7 +130,7 @@ class Riffer::Providers::Test < Riffer::Providers::Base
       @current_index += 1
       response
     else
-      {role: "assistant", content: "Test response"}
+      {role: "assistant", content: "Mock response"}
     end
   end
 end

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -8,7 +8,7 @@ class Riffer::Providers::Repository
     amazon_bedrock: -> { Riffer::Providers::AmazonBedrock },
     anthropic: -> { Riffer::Providers::Anthropic },
     openai: -> { Riffer::Providers::OpenAI },
-    test: -> { Riffer::Providers::Test }
+    mock: -> { Riffer::Providers::Mock }
   }.freeze #: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
   # Finds a provider class by identifier.

--- a/sig/generated/riffer/providers.rbs
+++ b/sig/generated/riffer/providers.rbs
@@ -5,6 +5,6 @@
 # Providers connect Riffer to LLM services:
 # - Riffer::Providers::OpenAI - OpenAI GPT models
 # - Riffer::Providers::AmazonBedrock - AWS Bedrock models
-# - Riffer::Providers::Test - Mock provider for testing
+# - Riffer::Providers::Mock - Mock provider for testing
 module Riffer::Providers
 end

--- a/sig/generated/riffer/providers/mock.rbs
+++ b/sig/generated/riffer/providers/mock.rbs
@@ -1,13 +1,13 @@
-# Generated from lib/riffer/providers/test.rb with RBS::Inline
+# Generated from lib/riffer/providers/mock.rb with RBS::Inline
 
-# Test provider for mocking LLM responses in tests.
+# Mock provider for mocking LLM responses in tests.
 #
 # No external gems required.
-class Riffer::Providers::Test < Riffer::Providers::Base
+class Riffer::Providers::Mock < Riffer::Providers::Base
   # Array of recorded method calls for assertions.
   attr_reader calls: Array[Hash[Symbol, untyped]]
 
-  # Initializes the test provider.
+  # Initializes the mock provider.
   #
   # : (**untyped) -> void
   def initialize: (**untyped) -> void

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -6,7 +6,7 @@ describe Riffer::Agent do
   let(:agent_class) do
     Class.new(Riffer::Agent) do
       identifier "test-agent"
-      model "test/riffer-1"
+      model "mock/riffer-1"
       instructions "You are a helpful assistant."
     end
   end
@@ -28,7 +28,7 @@ describe Riffer::Agent do
 
   describe ".model" do
     it "sets the model" do
-      expect(agent_class.model).must_equal "test/riffer-1"
+      expect(agent_class.model).must_equal "mock/riffer-1"
     end
 
     it "raises error when model is not a string" do
@@ -43,7 +43,7 @@ describe Riffer::Agent do
 
     it "accepts a Proc" do
       agent = Class.new(Riffer::Agent) do
-        model -> { "test/riffer-1" }
+        model -> { "mock/riffer-1" }
       end
       expect(agent.model).must_be_instance_of Proc
     end
@@ -128,7 +128,7 @@ describe Riffer::Agent do
       let(:options_agent_class) do
         Class.new(Riffer::Agent) do
           identifier "options-agent"
-          model "test/riffer-1"
+          model "mock/riffer-1"
           instructions "You are a helpful assistant."
           model_options reasoning: "medium", temperature: 0.7
         end
@@ -162,7 +162,7 @@ describe Riffer::Agent do
       it "runs unlimited steps by default" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps Float::INFINITY
           uses_tools [tc]
         end
@@ -179,7 +179,7 @@ describe Riffer::Agent do
       it "limits LLM calls when max_steps is set" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 2
           uses_tools [tc]
         end
@@ -196,7 +196,7 @@ describe Riffer::Agent do
       it "returns last assistant response content when limit is reached" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
         end
@@ -212,7 +212,7 @@ describe Riffer::Agent do
       it "sets interrupted? to true when limit is reached" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
         end
@@ -228,7 +228,7 @@ describe Riffer::Agent do
       it "sets interrupt_reason to :max_steps when limit is reached" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
         end
@@ -242,7 +242,7 @@ describe Riffer::Agent do
       end
     end
 
-    describe "with test provider" do
+    describe "with mock provider" do
       it "returns a Response object" do
         agent = agent_class.new
         result = agent.generate("What is the weather?")
@@ -344,7 +344,7 @@ describe Riffer::Agent do
     describe "without instructions" do
       let(:no_instructions_agent_class) do
         Class.new(Riffer::Agent) do
-          model "test/gpt-4o"
+          model "mock/gpt-4o"
         end
       end
 
@@ -374,7 +374,7 @@ describe Riffer::Agent do
       let(:options_agent_class) do
         Class.new(Riffer::Agent) do
           identifier "options-stream-agent"
-          model "test/riffer-1"
+          model "mock/riffer-1"
           instructions "You are a helpful assistant."
           model_options reasoning: "high", temperature: 0.5
         end
@@ -408,7 +408,7 @@ describe Riffer::Agent do
       it "limits LLM calls when max_steps is set" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 2
           uses_tools [tc]
         end
@@ -425,7 +425,7 @@ describe Riffer::Agent do
       it "emits Interrupt event with :max_steps reason when limit is reached" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
         end
@@ -443,7 +443,7 @@ describe Riffer::Agent do
       it "does not emit Interrupt event when limit is not reached" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           max_steps 10
           uses_tools [tc]
         end
@@ -459,7 +459,7 @@ describe Riffer::Agent do
       end
     end
 
-    describe "with test provider" do
+    describe "with mock provider" do
       it "returns an enumerator" do
         agent = agent_class.new
         result = agent.stream("What is the weather?")
@@ -561,7 +561,7 @@ describe Riffer::Agent do
     describe "without instructions" do
       let(:no_instructions_agent_class) do
         Class.new(Riffer::Agent) do
-          model "test/gpt-4o"
+          model "mock/gpt-4o"
         end
       end
 
@@ -595,7 +595,7 @@ describe Riffer::Agent do
       params = Riffer::Params.new
       params.required(:sentiment, String)
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       klass.structured_output(params)
       expect(klass.structured_output).must_equal params
@@ -603,7 +603,7 @@ describe Riffer::Agent do
 
     it "stores Params from block DSL" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output do
           required :sentiment, String, description: "The sentiment"
           optional :score, Float
@@ -615,7 +615,7 @@ describe Riffer::Agent do
 
     it "raises ArgumentError for non-Params argument" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       error = expect { klass.structured_output({sentiment: String}) }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/structured_output must be a Riffer::Params/)
@@ -625,7 +625,7 @@ describe Riffer::Agent do
   describe "#generate with structured_output" do
     it "returns Response with parsed structured_output from class-level schema" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output do
           required :sentiment, String
           required :score, Float
@@ -642,7 +642,7 @@ describe Riffer::Agent do
 
     it "sets structured_output to nil when LLM returns invalid JSON" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output do
           required :sentiment, String
         end
@@ -658,7 +658,7 @@ describe Riffer::Agent do
 
     it "preserves raw content when structured_output parsing fails" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output do
           required :sentiment, String
         end
@@ -677,7 +677,7 @@ describe Riffer::Agent do
       params.required(:sentiment, String)
 
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output params
       end
 
@@ -699,7 +699,7 @@ describe Riffer::Agent do
   describe "#stream with structured_output" do
     it "raises ArgumentError when class-level structured_output is configured" do
       klass = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         structured_output do
           required :sentiment, String
         end
@@ -721,7 +721,7 @@ describe Riffer::Agent do
     it "raises error when instructions is empty string" do
       error = expect do
         Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           instructions "   "
         end
       end.must_raise(Riffer::ArgumentError)
@@ -733,7 +733,7 @@ describe Riffer::Agent do
     before do
       @test_agent_class = Class.new(Riffer::Agent) do
         identifier "findable-agent"
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
     end
 
@@ -752,12 +752,12 @@ describe Riffer::Agent do
     before do
       @agent1 = Class.new(Riffer::Agent) do
         identifier "all-test-agent-1"
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
 
       @agent2 = Class.new(Riffer::Agent) do
         identifier "all-test-agent-2"
-        model "test/riffer-2"
+        model "mock/riffer-2"
       end
     end
 
@@ -798,7 +798,7 @@ describe Riffer::Agent do
       tool = context_tool
       received_context = nil
       custom_agent_class = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools ->(ctx) {
           received_context = ctx
           [tool]
@@ -836,7 +836,7 @@ describe Riffer::Agent do
       tool = context_tool
       received_context = nil
       custom_agent_class = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools ->(ctx) {
           received_context = ctx
           [tool]
@@ -866,7 +866,7 @@ describe Riffer::Agent do
     let(:agent_with_tools_class) do
       tool_class = weather_tool_class
       Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools [tool_class]
       end
     end
@@ -882,7 +882,7 @@ describe Riffer::Agent do
     it "accepts a lambda" do
       tool_class = weather_tool_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools -> { [tool_class] }
       end
       expect(agent.uses_tools).must_be_instance_of Proc
@@ -892,7 +892,7 @@ describe Riffer::Agent do
   describe "dynamic model selection" do
     it "resolves lambda for generate" do
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model -> { "test/riffer-1" }
+        model -> { "mock/riffer-1" }
       end
 
       result = dynamic_agent_class.generate("Hello")
@@ -901,7 +901,7 @@ describe Riffer::Agent do
 
     it "resolves lambda for stream" do
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model -> { "test/riffer-1" }
+        model -> { "mock/riffer-1" }
       end
 
       events = dynamic_agent_class.stream("Hello").to_a
@@ -913,7 +913,7 @@ describe Riffer::Agent do
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model ->(ctx) {
           received_context = ctx
-          "test/riffer-1"
+          "mock/riffer-1"
         }
       end
 
@@ -926,7 +926,7 @@ describe Riffer::Agent do
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model -> {
           called = true
-          "test/riffer-1"
+          "mock/riffer-1"
         }
       end
 
@@ -936,13 +936,13 @@ describe Riffer::Agent do
 
     it "uses resolved model for provider lookup" do
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model -> { "test/riffer-1" }
+        model -> { "mock/riffer-1" }
       end
 
       agent = dynamic_agent_class.new
       agent.generate("Hello")
       provider = agent.send(:provider_instance)
-      expect(provider).must_be_instance_of Riffer::Providers::Test
+      expect(provider).must_be_instance_of Riffer::Providers::Mock
     end
 
     it "re-evaluates lambda for each generate call" do
@@ -950,7 +950,7 @@ describe Riffer::Agent do
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model -> {
           call_count += 1
-          "test/riffer-1"
+          "mock/riffer-1"
         }
       end
 
@@ -964,7 +964,7 @@ describe Riffer::Agent do
       models_used = []
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model ->(ctx) {
-          model = ctx&.dig(:premium) ? "test/riffer-premium" : "test/riffer-basic"
+          model = ctx&.dig(:premium) ? "mock/riffer-premium" : "mock/riffer-basic"
           models_used << model
           model
         }
@@ -973,12 +973,12 @@ describe Riffer::Agent do
       agent = dynamic_agent_class.new
       agent.generate("Hello", tool_context: {premium: false})
       agent.generate("Hello", tool_context: {premium: true})
-      expect(models_used).must_equal ["test/riffer-basic", "test/riffer-premium"]
+      expect(models_used).must_equal ["mock/riffer-basic", "mock/riffer-premium"]
     end
 
     it "passes resolved model name to provider" do
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model -> { "test/my-model" }
+        model -> { "mock/my-model" }
       end
 
       agent = dynamic_agent_class.new
@@ -1010,7 +1010,7 @@ describe Riffer::Agent do
 
     it "static string still works" do
       static_agent_class = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
 
       result = static_agent_class.generate("Hello")
@@ -1052,7 +1052,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1073,7 +1073,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1094,7 +1094,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1114,7 +1114,7 @@ describe Riffer::Agent do
         tool_class = context_tool_class
         tool_class.identifier("context_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1133,7 +1133,7 @@ describe Riffer::Agent do
 
       it "returns error message for unknown tool" do
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools []
         end
 
@@ -1152,7 +1152,7 @@ describe Riffer::Agent do
 
       it "sets error attributes for unknown tool" do
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools []
         end
 
@@ -1175,7 +1175,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1196,7 +1196,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1218,7 +1218,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1241,7 +1241,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1256,7 +1256,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1273,7 +1273,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1294,7 +1294,7 @@ describe Riffer::Agent do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1315,7 +1315,7 @@ describe Riffer::Agent do
         tool_class = context_tool_class
         tool_class.identifier("context_tool")
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1361,7 +1361,7 @@ describe Riffer::Agent do
         tool_class.identifier("slow_tool")
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1383,7 +1383,7 @@ describe Riffer::Agent do
         tool_class.identifier("slow_tool")
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1406,7 +1406,7 @@ describe Riffer::Agent do
         tool_class.identifier("slow_tool")
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1429,7 +1429,7 @@ describe Riffer::Agent do
         tool_class.identifier("fast_tool")
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tool_class]
         end
 
@@ -1455,7 +1455,7 @@ describe Riffer::Agent do
         call_count = 0
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools -> {
             call_count += 1
             [tool_class]
@@ -1474,7 +1474,7 @@ describe Riffer::Agent do
         received_context = nil
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools ->(context) {
             received_context = context
             [tool_class]
@@ -1502,7 +1502,7 @@ describe Riffer::Agent do
         basic_tool_class.identifier("weather_tool")
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools ->(context) {
             tools = [basic_tool_class]
             tools << admin_tool_class if context&.dig(:admin)
@@ -1532,7 +1532,7 @@ describe Riffer::Agent do
         contexts_received = []
 
         agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools ->(context) {
             contexts_received << context
             [tool_class]
@@ -1623,7 +1623,7 @@ describe Riffer::Agent do
       let(:agent) do
         tc = tool_class
         agent_with_tools = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -1682,7 +1682,7 @@ describe Riffer::Agent do
       let(:tool_message) do
         tc = tool_class
         agent_with_tools = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -1752,7 +1752,7 @@ describe Riffer::Agent do
       it "stops tool execution on interrupt and resumes pending tools" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -1787,7 +1787,7 @@ describe Riffer::Agent do
       it "resumes all pending tools when interrupt fires on assistant callback" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -1929,7 +1929,7 @@ describe Riffer::Agent do
       it "completes tool loop after resume" do
         tc = tool_class
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -2002,7 +2002,7 @@ describe Riffer::Agent do
 
         tc = context_tool
         custom_agent_class = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -2130,7 +2130,7 @@ describe Riffer::Agent do
 
       tc = tool_class
       custom_agent_class = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools [tc]
       end
 
@@ -2159,7 +2159,7 @@ describe Riffer::Agent do
 
       tc = tool_class
       custom_agent_class = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools [tc]
       end
 
@@ -2257,7 +2257,7 @@ describe Riffer::Agent do
       let(:agent) do
         tc = tool_class
         agent_with_tools = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           uses_tools [tc]
         end
 
@@ -2318,7 +2318,7 @@ describe Riffer::Agent do
 
       tc = tool_class
       agent_with_tools = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools [tc]
       end
 
@@ -2394,7 +2394,7 @@ describe Riffer::Agent do
 
       tc = tool_class
       agent_with_tools = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
         uses_tools [tc]
       end
 
@@ -2432,7 +2432,7 @@ describe Riffer::Agent do
     it "raises error for invalid phase" do
       error = expect do
         Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           guardrail :invalid, with: Riffer::Guardrail
         end
       end.must_raise(Riffer::ArgumentError)
@@ -2442,7 +2442,7 @@ describe Riffer::Agent do
     it "raises error for non-guardrail class" do
       error = expect do
         Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
           guardrail :before, with: String
         end
       end.must_raise(Riffer::ArgumentError)
@@ -2452,7 +2452,7 @@ describe Riffer::Agent do
     it "registers before guardrails" do
       gr = pass_guardrail_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       agent.guardrail(:before, with: gr)
       configs = agent.guardrails_for(:before)
@@ -2462,7 +2462,7 @@ describe Riffer::Agent do
     it "registers after guardrails" do
       gr = pass_guardrail_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       agent.guardrail(:after, with: gr)
       configs = agent.guardrails_for(:after)
@@ -2472,7 +2472,7 @@ describe Riffer::Agent do
     it "registers around guardrails for both phases" do
       gr = pass_guardrail_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       agent.guardrail(:around, with: gr)
       configs = agent.guardrails_for(:before)
@@ -2482,7 +2482,7 @@ describe Riffer::Agent do
     it "registers around guardrails for output" do
       gr = pass_guardrail_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       agent.guardrail(:around, with: gr)
       configs = agent.guardrails_for(:after)
@@ -2492,7 +2492,7 @@ describe Riffer::Agent do
     it "stores options in config" do
       gr = pass_guardrail_class
       agent = Class.new(Riffer::Agent) do
-        model "test/riffer-1"
+        model "mock/riffer-1"
       end
       agent.guardrail(:before, with: gr, foo: :bar)
       config = agent.guardrails_for(:before).first
@@ -2555,7 +2555,7 @@ describe Riffer::Agent do
       let(:agent_with_blocking_input) do
         gr = block_input_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
         klass
@@ -2596,7 +2596,7 @@ describe Riffer::Agent do
       let(:agent_with_blocking_output) do
         gr = block_output_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:after, with: gr)
         klass
@@ -2622,7 +2622,7 @@ describe Riffer::Agent do
       let(:agent_with_transform) do
         gr = transform_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:around, with: gr)
         klass
@@ -2698,7 +2698,7 @@ describe Riffer::Agent do
       let(:agent_with_blocking_input) do
         gr = block_input_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
         klass
@@ -2727,7 +2727,7 @@ describe Riffer::Agent do
       let(:agent_with_blocking_output) do
         gr = block_output_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:after, with: gr)
         klass
@@ -2771,7 +2771,7 @@ describe Riffer::Agent do
       let(:agent_with_stream_transform) do
         gr = transform_guardrail_class
         klass = Class.new(Riffer::Agent) do
-          model "test/riffer-1"
+          model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
         klass

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -69,7 +69,7 @@ describe Riffer::Evals::Evaluator do
     it "calls judge with instructions when instructions are set" do
       klass = Class.new(Riffer::Evals::Evaluator) do
         instructions "Evaluate quality."
-        judge_model "test/eval-model"
+        judge_model "mock/eval-model"
       end
 
       evaluator = klass.new
@@ -86,7 +86,7 @@ describe Riffer::Evals::Evaluator do
     it "formats array input as labeled messages" do
       klass = Class.new(Riffer::Evals::Evaluator) do
         instructions "Evaluate quality."
-        judge_model "test/eval-model"
+        judge_model "mock/eval-model"
       end
 
       evaluator = klass.new
@@ -108,7 +108,7 @@ describe Riffer::Evals::Evaluator do
     it "passes ground_truth to judge" do
       klass = Class.new(Riffer::Evals::Evaluator) do
         instructions "Compare to ground truth."
-        judge_model "test/eval-model"
+        judge_model "mock/eval-model"
       end
 
       evaluator = klass.new

--- a/test/riffer/evals/evaluators/answer_relevancy_test.rb
+++ b/test/riffer/evals/evaluators/answer_relevancy_test.rb
@@ -20,10 +20,10 @@ describe Riffer::Evals::Evaluators::AnswerRelevancy do
     end
   end
 
-  describe "integration with test provider" do
+  describe "integration with mock provider" do
     it "evaluates and returns a result" do
       original = Riffer.config.evals.judge_model
-      Riffer.config.evals.judge_model = "test/test-model"
+      Riffer.config.evals.judge_model = "mock/mock-model"
 
       evaluator = Riffer::Evals::Evaluators::AnswerRelevancy.new
       provider = evaluator.send(:judge).send(:provider_instance)

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 describe Riffer::Evals::Judge do
   describe "#initialize" do
     it "sets the model" do
-      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
-      expect(judge.model).must_equal "test/eval-model"
+      judge = Riffer::Evals::Judge.new(model: "mock/eval-model")
+      expect(judge.model).must_equal "mock/eval-model"
     end
 
     it "raises error for invalid model string" do
@@ -20,7 +20,7 @@ describe Riffer::Evals::Judge do
 
   describe "#evaluate" do
     it "evaluates with instructions, input, and output" do
-      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+      judge = Riffer::Evals::Judge.new(model: "mock/eval-model")
       provider = judge.send(:provider_instance)
       provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.85, reason: "Good response."}}])
 
@@ -34,7 +34,7 @@ describe Riffer::Evals::Judge do
     end
 
     it "evaluates with ground_truth" do
-      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
+      judge = Riffer::Evals::Judge.new(model: "mock/eval-model")
       provider = judge.send(:provider_instance)
       provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.9, reason: "Matches ground truth."}}])
 

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -62,8 +62,8 @@ describe Riffer::Evals::Profile do
 
   describe "Agent integration" do
     before do
-      # Ensure test provider is registered
-      Riffer::Providers::Repository.register("test", Riffer::Providers::Test) unless Riffer::Providers::Repository.find("test")
+      # Ensure mock provider is registered
+      Riffer::Providers::Repository.register("mock", Riffer::Providers::Mock) unless Riffer::Providers::Repository.find("mock")
     end
 
     it "adds run_eval method when included in Agent" do
@@ -77,7 +77,7 @@ describe Riffer::Evals::Profile do
       end
 
       agent_class = Class.new(Riffer::Agent) do
-        model "test/test-model"
+        model "mock/mock-model"
         instructions "You are a helpful assistant."
       end
 
@@ -97,18 +97,18 @@ describe Riffer::Evals::Profile do
       end
 
       agent_class = Class.new(Riffer::Agent) do
-        model "test/test-model"
+        model "mock/mock-model"
         instructions "You are a helpful assistant."
       end
 
       agent_class.include(profile_module)
 
-      # The test provider returns "Test response" by default
+      # The test provider returns "Mock response" by default
       result = agent_class.run_eval(input: "What is Ruby?")
 
       expect(result).must_be_instance_of Riffer::Evals::RunResult
       expect(result.input).must_equal "What is Ruby?"
-      expect(result.output).must_equal "Test response"
+      expect(result.output).must_equal "Mock response"
     end
 
     it "accepts a messages array as input" do
@@ -129,7 +129,7 @@ describe Riffer::Evals::Profile do
       end
 
       agent_class = Class.new(Riffer::Agent) do
-        model "test/test-model"
+        model "mock/mock-model"
         instructions "You are a helpful assistant."
       end
 
@@ -145,7 +145,7 @@ describe Riffer::Evals::Profile do
 
       expect(result).must_be_instance_of Riffer::Evals::RunResult
       expect(result.input).must_equal messages
-      expect(result.output).must_equal "Test response"
+      expect(result.output).must_equal "Mock response"
     end
   end
 

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -2,8 +2,8 @@
 
 require "test_helper"
 
-describe Riffer::Providers::Test do
-  let(:provider) { Riffer::Providers::Test.new }
+describe Riffer::Providers::Mock do
+  let(:provider) { Riffer::Providers::Mock.new }
 
   describe "#initialize" do
     it "initializes calls to empty array" do
@@ -33,7 +33,7 @@ describe Riffer::Providers::Test do
 
     it "returns default content when no stubbed response" do
       result = provider.generate_text(prompt: "Hello")
-      expect(result.content).must_equal "Test response"
+      expect(result.content).must_equal "Mock response"
     end
 
     it "stores normalized messages in calls" do
@@ -89,13 +89,13 @@ describe Riffer::Providers::Test do
       it "formats tool_calls with generated id" do
         provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
         result = provider.generate_text(prompt: "Call a tool")
-        expect(result.tool_calls.first.id).must_equal "test_id_0"
+        expect(result.tool_calls.first.id).must_equal "mock_id_0"
       end
 
       it "formats tool_calls with generated call_id" do
         provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
         result = provider.generate_text(prompt: "Call a tool")
-        expect(result.tool_calls.first.call_id).must_equal "test_call_0"
+        expect(result.tool_calls.first.call_id).must_equal "mock_call_0"
       end
 
       it "preserves the tool name" do
@@ -235,7 +235,7 @@ describe Riffer::Providers::Test do
         provider.stub_response("Only response")
         provider.generate_text(prompt: "First")
         result = provider.generate_text(prompt: "Second")
-        expect(result.content).must_equal "Test response"
+        expect(result.content).must_equal "Mock response"
       end
 
       it "first response has tool calls" do
@@ -268,7 +268,7 @@ describe Riffer::Providers::Test do
         provider.stub_response("Stubbed")
         provider.clear_stubs
         result = provider.generate_text(prompt: "Hello")
-        expect(result.content).must_equal "Test response"
+        expect(result.content).must_equal "Mock response"
       end
     end
   end

--- a/test/riffer/providers/repository_test.rb
+++ b/test/riffer/providers/repository_test.rb
@@ -24,12 +24,12 @@ describe Riffer::Providers::Repository do
       expect(result).must_equal Riffer::Providers::AmazonBedrock
     end
 
-    it "returns the Test provider class for :test symbol" do
-      expect(Riffer::Providers::Repository.find(:test)).must_equal Riffer::Providers::Test
+    it "returns the Mock provider class for :mock symbol" do
+      expect(Riffer::Providers::Repository.find(:mock)).must_equal Riffer::Providers::Mock
     end
 
-    it "returns the Test provider class for 'test' string" do
-      expect(Riffer::Providers::Repository.find("test")).must_equal Riffer::Providers::Test
+    it "returns the Mock provider class for 'mock' string" do
+      expect(Riffer::Providers::Repository.find("mock")).must_equal Riffer::Providers::Mock
     end
 
     it "returns nil for unknown identifiers" do


### PR DESCRIPTION
## Summary

- Rename `Riffer::Providers::Test` to `Riffer::Providers::Mock` across the entire codebase
- Change the provider registry key from `:test` to `:mock` and all model strings from `test/...` to `mock/...`
- Update default IDs (`test_id_` → `mock_id_`, `test_call_` → `mock_call_`), default response (`"Test response"` → `"Mock response"`), and web search stubs
- Rename files preserving git history: `test.rb` → `mock.rb`, `test_test.rb` → `mock_test.rb`, RBS sig, and docs
- Update all documentation (provider guides, overview, agents, architecture)
- Fix evaluator tests added by #132 to use `mock/eval-model` instead of `test/eval-model`

## Test plan

- [x] `bundle exec rake` — 903 tests pass, 0 failures, 0 errors
- [x] `bundle exec steep check` — no type errors
- [x] Grep for stale `Providers::Test` references — none found
- [x] Grep for stale `"test/` model strings — none found (only VCR cassette path, which is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)