### PR TITLE
feat: replace eval prompt API with semantic fields

### DIFF
--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -110,12 +110,12 @@ end
 
 ## Running Evals
 
-Once a profile is included, call `.eval` on the agent class:
+Once a profile is included, call `.run_eval` on the agent class:
 
 ```ruby
 result = MyAgent.run_eval(
   input: "What is the capital of France?",
-  context: { ground_truth: "Paris" }  # Optional context
+  ground_truth: "Paris"  # Optional reference answer
 )
 
 # You can also pass a messages array as input
@@ -139,6 +139,7 @@ result.failures         # => Array of Result objects that failed
 result.results          # => Array of all Result objects
 result.input            # => The input that was evaluated
 result.output           # => The agent's output
+result.ground_truth     # => The ground truth (if provided)
 result.to_h             # => Hash representation
 ```
 
@@ -155,37 +156,29 @@ result.results.first.higher_is_better # => true
 
 ## Defining Custom Evaluators
 
-Create evaluators by subclassing `Riffer::Evals::Evaluator`:
+Create evaluators by subclassing `Riffer::Evals::Evaluator`. The simplest approach uses the `instructions` DSL — the base class handles calling the judge automatically:
 
 ```ruby
-# app/evals/medical_accuracy_evaluator.rb
 class MedicalAccuracyEvaluator < Riffer::Evals::Evaluator
-  description "Evaluates medical information accuracy"
   higher_is_better true
   judge_model "anthropic/claude-opus-4-5-20251101"  # Optional override
 
-  SYSTEM_PROMPT = <<~PROMPT
-    You are an evaluation assistant that assesses medical accuracy.
+  instructions <<~TEXT
+    Assess the medical accuracy of the response.
 
-    Use the evaluation tool to submit your score (0.0-1.0) and reasoning.
-  PROMPT
+    Score between 0.0 and 1.0 where:
+      - 1.0 = Medically accurate and complete
+      - 0.7-0.9 = Mostly accurate with minor omissions
+      - 0.4-0.6 = Partially accurate
+      - 0.1-0.3 = Mostly inaccurate
+      - 0.0 = Completely inaccurate
 
-  def evaluate(input:, output:, context: nil)
-    user_prompt = <<~PROMPT
-      Question: #{input}
-      Response: #{output}
-      Ground truth: #{context[:ground_truth]}
-    PROMPT
-
-    evaluation = judge.evaluate(
-      system_prompt: SYSTEM_PROMPT,
-      user_prompt: user_prompt
-    )
-
-    result(score: evaluation[:score], reason: evaluation[:reason])
-  end
+    When ground truth is provided, compare the response against it.
+  TEXT
 end
 ```
+
+The judge receives `input`, `output`, and optionally `ground_truth` alongside your instructions. No manual prompt composition needed.
 
 ### Using Custom Evaluators
 
@@ -201,37 +194,37 @@ end
 
 Class methods:
 
-- `description(value)` - Human-readable description
+- `instructions(value)` - Evaluation criteria and scoring rubric (enables default `evaluate`)
 - `higher_is_better(value)` - Whether higher scores are better (default: true)
 - `judge_model(value)` - Override the global judge model
 
 Instance methods:
 
-- `evaluate(input:, output:, context:)` - Must be implemented, returns a Result
+- `evaluate(input:, output:, ground_truth:)` - Override for custom logic; default calls judge with `instructions`
 - `judge` - Returns a Judge instance for LLM-as-judge calls
 - `result(score:, reason:, metadata:)` - Helper to build Result objects
 
-### Judge Options
+### Advanced: Custom Evaluate Override
 
-The `judge.evaluate` method accepts either `system_prompt:` and `user_prompt:` or a `messages:` array:
+For evaluators that need full control over the evaluation logic, override `evaluate` directly:
 
 ```ruby
-# Using system_prompt and user_prompt
-evaluation = judge.evaluate(
-  system_prompt: "You are a judge.",
-  user_prompt: "Evaluate this response."
-)
+class CustomEvaluator < Riffer::Evals::Evaluator
+  higher_is_better true
+  judge_model "anthropic/claude-opus-4-5-20251101"
 
-# Using messages array (for more control)
-evaluation = judge.evaluate(
-  messages: [
-    { role: "system", content: "You are a judge." },
-    { role: "user", content: "Evaluate this response." }
-  ]
-)
+  def evaluate(input:, output:, ground_truth: nil)
+    evaluation = judge.evaluate(
+      instructions: "Custom evaluation criteria...",
+      input: input,
+      output: output,
+      ground_truth: ground_truth
+    )
+
+    result(score: evaluation[:score], reason: evaluation[:reason])
+  end
+end
 ```
-
-The Judge uses tool calling internally to get structured output. An `evaluation` tool with `score` (Float) and `reason` (String) parameters is automatically provided to the judge model, so your prompts should instruct the model to use the evaluation tool rather than respond with raw JSON.
 
 ### Rule-Based Evaluators
 
