### PR TITLE
feat: add support for agent skills

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -4,7 +4,7 @@
 
 ### Agent (`lib/riffer/agent.rb`)
 
-Base class for AI agents. Subclass and use DSL methods `model`, `instructions`, and `structured_output` to configure. Orchestrates message flow, LLM calls, tool execution, and structured output parsing via a generate/stream loop.
+Base class for AI agents. Subclass and use DSL methods `model`, `instructions`, `structured_output`, and `skills` to configure. Orchestrates message flow, LLM calls, tool execution, structured output parsing, and skill activation via a generate/stream loop.
 
 ```ruby
 class EchoAgent < Riffer::Agent
@@ -39,6 +39,22 @@ Adapters for LLM APIs. The base class uses a template-method pattern — `genera
 - `extract_tool_calls(response)` — extract tool calls from the SDK response
 
 Providers are registered in `Riffer::Providers::Repository::REPO` with identifiers (e.g., `openai`, `amazon_bedrock`).
+
+Each provider declares a preferred skill adapter via `self.skills_adapter` (Markdown for most, XML for Anthropic).
+
+### Skills (`lib/riffer/skills/`)
+
+Support for the [Agent Skills spec](https://agentskills.io/). Skills are packaged as directories containing `SKILL.md` files with YAML frontmatter. The framework discovers skills through a pluggable backend, injects metadata into the system prompt, and provides a tool (`skill_activate`) for the LLM to load full skill instructions on demand.
+
+- `Config` - DSL configuration object (`backend`, `adapter`, `activate`)
+- `Backend` - base class interface (`list_skills`, `read_skill`)
+- `FilesystemBackend` - built-in filesystem scanner
+- `Frontmatter` - parsed YAML frontmatter value object with `.parse(raw)` class method
+- `Context` - coordinates discovery, activation, caching, and prompt rendering for a generation cycle
+- `Adapter` - base class for skill adapters (`render_catalog`, `activate_tool`)
+- `MarkdownAdapter` - default Markdown skill adapter
+- `XmlAdapter` - XML skill adapter for Anthropic/Claude
+- `ActivateTool` - default tool the LLM calls to activate a skill
 
 ### Messages (`lib/riffer/messages/`)
 
@@ -105,6 +121,17 @@ lib/
     params.rb            # Parameter collection with DSL and validation
     structured_output.rb # Structured output schema wrapper
     stream_events.rb     # Stream events namespace/module
+    skills.rb            # Skills namespace/module
+    skills/
+      config.rb          # DSL configuration object
+      adapter.rb         # Adapter base class (render_catalog, activate_tool)
+      markdown_adapter.rb # Default Markdown skill adapter
+      xml_adapter.rb     # XML skill adapter for Anthropic/Claude
+      backend.rb         # Backend base class (interface)
+      filesystem_backend.rb # Built-in filesystem backend
+      frontmatter.rb     # Parsed YAML frontmatter value object with .parse
+      context.rb         # Skills context for a generation cycle
+      activate_tool.rb   # Default skill_activate tool
     structured_output/
       result.rb          # Parse/validation result object
     helpers/

--- a/docs/10_SKILLS.md
+++ b/docs/10_SKILLS.md
@@ -1,0 +1,164 @@
+# Skills
+
+Skills are packaged AI agent capabilities per the [Agent Skills spec](https://agentskills.io/). Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. The framework discovers skills through a pluggable backend, injects a compact catalog into the system prompt (~50 tokens/skill), and provides a tool for the LLM to activate skills on demand.
+
+## Creating a Skill
+
+Create a directory with a `SKILL.md` file:
+
+```
+.skills/
+  code-review/
+    SKILL.md
+  data-analysis/
+    SKILL.md
+```
+
+Each `SKILL.md` has YAML frontmatter and a Markdown body:
+
+```markdown
+---
+name: code-review
+description: Reviews code for quality, style, and potential issues.
+---
+You are a code review assistant.
+
+Review the code for:
+- Style issues
+- Potential bugs
+- Performance problems
+```
+
+**Required frontmatter fields:**
+
+- `name` — lowercase alphanumeric with hyphens, 1-64 chars (must match directory name)
+- `description` — 1-1024 chars, helps the LLM decide when to activate
+
+Additional frontmatter keys are passed through as metadata.
+
+## Configuring an Agent
+
+Use the `skills` block DSL to configure skills:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model "openai/gpt-4o"
+  instructions "You are a helpful assistant."
+  skills do
+    backend Riffer::Skills::FilesystemBackend.new(".skills")
+  end
+end
+```
+
+Multiple directories can be scanned (first-path-wins for duplicates):
+
+```ruby
+skills do
+  backend Riffer::Skills::FilesystemBackend.new(".skills", "~/.riffer/skills")
+end
+```
+
+### Dynamic Backend via Proc
+
+```ruby
+skills do
+  backend ->(context) { tenant_backend(context[:tenant_id]) }
+end
+```
+
+### Custom Adapter
+
+The adapter controls how the skill catalog is rendered in the system prompt and which tool the LLM calls to activate a skill. The adapter is auto-selected by provider (Markdown for most, XML for Anthropic). Override with:
+
+```ruby
+skills do
+  backend Riffer::Skills::FilesystemBackend.new(".skills")
+  adapter Riffer::Skills::XmlAdapter
+end
+```
+
+### Activated Skills
+
+Load skill instructions into the system prompt at startup (no tool call needed):
+
+```ruby
+skills do
+  backend Riffer::Skills::FilesystemBackend.new(".skills")
+  activate ["code-review"]
+end
+```
+
+Accepts a Proc for dynamic resolution:
+
+```ruby
+skills do
+  backend Riffer::Skills::FilesystemBackend.new(".skills")
+  activate ->(context) { context[:active_skills] || [] }
+end
+```
+
+## How It Works
+
+1. **Discovery** — At the start of `generate`/`stream`, the backend's `list_skills` returns frontmatter for all available skills.
+2. **Catalog injection** — The adapter formats the catalog and appends it to the system prompt.
+3. **Activation** — When the LLM matches a task to a skill, it calls the `skill_activate` tool with the skill name. The tool returns the full SKILL.md body.
+4. **Execution** — The LLM follows the skill's instructions to complete the task.
+
+## Custom Backends
+
+Implement `Riffer::Skills::Backend` for non-filesystem storage:
+
+```ruby
+class DatabaseBackend < Riffer::Skills::Backend
+  def list_skills
+    # Return Array[Riffer::Skills::Frontmatter]
+  end
+
+  def read_skill(name)
+    # Return String (skill body)
+    # Raise Riffer::ArgumentError if not found
+  end
+end
+```
+
+## Custom Adapters
+
+Subclass `Riffer::Skills::Adapter` to customize how the skill catalog is rendered and which tool the LLM uses to activate skills:
+
+```ruby
+class CustomAdapter < Riffer::Skills::Adapter
+  def render_catalog(skills)
+    # Return String (skill catalog for the system prompt)
+    # Use `activate_tool.name` to reference the activation tool
+  end
+
+  def activate_tool
+    # Return a Riffer::Tool subclass
+    # Defaults to Riffer::Skills::ActivateTool
+    Riffer::Skills::ActivateTool
+  end
+end
+```
+
+The built-in adapters are `Riffer::Skills::MarkdownAdapter` (default) and `Riffer::Skills::XmlAdapter` (used by Anthropic).
+
+## Accessing Skills in Tools
+
+The skills context (`Riffer::Skills::Context`) is available via `context[:skills]` during execution:
+
+```ruby
+class SkillSearchTool < Riffer::Tool
+  identifier "skill_search"
+  description "Searches available skills."
+
+  params do
+    required :query, String
+  end
+
+  def call(context:, query:)
+    skills_context = context[:skills]  # Riffer::Skills::Context
+    matches = skills_context.skills.values.select { |s| s.description.include?(query) }
+    json(matches.map { |s| {name: s.name, description: s.description} })
+  end
+end
+```

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -142,6 +142,25 @@ class Riffer::Agent
     end
   end
 
+  # Configures skills for this agent via a block DSL.
+  #
+  # Returns the current Riffer::Skills::Config when called without a block.
+  #
+  #   skills do
+  #     backend Riffer::Skills::FilesystemBackend.new(".skills")
+  #     adapter Riffer::Skills::XmlAdapter
+  #     activate ["code-review"]
+  #   end
+  #
+  #: () ?{ () -> void } -> Riffer::Skills::Config?
+  def self.skills(&block)
+    if block
+      @skills_config = Riffer::Skills::Config.new
+      @skills_config.instance_eval(&block)
+    end
+    @skills_config
+  end
+
   # Finds an agent class by identifier.
   #
   #: (String) -> singleton(Riffer::Agent)?
@@ -393,8 +412,13 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages(prompt_or_messages, files: nil)
     @messages = []
-    instructions_text = generate_instructions
-    @messages << Riffer::Messages::System.new(instructions_text) if instructions_text
+
+    system_content = [
+      generate_instructions,
+      @skills_state&.system_prompt
+    ].compact.join("\n\n")
+
+    @messages << Riffer::Messages::System.new(system_content) unless system_content.empty?
 
     if prompt_or_messages.is_a?(Array)
       if files && !files.empty?
@@ -588,6 +612,7 @@ class Riffer::Agent
     clear_resolved_model
     @interrupted = false
     resolve_model
+    @skills_state = resolve_skills
   end
 
   #: (untyped) -> void
@@ -631,12 +656,21 @@ class Riffer::Agent
   def resolved_tools
     @resolved_tools ||= begin
       config = self.class.uses_tools
-      return [] if config.nil?
 
-      if config.is_a?(Proc)
+      tools = if config.nil?
+        []
+      elsif config.is_a?(Proc)
         (config.arity == 0) ? config.call : config.call(@context)
       else
         config
+      end
+
+      if @skills_state
+        activate_tool = @skills_state.adapter.activate_tool
+        raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{activate_tool.name}" if tools.any? { |t| t.name == activate_tool.name }
+        tools + [activate_tool]
+      else
+        tools
       end
     end
   end
@@ -658,6 +692,36 @@ class Riffer::Agent
       else raise Riffer::ArgumentError, "Invalid tool_runtime: #{runtime.inspect}"
       end
     end
+  end
+
+  # Resolves the skills backend, lists skills, and selects an adapter.
+  #
+  # Returns nil if skills are not configured or empty.
+  #
+  #: () -> Riffer::Skills::Context?
+  def resolve_skills
+    return nil unless self.class.skills
+
+    backend = self.class.skills.backend
+    return nil unless backend
+
+    backend = backend.is_a?(Proc) ? backend.call(@context) : backend
+    skills_list = backend.list_skills
+    return nil if skills_list.empty?
+
+    skills = skills_list.to_h { |s| [s.name, s] }
+    adapter_class = self.class.skills.adapter || provider_class.skills_adapter
+
+    skills_context = Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: adapter_class.new)
+    @context = (@context || {}).merge(skills: skills_context)
+
+    activate = self.class.skills.activate
+    if activate
+      names = activate.is_a?(Proc) ? activate.call(@context) : Array(activate)
+      names.each { |name| skills_context.activate(name) }
+    end
+
+    skills_context
   end
 
   #: () -> singleton(Riffer::Providers::Base)

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -450,6 +450,10 @@ class Riffer::Agent
   def run_stream_loop(yielder, resume: false)
     step = resume ? count_assistant_messages : 0
 
+    if @skills_state
+      @skills_state.on_activate = ->(name) { yielder << Riffer::StreamEvents::SkillActivation.new(name) }
+    end
+
     completed = catch(:riffer_interrupt) do
       execute_pending_tool_calls if resume
 

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -9,6 +9,13 @@
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
   WEB_SEARCH_TOOL_TYPE = "web_search_20250305" #: String
 
+  # Returns the XML skill adapter for Anthropic/Claude.
+  #
+  #: () -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter
+    Riffer::Skills::XmlAdapter
+  end
+
   # Initializes the Anthropic provider.
   #
   #: (?api_key: String?, **untyped) -> void

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -20,6 +20,15 @@ class Riffer::Providers::Base
   include Riffer::Helpers::Dependencies
   include Riffer::Messages::Converter
 
+  # Returns the preferred skill adapter for this provider.
+  #
+  # Override in subclasses for provider-specific formats.
+  #
+  #: () -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter
+    Riffer::Skills::MarkdownAdapter
+  end
+
   # Generates text using the provider.
   #
   #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant

--- a/lib/riffer/skills.rb
+++ b/lib/riffer/skills.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+module Riffer::Skills
+end

--- a/lib/riffer/skills/activate_tool.rb
+++ b/lib/riffer/skills/activate_tool.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Tool for the LLM to activate a skill and receive its full instructions.
+#
+# Registered automatically when an agent has skills configured.
+# The LLM calls this when a task matches an available skill's description.
+#
+# See Riffer::Skills::Context.
+class Riffer::Skills::ActivateTool < Riffer::Tool
+  identifier "skill_activate"
+  description "Activates a skill and returns its instructions. " \
+              "Call this when a task matches an available skill's description."
+  timeout 1
+
+  params do
+    required :name, String, description: "The skill name to activate"
+  end
+
+  # Activates a skill by name and returns its body.
+  #
+  # +context+ - tool context containing +:skills+ (a Riffer::Skills::Context).
+  # +name+ - the skill name to activate.
+  #
+  #: (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
+  def call(context:, name:)
+    skills_context = context&.dig(:skills)
+    return error("Skills not configured") unless skills_context
+
+    text(skills_context.activate(name))
+  rescue Riffer::ArgumentError => e
+    error(e.message)
+  end
+end

--- a/lib/riffer/skills/adapter.rb
+++ b/lib/riffer/skills/adapter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class defining the interface for skill adapters.
+#
+# A skill adapter encapsulates the provider-specific behavior for skills:
+# how the skill catalog is rendered in the system prompt, and which tool
+# the LLM calls to activate a skill.
+#
+# Subclass and override +render_catalog+ and optionally +activate_tool+
+# to customize behavior.
+#
+# See Riffer::Skills::MarkdownAdapter for the default implementation.
+# See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
+class Riffer::Skills::Adapter
+  # Renders a skill catalog section for the system prompt.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  #: (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog(skills)
+    raise NotImplementedError, "#{self.class} must implement #render_catalog"
+  end
+
+  # Returns the tool class used to activate skills.
+  #
+  # Override to provide a custom activation tool.
+  #
+  #: () -> singleton(Riffer::Tool)
+  def activate_tool
+    Riffer::Skills::ActivateTool
+  end
+end

--- a/lib/riffer/skills/backend.rb
+++ b/lib/riffer/skills/backend.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class defining the interface for skill storage backends.
+#
+# Subclass and implement +list_skills+ and +read_skill+ to provide
+# custom skill storage (database, S3, etc.).
+#
+# Use Riffer::Skills::Frontmatter.parse to parse raw SKILL.md content.
+#
+# See Riffer::Skills::FilesystemBackend for the built-in implementation.
+class Riffer::Skills::Backend
+  SKILL_FILENAME = "SKILL.md" #: String
+
+  # Returns frontmatter for all available skills.
+  #
+  # Called once at the start of generate/stream.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  #: () -> Array[Riffer::Skills::Frontmatter]
+  def list_skills
+    raise NotImplementedError, "#{self.class} must implement #list_skills"
+  end
+
+  # Returns the full SKILL.md body (without frontmatter) for a skill.
+  #
+  # +name+ - the skill name to read.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  # Raises Riffer::ArgumentError if skill not found.
+  #
+  #: (String) -> String
+  def read_skill(name)
+    raise NotImplementedError, "#{self.class} must implement #read_skill"
+  end
+end

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Configuration object for the skills block DSL.
+#
+# Used inside the +skills+ block on Riffer::Agent:
+#
+#   skills do
+#     backend Riffer::Skills::FilesystemBackend.new(".skills")
+#     adapter Riffer::Skills::XmlAdapter
+#     activate ["code-review"]
+#   end
+class Riffer::Skills::Config
+  # Creates a new Config with all options unset.
+  #
+  #: () -> void
+  def initialize
+    @backend = nil
+    @adapter = nil
+    @activate = nil
+  end
+
+  # Gets or sets the skills backend.
+  #
+  # Accepts a Riffer::Skills::Backend instance, or a Proc that receives
+  # +context+ and returns a Backend.
+  #
+  #: (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
+  def backend(value = nil)
+    return @backend if value.nil?
+    @backend = value
+  end
+
+  # Gets or sets a custom skill adapter class.
+  #
+  # Must be a subclass of Riffer::Skills::Adapter.
+  # Defaults to the provider's preferred adapter.
+  #
+  #: (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
+  def adapter(value = nil)
+    return @adapter if value.nil?
+    @adapter = value
+  end
+
+  # Gets or sets skill names to activate at startup.
+  #
+  # Activated skills have their full body included in the system prompt
+  # without requiring a tool call.
+  #
+  # Accepts an array of skill name strings or a Proc that receives
+  # +context+ and returns an array of names.
+  #
+  #: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
+  def activate(value = nil)
+    return @activate if value.nil?
+    @activate = value
+  end
+end

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Skills context for an agent generation cycle.
+#
+# Coordinates skill discovery, activation, and prompt rendering.
+# Tracks activations with caching to avoid redundant backend reads.
+#
+# Built by the agent at the start of generate/stream and passed to
+# tools via +context[:skills]+.
+#
+# See Riffer::Skills::Backend, Riffer::Skills::Frontmatter.
+class Riffer::Skills::Context
+  # Skill catalog indexed by name.
+  attr_reader :skills #: Hash[String, Riffer::Skills::Frontmatter]
+
+  # The skill adapter used for this context.
+  attr_reader :adapter #: Riffer::Skills::Adapter
+
+  # Creates a new skills context for a generation cycle.
+  #
+  # +backend+ - the skills backend for reading skill bodies.
+  # +skills+ - skill catalog indexed by name.
+  # +adapter+ - the adapter used to render skill content.
+  #
+  #: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
+  def initialize(backend:, skills:, adapter:)
+    @backend = backend
+    @skills = skills
+    @adapter = adapter
+    @activated = {} #: Hash[String, String]
+  end
+
+  # Activates a skill by name. Returns the cached body on re-activation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  #: (String) -> String
+  def activate(name)
+    raise Riffer::ArgumentError, "Unknown skill: '#{name}'" unless skills.key?(name)
+    @activated[name] ||= @backend.read_skill(name)
+  end
+
+  # Returns whether a skill has been activated.
+  #
+  #: (String) -> bool
+  def activated?(name)
+    @activated.key?(name)
+  end
+
+  # Returns the complete skills section for the system prompt.
+  #
+  # Includes the catalog and any pre-activated skill bodies.
+  #
+  #: () -> String
+  def system_prompt
+    parts = [@adapter.render_catalog(skills.values)]
+    @activated.each_value { |body| parts << body }
+    parts.join("\n\n")
+  end
+end

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -17,6 +17,9 @@ class Riffer::Skills::Context
   # The skill adapter used for this context.
   attr_reader :adapter #: Riffer::Skills::Adapter
 
+  # Optional callback invoked when a skill is first activated.
+  attr_writer :on_activate #: (^(String) -> void)?
+
   # Creates a new skills context for a generation cycle.
   #
   # +backend+ - the skills backend for reading skill bodies.
@@ -38,7 +41,10 @@ class Riffer::Skills::Context
   #: (String) -> String
   def activate(name)
     raise Riffer::ArgumentError, "Unknown skill: '#{name}'" unless skills.key?(name)
-    @activated[name] ||= @backend.read_skill(name)
+    return @activated[name] if @activated.key?(name)
+    @activated[name] = @backend.read_skill(name)
+    @on_activate&.call(name)
+    @activated[name]
   end
 
   # Returns whether a skill has been activated.

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -60,8 +60,17 @@ class Riffer::Skills::Context
   #
   #: () -> String
   def system_prompt
-    parts = [@adapter.render_catalog(skills.values)]
+    available = available_skills
+    parts = []
+    parts << @adapter.render_catalog(available) unless available.empty?
     @activated.each_value { |body| parts << body }
     parts.join("\n\n")
+  end
+
+  private
+
+  #: () -> Array[Riffer::Skills::Frontmatter]
+  def available_skills
+    skills.values.reject { |skill| @activated.key?(skill.name) }
   end
 end

--- a/lib/riffer/skills/filesystem_backend.rb
+++ b/lib/riffer/skills/filesystem_backend.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Built-in backend that reads skills from the filesystem.
+#
+# Scans configured directories for immediate child directories containing
+# +SKILL.md+ files. Directory names must match the skill +name+ field.
+#
+#   backend = Riffer::Skills::FilesystemBackend.new(".skills", "~/.riffer/skills")
+#   backend.list_skills  # => [Riffer::Skills::Frontmatter, ...]
+#   backend.read_skill("code-review")  # => "Full skill instructions..."
+#
+class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
+  # Creates a new FilesystemBackend.
+  #
+  # +paths+ - one or more directory paths to scan for skills.
+  #
+  #: (*String) -> void
+  def initialize(*paths)
+    @paths = paths.flatten.map { |p| File.expand_path(p) }
+    @skills_cache = nil #: Hash[String, String]?
+  end
+
+  # Returns frontmatter for all discovered skills.
+  #
+  # Scans each configured path for immediate child directories containing
+  # SKILL.md. When multiple paths contain a skill with the same name,
+  # first-path-wins.
+  #
+  #: () -> Array[Riffer::Skills::Frontmatter]
+  def list_skills
+    @skills_cache = {}
+    frontmatters = []
+
+    @paths.each do |path|
+      next unless File.directory?(path)
+
+      Dir.children(path).sort.each do |dirname|
+        dir = File.join(path, dirname)
+        skill_file = File.join(dir, SKILL_FILENAME)
+        next unless File.directory?(dir) && File.file?(skill_file)
+
+        frontmatter = Riffer::Skills::Frontmatter.parse_frontmatter(File.read(skill_file))
+
+        validate_dirname_matches_name!(dirname, frontmatter.name)
+        next if @skills_cache.key?(frontmatter.name)
+
+        frontmatters << frontmatter
+        @skills_cache[frontmatter.name] = dir
+      end
+    end
+
+    frontmatters
+  end
+
+  # Returns the full SKILL.md body (without frontmatter) for a skill.
+  #
+  # +name+ - the skill name to read.
+  #
+  # Raises Riffer::ArgumentError if skill not found.
+  #
+  #: (String) -> String
+  def read_skill(name)
+    list_skills unless @skills_cache
+    dir = @skills_cache[name]
+    raise Riffer::ArgumentError, "Skill not found: '#{name}'" unless dir
+
+    _, body = Riffer::Skills::Frontmatter.parse(File.read(File.join(dir, SKILL_FILENAME)))
+    body
+  end
+
+  private
+
+  #: (String, String) -> void
+  def validate_dirname_matches_name!(dirname, name)
+    return if dirname == name
+    raise Riffer::ArgumentError, "Skill directory '#{dirname}' does not match name '#{name}'"
+  end
+end

--- a/lib/riffer/skills/frontmatter.rb
+++ b/lib/riffer/skills/frontmatter.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "yaml"
+
+# Immutable value object holding parsed SKILL.md YAML frontmatter.
+#
+# Required fields per the Agent Skills spec: +name+ and +description+.
+# All unrecognized top-level frontmatter keys are merged into +metadata+.
+#
+#   frontmatter, body = Riffer::Skills::Frontmatter.parse(raw_content)
+#
+class Riffer::Skills::Frontmatter
+  NAME_PATTERN = /\A[a-z0-9]+(-[a-z0-9]+)*\z/ #: Regexp
+  MAX_NAME_LENGTH = 64 #: Integer
+  MAX_DESCRIPTION_LENGTH = 1024 #: Integer
+
+  # The skill name (1-64 chars, lowercase alphanumeric and hyphens).
+  attr_reader :name #: String
+
+  # The skill description (1-1024 chars).
+  attr_reader :description #: String
+
+  # Arbitrary key-value metadata from the spec's +metadata+ field
+  # and any unrecognized top-level frontmatter keys.
+  attr_reader :metadata #: Hash[Symbol, untyped]
+
+  # Parses a raw SKILL.md string into a Frontmatter and body.
+  #
+  # Splits on YAML front matter delimiters (+---+). Unrecognized
+  # top-level keys become +metadata+. Available to custom backends
+  # so they don't need to reimplement parsing.
+  #
+  # Raises Riffer::ArgumentError if frontmatter is invalid.
+  #
+  #: (String) -> [Riffer::Skills::Frontmatter, String]
+  def self.parse(raw)
+    yaml, body = split_frontmatter(raw)
+    raise Riffer::ArgumentError, "missing YAML frontmatter (expected --- delimiters)" if yaml.empty?
+    [new(name: yaml.delete(:name), description: yaml.delete(:description), metadata: yaml), body]
+  end
+
+  # Parses only the frontmatter from a raw SKILL.md string, ignoring the body.
+  #
+  # Raises Riffer::ArgumentError if frontmatter is invalid.
+  #
+  #: (String) -> Riffer::Skills::Frontmatter
+  def self.parse_frontmatter(raw)
+    yaml, _ = split_frontmatter(raw)
+    raise Riffer::ArgumentError, "missing YAML frontmatter (expected --- delimiters)" if yaml.empty?
+    new(name: yaml.delete(:name), description: yaml.delete(:description), metadata: yaml)
+  end
+
+  #: (String) -> [Hash[Symbol, untyped], String]
+  def self.split_frontmatter(raw) # :nodoc:
+    parts = raw.split(/^---\s*$/, 3)
+
+    if parts.length >= 3 && parts[0].strip.empty?
+      parsed = YAML.safe_load(parts[1])
+      raise Riffer::ArgumentError, "frontmatter must be a YAML mapping" unless parsed.nil? || parsed.is_a?(Hash)
+      [parsed&.transform_keys(&:to_sym) || {}, parts[2].lstrip]
+    else
+      [{}, raw]
+    end
+  end
+  private_class_method :split_frontmatter
+
+  # Creates a new Frontmatter.
+  #
+  # +name+ - the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
+  # +description+ - the skill description (1-1024 chars).
+  # +metadata+ - optional metadata hash.
+  #
+  # Raises Riffer::ArgumentError if name or description is invalid.
+  #
+  #: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
+  def initialize(name:, description:, metadata: {})
+    validate_name!(name)
+    validate_description!(description)
+    @name = name.freeze
+    @description = description.freeze
+    @metadata = metadata.freeze
+  end
+
+  private
+
+  #: (untyped) -> void
+  def validate_name!(name)
+    raise Riffer::ArgumentError, "name must be a String" unless name.is_a?(String)
+    raise Riffer::ArgumentError, "name must be 1-#{MAX_NAME_LENGTH} characters" if name.empty? || name.length > MAX_NAME_LENGTH
+    raise Riffer::ArgumentError, "name must match #{NAME_PATTERN.source}" unless NAME_PATTERN.match?(name)
+  end
+
+  #: (untyped) -> void
+  def validate_description!(description)
+    raise Riffer::ArgumentError, "description must be a String" unless description.is_a?(String)
+    raise Riffer::ArgumentError, "description must be 1-#{MAX_DESCRIPTION_LENGTH} characters" if description.empty? || description.length > MAX_DESCRIPTION_LENGTH
+  end
+end

--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Default Markdown skill adapter.
+#
+# Renders a skill catalog as Markdown for the system prompt.
+# Used by OpenAI, Amazon Bedrock, and other providers.
+#
+# See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
+class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
+  # Renders a skill catalog as Markdown.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  #: (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog(skills)
+    lines = []
+    lines << "## Available Skills"
+    lines << ""
+    lines << "When a user's request matches a skill description below, call the `#{activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << ""
+    skills.each do |skill|
+      lines << "- **#{skill.name}**: #{skill.description}"
+    end
+    lines.join("\n")
+  end
+end

--- a/lib/riffer/skills/xml_adapter.rb
+++ b/lib/riffer/skills/xml_adapter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "cgi"
+
+# XML skill adapter, optimized for Anthropic/Claude.
+#
+# Renders a skill catalog as XML for the system prompt.
+#
+# See Riffer::Skills::MarkdownAdapter for the default variant.
+class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
+  # Renders a skill catalog as XML.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  #: (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog(skills)
+    lines = []
+    lines << "When a user's request matches a skill description below, call the `#{activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << ""
+    lines << "<available_skills>"
+    skills.each do |skill|
+      lines << "  <skill>"
+      lines << "    <name>#{CGI.escapeHTML(skill.name)}</name>"
+      lines << "    <description>#{CGI.escapeHTML(skill.description)}</description>"
+      lines << "  </skill>"
+    end
+    lines << "</available_skills>"
+    lines.join("\n")
+  end
+end

--- a/lib/riffer/stream_events.rb
+++ b/lib/riffer/stream_events.rb
@@ -10,5 +10,6 @@
 # - Riffer::StreamEvents::ToolCallDone - Complete tool call
 # - Riffer::StreamEvents::ReasoningDelta - Incremental reasoning content
 # - Riffer::StreamEvents::ReasoningDone - Complete reasoning content
+# - Riffer::StreamEvents::SkillActivation - Skill activated during streaming
 module Riffer::StreamEvents
 end

--- a/lib/riffer/stream_events/skill_activation.rb
+++ b/lib/riffer/stream_events/skill_activation.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Emitted when a skill is activated during streaming.
+#
+# Fired by the +on_activate+ callback on Riffer::Skills::Context
+# when the LLM calls the skill activation tool.
+class Riffer::StreamEvents::SkillActivation < Riffer::StreamEvents::Base
+  # The activated skill name.
+  attr_reader :name #: String
+
+  #: (String, ?role: Symbol) -> void
+  def initialize(name, role: :system)
+    super(role: role)
+    @name = name
+  end
+
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    {role: @role, name: @name}
+  end
+end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -91,6 +91,19 @@ class Riffer::Agent
   # : (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime: (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
 
+  # Configures skills for this agent via a block DSL.
+  #
+  # Returns the current Riffer::Skills::Config when called without a block.
+  #
+  #   skills do
+  #     backend Riffer::Skills::FilesystemBackend.new(".skills")
+  #     adapter Riffer::Skills::XmlAdapter
+  #     activate ["code-review"]
+  #   end
+  #
+  # : () ?{ () -> void } -> Riffer::Skills::Config?
+  def self.skills: () ?{ () -> void } -> Riffer::Skills::Config?
+
   # Finds an agent class by identifier.
   #
   # : (String) -> singleton(Riffer::Agent)?
@@ -264,6 +277,13 @@ class Riffer::Agent
 
   # : () -> Riffer::ToolRuntime
   def resolve_tool_runtime: () -> Riffer::ToolRuntime
+
+  # Resolves the skills backend, lists skills, and selects an adapter.
+  #
+  # Returns nil if skills are not configured or empty.
+  #
+  # : () -> Riffer::Skills::Context?
+  def resolve_skills: () -> Riffer::Skills::Context?
 
   # : () -> singleton(Riffer::Providers::Base)
   def provider_class: () -> singleton(Riffer::Providers::Base)

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -8,6 +8,11 @@
 class Riffer::Providers::Anthropic < Riffer::Providers::Base
   WEB_SEARCH_TOOL_TYPE: String
 
+  # Returns the XML skill adapter for Anthropic/Claude.
+  #
+  # : () -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
+
   # Initializes the Anthropic provider.
   #
   # : (?api_key: String?, **untyped) -> void

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -18,6 +18,13 @@ class Riffer::Providers::Base
 
   include Riffer::Messages::Converter
 
+  # Returns the preferred skill adapter for this provider.
+  #
+  # Override in subclasses for provider-specific formats.
+  #
+  # : () -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
+
   # Generates text using the provider.
   #
   # : (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant

--- a/sig/generated/riffer/skills.rbs
+++ b/sig/generated/riffer/skills.rbs
@@ -1,0 +1,4 @@
+# Generated from lib/riffer/skills.rb with RBS::Inline
+
+module Riffer::Skills
+end

--- a/sig/generated/riffer/skills/activate_tool.rbs
+++ b/sig/generated/riffer/skills/activate_tool.rbs
@@ -1,0 +1,17 @@
+# Generated from lib/riffer/skills/activate_tool.rb with RBS::Inline
+
+# Tool for the LLM to activate a skill and receive its full instructions.
+#
+# Registered automatically when an agent has skills configured.
+# The LLM calls this when a task matches an available skill's description.
+#
+# See Riffer::Skills::Context.
+class Riffer::Skills::ActivateTool < Riffer::Tool
+  # Activates a skill by name and returns its body.
+  #
+  # +context+ - tool context containing +:skills+ (a Riffer::Skills::Context).
+  # +name+ - the skill name to activate.
+  #
+  # : (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
+  def call: (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
+end

--- a/sig/generated/riffer/skills/adapter.rbs
+++ b/sig/generated/riffer/skills/adapter.rbs
@@ -1,0 +1,30 @@
+# Generated from lib/riffer/skills/adapter.rb with RBS::Inline
+
+# Base class defining the interface for skill adapters.
+#
+# A skill adapter encapsulates the provider-specific behavior for skills:
+# how the skill catalog is rendered in the system prompt, and which tool
+# the LLM calls to activate a skill.
+#
+# Subclass and override +render_catalog+ and optionally +activate_tool+
+# to customize behavior.
+#
+# See Riffer::Skills::MarkdownAdapter for the default implementation.
+# See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
+class Riffer::Skills::Adapter
+  # Renders a skill catalog section for the system prompt.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  # : (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
+
+  # Returns the tool class used to activate skills.
+  #
+  # Override to provide a custom activation tool.
+  #
+  # : () -> singleton(Riffer::Tool)
+  def activate_tool: () -> singleton(Riffer::Tool)
+end

--- a/sig/generated/riffer/skills/backend.rbs
+++ b/sig/generated/riffer/skills/backend.rbs
@@ -1,0 +1,32 @@
+# Generated from lib/riffer/skills/backend.rb with RBS::Inline
+
+# Base class defining the interface for skill storage backends.
+#
+# Subclass and implement +list_skills+ and +read_skill+ to provide
+# custom skill storage (database, S3, etc.).
+#
+# Use Riffer::Skills::Frontmatter.parse to parse raw SKILL.md content.
+#
+# See Riffer::Skills::FilesystemBackend for the built-in implementation.
+class Riffer::Skills::Backend
+  SKILL_FILENAME: String
+
+  # Returns frontmatter for all available skills.
+  #
+  # Called once at the start of generate/stream.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  # : () -> Array[Riffer::Skills::Frontmatter]
+  def list_skills: () -> Array[Riffer::Skills::Frontmatter]
+
+  # Returns the full SKILL.md body (without frontmatter) for a skill.
+  #
+  # +name+ - the skill name to read.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  # Raises Riffer::ArgumentError if skill not found.
+  #
+  # : (String) -> String
+  def read_skill: (String) -> String
+end

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -1,0 +1,44 @@
+# Generated from lib/riffer/skills/config.rb with RBS::Inline
+
+# Configuration object for the skills block DSL.
+#
+# Used inside the +skills+ block on Riffer::Agent:
+#
+#   skills do
+#     backend Riffer::Skills::FilesystemBackend.new(".skills")
+#     adapter Riffer::Skills::XmlAdapter
+#     activate ["code-review"]
+#   end
+class Riffer::Skills::Config
+  # Creates a new Config with all options unset.
+  #
+  # : () -> void
+  def initialize: () -> void
+
+  # Gets or sets the skills backend.
+  #
+  # Accepts a Riffer::Skills::Backend instance, or a Proc that receives
+  # +context+ and returns a Backend.
+  #
+  # : (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
+  def backend: (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
+
+  # Gets or sets a custom skill adapter class.
+  #
+  # Must be a subclass of Riffer::Skills::Adapter.
+  # Defaults to the provider's preferred adapter.
+  #
+  # : (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
+  def adapter: (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
+
+  # Gets or sets skill names to activate at startup.
+  #
+  # Activated skills have their full body included in the system prompt
+  # without requiring a tool call.
+  #
+  # Accepts an array of skill name strings or a Proc that receives
+  # +context+ and returns an array of names.
+  #
+  # : (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
+  def activate: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
+end

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -46,4 +46,9 @@ class Riffer::Skills::Context
   #
   # : () -> String
   def system_prompt: () -> String
+
+  private
+
+  # : () -> Array[Riffer::Skills::Frontmatter]
+  def available_skills: () -> Array[Riffer::Skills::Frontmatter]
 end

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -16,6 +16,9 @@ class Riffer::Skills::Context
   # The skill adapter used for this context.
   attr_reader adapter: Riffer::Skills::Adapter
 
+  # Optional callback invoked when a skill is first activated.
+  attr_writer on_activate: (^(String) -> void)?
+
   # Creates a new skills context for a generation cycle.
   #
   # +backend+ - the skills backend for reading skill bodies.

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -1,0 +1,46 @@
+# Generated from lib/riffer/skills/context.rb with RBS::Inline
+
+# Skills context for an agent generation cycle.
+#
+# Coordinates skill discovery, activation, and prompt rendering.
+# Tracks activations with caching to avoid redundant backend reads.
+#
+# Built by the agent at the start of generate/stream and passed to
+# tools via +context[:skills]+.
+#
+# See Riffer::Skills::Backend, Riffer::Skills::Frontmatter.
+class Riffer::Skills::Context
+  # Skill catalog indexed by name.
+  attr_reader skills: Hash[String, Riffer::Skills::Frontmatter]
+
+  # The skill adapter used for this context.
+  attr_reader adapter: Riffer::Skills::Adapter
+
+  # Creates a new skills context for a generation cycle.
+  #
+  # +backend+ - the skills backend for reading skill bodies.
+  # +skills+ - skill catalog indexed by name.
+  # +adapter+ - the adapter used to render skill content.
+  #
+  # : (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
+  def initialize: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
+
+  # Activates a skill by name. Returns the cached body on re-activation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  # : (String) -> String
+  def activate: (String) -> String
+
+  # Returns whether a skill has been activated.
+  #
+  # : (String) -> bool
+  def activated?: (String) -> bool
+
+  # Returns the complete skills section for the system prompt.
+  #
+  # Includes the catalog and any pre-activated skill bodies.
+  #
+  # : () -> String
+  def system_prompt: () -> String
+end

--- a/sig/generated/riffer/skills/filesystem_backend.rbs
+++ b/sig/generated/riffer/skills/filesystem_backend.rbs
@@ -1,0 +1,41 @@
+# Generated from lib/riffer/skills/filesystem_backend.rb with RBS::Inline
+
+# Built-in backend that reads skills from the filesystem.
+#
+# Scans configured directories for immediate child directories containing
+# +SKILL.md+ files. Directory names must match the skill +name+ field.
+#
+#   backend = Riffer::Skills::FilesystemBackend.new(".skills", "~/.riffer/skills")
+#   backend.list_skills  # => [Riffer::Skills::Frontmatter, ...]
+#   backend.read_skill("code-review")  # => "Full skill instructions..."
+class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
+  # Creates a new FilesystemBackend.
+  #
+  # +paths+ - one or more directory paths to scan for skills.
+  #
+  # : (*String) -> void
+  def initialize: (*String) -> void
+
+  # Returns frontmatter for all discovered skills.
+  #
+  # Scans each configured path for immediate child directories containing
+  # SKILL.md. When multiple paths contain a skill with the same name,
+  # first-path-wins.
+  #
+  # : () -> Array[Riffer::Skills::Frontmatter]
+  def list_skills: () -> Array[Riffer::Skills::Frontmatter]
+
+  # Returns the full SKILL.md body (without frontmatter) for a skill.
+  #
+  # +name+ - the skill name to read.
+  #
+  # Raises Riffer::ArgumentError if skill not found.
+  #
+  # : (String) -> String
+  def read_skill: (String) -> String
+
+  private
+
+  # : (String, String) -> void
+  def validate_dirname_matches_name!: (String, String) -> void
+end

--- a/sig/generated/riffer/skills/frontmatter.rbs
+++ b/sig/generated/riffer/skills/frontmatter.rbs
@@ -1,0 +1,65 @@
+# Generated from lib/riffer/skills/frontmatter.rb with RBS::Inline
+
+# Immutable value object holding parsed SKILL.md YAML frontmatter.
+#
+# Required fields per the Agent Skills spec: +name+ and +description+.
+# All unrecognized top-level frontmatter keys are merged into +metadata+.
+#
+#   frontmatter, body = Riffer::Skills::Frontmatter.parse(raw_content)
+class Riffer::Skills::Frontmatter
+  NAME_PATTERN: Regexp
+
+  MAX_NAME_LENGTH: Integer
+
+  MAX_DESCRIPTION_LENGTH: Integer
+
+  # The skill name (1-64 chars, lowercase alphanumeric and hyphens).
+  attr_reader name: String
+
+  # The skill description (1-1024 chars).
+  attr_reader description: String
+
+  # Arbitrary key-value metadata from the spec's +metadata+ field
+  # and any unrecognized top-level frontmatter keys.
+  attr_reader metadata: Hash[Symbol, untyped]
+
+  # Parses a raw SKILL.md string into a Frontmatter and body.
+  #
+  # Splits on YAML front matter delimiters (+---+). Unrecognized
+  # top-level keys become +metadata+. Available to custom backends
+  # so they don't need to reimplement parsing.
+  #
+  # Raises Riffer::ArgumentError if frontmatter is invalid.
+  #
+  # : (String) -> [Riffer::Skills::Frontmatter, String]
+  def self.parse: (String) -> [ Riffer::Skills::Frontmatter, String ]
+
+  # Parses only the frontmatter from a raw SKILL.md string, ignoring the body.
+  #
+  # Raises Riffer::ArgumentError if frontmatter is invalid.
+  #
+  # : (String) -> Riffer::Skills::Frontmatter
+  def self.parse_frontmatter: (String) -> Riffer::Skills::Frontmatter
+
+  # : (String) -> [Hash[Symbol, untyped], String]
+  def self.split_frontmatter: (String) -> [ Hash[Symbol, untyped], String ]
+
+  # Creates a new Frontmatter.
+  #
+  # +name+ - the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
+  # +description+ - the skill description (1-1024 chars).
+  # +metadata+ - optional metadata hash.
+  #
+  # Raises Riffer::ArgumentError if name or description is invalid.
+  #
+  # : (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
+  def initialize: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
+
+  private
+
+  # : (untyped) -> void
+  def validate_name!: (untyped) -> void
+
+  # : (untyped) -> void
+  def validate_description!: (untyped) -> void
+end

--- a/sig/generated/riffer/skills/markdown_adapter.rbs
+++ b/sig/generated/riffer/skills/markdown_adapter.rbs
@@ -1,0 +1,16 @@
+# Generated from lib/riffer/skills/markdown_adapter.rb with RBS::Inline
+
+# Default Markdown skill adapter.
+#
+# Renders a skill catalog as Markdown for the system prompt.
+# Used by OpenAI, Amazon Bedrock, and other providers.
+#
+# See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
+class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
+  # Renders a skill catalog as Markdown.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  # : (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
+end

--- a/sig/generated/riffer/skills/xml_adapter.rbs
+++ b/sig/generated/riffer/skills/xml_adapter.rbs
@@ -1,0 +1,15 @@
+# Generated from lib/riffer/skills/xml_adapter.rb with RBS::Inline
+
+# XML skill adapter, optimized for Anthropic/Claude.
+#
+# Renders a skill catalog as XML for the system prompt.
+#
+# See Riffer::Skills::MarkdownAdapter for the default variant.
+class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
+  # Renders a skill catalog as XML.
+  #
+  # +skills+ - array of Frontmatter objects to render.
+  #
+  # : (Array[Riffer::Skills::Frontmatter]) -> String
+  def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
+end

--- a/sig/generated/riffer/stream_events.rbs
+++ b/sig/generated/riffer/stream_events.rbs
@@ -9,5 +9,6 @@
 # - Riffer::StreamEvents::ToolCallDone - Complete tool call
 # - Riffer::StreamEvents::ReasoningDelta - Incremental reasoning content
 # - Riffer::StreamEvents::ReasoningDone - Complete reasoning content
+# - Riffer::StreamEvents::SkillActivation - Skill activated during streaming
 module Riffer::StreamEvents
 end

--- a/sig/generated/riffer/stream_events/skill_activation.rbs
+++ b/sig/generated/riffer/stream_events/skill_activation.rbs
@@ -1,0 +1,16 @@
+# Generated from lib/riffer/stream_events/skill_activation.rb with RBS::Inline
+
+# Emitted when a skill is activated during streaming.
+#
+# Fired by the +on_activate+ callback on Riffer::Skills::Context
+# when the LLM calls the skill activation tool.
+class Riffer::StreamEvents::SkillActivation < Riffer::StreamEvents::Base
+  # The activated skill name.
+  attr_reader name: String
+
+  # : (String, ?role: Symbol) -> void
+  def initialize: (String, ?role: Symbol) -> void
+
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/test/fixtures/skills/code-review/SKILL.md
+++ b/test/fixtures/skills/code-review/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: code-review
+description: Reviews code for quality, style, and potential issues.
+author: test
+---
+You are a code review assistant.
+
+Review the code for:
+- Style issues
+- Potential bugs
+- Performance problems

--- a/test/fixtures/skills/data-analysis/SKILL.md
+++ b/test/fixtures/skills/data-analysis/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: data-analysis
+description: Analyzes datasets and generates summary reports.
+---
+You are a data analysis assistant.
+
+Analyze the provided data and generate insights.

--- a/test/fixtures/skills_extra/summarize/SKILL.md
+++ b/test/fixtures/skills_extra/summarize/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: summarize
+description: Summarizes long text into concise bullet points.
+---
+You are a summarization assistant.
+
+Summarize the provided text into concise bullet points.

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -402,7 +402,7 @@ describe Riffer::Agent do
       end
 
       it "does not add system message when Proc returns nil" do
-        returner = ->(_tool_context) {}
+        returner = ->(_context) {}
         klass = Class.new(Riffer::Agent) do
           model "mock/riffer-1"
           instructions returner

--- a/test/riffer/skills/activate_tool_test.rb
+++ b/test/riffer/skills/activate_tool_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::ActivateTool do
+  let(:fixtures_path) { File.expand_path("../../../fixtures/skills", __FILE__) }
+  let(:backend) { Riffer::Skills::FilesystemBackend.new(fixtures_path) }
+  let(:skills) { backend.list_skills.to_h { |s| [s.name, s] } }
+  let(:skills_context) { Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: Riffer::Skills::MarkdownAdapter.new) }
+  let(:context) { {skills: skills_context} }
+
+  describe "#call" do
+    it "returns skill body for a valid skill" do
+      tool = Riffer::Skills::ActivateTool.new
+      result = tool.call(context: context, name: "code-review")
+      assert result.success?
+      assert_includes result.content, "code review assistant"
+    end
+
+    it "returns cached body on re-activation" do
+      tool = Riffer::Skills::ActivateTool.new
+      result1 = tool.call(context: context, name: "code-review")
+      result2 = tool.call(context: context, name: "code-review")
+      assert_equal result1.content, result2.content
+      assert skills_context.activated?("code-review")
+    end
+
+    it "returns error for unknown skill" do
+      tool = Riffer::Skills::ActivateTool.new
+      result = tool.call(context: context, name: "nonexistent")
+      assert result.error?
+      assert_includes result.content, "Unknown skill"
+    end
+
+    it "returns error when skills not configured" do
+      tool = Riffer::Skills::ActivateTool.new
+      result = tool.call(context: {}, name: "code-review")
+      assert result.error?
+      assert_includes result.content, "Skills not configured"
+    end
+
+    it "returns error when context is nil" do
+      tool = Riffer::Skills::ActivateTool.new
+      result = tool.call(context: nil, name: "code-review")
+      assert result.error?
+      assert_includes result.content, "Skills not configured"
+    end
+  end
+end

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -259,6 +259,51 @@ describe "Agent skills integration" do
     end
   end
 
+  describe "stream emits SkillActivation events" do
+    it "emits SkillActivation event when skill is activated via tool call" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      provider.stub_response("Here is my review.")
+
+      agent = agent_class.new
+      agent.instance_variable_set(:@provider_instance, provider)
+
+      events = agent.stream("Review this code").select { |e| e.is_a?(Riffer::StreamEvents::SkillActivation) }
+
+      assert_equal 1, events.size
+      assert_equal "code-review", events.first.name
+      assert_equal :system, events.first.role
+    end
+
+    it "does not emit duplicate events for re-activation of the same skill" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      provider.stub_response("Done.")
+
+      agent = agent_class.new
+      agent.instance_variable_set(:@provider_instance, provider)
+
+      events = agent.stream("Review").select { |e| e.is_a?(Riffer::StreamEvents::SkillActivation) }
+
+      assert_equal 1, events.size
+    end
+  end
+
   describe "skill activation end-to-end" do
     it "activates a skill via tool call and returns body" do
       agent_class = Class.new(Riffer::Agent) do

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -204,8 +204,29 @@ describe "Agent skills integration" do
 
       system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
       assert_includes system_message.content, "Base instructions."
-      assert_includes system_message.content, "Available Skills"
       assert_includes system_message.content, "code review assistant"
+      # Pre-activated skill should not appear in the catalog
+      refute_includes system_message.content, "- **code-review**"
+      # Non-activated skill should still be in the catalog
+      assert_includes system_message.content, "- **data-analysis**"
+    end
+
+    it "omits catalog entirely when all skills are pre-activated" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          activate ["code-review", "data-analysis"]
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      refute_includes system_message.content, "Available Skills"
+      assert_includes system_message.content, "code review assistant"
+      assert_includes system_message.content, "data analysis assistant"
     end
 
     it "raises on unknown activated skill" do

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -1,0 +1,308 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+SKILLS_FIXTURES_PATH = File.expand_path("../../fixtures/skills", __dir__)
+
+describe "Agent skills integration" do
+  let(:backend) { Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH) }
+
+  describe "generate with skills" do
+    it "injects skills catalog into system prompt" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions "You are helpful."
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      refute_nil system_message
+      assert_includes system_message.content, "You are helpful."
+      assert_includes system_message.content, "Available Skills"
+      assert_includes system_message.content, "code-review"
+      assert_includes system_message.content, "data-analysis"
+    end
+
+    it "uses Markdown renderer for mock provider by default" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      assert_includes system_message.content, "## Available Skills"
+      assert_includes system_message.content, "- **code-review**"
+    end
+
+    it "allows custom adapter override" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          adapter Riffer::Skills::XmlAdapter
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      assert_includes system_message.content, "<available_skills>"
+    end
+
+    it "includes skill_activate tool in resolved tools" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      tool_names = agent.send(:resolved_tools).map(&:name)
+      assert_includes tool_names, "skill_activate"
+    end
+
+    it "merges skill tools with existing tools" do
+      tool_class = Class.new(Riffer::Tool) do
+        identifier "my_tool"
+        description "A custom tool"
+        def call(context:)
+          text("ok")
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tool_class]
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      tool_names = agent.send(:resolved_tools).map(&:name)
+      assert_includes tool_names, "my_tool"
+      assert_includes tool_names, "skill_activate"
+    end
+
+    it "raises on tool name conflict" do
+      conflict_tool = Class.new(Riffer::Tool) do
+        identifier "skill_activate"
+        description "Conflicts with skill_activate"
+        def call(context:)
+          text("ok")
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [conflict_tool]
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      error = assert_raises(Riffer::ArgumentError) { agent.generate("Hello") }
+      assert_match(/Tool name conflict/, error.message)
+    end
+
+    it "passes skills context in context" do
+      tool_class = Class.new(Riffer::Tool) do
+        identifier "spy_tool"
+        description "Captures context"
+        def call(context:)
+          text(context[:skills].skills.keys.sort.join(","))
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tool_class]
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("", tool_calls: [{name: "spy_tool", arguments: "{}"}])
+      provider.stub_response("Done")
+
+      agent = agent_class.new
+      agent.instance_variable_set(:@provider_instance, provider)
+      agent.generate("Hello")
+
+      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "spy_tool" }
+      refute_nil tool_msg
+      assert_includes tool_msg.content, "code-review"
+      assert_includes tool_msg.content, "data-analysis"
+    end
+
+    it "handles Proc backend" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend ->(ctx) {
+            Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          }
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      assert_includes system_message.content, "code-review"
+    end
+
+    it "generates no system message when skills backend returns empty" do
+      Dir.mktmpdir do |dir|
+        agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          skills do
+            backend Riffer::Skills::FilesystemBackend.new(dir)
+          end
+        end
+
+        agent = agent_class.new
+        agent.generate("Hello")
+
+        system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+        assert_nil system_message
+      end
+    end
+  end
+
+  describe "activated skills" do
+    it "appends activated skill bodies to system prompt" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions "Base instructions."
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          activate ["code-review"]
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      assert_includes system_message.content, "Base instructions."
+      assert_includes system_message.content, "Available Skills"
+      assert_includes system_message.content, "code review assistant"
+    end
+
+    it "raises on unknown activated skill" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          activate ["nonexistent"]
+        end
+      end
+
+      agent = agent_class.new
+      error = assert_raises(Riffer::ArgumentError) { agent.generate("Hello") }
+      assert_match(/Unknown skill/, error.message)
+    end
+
+    it "supports Proc for activate" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          activate ->(ctx) { ctx&.dig(:activate_skills) || [] }
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello", context: {activate_skills: ["data-analysis"]})
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      assert_includes system_message.content, "data analysis assistant"
+    end
+  end
+
+  describe "stream with skills" do
+    it "injects skills catalog into system prompt" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions "You are helpful."
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.stream("Hello").each { |_| }
+
+      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+      refute_nil system_message
+      assert_includes system_message.content, "Available Skills"
+      assert_includes system_message.content, "code-review"
+    end
+  end
+
+  describe "skill activation end-to-end" do
+    it "activates a skill via tool call and returns body" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      provider.stub_response("Here is my review.")
+
+      agent = agent_class.new
+      agent.instance_variable_set(:@provider_instance, provider)
+      response = agent.generate("Review this code")
+
+      assert_equal "Here is my review.", response.content
+
+      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      refute_nil tool_msg
+      assert_includes tool_msg.content, "code review assistant"
+      refute tool_msg.error
+    end
+
+    it "returns error for unknown skill activation" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"nonexistent"}'}])
+      provider.stub_response("Sorry, skill not found.")
+
+      agent = agent_class.new
+      agent.instance_variable_set(:@provider_instance, provider)
+      agent.generate("Use nonexistent skill")
+
+      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      refute_nil tool_msg
+      assert_includes tool_msg.content, "Unknown skill"
+    end
+  end
+end

