### PR TITLE
feat: auto-derive step offset on resume for max_steps enforcement

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -260,6 +260,8 @@ class Riffer::Agent
   # state from persisted data (useful for cross-process resume).
   #
   # Skips message initialization and before guardrails in both cases.
+  # The step offset is derived automatically from the number of assistant
+  # messages so +max_steps+ is enforced across the full session.
   #
   #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def resume(messages: nil, tool_context: nil)
@@ -305,7 +307,7 @@ class Riffer::Agent
 
   #: (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response
   def run_generate_loop(all_modifications = [], resume: false)
-    step = 0
+    step = resume ? count_assistant_messages : 0
 
     reason = catch(:riffer_interrupt) do
       execute_pending_tool_calls if resume
@@ -384,9 +386,14 @@ class Riffer::Agent
     clear_resolved_model
   end
 
+  #: () -> Integer
+  def count_assistant_messages
+    @messages.count { |m| m.is_a?(Riffer::Messages::Assistant) }
+  end
+
   #: (Enumerator::Yielder, ?resume: bool) -> void
   def run_stream_loop(yielder, resume: false)
-    step = 0
+    step = resume ? count_assistant_messages : 0
 
     completed = catch(:riffer_interrupt) do
       execute_pending_tool_calls if resume

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -144,6 +144,8 @@ class Riffer::Agent
   # state from persisted data (useful for cross-process resume).
   #
   # Skips message initialization and before guardrails in both cases.
+  # The step offset is derived automatically from the number of assistant
+  # messages so +max_steps+ is enforced across the full session.
   #
   # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def resume: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
@@ -186,6 +188,9 @@ class Riffer::Agent
 
   # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> void
   def restore_state: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> void
+
+  # : () -> Integer
+  def count_assistant_messages: () -> Integer
 
   # : (Enumerator::Yielder, ?resume: bool) -> void
   def run_stream_loop: (Enumerator::Yielder, ?resume: bool) -> void

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2166,6 +2166,73 @@ describe Riffer::Agent do
         expect(system_messages.first.content).must_equal "Custom instructions."
       end
     end
+
+    describe "auto-derived step offset" do
+      let(:tool_class) do
+        Class.new(Riffer::Tool) do
+          description "Simple tool"
+          def call(context:)
+            text("done")
+          end
+        end.tap { |t| t.identifier("resume_step_tool") }
+      end
+
+      it "enforces max_steps across sessions" do
+        tc = tool_class
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          max_steps 3
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        3.times { provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}]) }
+
+        # First generate: runs 2 steps then gets interrupted by callback
+        interrupted_once = false
+        agent.on_message do |msg|
+          if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
+            interrupted_once = true
+            throw :riffer_interrupt
+          end
+        end
+
+        result = agent.generate("Do stuff")
+        expect(result.interrupted?).must_equal true
+
+        # Resume: step offset is auto-derived from assistant messages
+        result = agent.resume
+        expect(result.interrupted?).must_equal true
+        expect(result.interrupt_reason).must_equal :max_steps
+      end
+
+      it "enforces max_steps on cross-process resume via message counting" do
+        tc = tool_class
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          max_steps 4
+          uses_tools [tc]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        # Only 1 more step fits before max_steps (3 prior + 1 = 4)
+        provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}])
+
+        result = agent.resume(
+          messages: [
+            Riffer::Messages::User.new("Original prompt"),
+            Riffer::Messages::Assistant.new("Step 1", tool_calls: []),
+            Riffer::Messages::Assistant.new("Step 2", tool_calls: []),
+            Riffer::Messages::Assistant.new("Step 3", tool_calls: []),
+            Riffer::Messages::User.new("Continue")
+          ]
+        )
+        expect(result.interrupted?).must_equal true
+        expect(result.interrupt_reason).must_equal :max_steps
+      end
+    end
   end
 
   describe "#resume_stream" do


### PR DESCRIPTION
## Summary

- On resume, auto-derive the step offset by counting assistant messages in the conversation history
- `max_steps` is enforced across the full session transparently — no explicit step parameter needed

Split from #145 for independent review.

## Test plan

- [x] In-memory resume hits `max_steps` based on prior assistant messages
- [x] Cross-process resume counts persisted assistant messages for step offset
- [x] `bundle exec rake` passes (tests + lint + type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)