@@ -239,12 +232,11 @@ Evaluators don't have to use LLM-as-judge:
 
 ```ruby
 class LengthEvaluator < Riffer::Evals::Evaluator
-  description "Checks response is within expected length"
   higher_is_better true
 
-  def evaluate(input:, output:, context: nil)
-    min_length = context&.dig(:min_length) || 50
-    max_length = context&.dig(:max_length) || 500
+  def evaluate(input:, output:, ground_truth: nil)
+    min_length = 50
+    max_length = 500
 
     length = output.length
 
@@ -311,9 +303,9 @@ end
 # test/agents/support_agent_test.rb
 class SupportAgentTest < Minitest::Test
   def test_response_quality
-    result = SupportAgent.run_eval
+    result = SupportAgent.run_eval(
       input: "How do I reset my password?",
-      context: {}
+      ground_truth: "Navigate to Settings > Security > Reset Password"
     )
 
     assert result.passed?, "Expected eval to pass: #{result.failures.map(&:reason)}"

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -47,6 +47,10 @@ class Riffer::Evals::Evaluator
   # The default implementation calls the judge with the class-level +instructions+.
   # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
+  # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
+  # +output+ - the agent's response to evaluate.
+  # +ground_truth+ - optional reference answer for comparison.
+  #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
   #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -56,12 +56,31 @@ class Riffer::Evals::Evaluator
 
     evaluation = judge.evaluate(
       instructions: instr,
-      input: input.is_a?(String) ? input : input.map(&:to_s).join("\n"),
+      input: format_input(input),
       output: output,
       ground_truth: ground_truth
     )
 
     result(score: evaluation[:score], reason: evaluation[:reason])
+  end
+
+  private
+
+  # Formats the input for the judge.
+  #
+  # String inputs are passed through as-is.
+  # Array inputs (message hashes or Message objects) are formatted
+  # as labeled role/content pairs separated by blank lines.
+  #
+  #: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
+  def format_input(input)
+    return input if input.is_a?(String)
+
+    input.map do |msg|
+      role = msg.is_a?(Hash) ? (msg[:role] || msg["role"]) : msg.role
+      content = msg.is_a?(Hash) ? (msg[:content] || msg["content"]) : msg.content
+      "#{role}: #{content}"
+    end.join("\n\n")
   end
 
   protected

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -4,32 +4,25 @@
 # Base class for all evaluators in the Riffer framework.
 #
 # Provides a DSL for defining evaluator metadata and the evaluate method.
-# Subclasses must implement the +evaluate+ method.
+# Simple evaluators only need to set +instructions+ — the base class
+# handles calling the judge automatically.
 #
 # See Riffer::Evals::Evaluators.
 #
 #   class MyEvaluator < Riffer::Evals::Evaluator
-#     description "Evaluates response quality"
+#     instructions "Assess medical accuracy of the response..."
 #     higher_is_better true
 #     judge_model "anthropic/claude-opus-4-5-20251101"
-#
-#     def evaluate(input:, output:, context: nil)
-#       evaluation = judge.evaluate(
-#         system_prompt: "...",
-#         user_prompt: "..."
-#       )
-#       result(score: evaluation[:score], reason: evaluation[:reason])
-#     end
 #   end
 #
 class Riffer::Evals::Evaluator
   class << self
-    # Gets or sets the evaluator description.
+    # Gets or sets the evaluation instructions (criteria and scoring rubric).
     #
     #: (?String?) -> String?
-    def description(value = nil)
-      return @description if value.nil?
-      @description = value.to_s
+    def instructions(value = nil)
+      return @instructions if value.nil?
+      @instructions = value.to_s
     end
 
     # Gets or sets whether higher scores are better.
@@ -51,11 +44,24 @@ class Riffer::Evals::Evaluator
 
   # Evaluates an input/output pair.
   #
-  # Raises NotImplementedError if not implemented by subclass.
+  # The default implementation calls the judge with the class-level +instructions+.
+  # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
-  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-  def evaluate(input:, output:, context: nil)
-    raise NotImplementedError, "#{self.class} must implement #evaluate"
+  # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
+  #
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
+  def evaluate(input:, output:, ground_truth: nil)
+    instr = self.class.instructions
+    raise NotImplementedError, "#{self.class} must set instructions or implement #evaluate" unless instr
+
+    evaluation = judge.evaluate(
+      instructions: instr,
+      input: input.is_a?(String) ? input : input.map(&:to_s).join("\n"),
+      output: output,
+      ground_truth: ground_truth
+    )
+
+    result(score: evaluation[:score], reason: evaluation[:reason])
   end
 
   protected

--- a/lib/riffer/evals/evaluators/answer_relevancy.rb
+++ b/lib/riffer/evals/evaluators/answer_relevancy.rb
@@ -14,13 +14,10 @@
 #   result.score  # => 0.95
 #
 class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
-  description "Evaluates how well the response addresses the input question"
   higher_is_better true
 
-  SYSTEM_PROMPT = <<~PROMPT #: String
-    You are an evaluation assistant that assesses answer relevancy.
-
-    Your task is to evaluate how well a response addresses the given input/question.
+  instructions <<~TEXT
+    Assess how well the response addresses the given input/question.
 
     Consider the following criteria:
     1. Does the response directly address what was asked?
@@ -28,32 +25,11 @@ class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
     3. Does the response provide the type of information requested?
     4. Does the response avoid going off on tangents?
 
-    Use the evaluation tool to submit your score and reasoning. The score should be
-    a float between 0.0 and 1.0 where:
+    Score between 0.0 and 1.0 where:
       - 1.0 = Perfectly relevant, directly addresses the question
       - 0.7-0.9 = Mostly relevant with minor tangents
       - 0.4-0.6 = Partially relevant, some off-topic content
       - 0.1-0.3 = Mostly irrelevant
       - 0.0 = Completely irrelevant
-  PROMPT
-
-  #: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-  def evaluate(input:, output:, context: nil)
-    user_prompt = build_user_prompt(input: input, output: output)
-    evaluation = judge.evaluate(system_prompt: SYSTEM_PROMPT, user_prompt: user_prompt)
-    result(score: evaluation[:score], reason: evaluation[:reason])
-  end
-
-  private
-
-  #: (input: String, output: String) -> String
-  def build_user_prompt(input:, output:)
-    <<~PROMPT
-      Input/Question:
-      #{input}
-
-      Response to evaluate:
-      #{output}
-    PROMPT
-  end
+  TEXT
 end

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -54,10 +54,10 @@ class Riffer::Evals::Judge
   # Evaluates using the configured LLM.
   #
   # Composes system and user messages from the semantic fields:
-  # - +instructions+ — evaluation criteria and scoring rubric
-  # - +input+ — the original input/question
-  # - +output+ — the agent's response to evaluate
-  # - +ground_truth+ — optional reference answer for comparison
+  # +instructions+ - evaluation criteria and scoring rubric.
+  # +input+ - the original input/question.
+  # +output+ - the agent's response to evaluate.
+  # +ground_truth+ - optional reference answer for comparison.
   #
   #: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
   def evaluate(instructions:, input:, output:, ground_truth: nil)

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -11,8 +11,9 @@ require "json"
 #
 #   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-opus-4-5-20251101")
 #   result = judge.evaluate(
-#     system_prompt: "You are an evaluation assistant...",
-#     user_prompt: "Evaluate this response..."
+#     instructions: "Assess answer relevancy...",
+#     input: "What is Ruby?",
+#     output: "Ruby is a programming language."
 #   )
 #   result[:score]  # => 0.85
 #   result[:reason] # => "The response is relevant..."
@@ -52,23 +53,48 @@ class Riffer::Evals::Judge
 
   # Evaluates using the configured LLM.
   #
-  # Raises Riffer::ArgumentError if both messages and system_prompt/user_prompt are provided,
-  # or if user_prompt is missing when messages is not provided.
+  # Composes system and user messages from the semantic fields:
+  # - +instructions+ — evaluation criteria and scoring rubric
+  # - +input+ — the original input/question
+  # - +output+ — the agent's response to evaluate
+  # - +ground_truth+ — optional reference answer for comparison
   #
-  #: (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
-  def evaluate(messages: nil, system_prompt: nil, user_prompt: nil)
-    response = if messages
-      raise Riffer::ArgumentError, "cannot provide both messages and system_prompt/user_prompt" if system_prompt || user_prompt
-      provider_instance.generate_text(messages: messages, model: model_name, tools: [EvaluationTool])
-    else
-      raise Riffer::ArgumentError, "user_prompt is required when messages is not provided" unless user_prompt
-      provider_instance.generate_text(system: system_prompt, prompt: user_prompt, model: model_name, tools: [EvaluationTool])
-    end
+  #: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
+  def evaluate(instructions:, input:, output:, ground_truth: nil)
+    system_message = build_system_message(instructions)
+    user_message = build_user_message(input: input, output: output, ground_truth: ground_truth)
+
+    response = provider_instance.generate_text(
+      system: system_message,
+      prompt: user_message,
+      model: model_name,
+      tools: [EvaluationTool]
+    )
 
     parse_tool_response(response)
   end
 
   private
+
+  #: (String) -> String
+  def build_system_message(instructions)
+    <<~SYSTEM.strip
+      You are an evaluation assistant. Score the output based on the instructions below.
+
+      #{instructions}
+
+      Use the evaluation tool to submit your score and reasoning.
+    SYSTEM
+  end
+
+  #: (input: String, output: String, ground_truth: String?) -> String
+  def build_user_message(input:, output:, ground_truth: nil)
+    parts = []
+    parts << "## Input\n\n#{input}"
+    parts << "## Output\n\n#{output}"
+    parts << "## Ground Truth\n\n#{ground_truth}" if ground_truth
+    parts.join("\n\n")
+  end
 
   #: () -> Riffer::Providers::Base
   def provider_instance

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -87,7 +87,7 @@ class Riffer::Evals::Judge
     SYSTEM
   end
 
-  #: (input: String, output: String, ground_truth: String?) -> String
+  #: (input: String, output: String, ?ground_truth: String?) -> String
   def build_user_message(input:, output:, ground_truth: nil)
     parts = []
     parts << "## Input\n\n#{input}"

--- a/lib/riffer/evals/profile.rb
+++ b/lib/riffer/evals/profile.rb
@@ -80,8 +80,8 @@ module Riffer::Evals::Profile
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-    def run_eval(input:, context: nil, tool_context: nil)
+    #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?ground_truth: String?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    def run_eval(input:, ground_truth: nil, tool_context: nil)
       profile = @eval_profile
       raise Riffer::ArgumentError, "No eval profile configured" unless profile
 
@@ -93,7 +93,7 @@ module Riffer::Evals::Profile
 
       # Run evaluations
       runner = Riffer::Evals::Runner.new(metrics: metrics)
-      runner.run(input: input, output: response.content, context: context)
+      runner.run(input: input, output: response.content, ground_truth: ground_truth)
     end
   end
 end

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -8,7 +8,7 @@
 #   run_result = Riffer::Evals::RunResult.new(
 #     input: "question",
 #     output: "answer",
-#     context: {},
+#     ground_truth: "expected answer",
 #     results: [result1, result2],
 #     metrics: [metric1, metric2]
 #   )
@@ -24,8 +24,8 @@ class Riffer::Evals::RunResult
   # The output that was evaluated.
   attr_reader :output #: String
 
-  # The context used during evaluation.
-  attr_reader :context #: Hash[Symbol, untyped]?
+  # The ground truth used during evaluation.
+  attr_reader :ground_truth #: String?
 
   # Individual evaluation results.
   attr_reader :results #: Array[Riffer::Evals::Result]
@@ -35,11 +35,11 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
-  def initialize(input:, output:, context:, results:, metrics:)
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  def initialize(input:, output:, ground_truth:, results:, metrics:)
     @input = input
     @output = output
-    @context = context
+    @ground_truth = ground_truth
     @results = results
     @metrics = metrics
   end
@@ -90,7 +90,7 @@ class Riffer::Evals::RunResult
     {
       input: input,
       output: output,
-      context: context,
+      ground_truth: ground_truth,
       results: results.map(&:to_h),
       passed: passed?,
       aggregate_score: aggregate_score

--- a/lib/riffer/evals/runner.rb
+++ b/lib/riffer/evals/runner.rb
@@ -10,7 +10,7 @@
 #   run_result = runner.run(
 #     input: "What is the capital of France?",
 #     output: "The capital of France is Paris.",
-#     context: {}
+#     ground_truth: "Paris"
 #   )
 #
 class Riffer::Evals::Runner
@@ -26,17 +26,17 @@ class Riffer::Evals::Runner
 
   # Runs all evaluators and collects results.
   #
-  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-  def run(input:, output:, context: nil)
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::RunResult
+  def run(input:, output:, ground_truth: nil)
     results = metrics.map do |metric|
       evaluator = metric.evaluator_class.new
-      evaluator.evaluate(input: input, output: output, context: context)
+      evaluator.evaluate(input: input, output: output, ground_truth: ground_truth)
     end
 
     Riffer::Evals::RunResult.new(
       input: input,
       output: output,
-      context: context,
+      ground_truth: ground_truth,
       results: results,
       metrics: metrics
     )

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -39,6 +39,17 @@ class Riffer::Evals::Evaluator
   # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
   def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
 
+  private
+
+  # Formats the input for the judge.
+  #
+  # String inputs are passed through as-is.
+  # Array inputs (message hashes or Message objects) are formatted
+  # as labeled role/content pairs separated by blank lines.
+  #
+  # : (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
+  def format_input: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
+
   # Returns a Judge instance configured for this evaluator.
   #
   # : () -> Riffer::Evals::Judge

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -3,28 +3,21 @@
 # Base class for all evaluators in the Riffer framework.
 #
 # Provides a DSL for defining evaluator metadata and the evaluate method.
-# Subclasses must implement the +evaluate+ method.
+# Simple evaluators only need to set +instructions+ — the base class
+# handles calling the judge automatically.
 #
 # See Riffer::Evals::Evaluators.
 #
 #   class MyEvaluator < Riffer::Evals::Evaluator
-#     description "Evaluates response quality"
+#     instructions "Assess medical accuracy of the response..."
 #     higher_is_better true
 #     judge_model "anthropic/claude-opus-4-5-20251101"
-#
-#     def evaluate(input:, output:, context: nil)
-#       evaluation = judge.evaluate(
-#         system_prompt: "...",
-#         user_prompt: "..."
-#       )
-#       result(score: evaluation[:score], reason: evaluation[:reason])
-#     end
 #   end
 class Riffer::Evals::Evaluator
-  # Gets or sets the evaluator description.
+  # Gets or sets the evaluation instructions (criteria and scoring rubric).
   #
   # : (?String?) -> String?
-  def self.description: (?String?) -> String?
+  def self.instructions: (?String?) -> String?
 
   # Gets or sets whether higher scores are better.
   #
@@ -38,10 +31,13 @@ class Riffer::Evals::Evaluator
 
   # Evaluates an input/output pair.
   #
-  # Raises NotImplementedError if not implemented by subclass.
+  # The default implementation calls the judge with the class-level +instructions+.
+  # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
-  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-  def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
+  # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
+  #
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
+  def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
 
   # Returns a Judge instance configured for this evaluator.
   #

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -34,6 +34,10 @@ class Riffer::Evals::Evaluator
   # The default implementation calls the judge with the class-level +instructions+.
   # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
+  # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
+  # +output+ - the agent's response to evaluate.
+  # +ground_truth+ - optional reference answer for comparison.
+  #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
   # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result

--- a/sig/generated/riffer/evals/evaluators/answer_relevancy.rbs
+++ b/sig/generated/riffer/evals/evaluators/answer_relevancy.rbs
@@ -12,13 +12,4 @@
 #   )
 #   result.score  # => 0.95
 class Riffer::Evals::Evaluators::AnswerRelevancy < Riffer::Evals::Evaluator
-  SYSTEM_PROMPT: String
-
-  # : (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-  def evaluate: (input: String, output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::Result
-
-  private
-
-  # : (input: String, output: String) -> String
-  def build_user_prompt: (input: String, output: String) -> String
 end

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -45,8 +45,8 @@ class Riffer::Evals::Judge
   # : (String) -> String
   def build_system_message: (String) -> String
 
-  # : (input: String, output: String, ground_truth: String?) -> String
-  def build_user_message: (input: String, output: String, ground_truth: String?) -> String
+  # : (input: String, output: String, ?ground_truth: String?) -> String
+  def build_user_message: (input: String, output: String, ?ground_truth: String?) -> String
 
   # : () -> Riffer::Providers::Base
   def provider_instance: () -> Riffer::Providers::Base

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -8,8 +8,9 @@
 #
 #   judge = Riffer::Evals::Judge.new(model: "anthropic/claude-opus-4-5-20251101")
 #   result = judge.evaluate(
-#     system_prompt: "You are an evaluation assistant...",
-#     user_prompt: "Evaluate this response..."
+#     instructions: "Assess answer relevancy...",
+#     input: "What is Ruby?",
+#     output: "Ruby is a programming language."
 #   )
 #   result[:score]  # => 0.85
 #   result[:reason] # => "The response is relevant..."
@@ -30,13 +31,22 @@ class Riffer::Evals::Judge
 
   # Evaluates using the configured LLM.
   #
-  # Raises Riffer::ArgumentError if both messages and system_prompt/user_prompt are provided,
-  # or if user_prompt is missing when messages is not provided.
+  # Composes system and user messages from the semantic fields:
+  # - +instructions+ — evaluation criteria and scoring rubric
+  # - +input+ — the original input/question
+  # - +output+ — the agent's response to evaluate
+  # - +ground_truth+ — optional reference answer for comparison
   #
-  # : (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
-  def evaluate: (?messages: Array[Hash[Symbol, untyped]]?, ?system_prompt: String?, ?user_prompt: String?) -> Hash[Symbol, untyped]
+  # : (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
+  def evaluate: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
 
   private
+
+  # : (String) -> String
+  def build_system_message: (String) -> String
+
+  # : (input: String, output: String, ground_truth: String?) -> String
+  def build_user_message: (input: String, output: String, ground_truth: String?) -> String
 
   # : () -> Riffer::Providers::Base
   def provider_instance: () -> Riffer::Providers::Base

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -32,10 +32,10 @@ class Riffer::Evals::Judge
   # Evaluates using the configured LLM.
   #
   # Composes system and user messages from the semantic fields:
-  # - +instructions+ — evaluation criteria and scoring rubric
-  # - +input+ — the original input/question
-  # - +output+ — the agent's response to evaluate
-  # - +ground_truth+ — optional reference answer for comparison
+  # +instructions+ - evaluation criteria and scoring rubric.
+  # +input+ - the original input/question.
+  # +output+ - the agent's response to evaluate.
+  # +ground_truth+ - optional reference answer for comparison.
   #
   # : (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
   def evaluate: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/evals/profile.rbs
+++ b/sig/generated/riffer/evals/profile.rbs
@@ -53,7 +53,7 @@ module Riffer::Evals::Profile
   module AgentClassMethods
     # Runs evaluations against the agent.
     #
-    # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-    def run_eval: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?context: Hash[Symbol, untyped]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?ground_truth: String?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+    def run_eval: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?ground_truth: String?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   end
 end

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -7,7 +7,7 @@
 #   run_result = Riffer::Evals::RunResult.new(
 #     input: "question",
 #     output: "answer",
-#     context: {},
+#     ground_truth: "expected answer",
 #     results: [result1, result2],
 #     metrics: [metric1, metric2]
 #   )
@@ -22,8 +22,8 @@ class Riffer::Evals::RunResult
   # The output that was evaluated.
   attr_reader output: String
 
-  # The context used during evaluation.
-  attr_reader context: Hash[Symbol, untyped]?
+  # The ground truth used during evaluation.
+  attr_reader ground_truth: String?
 
   # Individual evaluation results.
   attr_reader results: Array[Riffer::Evals::Result]
@@ -33,8 +33,8 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
-  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
-  def initialize: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, context: Hash[Symbol, untyped]?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
+  def initialize: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], metrics: Array[Riffer::Evals::Metric]) -> void
 
   # Checks if all metrics passed their thresholds.
   #

--- a/sig/generated/riffer/evals/runner.rbs
+++ b/sig/generated/riffer/evals/runner.rbs
@@ -9,7 +9,7 @@
 #   run_result = runner.run(
 #     input: "What is the capital of France?",
 #     output: "The capital of France is Paris.",
-#     context: {}
+#     ground_truth: "Paris"
 #   )
 class Riffer::Evals::Runner
   # The metrics to evaluate.
@@ -22,6 +22,6 @@ class Riffer::Evals::Runner
 
   # Runs all evaluators and collects results.
   #
-  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-  def run: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::RunResult
+  def run: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::RunResult
 end

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -83,6 +83,28 @@ describe Riffer::Evals::Evaluator do
       expect(result.reason).must_equal "Good"
     end
 
+    it "formats array input as labeled messages" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        instructions "Evaluate quality."
+        judge_model "test/eval-model"
+      end
+
+      evaluator = klass.new
+      judge = evaluator.send(:judge)
+      provider = judge.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.8, reason: "Good"}}])
+
+      messages = [
+        {role: "user", content: "What is Ruby?"},
+        {role: "assistant", content: "Ruby is a programming language."},
+        {role: "user", content: "Tell me more."}
+      ]
+
+      result = evaluator.evaluate(input: messages, output: "test output")
+
+      expect(result.score).must_equal 0.8
+    end
+
     it "passes ground_truth to judge" do
       klass = Class.new(Riffer::Evals::Evaluator) do
         instructions "Compare to ground truth."

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -5,26 +5,26 @@ require "test_helper"
 describe Riffer::Evals::Evaluator do
   let(:evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      description "A test evaluator"
+      instructions "Test evaluation instructions"
       higher_is_better true
     end
   end
 
   let(:lower_is_better_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      description "Detects toxicity"
+      instructions "Detects toxicity"
       higher_is_better false
     end
   end
 
-  describe ".description" do
-    it "returns the set description" do
-      expect(evaluator_class.description).must_equal "A test evaluator"
+  describe ".instructions" do
+    it "returns the set instructions" do
+      expect(evaluator_class.instructions).must_equal "Test evaluation instructions"
     end
 
     it "returns nil when not set" do
       anon_class = Class.new(Riffer::Evals::Evaluator)
-      expect(anon_class.description).must_be_nil
+      expect(anon_class.instructions).must_be_nil
     end
   end
 
@@ -57,9 +57,46 @@ describe Riffer::Evals::Evaluator do
   end
 
   describe "#evaluate" do
-    it "raises NotImplementedError when not implemented" do
-      evaluator = evaluator_class.new
+    it "raises NotImplementedError when instructions not set and evaluate not overridden" do
+      anon_class = Class.new(Riffer::Evals::Evaluator) do
+        higher_is_better true
+      end
+
+      evaluator = anon_class.new
       expect { evaluator.evaluate(input: "test", output: "test") }.must_raise(NotImplementedError)
+    end
+
+    it "calls judge with instructions when instructions are set" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        instructions "Evaluate quality."
+        judge_model "test/eval-model"
+      end
+
+      evaluator = klass.new
+      judge = evaluator.send(:judge)
+      provider = judge.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.8, reason: "Good"}}])
+
+      result = evaluator.evaluate(input: "test input", output: "test output")
+
+      expect(result.score).must_equal 0.8
+      expect(result.reason).must_equal "Good"
+    end
+
+    it "passes ground_truth to judge" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        instructions "Compare to ground truth."
+        judge_model "test/eval-model"
+      end
+
+      evaluator = klass.new
+      judge = evaluator.send(:judge)
+      provider = judge.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.95, reason: "Matches"}}])
+
+      result = evaluator.evaluate(input: "question", output: "answer", ground_truth: "expected")
+
+      expect(result.score).must_equal 0.95
     end
   end
 
@@ -68,7 +105,7 @@ describe Riffer::Evals::Evaluator do
       klass = Class.new(Riffer::Evals::Evaluator) do
         higher_is_better true
 
-        def evaluate(input:, output:, context: nil)
+        def evaluate(input:, output:, ground_truth: nil)
           result(score: 0.9, reason: "Good")
         end
       end
@@ -87,7 +124,7 @@ describe Riffer::Evals::Evaluator do
       klass = Class.new(Riffer::Evals::Evaluator) do
         higher_is_better false
 
-        def evaluate(input:, output:, context: nil)
+        def evaluate(input:, output:, ground_truth: nil)
           result(score: 0.1, reason: "Low toxicity")
         end
       end

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -19,48 +19,33 @@ describe Riffer::Evals::Judge do
   end
 
   describe "#evaluate" do
-    it "evaluates with system_prompt and user_prompt" do
+    it "evaluates with instructions, input, and output" do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
       provider = judge.send(:provider_instance)
       provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.85, reason: "Good response."}}])
 
-      result = judge.evaluate(system_prompt: "You are a judge.", user_prompt: "Evaluate this.")
+      result = judge.evaluate(
+        instructions: "Assess answer relevancy.",
+        input: "What is Ruby?",
+        output: "Ruby is a programming language."
+      )
 
       expect(result).must_equal({score: 0.85, reason: "Good response."})
     end
 
-    it "evaluates with messages array" do
+    it "evaluates with ground_truth" do
       judge = Riffer::Evals::Judge.new(model: "test/eval-model")
       provider = judge.send(:provider_instance)
-      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.9, reason: "Excellent."}}])
+      provider.stub_response("", tool_calls: [{name: "evaluation", arguments: {score: 0.9, reason: "Matches ground truth."}}])
 
-      messages = [
-        {role: "system", content: "You are a judge."},
-        {role: "user", content: "Evaluate this."}
-      ]
-      result = judge.evaluate(messages: messages)
+      result = judge.evaluate(
+        instructions: "Compare output to ground truth.",
+        input: "What is the capital of France?",
+        output: "Paris is the capital.",
+        ground_truth: "Paris"
+      )
 
-      expect(result).must_equal({score: 0.9, reason: "Excellent."})
-    end
-
-    it "raises error when both messages and system_prompt/user_prompt provided" do
-      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
-
-      error = expect {
-        judge.evaluate(messages: [], system_prompt: "test")
-      }.must_raise(Riffer::ArgumentError)
-
-      expect(error.message).must_equal "cannot provide both messages and system_prompt/user_prompt"
-    end
-
-    it "raises error when user_prompt is missing" do
-      judge = Riffer::Evals::Judge.new(model: "test/eval-model")
-
-      error = expect {
-        judge.evaluate(system_prompt: "test")
-      }.must_raise(Riffer::ArgumentError)
-
-      expect(error.message).must_equal "user_prompt is required when messages is not provided"
+      expect(result).must_equal({score: 0.9, reason: "Matches ground truth."})
     end
   end
 end

--- a/test/riffer/evals/metric_test.rb
+++ b/test/riffer/evals/metric_test.rb
@@ -5,7 +5,6 @@ require "test_helper"
 describe Riffer::Evals::Metric do
   let(:stub_evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      description "Test evaluator"
       higher_is_better true
     end
   end

--- a/test/riffer/evals/profile_test.rb
+++ b/test/riffer/evals/profile_test.rb
@@ -6,10 +6,9 @@ describe Riffer::Evals::Profile do
   # Create a simple evaluator for testing
   let(:profile_evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      description "Test evaluator for profile tests"
       higher_is_better true
 
-      def evaluate(input:, output:, context: nil)
+      def evaluate(input:, output:, ground_truth: nil)
         # Simple scoring based on output containing the word from input
         score = output.downcase.include?(input.downcase.split.first) ? 0.9 : 0.5
         result(score: score, reason: "Test evaluation")
@@ -116,7 +115,7 @@ describe Riffer::Evals::Profile do
       evaluator = Class.new(Riffer::Evals::Evaluator) do
         higher_is_better true
 
-        def evaluate(input:, output:, context: nil)
+        def evaluate(input:, output:, ground_truth: nil)
           result(score: 0.9, reason: "Test evaluation")
         end
       end

--- a/test/riffer/evals/run_result_test.rb
+++ b/test/riffer/evals/run_result_test.rb
@@ -44,14 +44,14 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "question",
         output: "answer",
-        context: {key: "value"},
+        ground_truth: "expected answer",
         results: [passing_result],
         metrics: [passing_metric]
       )
 
       expect(run_result.input).must_equal "question"
       expect(run_result.output).must_equal "answer"
-      expect(run_result.context).must_equal({key: "value"})
+      expect(run_result.ground_truth).must_equal "expected answer"
       expect(run_result.results).must_equal [passing_result]
       expect(run_result.metrics).must_equal [passing_metric]
     end
@@ -62,7 +62,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [passing_result],
         metrics: [passing_metric]
       )
@@ -74,7 +74,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [failing_result],
         metrics: [failing_metric]
       )
@@ -86,7 +86,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [passing_result, failing_result],
         metrics: [passing_metric, failing_metric]
       )
@@ -100,7 +100,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [passing_result],
         metrics: [passing_metric]
       )
@@ -112,7 +112,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [failing_result],
         metrics: [failing_metric]
       )
@@ -124,7 +124,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [passing_result, failing_result],
         metrics: [passing_metric, failing_metric]
       )
@@ -139,7 +139,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [],
         metrics: []
       )
@@ -151,7 +151,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [passing_result],
         metrics: [passing_metric]
       )
@@ -172,7 +172,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [result1, result2],
         metrics: [metric1, metric2]
       )
@@ -186,7 +186,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [toxicity_result],
         metrics: [toxicity_metric]
       )
@@ -206,7 +206,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "test",
         output: "test",
-        context: nil,
+        ground_truth: nil,
         results: [result1, result2],
         metrics: [metric1, metric2]
       )
@@ -223,7 +223,7 @@ describe Riffer::Evals::RunResult do
       run_result = Riffer::Evals::RunResult.new(
         input: "question",
         output: "answer",
-        context: {key: "value"},
+        ground_truth: "expected",
         results: [passing_result],
         metrics: [passing_metric]
       )
@@ -231,7 +231,7 @@ describe Riffer::Evals::RunResult do
       hash = run_result.to_h
       expect(hash[:input]).must_equal "question"
       expect(hash[:output]).must_equal "answer"
-      expect(hash[:context]).must_equal({key: "value"})
+      expect(hash[:ground_truth]).must_equal "expected"
       expect(hash[:passed]).must_equal true
       expect(hash[:aggregate_score]).must_equal 0.9
       expect(hash[:results].length).must_equal 1

--- a/test/riffer/evals/runner_test.rb
+++ b/test/riffer/evals/runner_test.rb
@@ -6,10 +6,9 @@ describe Riffer::Evals::Runner do
   # Create a simple evaluator that returns a fixed score
   let(:runner_evaluator_class) do
     Class.new(Riffer::Evals::Evaluator) do
-      description "Test evaluator for runner tests"
       higher_is_better true
 
-      def evaluate(input:, output:, context: nil)
+      def evaluate(input:, output:, ground_truth: nil)
         # Return a score based on output length
         score = [output.length / 100.0, 1.0].min
         result(score: score, reason: "Based on output length")
@@ -33,7 +32,7 @@ describe Riffer::Evals::Runner do
       result = runner.run(
         input: "What is Ruby?",
         output: "Ruby is a programming language designed for programmer happiness. It was created by Yukihiro Matsumoto.",
-        context: nil
+        ground_truth: nil
       )
 
       expect(result).must_be_instance_of Riffer::Evals::RunResult
@@ -49,30 +48,30 @@ describe Riffer::Evals::Runner do
       result = runner.run(
         input: "test",
         output: "This is a test output with enough length to score reasonably well in our test evaluator.",
-        context: nil
+        ground_truth: nil
       )
 
       expect(result.results.length).must_equal 2
     end
 
-    it "passes context to evaluators" do
-      context_evaluator_class = Class.new(Riffer::Evals::Evaluator) do
-        def evaluate(input:, output:, context: nil)
-          score = context&.dig(:expected_score) || 0.5
-          result(score: score, reason: "From context")
+    it "passes ground_truth to evaluators" do
+      ground_truth_evaluator_class = Class.new(Riffer::Evals::Evaluator) do
+        def evaluate(input:, output:, ground_truth: nil)
+          score = (ground_truth == "expected") ? 1.0 : 0.5
+          result(score: score, reason: "From ground_truth")
         end
       end
 
-      metrics = [Riffer::Evals::Metric.new(evaluator_class: context_evaluator_class)]
+      metrics = [Riffer::Evals::Metric.new(evaluator_class: ground_truth_evaluator_class)]
       runner = Riffer::Evals::Runner.new(metrics: metrics)
 
       result = runner.run(
         input: "test",
         output: "test output",
-        context: {expected_score: 0.95}
+        ground_truth: "expected"
       )
 
-      expect(result.results.first.score).must_equal 0.95
+      expect(result.results.first.score).must_equal 1.0
     end
   end
 end


### PR DESCRIPTION
## Summary

- Replace Judge's `system_prompt`/`user_prompt`/`messages` params with four semantic fields: `instructions`, `input`, `output`, `ground_truth` — Judge now composes system/user messages internally
- Add `instructions` class-level DSL to Evaluator with a default `evaluate` implementation, so simple evaluators need zero boilerplate (remove unused `description` DSL)
- Simplify `AnswerRelevancy` to DSL-only — no more `SYSTEM_PROMPT` constant, `evaluate` override, or `build_user_prompt`
- Rename `context:` → `ground_truth:` across Runner, RunResult, and Profile for clearer semantics
- Fix array-input formatting in `Evaluator#evaluate` — extract `format_input` helper that renders message hashes/objects as labeled `role: content` pairs instead of broken `to_s` output
- Fix RBS annotation for optional `ground_truth` keyword in `Judge#build_user_message`
- Fix RDoc parameter format in Judge and add missing parameter docs to Evaluator#evaluate

## Test plan

- [x] `bundle exec rake` — all tests pass, 0 failures, 0 errors
- [x] StandardRB lint clean
- [x] Steep type check clean (`No type error detected`)
- [x] RBS signatures regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)