--- a/test/riffer/skills/filesystem_backend_test.rb
+++ b/test/riffer/skills/filesystem_backend_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::FilesystemBackend do
+  let(:fixtures_path) { File.expand_path("../../../fixtures/skills", __FILE__) }
+  let(:extra_path) { File.expand_path("../../../fixtures/skills_extra", __FILE__) }
+  let(:backend) { Riffer::Skills::FilesystemBackend.new(fixtures_path) }
+
+  describe "#list_skills" do
+    it "returns frontmatter for all discovered skills" do
+      skills = backend.list_skills
+      assert_equal 2, skills.length
+      names = skills.map(&:name).sort
+      assert_equal ["code-review", "data-analysis"], names
+    end
+
+    it "parses name and description from frontmatter" do
+      skills = backend.list_skills
+      code_review = skills.find { |s| s.name == "code-review" }
+      assert_equal "Reviews code for quality, style, and potential issues.", code_review.description
+    end
+
+    it "merges unrecognized frontmatter keys into metadata" do
+      skills = backend.list_skills
+      code_review = skills.find { |s| s.name == "code-review" }
+      assert_equal "test", code_review.metadata[:author]
+    end
+
+    it "returns empty metadata when no extra keys" do
+      skills = backend.list_skills
+      data_analysis = skills.find { |s| s.name == "data-analysis" }
+      assert_equal({}, data_analysis.metadata)
+    end
+
+    it "returns empty array for non-existent path" do
+      backend = Riffer::Skills::FilesystemBackend.new("/nonexistent/path")
+      assert_equal [], backend.list_skills
+    end
+
+    it "scans multiple paths" do
+      backend = Riffer::Skills::FilesystemBackend.new(fixtures_path, extra_path)
+      skills = backend.list_skills
+      assert_equal 3, skills.length
+      names = skills.map(&:name).sort
+      assert_equal ["code-review", "data-analysis", "summarize"], names
+    end
+
+    it "uses first-path-wins for duplicate skill names" do
+      backend = Riffer::Skills::FilesystemBackend.new(fixtures_path, fixtures_path)
+      skills = backend.list_skills
+      names = skills.map(&:name).sort
+      assert_equal ["code-review", "data-analysis"], names
+    end
+
+    it "raises when directory name does not match skill name" do
+      Dir.mktmpdir do |dir|
+        skill_dir = File.join(dir, "wrong-name")
+        FileUtils.mkdir_p(skill_dir)
+        File.write(File.join(skill_dir, "SKILL.md"), "---\nname: correct-name\ndescription: test\n---\nBody")
+        backend = Riffer::Skills::FilesystemBackend.new(dir)
+        error = assert_raises(Riffer::ArgumentError) { backend.list_skills }
+        assert_match(/does not match name/, error.message)
+      end
+    end
+  end
+
+  describe "#read_skill" do
+    it "returns the body without frontmatter" do
+      body = backend.read_skill("code-review")
+      assert_includes body, "You are a code review assistant."
+      refute_includes body, "---"
+      refute_includes body, "name: code-review"
+    end
+
+    it "raises for unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { backend.read_skill("nonexistent") }
+      assert_match(/Skill not found/, error.message)
+    end
+
+    it "auto-discovers skills on first read_skill call" do
+      fresh_backend = Riffer::Skills::FilesystemBackend.new(fixtures_path)
+      body = fresh_backend.read_skill("data-analysis")
+      assert_includes body, "data analysis assistant"
+    end
+  end
+end

