### PR TITLE
feat: experimental ToolRuntime abstraction

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -368,17 +368,17 @@ Works with both `generate` and `stream`. Only emits agent-generated messages (As
 
 #### Interrupting the Agent Loop
 
-Callbacks can interrupt the agent loop using Ruby's `throw`/`catch` pattern. This is useful for human-in-the-loop approval, cost limits, or content filtering.
+Callbacks can interrupt the agent loop. This is useful for human-in-the-loop approval, cost limits, or content filtering.
 
-Use `throw :riffer_interrupt` to stop the loop. The response will have `interrupted?` set to `true` and contain the accumulated content up to the point of interruption.
+Use `agent.interrupt!` (or the lower-level `throw :riffer_interrupt`) to stop the loop. The response will have `interrupted?` set to `true` and contain the accumulated content up to the point of interruption.
 
-An optional reason can be passed as the second argument to `throw`. It is available via `interrupt_reason` on the response (generate) or `reason` on the `Interrupt` event (stream):
+An optional reason can be passed to `interrupt!`. It is available via `interrupt_reason` on the response (generate) or `reason` on the `Interrupt` event (stream):
 
 ```ruby
 agent = MyAgent.new
 agent.on_message do |msg|
   if msg.is_a?(Riffer::Messages::Tool)
-    throw :riffer_interrupt, "needs human approval"
+    agent.interrupt!("needs human approval")
   end
 end
 
@@ -386,6 +386,7 @@ response = agent.generate('Call the tool')
 response.interrupted?      # => true
 response.interrupt_reason  # => "needs human approval"
 response.content           # => last assistant content before interrupt
+response.step              # => number of LLM calls completed
 ```
 
 **Streaming** — interrupts emit an `Interrupt` event:
@@ -476,6 +477,16 @@ end
 agent = MyAgent.new
 agent.resume_stream(messages: persisted_messages, step: persisted_step).each do |event|
   # handle stream events
+end
+```
+
+### interrupt!
+
+Interrupts the agent loop from an `on_message` callback. Equivalent to `throw :riffer_interrupt, reason`:
+
+```ruby
+agent.on_message do |msg|
+  agent.interrupt!(:needs_approval) if requires_approval?(msg)
 end
 ```
 
@@ -607,23 +618,23 @@ response.tripwire.reason   # => "Content policy violation"
 
 ### Callback Interrupt (imperative, external)
 
-Callbacks registered with `on_message` can call `throw :riffer_interrupt` to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
+Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :riffer_interrupt`) to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
 
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
-- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
-- **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
-- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason, `response.step` contains the step count at interruption.
+- **Streaming:** Yields an `Interrupt` event with `reason` and `step` attributes.
+- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pass `step:` to enforce `max_steps` across the full session. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 agent = MyAgent.new
 agent.on_message do |msg|
-  throw :riffer_interrupt, "approval needed" if requires_approval?(msg)
+  agent.interrupt!("approval needed") if requires_approval?(msg)
 end
 
 response = agent.generate('Do something risky')
 response.interrupted?      # => true
 response.interrupt_reason  # => "approval needed"
-response = agent.resume    # continues where it left off
+response = agent.resume(step: response.step)  # continues where it left off
 ```
 
 ### Max Steps Limit

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -420,16 +420,27 @@ if response.interrupted?
 end
 ```
 
+Pass `step:` to carry the step count across resume calls so `max_steps` is enforced across the full session:
+
+```ruby
+response = agent.generate('Do a long task')
+
+if response.interrupted?
+  response = agent.resume(step: response.step)
+  # max_steps budget now accounts for steps from the original generate
+end
+```
+
 For cross-process resume (e.g., after a process restart or async approval), pass persisted messages via the `messages:` keyword. Accepts both message objects and hashes:
 
 ```ruby
-# Persist messages during generation (e.g., via on_message callback)
+# Persist messages and step count during generation
 # Later, in a new process:
 agent = MyAgent.new
-response = agent.resume(messages: persisted_messages, tool_context: {user_id: 123})
+response = agent.resume(messages: persisted_messages, step: persisted_step, tool_context: {user_id: 123})
 
 # Or resume in streaming mode:
-agent.resume_stream(messages: persisted_messages).each do |event|
+agent.resume_stream(messages: persisted_messages, step: persisted_step).each do |event|
   # handle stream events
 end
 ```
@@ -444,8 +455,11 @@ Continues an agent loop synchronously. Returns a `Riffer::Agent::Response` objec
 # In-memory resume after an interrupt
 response = agent.resume
 
+# With step offset for max_steps enforcement across sessions
+response = agent.resume(step: prior_response.step)
+
 # Cross-process resume from persisted messages
-response = agent.resume(messages: persisted_messages, tool_context: {user_id: 123})
+response = agent.resume(messages: persisted_messages, step: persisted_step, tool_context: {user_id: 123})
 ```
 
 ### resume_stream
@@ -458,9 +472,9 @@ agent.resume_stream.each do |event|
   # handle stream events
 end
 
-# Cross-process resume
+# Cross-process resume with step offset
 agent = MyAgent.new
-agent.resume_stream(messages: persisted_messages).each do |event|
+agent.resume_stream(messages: persisted_messages, step: persisted_step).each do |event|
   # handle stream events
 end
 ```

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -496,6 +496,7 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 | `modifications`    | `Array`                     | List of guardrail modifications applied            |
 | `interrupted?`     | `Boolean`                   | `true` if the loop was interrupted                 |
 | `interrupt_reason` | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
+| `step`             | `Integer`                   | Number of LLM call steps completed                 |
 
 ### response.structured_output
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -219,6 +219,22 @@ Using both `of:` and a block raises `Riffer::ArgumentError`. Using `of:` with a 
 
 Structured output is not compatible with streaming — calling `stream` on an agent with structured output configured raises `Riffer::ArgumentError`.
 
