### PR TITLE
feat: add interrupt! public method for clean loop interrupts

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -370,7 +370,6 @@ response = agent.generate('Call the tool')
 response.interrupted?      # => true
 response.interrupt_reason  # => "needs human approval"
 response.content           # => last assistant content before interrupt
-response.step              # => number of LLM calls completed
 ```
 
 **Streaming** — interrupts emit an `Interrupt` event:
@@ -590,9 +589,9 @@ response.tripwire.reason   # => "Content policy violation"
 Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :riffer_interrupt`) to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
 
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
-- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason, `response.step` contains the step count at interruption.
-- **Streaming:** Yields an `Interrupt` event with `reason` and `step` attributes.
-- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pass `step:` to enforce `max_steps` across the full session. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
+- **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
+- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 agent = MyAgent.new
@@ -603,7 +602,7 @@ end
 response = agent.generate('Do something risky')
 response.interrupted?      # => true
 response.interrupt_reason  # => "approval needed"
-response = agent.resume(step: response.step)  # continues where it left off
+response = agent.resume    # continues where it left off
 ```
 
 ### Max Steps Limit

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -352,17 +352,17 @@ Works with both `generate` and `stream`. Only emits agent-generated messages (As
 
 #### Interrupting the Agent Loop
 
-Callbacks can interrupt the agent loop using Ruby's `throw`/`catch` pattern. This is useful for human-in-the-loop approval, cost limits, or content filtering.
+Callbacks can interrupt the agent loop. This is useful for human-in-the-loop approval, cost limits, or content filtering.
 
-Use `throw :riffer_interrupt` to stop the loop. The response will have `interrupted?` set to `true` and contain the accumulated content up to the point of interruption.
+Use `agent.interrupt!` (or the lower-level `throw :riffer_interrupt`) to stop the loop. The response will have `interrupted?` set to `true` and contain the accumulated content up to the point of interruption.
 
-An optional reason can be passed as the second argument to `throw`. It is available via `interrupt_reason` on the response (generate) or `reason` on the `Interrupt` event (stream):
+An optional reason can be passed to `interrupt!`. It is available via `interrupt_reason` on the response (generate) or `reason` on the `Interrupt` event (stream):
 
 ```ruby
 agent = MyAgent.new
 agent.on_message do |msg|
   if msg.is_a?(Riffer::Messages::Tool)
-    throw :riffer_interrupt, "needs human approval"
+    agent.interrupt!("needs human approval")
   end
 end
 
@@ -370,6 +370,7 @@ response = agent.generate('Call the tool')
 response.interrupted?      # => true
 response.interrupt_reason  # => "needs human approval"
 response.content           # => last assistant content before interrupt
+response.step              # => number of LLM calls completed
 ```
 
 **Streaming** — interrupts emit an `Interrupt` event:
@@ -446,6 +447,16 @@ end
 agent = MyAgent.new
 agent.resume_stream(messages: persisted_messages).each do |event|
   # handle stream events
+end
+```
+
+### interrupt!
+
+Interrupts the agent loop from an `on_message` callback. Equivalent to `throw :riffer_interrupt, reason`:
+
+```ruby
+agent.on_message do |msg|
+  agent.interrupt!(:needs_approval) if requires_approval?(msg)
 end
 ```
 
@@ -576,23 +587,23 @@ response.tripwire.reason   # => "Content policy violation"
 
 ### Callback Interrupt (imperative, external)
 
-Callbacks registered with `on_message` can call `throw :riffer_interrupt` to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
+Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :riffer_interrupt`) to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
 
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
-- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
-- **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
-- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason, `response.step` contains the step count at interruption.
+- **Streaming:** Yields an `Interrupt` event with `reason` and `step` attributes.
+- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pass `step:` to enforce `max_steps` across the full session. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 agent = MyAgent.new
 agent.on_message do |msg|
-  throw :riffer_interrupt, "approval needed" if requires_approval?(msg)
+  agent.interrupt!("approval needed") if requires_approval?(msg)
 end
 
 response = agent.generate('Do something risky')
 response.interrupted?      # => true
 response.interrupt_reason  # => "approval needed"
-response = agent.resume    # continues where it left off
+response = agent.resume(step: response.step)  # continues where it left off
 ```
 
 ### Max Steps Limit

--- a/docs/06_STREAM_EVENTS.md
+++ b/docs/06_STREAM_EVENTS.md
@@ -190,7 +190,7 @@ See [Guardrails](09_GUARDRAILS.md) for more information.
 
 Emitted when the agent loop is interrupted. This can happen in two ways:
 
-- An `on_message` callback calls `throw :riffer_interrupt` (reason is a String or `nil`).
+- An `on_message` callback calls `agent.interrupt!` or `throw :riffer_interrupt` (reason is a String or `nil`).
 - The `max_steps` limit is reached (reason is the Symbol `:max_steps`).
 
 This is the streaming equivalent of `Response#interrupted?` in generate mode.

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -291,6 +291,16 @@ class Riffer::Agent
     self
   end
 
+  # Interrupts the agent loop.
+  #
+  # Call from an +on_message+ callback to cleanly interrupt the loop.
+  # Equivalent to +throw :riffer_interrupt, reason+.
+  #
+  #: (?(String | Symbol)?) -> void
+  def interrupt!(reason = nil)
+    throw :riffer_interrupt, reason
+  end
+
   private
 
   #: (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -162,6 +162,14 @@ class Riffer::Agent
   # : () { (Riffer::Messages::Base) -> void } -> self
   def on_message: () { (Riffer::Messages::Base) -> void } -> self
 
+  # Interrupts the agent loop.
+  #
+  # Call from an +on_message+ callback to cleanly interrupt the loop.
+  # Equivalent to +throw :riffer_interrupt, reason+.
+  #
+  # : (?(String | Symbol)?) -> void
+  def interrupt!: (?(String | Symbol)?) -> void
+
   private
 
   # : (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1941,6 +1941,29 @@ describe Riffer::Agent do
         expect(first_called).must_equal true
       end
     end
+
+    describe "#interrupt!" do
+      it "interrupts the agent loop" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt! }
+        result = agent.generate("Hello")
+        expect(result.interrupted?).must_equal true
+      end
+
+      it "passes reason to interrupt_reason" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt!(:needs_approval) }
+        result = agent.generate("Hello")
+        expect(result.interrupt_reason).must_equal :needs_approval
+      end
+
+      it "defaults reason to nil" do
+        agent = agent_class.new
+        agent.on_message { |_msg| agent.interrupt! }
+        result = agent.generate("Hello")
+        expect(result.interrupt_reason).must_be_nil
+      end
+    end
   end
 
   describe "#resume" do


### PR DESCRIPTION
## Summary

- Add `interrupt!` public method that allows tools or callbacks to cleanly interrupt the agent loop
- Updated docs with interrupt! usage examples

Split from #145 for independent review.

## Test plan

- [x] `interrupt!` stops the agent loop and returns the interrupt event
- [x] `bundle exec rake` passes (tests + lint + type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)