### PR TITLE
refactor: standardize on symbol keys for internal hashes

### DIFF
--- a/.agents/code-style.md
+++ b/.agents/code-style.md
@@ -30,6 +30,13 @@ end
 - Explain **why** something is done, not **what** is being done
 - Comments should add value beyond what the code already expresses
 
+## Hash Key Convention
+
+- Use **symbol keys** for all internal hashes
+- Use `JSON.parse(str, symbolize_names: true)` at parse boundaries — never `JSON.parse` followed by `transform_keys(&:to_sym)`
+- String keys are only used at serialization boundaries (JSON Schema output, external API payloads)
+- Do not write dual-access patterns like `hash[:key] || hash["key"]` — normalize to symbol keys at the boundary instead
+
 ## Module Structure
 
 ```ruby

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -606,12 +606,11 @@ class Riffer::Agent
     resolved_tools.find { |tool_class| tool_class.name == name }
   end
 
-  #: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  #: (String?) -> Hash[Symbol, untyped]
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
 
-    args = arguments.is_a?(String) ? JSON.parse(arguments) : arguments
-    args.transform_keys(&:to_sym)
+    JSON.parse(arguments, symbolize_names: true)
   end
 
   #: () -> Riffer::Messages::Assistant?

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -120,9 +120,9 @@ class Riffer::Evals::Judge
     tool_call = response.tool_calls.first
     raise Riffer::Error, "Invalid judge response: no tool call found" unless tool_call
 
-    parsed = JSON.parse(tool_call[:arguments])
-    score = parsed["score"]
-    reason = parsed["reason"]
+    parsed = JSON.parse(tool_call[:arguments], symbolize_names: true)
+    score = parsed[:score]
+    reason = parsed[:reason]
 
     raise Riffer::Error, "Invalid judge response: missing score" if score.nil?
 

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -9,7 +9,7 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
-  #: ((Hash[Symbol | String, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
+  #: ((Hash[Symbol, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
   def convert_to_message_object(msg)
     return msg if msg.is_a?(Riffer::Messages::Base)
 
@@ -29,7 +29,7 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the hash format is invalid.
   #
-  #: ((Hash[Symbol | String, untyped] | Riffer::FilePart)) -> Riffer::FilePart
+  #: ((Hash[Symbol, untyped] | Riffer::FilePart)) -> Riffer::FilePart
   def convert_to_file_part(file)
     return file if file.is_a?(Riffer::FilePart)
 
@@ -37,10 +37,10 @@ module Riffer::Messages::Converter
       raise Riffer::ArgumentError, "File must be a Hash or FilePart object, got #{file.class}"
     end
 
-    url = file[:url] || file["url"]
-    data = file[:data] || file["data"]
-    media_type = file[:media_type] || file["media_type"]
-    filename = file[:filename] || file["filename"]
+    url = file[:url]
+    data = file[:data]
+    media_type = file[:media_type]
+    filename = file[:filename]
 
     if url
       Riffer::FilePart.from_url(url, media_type: media_type)
@@ -53,10 +53,10 @@ module Riffer::Messages::Converter
 
   private
 
-  #: (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
+  #: (Hash[Symbol, untyped]) -> Riffer::Messages::Base
   def convert_hash_to_message(hash)
-    role = hash[:role] || hash["role"]
-    content = hash[:content] || hash["content"]
+    role = hash[:role]
+    content = hash[:content]
 
     if role.nil? || role.empty?
       raise Riffer::ArgumentError, "Message hash must include a 'role' key"
@@ -64,17 +64,17 @@ module Riffer::Messages::Converter
 
     case role.to_sym
     when :user
-      files = (hash[:files] || hash["files"] || []).map { |f| convert_to_file_part(f) }
+      files = (hash[:files] || []).map { |f| convert_to_file_part(f) }
       Riffer::Messages::User.new(content, files: files)
     when :assistant
-      tool_calls = hash[:tool_calls] || hash["tool_calls"] || []
-      structured_output = hash[:structured_output] || hash["structured_output"]
+      tool_calls = hash[:tool_calls] || []
+      structured_output = hash[:structured_output]
       Riffer::Messages::Assistant.new(content, tool_calls: tool_calls, structured_output: structured_output)
     when :system
       Riffer::Messages::System.new(content)
     when :tool
-      tool_call_id = hash[:tool_call_id] || hash["tool_call_id"]
-      name = hash[:name] || hash["name"]
+      tool_call_id = hash[:tool_call_id]
+      name = hash[:name]
       Riffer::Messages::Tool.new(content, tool_call_id: tool_call_id, name: name)
     else
       raise Riffer::ArgumentError, "Unknown message role: #{role}"

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -163,13 +163,12 @@ class Riffer::Params
 
   #: (Riffer::Param, Hash[Symbol, untyped], Array[String]) -> Hash[Symbol, untyped]
   def validate_nested_hash(param, value, errors)
-    sym_value = deep_symbolize_keys(value)
-    param.nested_params.validate(sym_value)
+    param.nested_params.validate(value)
   rescue Riffer::ValidationError => e
     e.message.split("; ").each do |msg|
       errors << "#{param.name}.#{msg}"
     end
-    sym_value
+    value
   end
 
   #: (Riffer::Param, Array[untyped], Array[String]) -> Array[untyped]
@@ -179,13 +178,12 @@ class Riffer::Params
         errors << "#{param.name}[#{i}] must be an object"
         next item
       end
-      sym_item = deep_symbolize_keys(item)
-      param.nested_params.validate(sym_item)
+      param.nested_params.validate(item)
     rescue Riffer::ValidationError => e
       e.message.split("; ").each do |msg|
         errors << "#{param.name}[#{i}].#{msg}"
       end
-      sym_item
+      item
     end
   end
 
@@ -199,17 +197,6 @@ class Riffer::Params
         item.is_a?(param.item_type)
       end
       errors << "#{param.name}[#{i}] must be a #{type_name}" unless valid
-    end
-  end
-
-  #: (Hash[untyped, untyped]) -> Hash[Symbol, untyped]
-  def deep_symbolize_keys(hash)
-    hash.each_with_object({}) do |(key, value), result|
-      result[key.to_sym] = case value
-      when Hash then deep_symbolize_keys(value)
-      when Array then value.map { |v| v.is_a?(Hash) ? deep_symbolize_keys(v) : v }
-      else value
-      end
     end
   end
 end

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -231,11 +231,11 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   def handle_content_block_stop_server_tool_use(_event, state:, yielder:)
     return unless state[:web_search_json]
 
-    input = JSON.parse(state[:web_search_json])
-    state[:web_search_query] = input["query"]
+    input = JSON.parse(state[:web_search_json], symbolize_names: true)
+    state[:web_search_query] = input[:query]
     state[:web_search_index] = nil
     state[:web_search_json] = nil
-    yielder << Riffer::StreamEvents::WebSearchStatus.new("searching", query: input["query"])
+    yielder << Riffer::StreamEvents::WebSearchStatus.new("searching", query: input[:query])
   end
 
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void

--- a/lib/riffer/structured_output.rb
+++ b/lib/riffer/structured_output.rb
@@ -33,8 +33,8 @@ class Riffer::StructuredOutput
   #
   #: (String) -> Riffer::StructuredOutput::Result
   def parse_and_validate(json_string)
-    parsed = JSON.parse(json_string)
-    validated = @params.validate(parsed.transform_keys(&:to_sym))
+    parsed = JSON.parse(json_string, symbolize_names: true)
+    validated = @params.validate(parsed)
     Result.new(object: validated)
   rescue JSON::ParserError => e
     Result.new(error: "JSON parse error: #{e.message}")

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -228,8 +228,8 @@ class Riffer::Agent
   # : (String) -> singleton(Riffer::Tool)?
   def find_tool_class: (String) -> singleton(Riffer::Tool)?
 
-  # : ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
-  def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[Symbol, untyped]
+  # : (String?) -> Hash[Symbol, untyped]
+  def parse_tool_arguments: (String?) -> Hash[Symbol, untyped]
 
   # : () -> Riffer::Messages::Assistant?
   def extract_final_response: () -> Riffer::Messages::Assistant?

--- a/sig/generated/riffer/messages/converter.rbs
+++ b/sig/generated/riffer/messages/converter.rbs
@@ -8,8 +8,8 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
-  # : ((Hash[Symbol | String, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
-  def convert_to_message_object: (Hash[Symbol | String, untyped] | Riffer::Messages::Base) -> Riffer::Messages::Base
+  # : ((Hash[Symbol, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
+  def convert_to_message_object: (Hash[Symbol, untyped] | Riffer::Messages::Base) -> Riffer::Messages::Base
 
   # Converts a hash or FilePart object to a Riffer::FilePart.
   #
@@ -20,11 +20,11 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the hash format is invalid.
   #
-  # : ((Hash[Symbol | String, untyped] | Riffer::FilePart)) -> Riffer::FilePart
-  def convert_to_file_part: (Hash[Symbol | String, untyped] | Riffer::FilePart) -> Riffer::FilePart
+  # : ((Hash[Symbol, untyped] | Riffer::FilePart)) -> Riffer::FilePart
+  def convert_to_file_part: (Hash[Symbol, untyped] | Riffer::FilePart) -> Riffer::FilePart
 
   private
 
-  # : (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
-  def convert_hash_to_message: (Hash[Symbol | String, untyped]) -> Riffer::Messages::Base
+  # : (Hash[Symbol, untyped]) -> Riffer::Messages::Base
+  def convert_hash_to_message: (Hash[Symbol, untyped]) -> Riffer::Messages::Base
 end

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -57,7 +57,4 @@ class Riffer::Params
 
   # : (Riffer::Param, Array[untyped], Array[String]) -> void
   def validate_typed_array: (Riffer::Param, Array[untyped], Array[String]) -> void
-
-  # : (Hash[untyped, untyped]) -> Hash[Symbol, untyped]
-  def deep_symbolize_keys: (Hash[untyped, untyped]) -> Hash[Symbol, untyped]
 end

--- a/test/riffer/messages/converter_test.rb
+++ b/test/riffer/messages/converter_test.rb
@@ -83,12 +83,6 @@ describe Riffer::Messages::Converter do
         expect(result.structured_output).must_equal({sentiment: "positive"})
       end
 
-      it "handles string keys for structured_output" do
-        result = instance.convert_to_message_object({"role" => "assistant", "content" => '{"sentiment":"positive"}', "structured_output" => {sentiment: "positive"}})
-        expect(result.structured_output?).must_equal true
-        expect(result.structured_output).must_equal({sentiment: "positive"})
-      end
-
       it "defaults to nil when not provided" do
         result = instance.convert_to_message_object({role: "assistant", content: "Hello"})
         expect(result.structured_output?).must_equal false
@@ -111,12 +105,6 @@ describe Riffer::Messages::Converter do
         result = instance.convert_to_message_object(assistant_message)
         expect(result.tool_calls).must_equal [tool_call]
       end
-    end
-
-    it "handles string keys in hashes" do
-      result = instance.convert_to_message_object({"role" => "user", "content" => "Hello"})
-      expect(result).must_be_instance_of Riffer::Messages::User
-      expect(result.content).must_equal "Hello"
     end
 
     describe "with user message with files" do
@@ -151,15 +139,6 @@ describe Riffer::Messages::Converter do
       it "defaults to empty files when not provided" do
         result = instance.convert_to_message_object({role: "user", content: "Hello"})
         expect(result.files).must_equal []
-      end
-
-      it "handles string keys for files" do
-        result = instance.convert_to_message_object({
-          "role" => "user",
-          "content" => "Describe this",
-          "files" => [{"data" => "aGVsbG8=", "media_type" => "image/png"}]
-        })
-        expect(result.files.length).must_equal 1
       end
     end
   end

--- a/test/riffer/params_test.rb
+++ b/test/riffer/params_test.rb
@@ -317,15 +317,6 @@ describe Riffer::Params do
       expect(result[:address]).must_equal({city: "Toronto"})
     end
 
-    it "deep symbolizes string keys in nested Hash" do
-      params = Riffer::Params.new
-      params.required(:address, Hash) do
-        required :city, String
-      end
-      result = params.validate({address: {"city" => "Toronto"}})
-      expect(result[:address]).must_equal({city: "Toronto"})
-    end
-
     it "accepts valid array of objects" do
       params = Riffer::Params.new
       params.required(:items, Array) do
@@ -333,26 +324,6 @@ describe Riffer::Params do
       end
       result = params.validate({items: [{name: "A"}, {name: "B"}]})
       expect(result[:items]).must_equal [{name: "A"}, {name: "B"}]
-    end
-
-    it "deep symbolizes string keys in array of objects" do
-      params = Riffer::Params.new
-      params.required(:items, Array) do
-        required :name, String
-      end
-      result = params.validate({items: [{"name" => "A"}, {"name" => "B"}]})
-      expect(result[:items]).must_equal [{name: "A"}, {name: "B"}]
-    end
-
-    it "deep symbolizes keys in deeply nested structures" do
-      params = Riffer::Params.new
-      params.required(:order, Hash) do
-        required :shipping, Hash do
-          required :city, String
-        end
-      end
-      result = params.validate({order: {"shipping" => {"city" => "Toronto"}}})
-      expect(result[:order]).must_equal({shipping: {city: "Toronto"}})
     end
   end
 


### PR DESCRIPTION
## Summary

- Use `JSON.parse(str, symbolize_names: true)` at parse boundaries instead of `JSON.parse` followed by `transform_keys(&:to_sym)` — applies to `agent.rb`, `structured_output.rb`, `evals/judge.rb`, and `providers/anthropic.rb`
- Remove dual string/symbol key access (`hash[:key] || hash["key"]`) in the message converter — string keys were never part of the public API
- Remove `deep_symbolize_keys` from `Params` and the Hash branch from `Agent#parse_tool_arguments` since all providers pass JSON strings (not pre-parsed hashes)
- Narrow RBS type signatures from `Hash[Symbol | String, untyped]` to `Hash[Symbol, untyped]`
- Document the hash key convention in `.agents/code-style.md`

## Test plan

- [x] All tests pass
- [x] StandardRB lint passes
- [x] Steep type checking passes
- [ ] Verify no downstream consumers pass string-keyed hashes to Riffer

🤖 Generated with [Claude Code](https://claude.com/claude-code)