+### tool_runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+Configures how tool calls are executed. Defaults to sequential (inline) execution:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime :threaded
+end
+```
+
+Accepts `:inline`, `:threaded`, a `Riffer::ToolRuntime` instance, or a `Proc`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+
 ### guardrail
 
 Registers guardrails for pre/post processing of messages. Pass the guardrail class and any options:
@@ -532,7 +548,7 @@ end
 When an agent receives a response with tool calls:
 
 1. Agent detects `tool_calls` in the assistant message
-2. For each tool call:
+2. The configured tool runtime executes the tool calls (sequentially by default, or concurrently with `:threaded`):
    - Finds the matching tool class
    - Validates arguments against the tool's parameter schema
    - Calls the tool's `call` method with `context` and arguments

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -371,3 +371,125 @@ end
 Unhandled exceptions are caught by Riffer and converted to error responses with type `:execution_error`. However, it's recommended to handle expected errors explicitly for better error messages.
 
 The LLM receives the error message and can decide how to respond (retry, apologize, ask for different input, etc.).
+
+## Tool Runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+By default, tool calls are executed sequentially in the current thread using `Riffer::ToolRuntime::Inline`. You can change how tool calls are executed by configuring a different tool runtime.
+
+### Built-in Runtimes
+
+| Runtime | Description |
+|---------|-------------|
+| `Riffer::ToolRuntime::Inline` | Executes tool calls sequentially (default) |
+| `Riffer::ToolRuntime::Threaded` | Executes tool calls concurrently using threads |
+
+### Per-Agent Configuration
+
+Use the `tool_runtime` class method on your agent:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime :threaded
+end
+```
+
+Accepted values:
+
+- `:inline` — sequential execution (default)
+- `:threaded` — concurrent execution using threads
+- A `Riffer::ToolRuntime` instance — for custom runtimes
+- A `Proc` — evaluated at runtime (see below)
+
+### Dynamic Resolution
+
+Use a lambda for context-aware runtime selection:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+
+  tool_runtime ->(context) {
+    context&.dig(:parallel) ? :threaded : :inline
+  }
+end
+
+agent.generate("Do work", tool_context: {parallel: true})
+```
+
+When the lambda accepts a parameter, it receives the `tool_context`. Zero-arity lambdas are also supported.
+
+### Global Configuration
+
+Set a default tool runtime for all agents:
+
+```ruby
+Riffer.configure do |config|
+  config.tool_runtime = :threaded
+end
+```
+
+Per-agent configuration overrides the global default.
+
+### Threaded Runtime Options
+
+The threaded runtime accepts a `max_concurrency` option (default: 5):
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
+end
+```
+
+### Custom Runtimes
+
+Create a custom runtime by subclassing `Riffer::ToolRuntime`:
+
+```ruby
+class HttpToolRuntime < Riffer::ToolRuntime
+  def call(tool_call, tools:, context:)
+    # Dispatch tool execution to an external service
+    response = HttpClient.post("/tools/execute", {
+      name: tool_call.name,
+      arguments: tool_call.arguments
+    })
+    Riffer::Tools::Response.text(response.body)
+  rescue => e
+    Riffer::Tools::Response.error(e.message)
+  end
+end
+```
+
+You can also compose with a custom `Riffer::Runner` for concurrency control:
+
+```ruby
+class HttpToolRuntime < Riffer::ToolRuntime
+  def initialize
+    super(runner: Riffer::Runner::Threaded.new(max_concurrency: 10))
+  end
+end
+```
+
+### Around-Execution Callbacks
+
+Register callbacks that wrap each tool execution:
+
+```ruby
+class InstrumentedRuntime < Riffer::ToolRuntime
+  around_tool_execution do |tool_call, context:, &block|
+    start = Time.now
+    result = block.call
+    duration = Time.now - start
+    Rails.logger.info("Tool #{tool_call.name} took #{duration}s")
+    result
+  end
+end
+```
+
+Multiple callbacks compose in registration order (first registered wraps outermost).

--- a/docs/06_STREAM_EVENTS.md
+++ b/docs/06_STREAM_EVENTS.md
@@ -193,27 +193,29 @@ Emitted when the agent loop is interrupted. This can happen in two ways:
 - An `on_message` callback calls `throw :riffer_interrupt` (reason is a String or `nil`).
 - The `max_steps` limit is reached (reason is the Symbol `:max_steps`).
 
-This is the streaming equivalent of `Response#interrupted?` in generate mode.
+This is the streaming equivalent of `Response#interrupted?` in generate mode. The `step` attribute contains the number of LLM call steps completed when the interrupt fired.
 
 ```ruby
 # Callback interrupt with a string reason
-event = Riffer::StreamEvents::Interrupt.new(reason: "needs approval")
+event = Riffer::StreamEvents::Interrupt.new(reason: "needs approval", step: 3)
 event.role    # => :system
 event.reason  # => "needs approval"
-event.to_h    # => {role: :system, interrupt: true, reason: "needs approval"}
+event.step    # => 3
+event.to_h    # => {role: :system, interrupt: true, step: 3, reason: "needs approval"}
 
 # Max steps interrupt with a symbol reason
-event = Riffer::StreamEvents::Interrupt.new(reason: :max_steps)
+event = Riffer::StreamEvents::Interrupt.new(reason: :max_steps, step: 8)
 event.reason  # => :max_steps
+event.step    # => 8
 ```
 
-The `reason` is `nil` when `throw :riffer_interrupt` is called without a second argument.
+The `reason` is `nil` when `throw :riffer_interrupt` is called without a reason. The `step` defaults to `0`.
 
 ```ruby
 agent.stream("Hello").each do |event|
   case event
   when Riffer::StreamEvents::Interrupt
-    puts "Loop was interrupted: #{event.reason}"
+    puts "Loop was interrupted at step #{event.step}: #{event.reason}"
   end
 end
 ```

--- a/docs/06_STREAM_EVENTS.md
+++ b/docs/06_STREAM_EVENTS.md
@@ -190,7 +190,7 @@ See [Guardrails](09_GUARDRAILS.md) for more information.
 
 Emitted when the agent loop is interrupted. This can happen in two ways:
 
-- An `on_message` callback calls `throw :riffer_interrupt` (reason is a String or `nil`).
+- An `on_message` callback calls `agent.interrupt!` or `throw :riffer_interrupt` (reason is a String or `nil`).
 - The `max_steps` limit is reached (reason is the Symbol `:max_steps`).
 
 This is the streaming equivalent of `Response#interrupted?` in generate mode. The `step` attribute contains the number of LLM call steps completed when the interrupt fired.