--- a/test/riffer/skills/frontmatter_test.rb
+++ b/test/riffer/skills/frontmatter_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::Frontmatter do
+  describe ".parse" do
+    it "parses valid SKILL.md content into frontmatter and body" do
+      raw = "---\nname: code-review\ndescription: Reviews code.\n---\nYou are a reviewer."
+      fm, body = Riffer::Skills::Frontmatter.parse(raw)
+      assert_equal "code-review", fm.name
+      assert_equal "Reviews code.", fm.description
+      assert_equal({}, fm.metadata)
+      assert_equal "You are a reviewer.", body
+    end
+
+    it "merges extra keys into metadata" do
+      raw = "---\nname: s\ndescription: d\nauthor: test\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      assert_equal({author: "test"}, fm.metadata)
+    end
+
+    it "raises ArgumentError when no frontmatter delimiters are present" do
+      raw = "Just plain text"
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.parse(raw) }
+      assert_match(/missing YAML frontmatter/, error.message)
+    end
+
+    it "raises ArgumentError when frontmatter is a bare string" do
+      raw = "---\nhello world\n---\nBody"
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.parse(raw) }
+      assert_match(/must be a YAML mapping/, error.message)
+    end
+
+    it "raises ArgumentError when frontmatter is an array" do
+      raw = "---\n- one\n- two\n---\nBody"
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.parse(raw) }
+      assert_match(/must be a YAML mapping/, error.message)
+    end
+
+    it "raises ArgumentError when frontmatter is a number" do
+      raw = "---\n42\n---\nBody"
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.parse(raw) }
+      assert_match(/must be a YAML mapping/, error.message)
+    end
+  end
+
+  describe "#initialize" do
+    it "creates a frontmatter with valid name and description" do
+      fm = Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code.")
+      assert_equal "code-review", fm.name
+      assert_equal "Reviews code.", fm.description
+      assert_equal({}, fm.metadata)
+    end
+
+    it "accepts metadata" do
+      fm = Riffer::Skills::Frontmatter.new(name: "s", description: "desc", metadata: {author: "test"})
+      assert_equal({author: "test"}, fm.metadata)
+    end
+
+    it "raises on empty name" do
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "", description: "desc") }
+      assert_match(/1-64 characters/, error.message)
+    end
+
+    it "raises on name with uppercase" do
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "Code", description: "desc") }
+      assert_match(/must match/, error.message)
+    end
+
+    it "raises on name starting with hyphen" do
+      assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "-skill", description: "desc") }
+    end
+
+    it "raises on name ending with hyphen" do
+      assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "skill-", description: "desc") }
+    end
+
+    it "raises on name with consecutive hyphens" do
+      assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "my--skill", description: "desc") }
+    end
+
+    it "raises on name with underscores" do
+      assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "my_skill", description: "desc") }
+    end
+
+    it "raises on name exceeding 64 characters" do
+      long_name = "a" * 65
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: long_name, description: "desc") }
+      assert_match(/1-64 characters/, error.message)
+    end
+
+    it "raises on non-string name" do
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: 123, description: "desc") }
+      assert_match(/must be a String/, error.message)
+    end
+
+    it "raises on empty description" do
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "s", description: "") }
+      assert_match(/1-1024 characters/, error.message)
+    end
+
+    it "raises on description exceeding 1024 characters" do
+      long_desc = "a" * 1025
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "s", description: long_desc) }
+      assert_match(/1-1024 characters/, error.message)
+    end
+
+    it "raises on non-string description" do
+      error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.new(name: "s", description: 123) }
+      assert_match(/must be a String/, error.message)
+    end
+  end
+end

