### PR TITLE
fix: address claude code review issues from PR #140

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -24,7 +24,8 @@ Adapters for LLM APIs. The base class uses a template-method pattern — `genera
 - `execute_generate(params)` — call the SDK and return the raw response
 - `execute_stream(params, yielder)` — call the streaming SDK, mapping events to the yielder
 - `extract_token_usage(response)` — pull token counts from the SDK response
-- `extract_assistant_message(response, token_usage)` — parse the SDK response into an `Assistant` message
+- `extract_content(response)` — extract text content from the SDK response
+- `extract_tool_calls(response)` — extract tool calls from the SDK response
 
 Providers are registered in `Riffer::Providers::Repository::REPO` with identifiers (e.g., `openai`, `amazon_bedrock`).
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -322,7 +322,7 @@ class Riffer::Agent
 
       response = extract_final_response
 
-      return build_response(response.content, modifications: all_modifications, structured_output: validate_structured_output(response))
+      return build_response(response&.content || "", modifications: all_modifications, structured_output: validate_structured_output(response))
     end
 
     # catch returns the thrown value when throw :riffer_interrupt fires;
@@ -330,7 +330,7 @@ class Riffer::Agent
     @interrupted = true
     response = extract_final_response
 
-    build_response(response.content, modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response))
+    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response))
   end
 
   #: (Riffer::Messages::Base) -> void

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -35,7 +35,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     :assistant
   end
 
-  # @rbs () -> bool
+  #: () -> bool
   def structured_output?
     !@structured_output.nil?
   end

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -37,7 +37,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # : () -> Symbol
   def role: () -> Symbol
 
-  # @rbs () -> bool
+  # : () -> bool
   def structured_output?: () -> bool
 
   # Converts the message to a hash.


### PR DESCRIPTION
## Summary

- Fix RBS annotation prefix on `structured_output?` — changed `# @rbs` to `#:` to match the project's rbs-inline convention
- Add nil guard (`&.content || ""`) for both `extract_final_response` call sites in the agent loop
- Update stale `extract_assistant_message` reference in architecture docs to the current `extract_content` and `extract_tool_calls` methods

## Test plan

- [x] `bundle exec rake` — full test suite (950 tests) + linting passes
- [x] `bundle exec rake rbs:generate` — RBS signatures regenerate cleanly
- [x] `steep check` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)