--- a/docs/07_CONFIGURATION.md
+++ b/docs/07_CONFIGURATION.md
@@ -72,6 +72,27 @@ Riffer.configure do |config|
 end
 ```
 
+### Tool Runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+Configure the default tool runtime for all agents:
+
+```ruby
+Riffer.configure do |config|
+  config.tool_runtime = :threaded
+end
+```
+
+| Value | Description |
+|-------|-------------|
+| `:inline` | Sequential execution (default) |
+| `:threaded` | Concurrent execution using threads |
+| `Riffer::ToolRuntime` instance | Custom runtime |
+| `Proc` | Dynamic resolution |
+
+Per-agent configuration overrides this global default. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+
 ## Agent-Level Configuration
 
 Override global configuration at the agent level:

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -109,6 +109,16 @@ class Riffer::Agent
     @tools_config = tools_or_lambda
   end
 
+  # Gets or sets the tool runtime for this agent.
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  #
+  #: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  def self.tool_runtime(value = nil)
+    return @tool_runtime if value.nil?
+    @tool_runtime = value
+  end
+
   # Finds an agent class by identifier.
   #
   #: (String) -> singleton(Riffer::Agent)?
@@ -484,8 +494,10 @@ class Riffer::Agent
 
   #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
-    response.tool_calls.each do |tool_call|
-      result = execute_tool_call(tool_call)
+    runtime = resolve_tool_runtime
+    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @tool_context)
+
+    results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.id,
@@ -520,10 +532,13 @@ class Riffer::Agent
       m.is_a?(Riffer::Messages::Tool)
     }.map(&:tool_call_id)
 
-    # Execute any tool calls whose id is not in the executed set.
-    assistant.tool_calls.each do |tool_call|
-      next if executed_ids.include?(tool_call.id)
-      result = execute_tool_call(tool_call)
+    pending = assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
+    return if pending.empty?
+
+    runtime = resolve_tool_runtime
+    results = runtime.execute(pending, tools: resolved_tools, context: @tool_context)
+
+    results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.id,
@@ -531,31 +546,6 @@ class Riffer::Agent
         error: result.error_message,
         error_type: result.error_type
       ))
-    end
-  end
-
-  #: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-  def execute_tool_call(tool_call)
-    tool_class = find_tool_class(tool_call.name)
-
-    if tool_class.nil?
-      return Riffer::Tools::Response.error(
-        "Unknown tool '#{tool_call.name}'",
-        type: :unknown_tool
-      )
-    end
-
-    tool_instance = tool_class.new
-    arguments = parse_tool_arguments(tool_call.arguments)
-
-    begin
-      tool_instance.call_with_validation(context: @tool_context, **arguments)
-    rescue Riffer::TimeoutError => e
-      Riffer::Tools::Response.error(e.message, type: :timeout_error)
-    rescue Riffer::ValidationError => e
-      Riffer::Tools::Response.error(e.message, type: :validation_error)
-    rescue => e
-      Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
     end
   end
 
@@ -601,17 +591,22 @@ class Riffer::Agent
     end
   end
 
-  #: (String) -> singleton(Riffer::Tool)?
-  def find_tool_class(name)
-    resolved_tools.find { |tool_class| tool_class.name == name }
-  end
+  #: () -> Riffer::ToolRuntime
+  def resolve_tool_runtime
+    config = self.class.tool_runtime || Riffer.config.tool_runtime
 
-  #: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
-  def parse_tool_arguments(arguments)
-    return {} if arguments.nil? || arguments.empty?
+    runtime = if config.is_a?(Proc)
+      (config.arity == 0) ? config.call : config.call(@tool_context)
+    else
+      config
+    end
 
-    args = arguments.is_a?(String) ? JSON.parse(arguments) : arguments
-    args.transform_keys(&:to_sym)
+    case runtime
+    when :inline then Riffer::ToolRuntime::Inline.new
+    when :threaded then Riffer::ToolRuntime::Threaded.new
+    when Riffer::ToolRuntime then runtime
+    else raise Riffer::ArgumentError, "Invalid tool_runtime: #{runtime.inspect}"
+    end
   end
 
   #: () -> Riffer::Messages::Assistant?

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -319,7 +319,7 @@ class Riffer::Agent
         processed_response, tripwire, modifications = run_after_guardrails(response)
         all_modifications.concat(modifications)
 
-        return build_response("", tripwire: tripwire, modifications: all_modifications) if tripwire
+        return build_response("", tripwire: tripwire, modifications: all_modifications, step: step) if tripwire
 
         add_message(processed_response)
 
@@ -332,7 +332,7 @@ class Riffer::Agent
 
       response = extract_final_response
 
-      return build_response(response&.content || "", modifications: all_modifications, structured_output: validate_structured_output(response))
+      return build_response(response&.content || "", modifications: all_modifications, structured_output: validate_structured_output(response), step: step)
     end
 
     # catch returns the thrown value when throw :riffer_interrupt fires;
@@ -340,7 +340,7 @@ class Riffer::Agent
     @interrupted = true
     response = extract_final_response
 
-    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response))
+    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response), step: step)
   end
 
   #: (Riffer::Messages::Base) -> void
@@ -452,7 +452,7 @@ class Riffer::Agent
 
     unless completed == :completed
       @interrupted = true
-      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed)
+      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed, step: step)
     end
   end
 
@@ -659,8 +659,8 @@ class Riffer::Agent
     opts
   end
 
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?step: Integer) -> Riffer::Agent::Response
+  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, step: 0)
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, step: step)
   end
 end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -307,6 +307,16 @@ class Riffer::Agent
     self
   end
 
+  # Interrupts the agent loop.
+  #
+  # Call from an +on_message+ callback to cleanly interrupt the loop.
+  # Equivalent to +throw :riffer_interrupt, reason+.
+  #
+  #: (?(String | Symbol)?) -> void
+  def interrupt!(reason = nil)
+    throw :riffer_interrupt, reason
+  end
+
   private
 
   #: (?Array[Riffer::Guardrails::Modification], ?resume: bool, ?step_offset: Integer) -> Riffer::Agent::Response

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -271,22 +271,28 @@ class Riffer::Agent
   #
   # Skips message initialization and before guardrails in both cases.
   #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def resume(messages: nil, tool_context: nil)
+  # +step+ - optional step offset so max_steps is enforced across the full
+  #   session. Typically the +step+ value from a prior interrupted Response.
+  #
+  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?, ?step: Integer) -> Riffer::Agent::Response
+  def resume(messages: nil, tool_context: nil, step: 0)
     restore_state(messages: messages, tool_context: tool_context)
-    run_generate_loop(resume: true)
+    run_generate_loop(resume: true, step_offset: step)
   end
 
   # Resumes an agent loop in streaming mode.
   #
   # Same as +resume+ but returns an Enumerator yielding stream events.
   #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def resume_stream(messages: nil, tool_context: nil)
+  # +step+ - optional step offset so max_steps is enforced across the full
+  #   session.
+  #
+  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?, ?step: Integer) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def resume_stream(messages: nil, tool_context: nil, step: 0)
     restore_state(messages: messages, tool_context: tool_context)
 
     Enumerator.new do |yielder|
-      run_stream_loop(yielder, resume: true)
+      run_stream_loop(yielder, resume: true, step_offset: step)
     end
   end
 
@@ -303,9 +309,9 @@ class Riffer::Agent
 
   private
 
-  #: (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response
-  def run_generate_loop(all_modifications = [], resume: false)
-    step = 0
+  #: (?Array[Riffer::Guardrails::Modification], ?resume: bool, ?step_offset: Integer) -> Riffer::Agent::Response
+  def run_generate_loop(all_modifications = [], resume: false, step_offset: 0)
+    step = step_offset
 
     reason = catch(:riffer_interrupt) do
       execute_pending_tool_calls if resume
@@ -384,9 +390,9 @@ class Riffer::Agent
     clear_resolved_model
   end
 
-  #: (Enumerator::Yielder, ?resume: bool) -> void
-  def run_stream_loop(yielder, resume: false)
-    step = 0
+  #: (Enumerator::Yielder, ?resume: bool, ?step_offset: Integer) -> void
+  def run_stream_loop(yielder, resume: false, step_offset: 0)
+    step = step_offset
 
     completed = catch(:riffer_interrupt) do
       execute_pending_tool_calls if resume

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -25,6 +25,9 @@ class Riffer::Agent::Response
   # The reason provided with the interrupt, if any.
   attr_reader :interrupt_reason #: (String | Symbol)?
 
+  # The number of LLM call steps completed during this generation.
+  attr_reader :step #: Integer
+
   # The parsed structured output, if structured output was configured.
   attr_reader :structured_output #: Hash[Symbol, untyped]?
 
@@ -36,15 +39,17 @@ class Riffer::Agent::Response
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
   # +structured_output+ - parsed structured output when structured output is configured.
+  # +step+ - the number of LLM call steps completed.
   #
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?step: Integer) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, step: 0)
     @content = content
     @tripwire = tripwire
     @modifications = modifications
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output
+    @step = step
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -32,11 +32,18 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader :evals #: Riffer::Config::Evals
 
+  # Global tool runtime configuration (experimental).
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  attr_accessor :tool_runtime #: (Symbol | Riffer::ToolRuntime | Proc)
+
   #: () -> void
   def initialize
     @amazon_bedrock = AmazonBedrock.new
     @anthropic = Anthropic.new
     @openai = OpenAI.new
     @evals = Evals.new
+    @tool_runtime = Riffer::ToolRuntime::Inline.new
   end
 end

--- a/lib/riffer/runner.rb
+++ b/lib/riffer/runner.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Generic concurrency primitive for batch execution.
+#
+# Subclasses implement +map+ to control how items are processed
+# (sequentially, threaded, etc.).
+#
+#   runner = Riffer::Runner::Sequential.new
+#   runner.map([1, 2, 3]) { |n| n * 2 }
+#   # => [2, 4, 6]
+#
+class Riffer::Runner
+  # Maps over items using the provided block.
+  #
+  # +items+ - the items to process.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    raise NotImplementedError, "#{self.class} must implement #map"
+  end
+end

--- a/lib/riffer/runner/sequential.rb
+++ b/lib/riffer/runner/sequential.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Processes items sequentially in the current thread.
+#
+# This is the default runner used when no concurrency is needed.
+#
+class Riffer::Runner::Sequential < Riffer::Runner
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    items.map(&block)
+  end
+end

--- a/lib/riffer/runner/threaded.rb
+++ b/lib/riffer/runner/threaded.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Processes items concurrently using threads.
+# Processes items concurrently using a thread pool.
 #
-# Items are executed in batches of +max_concurrency+ threads.
+# Maintains up to +max_concurrency+ worker threads that pull items from
+# a shared queue. When a worker finishes one item it immediately picks
+# up the next, so a single slow item does not block other workers.
 #
 #   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
 #   runner.map(items) { |item| expensive_operation(item) }
@@ -20,9 +22,27 @@ class Riffer::Runner::Threaded < Riffer::Runner
 
   #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
   def map(items, &block)
-    items.each_slice(@max_concurrency).flat_map do |batch|
-      threads = batch.map { |item| Thread.new { block.call(item) } }
-      threads.map(&:value)
+    return [] if items.empty?
+
+    results = Array.new(items.size)
+    queue = Queue.new
+    items.each_with_index { |item, i| queue << [item, i] }
+
+    workers = [items.size, @max_concurrency].min.times.map do
+      Thread.new do
+        loop do
+          pair = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          item, index = pair
+          results[index] = block.call(item)
+        end
+      end
     end
+
+    workers.each(&:join)
+    results
   end
 end

--- a/lib/riffer/runner/threaded.rb
+++ b/lib/riffer/runner/threaded.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Processes items concurrently using threads.
+#
+# Items are executed in batches of +max_concurrency+ threads.
+#
+#   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+#   runner.map(items) { |item| expensive_operation(item) }
+#
+class Riffer::Runner::Threaded < Riffer::Runner
+  DEFAULT_MAX_CONCURRENCY = 5 #: Integer
+
+  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  #
+  #: (?max_concurrency: Integer) -> void
+  def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
+    @max_concurrency = max_concurrency
+  end
+
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    items.each_slice(@max_concurrency).flat_map do |batch|
+      threads = batch.map { |item| Thread.new { block.call(item) } }
+      threads.map(&:value)
+    end
+  end
+end

--- a/lib/riffer/stream_events/interrupt.rb
+++ b/lib/riffer/stream_events/interrupt.rb
@@ -8,17 +8,21 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader :reason #: (String | Symbol)?
 
-  #: (?reason: (String | Symbol)?) -> void
-  def initialize(reason: nil)
+  # The number of LLM call steps completed when the interrupt fired.
+  attr_reader :step #: Integer
+
+  #: (?reason: (String | Symbol)?, ?step: Integer) -> void
+  def initialize(reason: nil, step: 0)
     super(role: :system)
     @reason = reason
+    @step = step
   end
 
   # Converts the event to a hash.
   #
   #: () -> Hash[Symbol, untyped]
   def to_h
-    h = {role: @role, interrupt: true}
+    h = {role: @role, interrupt: true, step: @step}
     h[:reason] = @reason if @reason
     h
   end

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "json"
+
+# Riffer::ToolRuntime handles tool call execution for an agent.
+#
+# Composes with a Riffer::Runner for concurrency control and provides
+# +execute+ (batch) and +call+ (single-call) methods.
+#
+# Subclass to customize execution behavior (e.g., HTTP dispatch,
+# background jobs).
+#
+#   runtime = Riffer::ToolRuntime::Inline.new
+#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+#
+class Riffer::ToolRuntime
+  # +runner+ - the concurrency runner to use for batch execution.
+  #
+  #: (?runner: Riffer::Runner) -> void
+  def initialize(runner: Riffer::Runner::Sequential.new)
+    @runner = runner
+  end
+
+  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  #
+  # +tool_calls+ - the tool calls to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute(tool_calls, tools:, context:)
+    @runner.map(tool_calls) do |tool_call|
+      result = with_execution_context(tool_call, context: context) do
+        call(tool_call, tools: tools, context: context)
+      end
+      [tool_call, result]
+    end
+  end
+
+  # Executes a single tool call.
+  #
+  # +tool_call+ - the tool call to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+  def call(tool_call, tools:, context:)
+    tool_class = tools.find { |tc| tc.name == tool_call.name }
+
+    if tool_class.nil?
+      return Riffer::Tools::Response.error(
+        "Unknown tool '#{tool_call.name}'",
+        type: :unknown_tool
+      )
+    end
+
+    tool_instance = tool_class.new
+    arguments = parse_arguments(tool_call.arguments)
+
+    tool_instance.call_with_validation(context: context, **arguments)
+  rescue Riffer::TimeoutError => e
+    Riffer::Tools::Response.error(e.message, type: :timeout_error)
+  rescue Riffer::ValidationError => e
+    Riffer::Tools::Response.error(e.message, type: :validation_error)
+  rescue => e
+    Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+  end
+
+  # Registers an around-execution callback on this class.
+  #
+  # The block receives +tool_call+, +context:+, and must yield to
+  # continue the chain.
+  #
+  #   class MyRuntime < Riffer::ToolRuntime
+  #     around_tool_execution do |tool_call, context:, &block|
+  #       puts "Before #{tool_call.name}"
+  #       result = block.call
+  #       puts "After #{tool_call.name}"
+  #       result
+  #     end
+  #   end
+  #
+  #: () { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+  def self.around_tool_execution(&block)
+    execution_callbacks << block
+  end
+
+  # Returns the registered around-execution callbacks for this class.
+  #
+  #: () -> Array[Proc]
+  def self.execution_callbacks
+    @execution_callbacks ||= []
+  end
+
+  private
+
+  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def with_execution_context(tool_call, context:, &block)
+    callbacks = self.class.execution_callbacks
+    return block.call if callbacks.empty?
+
+    chain = callbacks.reverse.reduce(block) do |next_block, callback|
+      -> { callback.call(tool_call, context: context, &next_block) }
+    end
+
+    chain.call
+  end
+
+  #: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  def parse_arguments(arguments)
+    return {} if arguments.nil? || arguments.empty?
+
+    args = arguments.is_a?(String) ? JSON.parse(arguments) : arguments
+    args.transform_keys(&:to_sym)
+  end
+end

--- a/lib/riffer/tool_runtime/inline.rb
+++ b/lib/riffer/tool_runtime/inline.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Executes tool calls sequentially in the current thread.
+#
+# This is the default tool runtime used when no runtime is configured.
+#
+class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+end

--- a/lib/riffer/tool_runtime/threaded.rb
+++ b/lib/riffer/tool_runtime/threaded.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Executes tool calls concurrently using threads.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime :threaded
+#   end
+#
+class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
+  DEFAULT_MAX_CONCURRENCY = 5 #: Integer
+
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #
+  #: (?max_concurrency: Integer) -> void
+  def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
+    super(runner: Riffer::Runner::Threaded.new(max_concurrency: max_concurrency))
+  end
+end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -70,6 +70,13 @@ class Riffer::Agent
   # : (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
 
+  # Gets or sets the tool runtime for this agent.
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  #
+  # : (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  def self.tool_runtime: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+
   # Finds an agent class by identifier.
   #
   # : (String) -> singleton(Riffer::Agent)?
@@ -208,9 +215,6 @@ class Riffer::Agent
   # : () -> void
   def execute_pending_tool_calls: () -> void
 
-  # : (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-  def execute_tool_call: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-
   # : (untyped) -> void
   def parse_model_string!: (untyped) -> void
 
@@ -225,11 +229,8 @@ class Riffer::Agent
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]
 
-  # : (String) -> singleton(Riffer::Tool)?
-  def find_tool_class: (String) -> singleton(Riffer::Tool)?
-
-  # : ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
-  def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  # : () -> Riffer::ToolRuntime
+  def resolve_tool_runtime: () -> Riffer::ToolRuntime
 
   # : () -> Riffer::Messages::Assistant?
   def extract_final_response: () -> Riffer::Messages::Assistant?

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -55,6 +55,12 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader evals: Riffer::Config::Evals
 
+  # Global tool runtime configuration (experimental).
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  attr_accessor tool_runtime: Symbol | Riffer::ToolRuntime | Proc
+
   # : () -> void
   def initialize: () -> void
 end

--- a/sig/generated/riffer/runner.rbs
+++ b/sig/generated/riffer/runner.rbs
@@ -1,0 +1,20 @@
+# Generated from lib/riffer/runner.rb with RBS::Inline
+
+# Generic concurrency primitive for batch execution.
+#
+# Subclasses implement +map+ to control how items are processed
+# (sequentially, threaded, etc.).
+#
+#   runner = Riffer::Runner::Sequential.new
+#   runner.map([1, 2, 3]) { |n| n * 2 }
+#   # => [2, 4, 6]
+class Riffer::Runner
+  # Maps over items using the provided block.
+  #
+  # +items+ - the items to process.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/sequential.rbs
+++ b/sig/generated/riffer/runner/sequential.rbs
@@ -1,0 +1,9 @@
+# Generated from lib/riffer/runner/sequential.rb with RBS::Inline
+
+# Processes items sequentially in the current thread.
+#
+# This is the default runner used when no concurrency is needed.
+class Riffer::Runner::Sequential < Riffer::Runner
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/threaded.rbs
+++ b/sig/generated/riffer/runner/threaded.rbs
@@ -1,0 +1,19 @@
+# Generated from lib/riffer/runner/threaded.rb with RBS::Inline
+
+# Processes items concurrently using threads.
+#
+# Items are executed in batches of +max_concurrency+ threads.
+#
+#   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+#   runner.map(items) { |item| expensive_operation(item) }
+class Riffer::Runner::Threaded < Riffer::Runner
+  DEFAULT_MAX_CONCURRENCY: Integer
+
+  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  #
+  # : (?max_concurrency: Integer) -> void
+  def initialize: (?max_concurrency: Integer) -> void
+
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/threaded.rbs
+++ b/sig/generated/riffer/runner/threaded.rbs
@@ -1,8 +1,10 @@
 # Generated from lib/riffer/runner/threaded.rb with RBS::Inline
 
-# Processes items concurrently using threads.
+# Processes items concurrently using a thread pool.
 #
-# Items are executed in batches of +max_concurrency+ threads.
+# Maintains up to +max_concurrency+ worker threads that pull items from
+# a shared queue. When a worker finishes one item it immediately picks
+# up the next, so a single slow item does not block other workers.
 #
 #   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
 #   runner.map(items) { |item| expensive_operation(item) }

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -1,0 +1,66 @@
+# Generated from lib/riffer/tool_runtime.rb with RBS::Inline
+
+# Riffer::ToolRuntime handles tool call execution for an agent.
+#
+# Composes with a Riffer::Runner for concurrency control and provides
+# +execute+ (batch) and +call+ (single-call) methods.
+#
+# Subclass to customize execution behavior (e.g., HTTP dispatch,
+# background jobs).
+#
+#   runtime = Riffer::ToolRuntime::Inline.new
+#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+class Riffer::ToolRuntime
+  # +runner+ - the concurrency runner to use for batch execution.
+  #
+  # : (?runner: Riffer::Runner) -> void
+  def initialize: (?runner: Riffer::Runner) -> void
+
+  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  #
+  # +tool_calls+ - the tool calls to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
+
+  # Executes a single tool call.
+  #
+  # +tool_call+ - the tool call to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+  def call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+
+  # Registers an around-execution callback on this class.
+  #
+  # The block receives +tool_call+, +context:+, and must yield to
+  # continue the chain.
+  #
+  #   class MyRuntime < Riffer::ToolRuntime
+  #     around_tool_execution do |tool_call, context:, &block|
+  #       puts "Before #{tool_call.name}"
+  #       result = block.call
+  #       puts "After #{tool_call.name}"
+  #       result
+  #     end
+  #   end
+  #
+  # : () { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+  def self.around_tool_execution: () { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+
+  # Returns the registered around-execution callbacks for this class.
+  #
+  # : () -> Array[Proc]
+  def self.execution_callbacks: () -> Array[Proc]
+
+  private
+
+  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def with_execution_context: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+
+  # : ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  def parse_arguments: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/tool_runtime/inline.rbs
+++ b/sig/generated/riffer/tool_runtime/inline.rbs
@@ -1,0 +1,7 @@
+# Generated from lib/riffer/tool_runtime/inline.rb with RBS::Inline
+
+# Executes tool calls sequentially in the current thread.
+#
+# This is the default tool runtime used when no runtime is configured.
+class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+end

--- a/sig/generated/riffer/tool_runtime/threaded.rbs
+++ b/sig/generated/riffer/tool_runtime/threaded.rbs
@@ -1,0 +1,15 @@
+# Generated from lib/riffer/tool_runtime/threaded.rb with RBS::Inline
+
+# Executes tool calls concurrently using threads.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime :threaded
+#   end
+class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
+  DEFAULT_MAX_CONCURRENCY: Integer
+
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #
+  # : (?max_concurrency: Integer) -> void
+  def initialize: (?max_concurrency: Integer) -> void
+end

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -88,6 +88,18 @@ describe Riffer::Agent::Response do
     end
   end
 
+  describe "#step" do
+    it "defaults to 0" do
+      response = Riffer::Agent::Response.new("Hello!")
+      expect(response.step).must_equal 0
+    end
+
+    it "stores the step count" do
+      response = Riffer::Agent::Response.new("Hello!", step: 5)
+      expect(response.step).must_equal 5
+    end
+  end
+
   describe "#interrupted?" do
     it "returns false by default" do
       response = Riffer::Agent::Response.new("Hello!")

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2091,6 +2091,29 @@ describe Riffer::Agent do
         expect(first_called).must_equal true
       end
     end
+
+    describe "#interrupt!" do
+      it "interrupts the agent loop" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt! }
+        result = agent.generate("Hello")
+        expect(result.interrupted?).must_equal true
+      end
+
+      it "passes reason to interrupt_reason" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt!(:needs_approval) }
+        result = agent.generate("Hello")
+        expect(result.interrupt_reason).must_equal :needs_approval
+      end
+
+      it "defaults reason to nil" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt! }
+        result = agent.generate("Hello")
+        expect(result.interrupt_reason).must_be_nil
+      end
+    end
   end
 
   describe "#resume" do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2293,6 +2293,68 @@ describe Riffer::Agent do
         expect(system_messages.first.content).must_equal "Custom instructions."
       end
     end
+
+    describe "with step offset" do
+      let(:tool_class) do
+        Class.new(Riffer::Tool) do
+          description "Simple tool"
+          def call(context:)
+            text("done")
+          end
+        end.tap { |t| t.identifier("resume_step_tool") }
+      end
+
+      it "enforces max_steps across sessions" do
+        tc = tool_class
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          max_steps 3
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        3.times { provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}]) }
+
+        # First generate: runs 2 steps then gets interrupted by callback
+        interrupted_once = false
+        agent.on_message do |msg|
+          if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
+            interrupted_once = true
+            throw :riffer_interrupt
+          end
+        end
+
+        result = agent.generate("Do stuff")
+        expect(result.interrupted?).must_equal true
+        prior_step = result.step
+
+        # Resume with step offset: should hit max_steps sooner
+        result = agent.resume(step: prior_step)
+        expect(result.interrupted?).must_equal true
+        expect(result.interrupt_reason).must_equal :max_steps
+      end
+
+      it "includes cumulative step count in response" do
+        tc = tool_class
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          max_steps 5
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}])
+        provider.stub_response("Done!")
+
+        result = agent.resume(
+          messages: [Riffer::Messages::User.new("Continue")],
+          step: 3
+        )
+        expect(result.step).must_equal 5
+      end
+    end
   end
 
   describe "#resume_stream" do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -240,6 +240,52 @@ describe Riffer::Agent do
         result = agent.generate("Do stuff")
         expect(result.interrupt_reason).must_equal :max_steps
       end
+
+      it "includes step count in response" do
+        tc = tool_class
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          max_steps 2
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        3.times { provider.stub_response("", tool_calls: [{name: "max_steps_tool", arguments: "{}"}]) }
+
+        result = agent.generate("Do stuff")
+        expect(result.step).must_equal 2
+      end
+    end
+
+    describe "response step count" do
+      it "returns step count of 1 for a single LLM call" do
+        agent = agent_class.new
+        result = agent.generate("Hello")
+        expect(result.step).must_equal 1
+      end
+
+      it "counts steps across tool loops" do
+        tc = Class.new(Riffer::Tool) do
+          description "Simple tool"
+          def call(context:)
+            text("done")
+          end
+        end.tap { |t| t.identifier("step_count_tool") }
+
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        2.times { provider.stub_response("", tool_calls: [{name: "step_count_tool", arguments: "{}"}]) }
+        provider.stub_response("Final answer")
+
+        result = agent.generate("Do stuff")
+        expect(result.step).must_equal 3
+      end
     end
 
     describe "with mock provider" do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1000,6 +1000,110 @@ describe Riffer::Agent do
     end
   end
 
+  describe ".tool_runtime" do
+    it "returns nil when not set" do
+      expect(agent_class.tool_runtime).must_be_nil
+    end
+
+    it "sets the tool_runtime symbol" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      expect(agent.tool_runtime).must_equal :threaded
+    end
+
+    it "defaults to inline when no config" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "uses threaded runtime with :threaded symbol" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Threaded
+    end
+
+    it "uses lambda resolution with zero arity" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime -> { :inline }
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "passes tool_context to lambda with arity 1" do
+      received_context = nil
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime ->(ctx) {
+          received_context = ctx
+          :inline
+        }
+      end
+
+      instance = agent.new
+      instance.instance_variable_set(:@tool_context, {user_id: 42})
+      instance.send(:resolve_tool_runtime)
+
+      expect(received_context).must_equal({user_id: 42})
+    end
+
+    it "uses global config as fallback" do
+      original = Riffer.config.tool_runtime
+      begin
+        Riffer.config.tool_runtime = :threaded
+        agent = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+        end
+        runtime = agent.new.send(:resolve_tool_runtime)
+        expect(runtime).must_be_instance_of Riffer::ToolRuntime::Threaded
+      ensure
+        Riffer.config.tool_runtime = original
+      end
+    end
+
+    it "per-agent config overrides global config" do
+      original = Riffer.config.tool_runtime
+      begin
+        Riffer.config.tool_runtime = :threaded
+        agent = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          tool_runtime :inline
+        end
+        runtime = agent.new.send(:resolve_tool_runtime)
+        expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+      ensure
+        Riffer.config.tool_runtime = original
+      end
+    end
+
+    it "accepts a ToolRuntime instance" do
+      custom_runtime = Riffer::ToolRuntime::Inline.new
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime custom_runtime
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_equal custom_runtime
+    end
+
+    it "raises for invalid tool_runtime" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime "invalid"
+      end
+      expect { agent.new.send(:resolve_tool_runtime) }.must_raise Riffer::ArgumentError
+    end
+  end
+
   describe "dynamic model selection" do
     it "resolves lambda for generate" do
       dynamic_agent_class = Class.new(Riffer::Agent) do

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -23,6 +23,19 @@ describe Riffer::Config do
     end
   end
 
+  describe "tool_runtime" do
+    it "defaults to Inline instance" do
+      config = Riffer::Config.new
+      expect(config.tool_runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "allows setting tool_runtime" do
+      config = Riffer::Config.new
+      config.tool_runtime = :threaded
+      expect(config.tool_runtime).must_equal :threaded
+    end
+  end
+
   describe "evals namespace" do
     it "initializes with nil judge_model" do
       config = Riffer::Config.new

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Runner do
+  describe "#map" do
+    it "raises NotImplementedError" do
+      runner = Riffer::Runner.new
+      expect { runner.map([1, 2, 3]) { |n| n } }.must_raise NotImplementedError
+    end
+  end
+end
+
+describe Riffer::Runner::Sequential do
+  describe "#map" do
+    it "returns results in order" do
+      runner = Riffer::Runner::Sequential.new
+      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      expect(results).must_equal [2, 4, 6]
+    end
+
+    it "handles empty items" do
+      runner = Riffer::Runner::Sequential.new
+      results = runner.map([]) { |n| n }
+      expect(results).must_equal []
+    end
+  end
+end
+
+describe Riffer::Runner::Threaded do
+  describe "#map" do
+    it "returns results in order" do
+      runner = Riffer::Runner::Threaded.new
+      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      expect(results).must_equal [2, 4, 6]
+    end
+
+    it "executes concurrently" do
+      runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+      thread_ids = Mutex.new
+      seen = []
+
+      runner.map([1, 2, 3]) do |n|
+        thread_ids.synchronize { seen << Thread.current.object_id }
+        sleep 0.01
+        n
+      end
+
+      # Each item runs in its own thread, so we should see distinct thread ids
+      expect(seen.uniq.length).must_equal 3
+    end
+
+    it "respects max_concurrency" do
+      runner = Riffer::Runner::Threaded.new(max_concurrency: 2)
+      mutex = Mutex.new
+      concurrent = 0
+      max_concurrent = 0
+
+      runner.map([1, 2, 3, 4]) do |n|
+        mutex.synchronize do
+          concurrent += 1
+          max_concurrent = [max_concurrent, concurrent].max
+        end
+        sleep 0.02
+        mutex.synchronize { concurrent -= 1 }
+        n
+      end
+
+      expect(max_concurrent).must_be :<=, 2
+    end
+
+    it "handles empty items" do
+      runner = Riffer::Runner::Threaded.new
+      results = runner.map([]) { |n| n }
+      expect(results).must_equal []
+    end
+  end
+end

--- a/test/riffer/stream_events/interrupt_test.rb
+++ b/test/riffer/stream_events/interrupt_test.rb
@@ -15,15 +15,27 @@ describe Riffer::StreamEvents::Interrupt do
     end
   end
 
-  describe "#to_h" do
-    it "returns hash with role" do
+  describe "#step" do
+    it "defaults to 0" do
       event = Riffer::StreamEvents::Interrupt.new
-      expect(event.to_h).must_equal({role: :system, interrupt: true})
+      expect(event.step).must_equal 0
+    end
+
+    it "stores the step count" do
+      event = Riffer::StreamEvents::Interrupt.new(step: 3)
+      expect(event.step).must_equal 3
+    end
+  end
+
+  describe "#to_h" do
+    it "returns hash with role and step" do
+      event = Riffer::StreamEvents::Interrupt.new
+      expect(event.to_h).must_equal({role: :system, interrupt: true, step: 0})
     end
 
     it "includes symbol reason in hash" do
-      event = Riffer::StreamEvents::Interrupt.new(reason: :max_steps)
-      expect(event.to_h).must_equal({role: :system, interrupt: true, reason: :max_steps})
+      event = Riffer::StreamEvents::Interrupt.new(reason: :max_steps, step: 2)
+      expect(event.to_h).must_equal({role: :system, interrupt: true, step: 2, reason: :max_steps})
     end
   end
 end

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::ToolRuntime do
+  let(:weather_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "weather_tool"
+      description "Gets the weather"
+
+      params do
+        required :city, String
+      end
+
+      def call(context:, city:)
+        text("Weather in #{city}: 20 degrees")
+      end
+    end
+  end
+
+  let(:slow_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "slow_tool"
+      description "A slow tool"
+      timeout 0.01
+
+      def call(context:, **)
+        sleep 0.02
+        text("done")
+      end
+    end
+  end
+
+  let(:tools) { [weather_tool_class] }
+  let(:context) { nil }
+
+  def make_tool_call(name:, arguments:, id: "call_1")
+    Riffer::Messages::Assistant::ToolCall.new(
+      id: id,
+      call_id: "call_id_#{id}",
+      name: name,
+      arguments: arguments
+    )
+  end
+
+  describe "#call" do
+    it "dispatches to correct tool and returns response" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      result = runtime.call(tool_call, tools: tools, context: context)
+
+      expect(result).must_be_instance_of Riffer::Tools::Response
+      expect(result.content).must_equal "Weather in Toronto: 20 degrees"
+      expect(result.success?).must_equal true
+    end
+
+    it "returns error response for unknown tool" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "nonexistent", arguments: "{}")
+
+      result = runtime.call(tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :unknown_tool
+      expect(result.content).must_match(/Unknown tool 'nonexistent'/)
+    end
+
+    it "returns error response for validation failure" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: "{}")
+
+      result = runtime.call(tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :validation_error
+    end
+
+    it "returns error response for timeout" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "slow_tool", arguments: "{}")
+
+      result = runtime.call(tool_call, tools: [slow_tool_class], context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :timeout_error
+    end
+
+    it "returns error response for execution error" do
+      error_tool = Class.new(Riffer::Tool) do
+        identifier "error_tool"
+        description "Raises an error"
+
+        def call(context:, **)
+          raise "Something went wrong"
+        end
+      end
+
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "error_tool", arguments: "{}")
+
+      result = runtime.call(tool_call, tools: [error_tool], context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :execution_error
+      expect(result.content).must_match(/Something went wrong/)
+    end
+  end
+
+  describe "#execute" do
+    it "returns [tool_call, response] pairs in order" do
+      runtime = Riffer::ToolRuntime.new
+      tc1 = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', id: "1")
+      tc2 = make_tool_call(name: "weather_tool", arguments: '{"city":"London"}', id: "2")
+
+      results = runtime.execute([tc1, tc2], tools: tools, context: context)
+
+      expect(results.length).must_equal 2
+      expect(results[0][0]).must_equal tc1
+      expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+      expect(results[1][0]).must_equal tc2
+      expect(results[1][1].content).must_equal "Weather in London: 20 degrees"
+    end
+  end
+
+  describe ".around_tool_execution" do
+    it "wraps each call" do
+      log = []
+      runtime_class = Class.new(Riffer::ToolRuntime) do
+        around_tool_execution do |tool_call, context:, &block|
+          log << "before:#{tool_call.name}"
+          result = block.call
+          log << "after:#{tool_call.name}"
+          result
+        end
+      end
+
+      runtime = runtime_class.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      runtime.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
+    end
+
+    it "composes multiple callbacks in order" do
+      log = []
+      runtime_class = Class.new(Riffer::ToolRuntime) do
+        around_tool_execution do |tool_call, context:, &block|
+          log << "outer:before"
+          result = block.call
+          log << "outer:after"
+          result
+        end
+
+        around_tool_execution do |tool_call, context:, &block|
+          log << "inner:before"
+          result = block.call
+          log << "inner:after"
+          result
+        end
+      end
+
+      runtime = runtime_class.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      runtime.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["outer:before", "inner:before", "inner:after", "outer:after"]
+    end
+  end
+end
+
+describe Riffer::ToolRuntime::Inline do
+  it "behaves identically to base" do
+    runtime = Riffer::ToolRuntime::Inline.new
+    expect(runtime).must_be_kind_of Riffer::ToolRuntime
+  end
+
+  it "executes tool calls sequentially" do
+    weather_tool = Class.new(Riffer::Tool) do
+      identifier "weather_tool"
+      description "Gets the weather"
+
+      params do
+        required :city, String
+      end
+
+      def call(context:, city:)
+        text("Weather in #{city}: 20 degrees")
+      end
+    end
+
+    runtime = Riffer::ToolRuntime::Inline.new
+    tool_call = Riffer::Messages::Assistant::ToolCall.new(
+      id: "1", call_id: "cid_1", name: "weather_tool", arguments: '{"city":"Toronto"}'
+    )
+
+    results = runtime.execute([tool_call], tools: [weather_tool], context: nil)
+
+    expect(results.length).must_equal 1
+    expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+  end
+end
+
+describe Riffer::ToolRuntime::Threaded do
+  it "executes tool calls in parallel" do
+    thread_ids = Mutex.new
+    seen = []
+
+    tracking_tool = Class.new(Riffer::Tool) do
+      identifier "tracking_tool"
+      description "Tracks threads"
+
+      define_method(:call) do |context:, **|
+        thread_ids.synchronize { seen << Thread.current.object_id }
+        sleep 0.01
+        text("done")
+      end
+    end
+
+    runtime = Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
+    tool_calls = 3.times.map do |i|
+      Riffer::Messages::Assistant::ToolCall.new(
+        id: i.to_s, call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
+      )
+    end
+
+    results = runtime.execute(tool_calls, tools: [tracking_tool], context: nil)
+
+    expect(results.length).must_equal 3
+    expect(seen.uniq.length).must_equal 3
+  end
+end


### PR DESCRIPTION
## Summary

- Introduces `Riffer::Runner` (Sequential/Threaded) as a generic concurrency primitive with `map(items, &block)` interface
- Introduces `Riffer::ToolRuntime` (Inline/Threaded) to decouple tool execution from the agent loop, with `execute` (batch), `call` (single), and `around_tool_execution` class-level callbacks
- Adds `tool_runtime` DSL to agents (per-agent and global config) with symbol, instance, and Proc resolution
- Refactors `Agent#execute_tool_calls` and `execute_pending_tool_calls` to delegate to the runtime
- Removes `execute_tool_call`, `find_tool_class`, `parse_tool_arguments` from Agent (moved to ToolRuntime)
- Config defaults `tool_runtime` to `Riffer::ToolRuntime::Inline.new`
- All marked as **experimental** — may be removed without warning

## Test plan

- [ ] All 980 existing + new tests pass (`bundle exec rake`)
- [ ] New runner tests verify sequential ordering, threaded concurrency, and max_concurrency
- [ ] New tool_runtime tests cover dispatch, error handling, around callbacks, inline/threaded
- [ ] New agent DSL tests cover symbol/lambda/instance resolution, global fallback, per-agent override
- [ ] Config tests verify default and setter

🤖 Generated with [Claude Code](https://claude.com/claude-code)