--- a/test/riffer/skills/markdown_adapter_test.rb
+++ b/test/riffer/skills/markdown_adapter_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::MarkdownAdapter do
+  let(:adapter) { Riffer::Skills::MarkdownAdapter.new }
+  let(:skills) do
+    [
+      Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code for quality."),
+      Riffer::Skills::Frontmatter.new(name: "data-analysis", description: "Analyzes datasets.")
+    ]
+  end
+
+  describe "#render_catalog" do
+    it "renders a Markdown skill catalog" do
+      output = adapter.render_catalog(skills)
+      assert_includes output, "## Available Skills"
+      assert_includes output, "skill_activate"
+      assert_includes output, "- **code-review**: Reviews code for quality."
+      assert_includes output, "- **data-analysis**: Analyzes datasets."
+    end
+  end
+end

--- a/test/riffer/skills/xml_adapter_test.rb
+++ b/test/riffer/skills/xml_adapter_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::XmlAdapter do
+  let(:adapter) { Riffer::Skills::XmlAdapter.new }
+  let(:skills) do
+    [
+      Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code for quality."),
+      Riffer::Skills::Frontmatter.new(name: "data-analysis", description: "Analyzes datasets.")
+    ]
+  end
+
+  describe "#render_catalog" do
+    it "renders an XML skill catalog" do
+      output = adapter.render_catalog(skills)
+      assert_includes output, "<available_skills>"
+      assert_includes output, "</available_skills>"
+      assert_includes output, "<name>code-review</name>"
+      assert_includes output, "<description>Reviews code for quality.</description>"
+      assert_includes output, "<name>data-analysis</name>"
+      assert_includes output, "skill_activate"
+    end
+
+    it "escapes XML-unsafe characters in descriptions" do
+      skill = Riffer::Skills::Frontmatter.new(name: "compare", description: "Compares A & B using <templates>")
+      output = adapter.render_catalog([skill])
+      assert_includes output, "<description>Compares A &amp; B using &lt;templates&gt;</description>"
+    end
+  end
+end

