### PR TITLE
fix: use anyOf for optional enum params in strict JSON Schema

### DIFF
--- a/lib/riffer/param.rb
+++ b/lib/riffer/param.rb
@@ -67,10 +67,22 @@ class Riffer::Param
   # (+["type", "null"]+) so that strict mode providers can distinguish
   # "absent" from "present" without rejecting the schema.
   #
+  # Optional parameters with an +enum+ use +anyOf+ to separate the enum
+  # constraint from the null type, since providers like Anthropic reject
+  # +{"type": ["string", "null"], "enum": [...]}+.
+  #
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema(strict: false)
+    nullable = strict && !required
+
+    if nullable && enum
+      schema = {anyOf: [{type: type_name, enum: enum}, {type: "null"}]}
+      schema[:description] = description if description
+      return schema
+    end
+
     type = type_name
-    type = [type, "null"] if strict && !required
+    type = [type, "null"] if nullable
 
     schema = {type: type}
     schema[:description] = description if description

--- a/sig/generated/riffer/param.rbs
+++ b/sig/generated/riffer/param.rbs
@@ -45,6 +45,10 @@ class Riffer::Param
   # (+["type", "null"]+) so that strict mode providers can distinguish
   # "absent" from "present" without rejecting the schema.
   #
+  # Optional parameters with an +enum+ use +anyOf+ to separate the enum
+  # constraint from the null type, since providers like Anthropic reject
+  # +{"type": ["string", "null"], "enum": [...]}+.
+  #
   # : (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema: (?strict: bool) -> Hash[Symbol, untyped]
 end

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_enum_value.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_enum_value.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"Classify the session:
+        yoga class, in-person format. Return session_type from the enum."}]}],"system":[],"outputConfig":{"textFormat":{"type":"json_schema","structure":{"jsonSchema":{"schema":"{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"description\":\"Session
+        name\"},\"session_type\":{\"anyOf\":[{\"type\":\"string\",\"enum\":[\"in_person\",\"online\",\"both\"]},{\"type\":\"null\"}],\"description\":\"Type
+        of session\"}},\"required\":[\"name\",\"session_type\"],\"additionalProperties\":false}","name":"response"}}}}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 6d4e04ce-96d7-43b4-8be3-a8b3c72c2ef1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.242.0 ua/2.1 api/bedrock_runtime#1.73.0 os/macos#25 md/arm64
+        lang/ruby#3.4.8 md/3.4.8 m/Z,b,D
+      Content-Length:
+      - '592'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:56:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '371'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 9e0ff700-b734-4c6d-b75a-04e21b3936b2
+    body:
+      encoding: UTF-8
+      string: '{"metrics":{"latencyMs":1682},"output":{"message":{"content":[{"text":"{\"name\":\"yoga
+        class\",\"session_type\":\"in_person\"}"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,"inputTokens":269,"outputTokens":17,"serverToolUsage":{},"totalTokens":286}}'
+  recorded_at: Mon, 02 Mar 2026 22:56:37 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_null.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_null.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"Classify the session:
+        yoga class, underwater format. The session_type enum does not cover this,
+        return null for session_type."}]}],"system":[],"outputConfig":{"textFormat":{"type":"json_schema","structure":{"jsonSchema":{"schema":"{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\",\"description\":\"Session
+        name\"},\"session_type\":{\"anyOf\":[{\"type\":\"string\",\"enum\":[\"in_person\",\"online\",\"both\"]},{\"type\":\"null\"}],\"description\":\"Type
+        of session\"}},\"required\":[\"name\",\"session_type\"],\"additionalProperties\":false}","name":"response"}}}}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 718607ee-789d-4e33-9c73-5a7fdd0bec05
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.242.0 ua/2.1 api/bedrock_runtime#1.73.0 os/macos#25 md/arm64
+        lang/ruby#3.4.8 md/3.4.8 m/Z,b,D
+      Content-Length:
+      - '631'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:56:38 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '381'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 8ec6741e-c930-4800-a9e1-e9467bf197f4
+    body:
+      encoding: UTF-8
+      string: '{"metrics":{"latencyMs":1576},"output":{"message":{"content":[{"text":"{\"name\":\"yoga
+        class, underwater format\",\"session_type\":null}"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"cacheWriteInputTokenCount":0,"cacheWriteInputTokens":0,"inputTokens":276,"outputTokens":18,"serverToolUsage":{},"totalTokens":294}}'
+  recorded_at: Mon, 02 Mar 2026 22:56:38 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_enum_value.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_enum_value.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Classify
+        the session: yoga class, in-person format. Return session_type from the enum."}],"max_tokens":4096,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"name":{"type":"string","description":"Session
+        name"},"session_type":{"anyOf":[{"type":"string","enum":["in_person","online","both"]},{"type":"null"}],"description":"Type
+        of session"}},"required":["name","session_type"],"additionalProperties":false}}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Anthropic::Client/Ruby 1.23.0
+      Host:
+      - api.anthropic.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 1.23.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Anthropic-Version:
+      - '2023-06-01'
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '523'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:54:48 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2026-03-02T22:54:48Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2026-03-02T22:54:48Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '4000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '3999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2026-03-02T22:54:47Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2026-03-02T22:54:48Z'
+      Request-Id:
+      - req_011CYf5RcAhm9CYowioStLJf
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 448f7295-c0ce-49f3-9599-c18ee47b4fc1
+      Server:
+      - cloudflare
+      X-Envoy-Upstream-Service-Time:
+      - '729'
+      Vary:
+      - Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Cf-Ray:
+      - 9d63fc3bacff243a-YVR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_013CfWhXKKmHHBmEParNZnEV","type":"message","role":"assistant","content":[{"type":"text","text":"{\"name\":\"yoga
+        class\",\"session_type\":\"in_person\"}"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":269,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":17,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: Mon, 02 Mar 2026 22:54:48 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_null.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_null.yml
@@ -1,0 +1,108 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"model":"claude-haiku-4-5-20251001","messages":[{"role":"user","content":"Classify
+        the session: yoga class, underwater format. The session_type enum does not
+        cover this, return null for session_type."}],"max_tokens":4096,"output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"name":{"type":"string","description":"Session
+        name"},"session_type":{"anyOf":[{"type":"string","enum":["in_person","online","both"]},{"type":"null"}],"description":"Type
+        of session"}},"required":["name","session_type"],"additionalProperties":false}}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - Anthropic::Client/Ruby 1.23.0
+      Host:
+      - api.anthropic.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 1.23.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Anthropic-Version:
+      - '2023-06-01'
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '562'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:54:49 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Input-Tokens-Limit:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Remaining:
+      - '4000000'
+      Anthropic-Ratelimit-Input-Tokens-Reset:
+      - '2026-03-02T22:54:49Z'
+      Anthropic-Ratelimit-Output-Tokens-Limit:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Remaining:
+      - '800000'
+      Anthropic-Ratelimit-Output-Tokens-Reset:
+      - '2026-03-02T22:54:49Z'
+      Anthropic-Ratelimit-Requests-Limit:
+      - '4000'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '3999'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2026-03-02T22:54:48Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '4800000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2026-03-02T22:54:49Z'
+      Request-Id:
+      - req_011CYf5RgDnSW4GPR1SoHdtF
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Anthropic-Organization-Id:
+      - 448f7295-c0ce-49f3-9599-c18ee47b4fc1
+      Server:
+      - cloudflare
+      X-Envoy-Upstream-Service-Time:
+      - '1005'
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 9d63fc418892cb95-YVR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"model":"claude-haiku-4-5-20251001","id":"msg_01ByaMqZZ8f69pPXYWpw8QP2","type":"message","role":"assistant","content":[{"type":"text","text":"{\"name\":\"yoga
+        class, underwater format\",\"session_type\":null}"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":276,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":18,"service_tier":"standard","inference_geo":"not_available"}}'
+  recorded_at: Mon, 02 Mar 2026 22:54:49 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_enum_value.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_enum_value.yml
@@ -1,0 +1,207 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"input":[{"role":"user","content":"Classify the session: yoga class,
+        in-person format. Return session_type from the enum."}],"model":"gpt-5-nano","text":{"format":{"type":"json_schema","name":"response","schema":{"type":"object","properties":{"name":{"type":"string","description":"Session
+        name"},"session_type":{"anyOf":[{"type":"string","enum":["in_person","online","both"]},{"type":"null"}],"description":"Type
+        of session"}},"required":["name","session_type"],"additionalProperties":false},"strict":true}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - OpenAI::Client/Ruby 0.49.0
+      Host:
+      - api.openai.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 0.49.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '510'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:55:05 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '180000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '179999451'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - team-c58089d6-6de8-4174-9362-b238cecaf04f
+      Openai-Project:
+      - proj_bAqiRfh7TFWmykwzXG5BVsrE
+      X-Request-Id:
+      - req_e1178187c43e4bafb4f3134e79a2f405
+      Openai-Processing-Ms:
+      - '7021'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=6shgkOGkx4eJus4T9S6SMC6cMCl.awiFV4nvIIWnGJs-1772492097.7545705-1.0.1.1-ZRX8x4k6VwqetAV9X8XP4F9OMX7aYhLijUkUlm6ERDpzaHnaGFpjF3YXJH7PpzatqGaXebFTMhUIN0I6d4p.PdSTpPKARMGE4gqMSm.zLw3nzJ5dPkm22m9Ifw0dfvRr;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Mon, 02 Mar 2026
+        23:25:05 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Ray:
+      - 9d63fc7afcfdadab-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_0016c23a704d4d900169a6154207488195b7a421519bdc570a",
+          "object": "response",
+          "created_at": 1772492098,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1772492105,
+          "error": null,
+          "frequency_penalty": 0.0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-5-nano-2025-08-07",
+          "output": [
+            {
+              "id": "rs_0016c23a704d4d900169a6154245e0819598b16318d1e7d518",
+              "type": "reasoning",
+              "summary": []
+            },
+            {
+              "id": "msg_0016c23a704d4d900169a615488be88195812ad3148672531a",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\"name\":\"Yoga class\",\"session_type\":\"in_person\"}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0.0,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "prompt_cache_retention": null,
+          "reasoning": {
+            "effort": "medium",
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": false,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "description": null,
+              "name": "response",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Session name"
+                  },
+                  "session_type": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "in_person",
+                          "online",
+                          "both"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Type of session"
+                  }
+                },
+                "required": [
+                  "name",
+                  "session_type"
+                ],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 84,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 767,
+            "output_tokens_details": {
+              "reasoning_tokens": 704
+            },
+            "total_tokens": 851
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Mon, 02 Mar 2026 22:55:05 GMT
+recorded_with: VCR 6.4.0

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_null.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_null.yml
@@ -1,0 +1,208 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"input":[{"role":"user","content":"Classify the session: yoga class,
+        underwater format. The session_type enum does not cover this, return null
+        for session_type."}],"model":"gpt-5-nano","text":{"format":{"type":"json_schema","name":"response","schema":{"type":"object","properties":{"name":{"type":"string","description":"Session
+        name"},"session_type":{"anyOf":[{"type":"string","enum":["in_person","online","both"]},{"type":"null"}],"description":"Type
+        of session"}},"required":["name","session_type"],"additionalProperties":false},"strict":true}}}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - application/json
+      User-Agent:
+      - OpenAI::Client/Ruby 0.49.0
+      Host:
+      - api.openai.com
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Lang:
+      - ruby
+      X-Stainless-Os:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 0.49.0
+      X-Stainless-Runtime:
+      - ruby
+      X-Stainless-Runtime-Version:
+      - 3.4.8
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      X-Stainless-Retry-Count:
+      - '0'
+      X-Stainless-Timeout:
+      - '600.0'
+      Content-Length:
+      - '549'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 22:54:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      X-Ratelimit-Limit-Requests:
+      - '30000'
+      X-Ratelimit-Limit-Tokens:
+      - '180000000'
+      X-Ratelimit-Remaining-Requests:
+      - '29999'
+      X-Ratelimit-Remaining-Tokens:
+      - '179999565'
+      X-Ratelimit-Reset-Requests:
+      - 2ms
+      X-Ratelimit-Reset-Tokens:
+      - 0s
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - team-c58089d6-6de8-4174-9362-b238cecaf04f
+      Openai-Project:
+      - proj_bAqiRfh7TFWmykwzXG5BVsrE
+      X-Request-Id:
+      - req_a4b0cb3c4bf645b8b06cbb730644c9ca
+      Openai-Processing-Ms:
+      - '7075'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=LK54soYCAW8nE3PofZkpfxhXmO5fmdQlUM0sK0jWX1c-1772492090.4266157-1.0.1.1-wehxv6ynV3fcjEhc6KMvBVLQcbeNyxhea.w2qOtnWTnzHX5xTFDcwufiraYZvbAc1Q2rFOg13922Ig67kz2_cziLupzyLOpKKlFad0WoMMjEbHSCjrR.c2PVKu077YzE;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Mon, 02 Mar 2026
+        23:24:57 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Ray:
+      - 9d63fc4d2eb9cb95-YVR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_07be166def3e18ef0169a6153aa7e08190a1f3ce38ede58149",
+          "object": "response",
+          "created_at": 1772492090,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "completed_at": 1772492097,
+          "error": null,
+          "frequency_penalty": 0.0,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-5-nano-2025-08-07",
+          "output": [
+            {
+              "id": "rs_07be166def3e18ef0169a6153ae9cc8190abe85ee74e8b9103",
+              "type": "reasoning",
+              "summary": []
+            },
+            {
+              "id": "msg_07be166def3e18ef0169a61541492081909bae3fcee93160f0",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "{\"name\":\"Underwater yoga class\",\"session_type\":null}"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "presence_penalty": 0.0,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "prompt_cache_retention": null,
+          "reasoning": {
+            "effort": "medium",
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": false,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "json_schema",
+              "description": null,
+              "name": "response",
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Session name"
+                  },
+                  "session_type": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "in_person",
+                          "online",
+                          "both"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Type of session"
+                  }
+                },
+                "required": [
+                  "name",
+                  "session_type"
+                ],
+                "additionalProperties": false
+              },
+              "strict": true
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 91,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 654,
+            "output_tokens_details": {
+              "reasoning_tokens": 576
+            },
+            "total_tokens": 745
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Mon, 02 Mar 2026 22:54:57 GMT
+recorded_with: VCR 6.4.0

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -267,6 +267,45 @@ describe Riffer::Providers::AmazonBedrock do
       end
     end
 
+    describe "structured output with optional enum" do
+      let(:session_types) { ["in_person", "online", "both"] }
+
+      let(:optional_enum_structured_output) do
+        params = Riffer::Params.new
+        params.required(:name, String, description: "Session name")
+        params.optional(:session_type, String, enum: session_types, description: "Type of session")
+        Riffer::StructuredOutput.new(params)
+      end
+
+      it "returns an enum value when present" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_enum_value") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, in-person format. Return session_type from the enum.",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(session_types).must_include parsed["session_type"]
+        end
+      end
+
+      it "returns null when the enum value is unknown" do
+        VCR.use_cassette("Riffer_Providers_AmazonBedrock/_generate_text/structured_output_optional_enum/returns_null") do
+          provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, underwater format. The session_type enum does not cover this, return null for session_type.",
+            model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(parsed["session_type"]).must_be_nil
+        end
+      end
+    end
+
     describe "structured output with typed array" do
       let(:typed_array_prompt) { "List 3 tags and 3 scores (0.0-1.0) for: 'Ruby is a great programming language'" }
 

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -242,6 +242,45 @@ describe Riffer::Providers::Anthropic do
       end
     end
 
+    describe "structured output with optional enum" do
+      let(:session_types) { ["in_person", "online", "both"] }
+
+      let(:optional_enum_structured_output) do
+        params = Riffer::Params.new
+        params.required(:name, String, description: "Session name")
+        params.optional(:session_type, String, enum: session_types, description: "Type of session")
+        Riffer::StructuredOutput.new(params)
+      end
+
+      it "returns an enum value when present" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_enum_value") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, in-person format. Return session_type from the enum.",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(session_types).must_include parsed["session_type"]
+        end
+      end
+
+      it "returns null when the enum value is unknown" do
+        VCR.use_cassette("Riffer_Providers_Anthropic/_generate_text/structured_output_optional_enum/returns_null") do
+          provider = Riffer::Providers::Anthropic.new(api_key: api_key)
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, underwater format. The session_type enum does not cover this, return null for session_type.",
+            model: "claude-haiku-4-5-20251001",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(parsed["session_type"]).must_be_nil
+        end
+      end
+    end
+
     describe "structured output with typed array" do
       let(:typed_array_prompt) { "List 3 tags and 3 scores (0.0-1.0) for: 'Ruby is a great programming language'" }
 

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -252,6 +252,45 @@ describe Riffer::Providers::OpenAI do
       end
     end
 
+    describe "structured output with optional enum" do
+      let(:session_types) { ["in_person", "online", "both"] }
+
+      let(:optional_enum_structured_output) do
+        params = Riffer::Params.new
+        params.required(:name, String, description: "Session name")
+        params.optional(:session_type, String, enum: session_types, description: "Type of session")
+        Riffer::StructuredOutput.new(params)
+      end
+
+      it "returns an enum value when present" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_enum_value") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, in-person format. Return session_type from the enum.",
+            model: "gpt-5-nano",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(session_types).must_include parsed["session_type"]
+        end
+      end
+
+      it "returns null when the enum value is unknown" do
+        VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/structured_output_optional_enum/returns_null") do
+          provider = Riffer::Providers::OpenAI.new(api_key: api_key)
+          result = provider.generate_text(
+            prompt: "Classify the session: yoga class, underwater format. The session_type enum does not cover this, return null for session_type.",
+            model: "gpt-5-nano",
+            structured_output: optional_enum_structured_output
+          )
+          parsed = JSON.parse(result.content)
+          expect(parsed["name"]).must_be_instance_of String
+          expect(parsed["session_type"]).must_be_nil
+        end
+      end
+    end
+
     describe "structured output with typed array" do
       let(:typed_array_prompt) { "List 3 tags and 3 scores (0.0-1.0) for: 'Ruby is a great programming language'" }
 


### PR DESCRIPTION
## Summary
- Optional parameters with an `enum` generated invalid JSON Schema (`{"type": ["string", "null"], "enum": [...]}`) which Anthropic and Bedrock reject
- Uses `anyOf` to separate the enum constraint from the null type, which is valid for all providers
- Adds VCR integration tests for all three providers covering both enum-value and null responses

## Test plan
- [x] Anthropic: returns enum value when present
- [x] Anthropic: returns null when unknown
- [x] OpenAI: returns enum value when present
- [x] OpenAI: returns null when unknown
- [x] Bedrock: returns enum value when present
- [x] Bedrock: returns null when unknown
- [x] Full test suite passes (1014 runs, 0 failures, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)