### PR TITLE
feat: Add Riffer::Boolean sentinel type for boolean params

### DIFF
--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -104,9 +104,12 @@ Options:
 | `String`                   | `string`         |
 | `Integer`                  | `integer`        |
 | `Float`                    | `number`         |
+| `Riffer::Boolean`          | `boolean`        |
 | `TrueClass` / `FalseClass` | `boolean`        |
 | `Array`                    | `array`          |
 | `Hash`                     | `object`         |
+
+`Riffer::Boolean` is the preferred way to declare boolean parameters. `TrueClass` and `FalseClass` continue to work for backwards compatibility.
 
 ### Nested Parameters
 

--- a/lib/riffer/boolean.rb
+++ b/lib/riffer/boolean.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Riffer::Boolean is a sentinel type for declaring boolean parameters.
+#
+# Ruby has no +Boolean+ class (+true+ is +TrueClass+, +false+ is +FalseClass+).
+# Use this module wherever you need a single type that means "boolean":
+#
+#   required :verbose, Riffer::Boolean
+#
+module Riffer::Boolean
+end

--- a/lib/riffer/param.rb
+++ b/lib/riffer/param.rb
@@ -10,11 +10,12 @@ class Riffer::Param
     String => "string",
     Integer => "integer",
     Float => "number",
+    Riffer::Boolean => "boolean",
     TrueClass => "boolean",
     FalseClass => "boolean",
     Array => "array",
     Hash => "object"
-  }.freeze #: Hash[Class, String]
+  }.freeze #: Hash[Module, String]
 
   # Primitive types allowed for the +of:+ keyword on Array params
   PRIMITIVE_TYPES = (TYPE_MAPPINGS.keys - [Array, Hash]).freeze #: Array[Class]
@@ -46,7 +47,7 @@ class Riffer::Param
   def valid_type?(value)
     return true if value.nil? && !required
 
-    if type == TrueClass || type == FalseClass
+    if type == Riffer::Boolean || type == TrueClass || type == FalseClass
       value == true || value == false
     else
       value.is_a?(type)

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -193,7 +193,7 @@ class Riffer::Params
   def validate_typed_array(param, value, errors)
     type_name = Riffer::Param::TYPE_MAPPINGS[param.item_type]
     value.each_with_index do |item, i|
-      valid = if param.item_type == TrueClass || param.item_type == FalseClass
+      valid = if param.item_type == Riffer::Boolean || param.item_type == TrueClass || param.item_type == FalseClass
         item == true || item == false
       else
         item.is_a?(param.item_type)

--- a/sig/generated/riffer/boolean.rbs
+++ b/sig/generated/riffer/boolean.rbs
@@ -1,0 +1,10 @@
+# Generated from lib/riffer/boolean.rb with RBS::Inline
+
+# Riffer::Boolean is a sentinel type for declaring boolean parameters.
+#
+# Ruby has no +Boolean+ class (+true+ is +TrueClass+, +false+ is +FalseClass+).
+# Use this module wherever you need a single type that means "boolean":
+#
+#   required :verbose, Riffer::Boolean
+module Riffer::Boolean
+end

--- a/sig/generated/riffer/param.rbs
+++ b/sig/generated/riffer/param.rbs
@@ -5,7 +5,7 @@
 # Handles type validation and JSON Schema generation for individual parameters.
 class Riffer::Param
   # Maps Ruby types to JSON Schema type strings
-  TYPE_MAPPINGS: Hash[Class, String]
+  TYPE_MAPPINGS: Hash[Module, String]
 
   # Primitive types allowed for the +of:+ keyword on Array params
   PRIMITIVE_TYPES: Array[Class]

--- a/test/riffer/param_test.rb
+++ b/test/riffer/param_test.rb
@@ -66,6 +66,21 @@ describe Riffer::Param do
       expect(param.valid_type?(false)).must_equal true
     end
 
+    it "returns true for true with Riffer::Boolean type" do
+      param = Riffer::Param.new(name: :enabled, type: Riffer::Boolean, required: true)
+      expect(param.valid_type?(true)).must_equal true
+    end
+
+    it "returns true for false with Riffer::Boolean type" do
+      param = Riffer::Param.new(name: :enabled, type: Riffer::Boolean, required: true)
+      expect(param.valid_type?(false)).must_equal true
+    end
+
+    it "returns false for non-boolean with Riffer::Boolean type" do
+      param = Riffer::Param.new(name: :enabled, type: Riffer::Boolean, required: true)
+      expect(param.valid_type?("true")).must_equal false
+    end
+
     it "returns true for nil on optional params" do
       param = Riffer::Param.new(name: :city, type: String, required: false)
       expect(param.valid_type?(nil)).must_equal true
@@ -100,6 +115,11 @@ describe Riffer::Param do
 
     it "returns 'boolean' for TrueClass" do
       param = Riffer::Param.new(name: :enabled, type: TrueClass, required: true)
+      expect(param.type_name).must_equal "boolean"
+    end
+
+    it "returns 'boolean' for Riffer::Boolean" do
+      param = Riffer::Param.new(name: :enabled, type: Riffer::Boolean, required: true)
       expect(param.type_name).must_equal "boolean"
     end
 


### PR DESCRIPTION
## Summary

- Add `Riffer::Boolean` module as a sentinel type so users can write `required :verbose, Riffer::Boolean` instead of `TrueClass`/`FalseClass`
- Update `Param` and `Params` validation to recognize the new type
- Keep `TrueClass`/`FalseClass` working for backwards compatibility
- Update docs and add tests

## Test plan

- [x] All tests pass
- [x] StandardRB lint passes
- [x] Steep type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)