--- a/test/riffer/stream_events/skill_activation_test.rb
+++ b/test/riffer/stream_events/skill_activation_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::StreamEvents::SkillActivation do
+  describe "#initialize" do
+    it "sets the name" do
+      event = Riffer::StreamEvents::SkillActivation.new("code-review")
+      expect(event.name).must_equal "code-review"
+    end
+
+    it "defaults role to system" do
+      event = Riffer::StreamEvents::SkillActivation.new("code-review")
+      expect(event.role).must_equal :system
+    end
+
+    it "allows setting custom role" do
+      event = Riffer::StreamEvents::SkillActivation.new("code-review", role: :assistant)
+      expect(event.role).must_equal :assistant
+    end
+  end
+
+  describe "#to_h" do
+    it "returns hash with role and name" do
+      event = Riffer::StreamEvents::SkillActivation.new("code-review")
+      expect(event.to_h).must_equal({role: :system, name: "code-review"})
+    end
+  end
+end


### PR DESCRIPTION
### Summary

- Add skills support using the [Agent Skills spec](https://agentskills.io/) tool-based activation pattern
- Skills are discovered through a pluggable `Backend` interface (built-in `FilesystemBackend` scans directories for `SKILL.md` files)
- Only frontmatter (name + description) is injected into the system prompt; full instructions are loaded on-demand via a `skill_activate` tool
- A skill `Adapter` encapsulates provider-specific behavior: how the catalog is rendered in the system prompt and which tool the LLM calls to activate skills (XML for Anthropic, Markdown for others)
- New agent DSL: `skills` block with `backend`, `adapter`, and `activate` options

### Out of scope

- Reference files, asset files, and script execution from skill directories
- Skill search tool (applications provide their own — the skill catalog is available in `tool_context`)
- Explicit invocation syntax (e.g., `/skill-name` parsing from user input)
- Skill versioning, pinning, registries, trust/sandboxing