### PR TITLE
feat: add experimental ToolRuntime abstraction for tool execution

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -219,6 +219,22 @@ Using both `of:` and a block raises `Riffer::ArgumentError`. Using `of:` with a 
 
 Structured output is not compatible with streaming — calling `stream` on an agent with structured output configured raises `Riffer::ArgumentError`.
 
+### tool_runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+Configures how tool calls are executed. Defaults to sequential (inline) execution:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime :threaded
+end
+```
+
+Accepts `:inline`, `:threaded`, a `Riffer::ToolRuntime` instance, or a `Proc`. This setting is **not inherited** by subclasses — each agent class must configure its own tool runtime explicitly. When unset, falls back to `Riffer.config.tool_runtime`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+
 ### guardrail
 
 Registers guardrails for pre/post processing of messages. Pass the guardrail class and any options:
@@ -542,7 +558,7 @@ end
 When an agent receives a response with tool calls:
 
 1. Agent detects `tool_calls` in the assistant message
-2. For each tool call:
+2. The configured tool runtime executes the tool calls (sequentially by default, or concurrently with `:threaded`):
    - Finds the matching tool class
    - Validates arguments against the tool's parameter schema
    - Calls the tool's `call` method with `context` and arguments

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -233,7 +233,7 @@ class MyAgent < Riffer::Agent
 end
 ```
 
-Accepts `:inline`, `:threaded`, a `Riffer::ToolRuntime` instance, or a `Proc`. This setting is **not inherited** by subclasses — each agent class must configure its own tool runtime explicitly. When unset, falls back to `Riffer.config.tool_runtime`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+Accepts `:inline`, `:threaded`, a `Riffer::ToolRuntime` instance, or a `Proc`. Inherited by subclasses. When unset, falls back to `Riffer.config.tool_runtime`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
 
 ### guardrail
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -229,11 +229,11 @@ Configures how tool calls are executed. Defaults to sequential (inline) executio
 class MyAgent < Riffer::Agent
   model 'openai/gpt-4o'
   uses_tools [WeatherTool, SearchTool]
-  tool_runtime :threaded
+  tool_runtime Riffer::ToolRuntime::Threaded
 end
 ```
 
-Accepts `:inline`, `:threaded`, a `Riffer::ToolRuntime` instance, or a `Proc`. Inherited by subclasses. When unset, falls back to `Riffer.config.tool_runtime`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+Accepts a `Riffer::ToolRuntime` subclass, a `Riffer::ToolRuntime` instance, or a `Proc`. Inherited by subclasses. When unset, falls back to `Riffer.config.tool_runtime`. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
 
 ### guardrail
 
@@ -558,7 +558,7 @@ end
 When an agent receives a response with tool calls:
 
 1. Agent detects `tool_calls` in the assistant message
-2. The configured tool runtime executes the tool calls (sequentially by default, or concurrently with `:threaded`):
+2. The configured tool runtime executes the tool calls (sequentially by default, or concurrently with `Riffer::ToolRuntime::Threaded`):
    - Finds the matching tool class
    - Validates arguments against the tool's parameter schema
    - Calls the tool's `call` method with `context` and arguments

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -474,16 +474,6 @@ class HttpToolRuntime < Riffer::ToolRuntime
 end
 ```
 
-You can also compose with a custom `Riffer::Runner` for concurrency control:
-
-```ruby
-class HttpToolRuntime < Riffer::ToolRuntime
-  def initialize
-    super(runner: Riffer::Runner::Threaded.new(max_concurrency: 10))
-  end
-end
-```
-
 ### Around-Call Hook
 
 Each tool call is wrapped by the `around_tool_call` instance method, which yields by default. Use the `around_tool_call` class method DSL to define custom behavior via a symbol or block:

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -368,6 +368,161 @@ rescue => e
 end
 ```
 
-Unhandled exceptions are caught by Riffer and converted to error responses with type `:execution_error`. However, it's recommended to handle expected errors explicitly for better error messages.
+Unhandled `RuntimeError` exceptions are caught by Riffer and converted to error responses with type `:execution_error`. For expected execution errors, raise `Riffer::ToolExecutionError` — these are also caught and returned to the LLM. Programming bugs (`NoMethodError`, `NameError`, `TypeError`, etc.) propagate to the caller. It's recommended to handle expected errors explicitly for better error messages.
 
 The LLM receives the error message and can decide how to respond (retry, apologize, ask for different input, etc.).
+
+## Tool Runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+By default, tool calls are executed sequentially in the current thread using `Riffer::ToolRuntime::Inline`. You can change how tool calls are executed by configuring a different tool runtime.
+
+### Built-in Runtimes
+
+| Runtime | Description |
+|---------|-------------|
+| `Riffer::ToolRuntime::Inline` | Executes tool calls sequentially (default) |
+| `Riffer::ToolRuntime::Threaded` | Executes tool calls concurrently using threads |
+
+### Per-Agent Configuration
+
+Use the `tool_runtime` class method on your agent:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime :threaded
+end
+```
+
+Accepted values:
+
+- `:inline` — sequential execution (default)
+- `:threaded` — concurrent execution using threads
+- A `Riffer::ToolRuntime` instance — for custom runtimes
+- A `Proc` — evaluated at runtime (see below)
+
+### Dynamic Resolution
+
+Use a lambda for context-aware runtime selection:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+
+  tool_runtime ->(context) {
+    context&.dig(:parallel) ? :threaded : :inline
+  }
+end
+
+agent.generate("Do work", tool_context: {parallel: true})
+```
+
+When the lambda accepts a parameter, it receives the `tool_context`. Zero-arity lambdas are also supported.
+
+### Global Configuration
+
+Set a default tool runtime for all agents:
+
+```ruby
+Riffer.configure do |config|
+  config.tool_runtime = :threaded
+end
+```
+
+Per-agent configuration overrides the global default.
+
+### Threaded Runtime Considerations
+
+When using `:threaded`, each tool call runs in its own thread. The `around_tool_call` hook also runs inside that thread. Be mindful of thread-local state — for example, `ActiveRecord::Base.connection`, `RequestStore`, or any `Thread.current[]` values may not be available or may behave differently across threads. Ensure your tools and hooks are thread-safe.
+
+### Threaded Runtime Options
+
+The threaded runtime accepts a `max_concurrency` option (default: 5):
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
+end
+```
+
+### Custom Runtimes
+
+Create a custom runtime by subclassing `Riffer::ToolRuntime` and overriding the private `dispatch_tool_call` method:
+
+```ruby
+class HttpToolRuntime < Riffer::ToolRuntime
+  private
+
+  def dispatch_tool_call(tool_call, tools:, context:)
+    # Dispatch tool execution to an external service
+    response = HttpClient.post("/tools/execute", {
+      name: tool_call.name,
+      arguments: tool_call.arguments
+    })
+    Riffer::Tools::Response.text(response.body)
+  rescue Riffer::ToolExecutionError => e
+    Riffer::Tools::Response.error(e.message, type: :execution_error)
+  rescue RuntimeError => e
+    Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+  end
+end
+```
+
+You can also compose with a custom `Riffer::Runner` for concurrency control:
+
+```ruby
+class HttpToolRuntime < Riffer::ToolRuntime
+  def initialize
+    super(runner: Riffer::Runner::Threaded.new(max_concurrency: 10))
+  end
+end
+```
+
+### Around-Call Hook
+
+Each tool call is wrapped by the `around_tool_call` instance method, which yields by default. Use the `around_tool_call` class method DSL to define custom behavior via a symbol or block:
+
+```ruby
+# Symbol — delegates to a named instance method (recommended for non-trivial logic):
+class InstrumentedRuntime < Riffer::ToolRuntime
+  around_tool_call :instrument
+
+  private
+
+  def instrument(tool_call, context:, &block)
+    start = Time.now
+    result = block.call
+    duration = Time.now - start
+    Rails.logger.info("Tool #{tool_call.name} took #{duration}s")
+    result
+  end
+end
+
+# Block — for simple inline hooks:
+class LoggingRuntime < Riffer::ToolRuntime
+  around_tool_call do |tool_call, context:, &block|
+    puts "Executing #{tool_call.name}"
+    block.call
+  end
+end
+```
+
+You can also override `around_tool_call` directly as an instance method:
+
+```ruby
+class CustomRuntime < Riffer::ToolRuntime
+  private
+
+  def around_tool_call(tool_call, context:)
+    yield
+  end
+end
+```
+
+Subclasses inherit the hook and can override it further.

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -476,41 +476,18 @@ end
 
 ### Around-Call Hook
 
-Each tool call is wrapped by the `around_tool_call` instance method, which yields by default. Use the `around_tool_call` class method DSL to define custom behavior via a symbol or block:
+Each tool call is wrapped by the `around_tool_call` method, which yields by default. Override it in a subclass to add instrumentation, logging, or other cross-cutting concerns:
 
 ```ruby
-# Symbol — delegates to a named instance method (recommended for non-trivial logic):
-class InstrumentedRuntime < Riffer::ToolRuntime
-  around_tool_call :instrument
-
-  private
-
-  def instrument(tool_call, context:, &block)
-    start = Time.now
-    result = block.call
-    duration = Time.now - start
-    Rails.logger.info("Tool #{tool_call.name} took #{duration}s")
-    result
-  end
-end
-
-# Block — for simple inline hooks:
-class LoggingRuntime < Riffer::ToolRuntime
-  around_tool_call do |tool_call, context:, &block|
-    puts "Executing #{tool_call.name}"
-    block.call
-  end
-end
-```
-
-You can also override `around_tool_call` directly as an instance method:
-
-```ruby
-class CustomRuntime < Riffer::ToolRuntime
+class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   private
 
   def around_tool_call(tool_call, context:)
-    yield
+    start = Time.now
+    result = yield
+    duration = Time.now - start
+    Rails.logger.info("Tool #{tool_call.name} took #{duration}s")
+    result
   end
 end
 ```

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -393,15 +393,14 @@ Use the `tool_runtime` class method on your agent:
 class MyAgent < Riffer::Agent
   model 'openai/gpt-4o'
   uses_tools [WeatherTool, SearchTool]
-  tool_runtime :threaded
+  tool_runtime Riffer::ToolRuntime::Threaded
 end
 ```
 
 Accepted values:
 
-- `:inline` — sequential execution (default)
-- `:threaded` — concurrent execution using threads
-- A `Riffer::ToolRuntime` instance — for custom runtimes
+- A `Riffer::ToolRuntime` subclass — instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`)
+- A `Riffer::ToolRuntime` instance — for custom runtimes with specific options
 - A `Proc` — evaluated at runtime (see below)
 
 ### Dynamic Resolution
@@ -414,7 +413,7 @@ class MyAgent < Riffer::Agent
   uses_tools [WeatherTool, SearchTool]
 
   tool_runtime ->(context) {
-    context&.dig(:parallel) ? :threaded : :inline
+    context&.dig(:parallel) ? Riffer::ToolRuntime::Threaded.new : Riffer::ToolRuntime::Inline.new
   }
 end
 
@@ -429,7 +428,7 @@ Set a default tool runtime for all agents:
 
 ```ruby
 Riffer.configure do |config|
-  config.tool_runtime = :threaded
+  config.tool_runtime = Riffer::ToolRuntime::Threaded
 end
 ```
 
@@ -437,7 +436,7 @@ Per-agent configuration overrides the global default.
 
 ### Threaded Runtime Considerations
 
-When using `:threaded`, each tool call runs in its own thread. The `around_tool_call` hook also runs inside that thread. Be mindful of thread-local state — for example, `ActiveRecord::Base.connection`, `RequestStore`, or any `Thread.current[]` values may not be available or may behave differently across threads. Ensure your tools and hooks are thread-safe.
+When using `Riffer::ToolRuntime::Threaded`, each tool call runs in its own thread. The `around_tool_call` hook also runs inside that thread. Be mindful of thread-local state — for example, `ActiveRecord::Base.connection`, `RequestStore`, or any `Thread.current[]` values may not be available or may behave differently across threads. Ensure your tools and hooks are thread-safe.
 
 ### Threaded Runtime Options
 

--- a/docs/07_CONFIGURATION.md
+++ b/docs/07_CONFIGURATION.md
@@ -80,15 +80,14 @@ Configure the default tool runtime for all agents:
 
 ```ruby
 Riffer.configure do |config|
-  config.tool_runtime = :threaded
+  config.tool_runtime = Riffer::ToolRuntime::Threaded
 end
 ```
 
 | Value | Description |
 |-------|-------------|
-| `:inline` | Sequential execution (default) |
-| `:threaded` | Concurrent execution using threads |
-| `Riffer::ToolRuntime` instance | Custom runtime |
+| `Riffer::ToolRuntime` subclass | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`) |
+| `Riffer::ToolRuntime` instance | Custom runtime with specific options |
 | `Proc` | Dynamic resolution |
 
 Per-agent configuration overrides this global default. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.

--- a/docs/07_CONFIGURATION.md
+++ b/docs/07_CONFIGURATION.md
@@ -72,6 +72,27 @@ Riffer.configure do |config|
 end
 ```
 
+### Tool Runtime (Experimental)
+
+> **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
+
+Configure the default tool runtime for all agents:
+
+```ruby
+Riffer.configure do |config|
+  config.tool_runtime = :threaded
+end
+```
+
+| Value | Description |
+|-------|-------------|
+| `:inline` | Sequential execution (default) |
+| `:threaded` | Concurrent execution using threads |
+| `Riffer::ToolRuntime` instance | Custom runtime |
+| `Proc` | Dynamic resolution |
+
+Per-agent configuration overrides this global default. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
+
 ## Agent-Level Configuration
 
 Override global configuration at the agent level:

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -27,6 +27,9 @@ module Riffer
   # Raised when tool execution times out.
   class TimeoutError < Error; end
 
+  # Raised when a tool encounters an expected execution error.
+  class ToolExecutionError < Error; end
+
   # Returns the Riffer configuration.
   #
   #: () -> Riffer::Config

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -109,6 +109,20 @@ class Riffer::Agent
     @tools_config = tools_or_lambda
   end
 
+  # Gets or sets the tool runtime for this agent.
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  #
+  # This setting is not inherited by subclasses — each agent class must
+  # configure its own tool runtime explicitly. When unset, falls back to
+  # the global +Riffer.config.tool_runtime+.
+  #
+  #: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  def self.tool_runtime(value = nil)
+    return @tool_runtime if value.nil?
+    @tool_runtime = value
+  end
+
   # Finds an agent class by identifier.
   #
   #: (String) -> singleton(Riffer::Agent)?
@@ -212,6 +226,7 @@ class Riffer::Agent
   def generate(prompt_or_messages, files: nil, tool_context: nil)
     @tool_context = tool_context
     @resolved_tools = nil
+    @resolved_tool_runtime = nil
     clear_resolved_model
     @interrupted = false
     @structured_output = resolve_structured_output
@@ -236,6 +251,7 @@ class Riffer::Agent
 
     @tool_context = tool_context
     @resolved_tools = nil
+    @resolved_tool_runtime = nil
     clear_resolved_model
     @interrupted = false
     initialize_messages(prompt_or_messages, files: files)
@@ -383,6 +399,7 @@ class Riffer::Agent
     @tool_context = tool_context if tool_context
     @interrupted = false
     @resolved_tools = nil
+    @resolved_tool_runtime = nil
     clear_resolved_model
   end
 
@@ -501,8 +518,10 @@ class Riffer::Agent
 
   #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
-    response.tool_calls.each do |tool_call|
-      result = execute_tool_call(tool_call)
+    runtime = resolve_tool_runtime
+    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @tool_context)
+
+    results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.id,
@@ -537,10 +556,13 @@ class Riffer::Agent
       m.is_a?(Riffer::Messages::Tool)
     }.map(&:tool_call_id)
 
-    # Execute any tool calls whose id is not in the executed set.
-    assistant.tool_calls.each do |tool_call|
-      next if executed_ids.include?(tool_call.id)
-      result = execute_tool_call(tool_call)
+    pending = assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
+    return if pending.empty?
+
+    runtime = resolve_tool_runtime
+    results = runtime.execute(pending, tools: resolved_tools, context: @tool_context)
+
+    results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.id,
@@ -548,31 +570,6 @@ class Riffer::Agent
         error: result.error_message,
         error_type: result.error_type
       ))
-    end
-  end
-
-  #: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-  def execute_tool_call(tool_call)
-    tool_class = find_tool_class(tool_call.name)
-
-    if tool_class.nil?
-      return Riffer::Tools::Response.error(
-        "Unknown tool '#{tool_call.name}'",
-        type: :unknown_tool
-      )
-    end
-
-    tool_instance = tool_class.new
-    arguments = parse_tool_arguments(tool_call.arguments)
-
-    begin
-      tool_instance.call_with_validation(context: @tool_context, **arguments)
-    rescue Riffer::TimeoutError => e
-      Riffer::Tools::Response.error(e.message, type: :timeout_error)
-    rescue Riffer::ValidationError => e
-      Riffer::Tools::Response.error(e.message, type: :validation_error)
-    rescue => e
-      Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
     end
   end
 
@@ -618,16 +615,24 @@ class Riffer::Agent
     end
   end
 
-  #: (String) -> singleton(Riffer::Tool)?
-  def find_tool_class(name)
-    resolved_tools.find { |tool_class| tool_class.name == name }
-  end
+  #: () -> Riffer::ToolRuntime
+  def resolve_tool_runtime
+    @resolved_tool_runtime ||= begin
+      config = self.class.tool_runtime || Riffer.config.tool_runtime
 
-  #: (String?) -> Hash[Symbol, untyped]
-  def parse_tool_arguments(arguments)
-    return {} if arguments.nil? || arguments.empty?
+      runtime = if config.is_a?(Proc)
+        (config.arity == 0) ? config.call : config.call(@tool_context)
+      else
+        config
+      end
 
-    JSON.parse(arguments, symbolize_names: true)
+      case runtime
+      when :inline then Riffer::ToolRuntime::Inline.new
+      when :threaded then Riffer::ToolRuntime::Threaded.new
+      when Riffer::ToolRuntime then runtime
+      else raise Riffer::ArgumentError, "Invalid tool_runtime: #{runtime.inspect}"
+      end
+    end
   end
 
   #: () -> Riffer::Messages::Assistant?

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -111,12 +111,13 @@ class Riffer::Agent
 
   # Gets or sets the tool runtime for this agent.
   #
-  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
+  # or a Proc.
   #
   # Inherited by subclasses. When unset, walks the ancestor chain and
   # falls back to the global +Riffer.config.tool_runtime+.
   #
-  #: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  #: (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime(value = nil)
     if value.nil?
       return @tool_runtime if instance_variable_defined?(:@tool_runtime)
@@ -630,8 +631,7 @@ class Riffer::Agent
       end
 
       case runtime
-      when :inline then Riffer::ToolRuntime::Inline.new
-      when :threaded then Riffer::ToolRuntime::Threaded.new
+      when Class then runtime.new
       when Riffer::ToolRuntime then runtime
       else raise Riffer::ArgumentError, "Invalid tool_runtime: #{runtime.inspect}"
       end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -113,14 +113,17 @@ class Riffer::Agent
   #
   # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
   #
-  # This setting is not inherited by subclasses — each agent class must
-  # configure its own tool runtime explicitly. When unset, falls back to
-  # the global +Riffer.config.tool_runtime+.
+  # Inherited by subclasses. When unset, walks the ancestor chain and
+  # falls back to the global +Riffer.config.tool_runtime+.
   #
   #: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime(value = nil)
-    return @tool_runtime if value.nil?
-    @tool_runtime = value
+    if value.nil?
+      return @tool_runtime if instance_variable_defined?(:@tool_runtime)
+      superclass.respond_to?(:tool_runtime) ? superclass.tool_runtime : nil
+    else
+      @tool_runtime = value
+    end
   end
 
   # Finds an agent class by identifier.

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -34,20 +34,19 @@ class Riffer::Config
 
   # Global tool runtime configuration (experimental).
   #
-  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
   # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
-  attr_reader :tool_runtime #: (Symbol | Riffer::ToolRuntime | Proc)
+  attr_reader :tool_runtime #: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)
 
   # Sets the global tool runtime.
   #
   # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
-  # (Symbol, ToolRuntime instance, or Proc).
+  # (ToolRuntime subclass, ToolRuntime instance, or Proc).
   #
-  #: ((Symbol | Riffer::ToolRuntime | Proc)) -> void
+  #: ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=(value)
-    unless value.is_a?(Symbol) || value.is_a?(Riffer::ToolRuntime) || value.is_a?(Proc)
-      raise Riffer::ArgumentError, "tool_runtime must be a Symbol (:inline, :threaded), a Riffer::ToolRuntime instance, or a Proc"
-    end
+    valid = (value.is_a?(Class) && value < Riffer::ToolRuntime) || value.is_a?(Riffer::ToolRuntime) || value.is_a?(Proc)
+    raise Riffer::ArgumentError, "tool_runtime must be a Riffer::ToolRuntime subclass, instance, or a Proc" unless valid
     @tool_runtime = value
   end
 

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -32,11 +32,31 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader :evals #: Riffer::Config::Evals
 
+  # Global tool runtime configuration (experimental).
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  attr_reader :tool_runtime #: (Symbol | Riffer::ToolRuntime | Proc)
+
+  # Sets the global tool runtime.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
+  # (Symbol, ToolRuntime instance, or Proc).
+  #
+  #: ((Symbol | Riffer::ToolRuntime | Proc)) -> void
+  def tool_runtime=(value)
+    unless value.is_a?(Symbol) || value.is_a?(Riffer::ToolRuntime) || value.is_a?(Proc)
+      raise Riffer::ArgumentError, "tool_runtime must be a Symbol (:inline, :threaded), a Riffer::ToolRuntime instance, or a Proc"
+    end
+    @tool_runtime = value
+  end
+
   #: () -> void
   def initialize
     @amazon_bedrock = AmazonBedrock.new
     @anthropic = Anthropic.new
     @openai = OpenAI.new
     @evals = Evals.new
+    @tool_runtime = Riffer::ToolRuntime::Inline.new
   end
 end

--- a/lib/riffer/runner.rb
+++ b/lib/riffer/runner.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Generic concurrency primitive for batch execution.
+#
+# Subclasses implement +map+ to control how items are processed
+# (sequentially, threaded, etc.).
+#
+#   runner = Riffer::Runner::Sequential.new
+#   runner.map([1, 2, 3]) { |n| n * 2 }
+#   # => [2, 4, 6]
+#
+class Riffer::Runner
+  # Maps over items using the provided block.
+  #
+  # +items+ - the items to process.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    raise NotImplementedError, "#{self.class} must implement #map"
+  end
+end

--- a/lib/riffer/runner/sequential.rb
+++ b/lib/riffer/runner/sequential.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Processes items sequentially in the current thread.
+#
+# This is the default runner used when no concurrency is needed.
+#
+class Riffer::Runner::Sequential < Riffer::Runner
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    items.map(&block)
+  end
+end

--- a/lib/riffer/runner/threaded.rb
+++ b/lib/riffer/runner/threaded.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Processes items concurrently using a thread pool.
+#
+# Maintains up to +max_concurrency+ worker threads that pull items from
+# a shared queue. When a worker finishes one item it immediately picks
+# up the next, so a single slow item does not block other workers.
+#
+# If multiple workers raise, only the first exception is re-raised
+# after all workers finish; subsequent errors are discarded.
+#
+#   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+#   runner.map(items) { |item| expensive_operation(item) }
+#
+class Riffer::Runner::Threaded < Riffer::Runner
+  DEFAULT_MAX_CONCURRENCY = 5 #: Integer
+
+  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  #
+  #: (?max_concurrency: Integer) -> void
+  def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
+    @max_concurrency = max_concurrency
+  end
+
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    return [] if items.empty?
+
+    results = Array.new(items.size)
+    errors = Array.new(items.size)
+    queue = Queue.new
+    items.each_with_index { |item, i| queue << [item, i] }
+
+    workers = [items.size, @max_concurrency].min.times.map do
+      Thread.new do
+        loop do
+          pair = begin
+            queue.pop(true)
+          rescue ThreadError
+            break
+          end
+          item, index = pair
+          begin
+            results[index] = block.call(item)
+          rescue => e
+            errors[index] = e
+          end
+        end
+      end
+    end
+
+    workers.each(&:join)
+
+    first_error = errors.compact.first
+    raise first_error if first_error
+
+    results
+  end
+end

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -43,64 +43,24 @@ class Riffer::ToolRuntime
   end
 
   # Hook that wraps each tool call execution. Override in subclasses
-  # or use the +around_tool_call+ class method DSL to customize.
-  # Must +yield+ to continue execution.
+  # to customize. Must +yield+ to continue execution.
   #
   # The default implementation simply yields.
   #
-  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-  def around_tool_call(tool_call, context:)
-    yield
-  end
-
-  # Class-level DSL to define the +around_tool_call+ hook via a symbol
-  # or block. Both forms use +define_method+ to override the instance
-  # method, so inheritance works naturally.
-  #
-  # Accepts a symbol (naming an instance method to delegate to) or a
-  # block. Raises +Riffer::ArgumentError+ if both are given or if
-  # neither is given.
-  #
-  # Note: when overriding +around_tool_call+ directly you can use +yield+,
-  # but both DSL forms (symbol and block) receive the continuation as an
-  # explicit +&block+ parameter that must be called with +block.call+.
-  #
-  #   # Symbol — delegates to a named instance method:
   #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
-  #     around_tool_call :instrument
-  #
   #     private
   #
-  #     def instrument(tool_call, context:, &block)
-  #       result = block.call
-  #       Rails.logger.info("Tool #{tool_call.name} completed")
+  #     def around_tool_call(tool_call, context:)
+  #       start = Time.now
+  #       result = yield
+  #       Rails.logger.info("Tool #{tool_call.name} took #{Time.now - start}s")
   #       result
   #     end
   #   end
   #
-  #   # Block — for simple inline hooks:
-  #   class LoggingRuntime < Riffer::ToolRuntime::Inline
-  #     around_tool_call do |tool_call, context:, &block|
-  #       puts "Executing #{tool_call.name}"
-  #       block.call
-  #     end
-  #   end
-  #
-  #: (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
-  def self.around_tool_call(method_name = nil, &block)
-    if method_name && block
-      raise Riffer::ArgumentError, "around_tool_call accepts a symbol or a block, not both"
-    end
-
-    if method_name
-      define_method(:around_tool_call) do |tool_call, context:, &blk|
-        send(method_name, tool_call, context: context, &blk)
-      end
-    elsif block
-      define_method(:around_tool_call, block)
-    else
-      raise Riffer::ArgumentError, "around_tool_call requires a symbol or a block"
-    end
+  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call(tool_call, context:)
+    yield
   end
 
   private

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "json"
+
+# Riffer::ToolRuntime handles tool call execution for an agent.
+#
+# Composes with a Riffer::Runner for concurrency control and provides
+# +execute+ as the sole public entry point.
+#
+# Subclass and override +dispatch_tool_call+ to customize how individual
+# tool calls are dispatched (e.g., HTTP, gRPC).
+#
+#   runtime = Riffer::ToolRuntime::Inline.new
+#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+#
+class Riffer::ToolRuntime
+  # +runner+ - the concurrency runner to use for batch execution.
+  #
+  #: (?runner: Riffer::Runner) -> void
+  def initialize(runner: Riffer::Runner::Sequential.new)
+    @runner = runner
+  end
+
+  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  #
+  # +tool_calls+ - the tool calls to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute(tool_calls, tools:, context:)
+    @runner.map(tool_calls) do |tool_call|
+      result = around_tool_call(tool_call, context: context) do
+        dispatch_tool_call(tool_call, tools: tools, context: context)
+      end
+      [tool_call, result]
+    end
+  end
+
+  # Hook that wraps each tool call execution. Override in subclasses
+  # or use the +around_tool_call+ class method DSL to customize.
+  # Must +yield+ to continue execution.
+  #
+  # The default implementation simply yields.
+  #
+  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call(tool_call, context:)
+    yield
+  end
+
+  # Class-level DSL to define the +around_tool_call+ hook via a symbol
+  # or block. Both forms use +define_method+ to override the instance
+  # method, so inheritance works naturally.
+  #
+  # Accepts a symbol (naming an instance method to delegate to) or a
+  # block. Raises +Riffer::ArgumentError+ if both are given or if
+  # neither is given.
+  #
+  # Note: when overriding +around_tool_call+ directly you can use +yield+,
+  # but both DSL forms (symbol and block) receive the continuation as an
+  # explicit +&block+ parameter that must be called with +block.call+.
+  #
+  #   # Symbol — delegates to a named instance method:
+  #   class InstrumentedRuntime < Riffer::ToolRuntime
+  #     around_tool_call :instrument
+  #
+  #     private
+  #
+  #     def instrument(tool_call, context:, &block)
+  #       result = block.call
+  #       Rails.logger.info("Tool #{tool_call.name} completed")
+  #       result
+  #     end
+  #   end
+  #
+  #   # Block — for simple inline hooks:
+  #   class LoggingRuntime < Riffer::ToolRuntime
+  #     around_tool_call do |tool_call, context:, &block|
+  #       puts "Executing #{tool_call.name}"
+  #       block.call
+  #     end
+  #   end
+  #
+  #: (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+  def self.around_tool_call(method_name = nil, &block)
+    if method_name && block
+      raise Riffer::ArgumentError, "around_tool_call accepts a symbol or a block, not both"
+    end
+
+    if method_name
+      define_method(:around_tool_call) do |tool_call, context:, &blk|
+        send(method_name, tool_call, context: context, &blk)
+      end
+    elsif block
+      define_method(:around_tool_call, block)
+    else
+      raise Riffer::ArgumentError, "around_tool_call requires a symbol or a block"
+    end
+  end
+
+  private
+
+  # Dispatches a single tool call. Override in subclasses to change
+  # how individual tools are invoked (e.g., HTTP, gRPC).
+  #
+  # +tool_call+ - the tool call to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+  def dispatch_tool_call(tool_call, tools:, context:)
+    tool_class = tools.find { |tc| tc.name == tool_call.name }
+
+    if tool_class.nil?
+      return Riffer::Tools::Response.error(
+        "Unknown tool '#{tool_call.name}'",
+        type: :unknown_tool
+      )
+    end
+
+    tool_instance = tool_class.new
+    arguments = parse_arguments(tool_call.arguments)
+
+    tool_instance.call_with_validation(context: context, **arguments)
+  rescue Riffer::TimeoutError => e
+    Riffer::Tools::Response.error(e.message, type: :timeout_error)
+  rescue Riffer::ValidationError => e
+    Riffer::Tools::Response.error(e.message, type: :validation_error)
+  rescue Riffer::ToolExecutionError => e
+    Riffer::Tools::Response.error(e.message, type: :execution_error)
+  rescue RuntimeError => e
+    Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+  end
+
+  #: (String?) -> Hash[Symbol, untyped]
+  def parse_arguments(arguments)
+    return {} if arguments.nil? || arguments.empty?
+
+    JSON.parse(arguments, symbolize_names: true)
+  end
+end

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -17,8 +17,12 @@ require "json"
 class Riffer::ToolRuntime
   # +runner+ - the concurrency runner to use for batch execution.
   #
-  #: (?runner: Riffer::Runner) -> void
-  def initialize(runner: Riffer::Runner::Sequential.new)
+  # Subclasses must provide a runner; instantiating ToolRuntime directly
+  # raises +NotImplementedError+.
+  #
+  #: (runner: Riffer::Runner) -> void
+  def initialize(runner:)
+    raise NotImplementedError, "#{self.class} is abstract — use a subclass like Riffer::ToolRuntime::Inline" if instance_of?(Riffer::ToolRuntime)
     @runner = runner
   end
 
@@ -62,7 +66,7 @@ class Riffer::ToolRuntime
   # explicit +&block+ parameter that must be called with +block.call+.
   #
   #   # Symbol — delegates to a named instance method:
-  #   class InstrumentedRuntime < Riffer::ToolRuntime
+  #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   #     around_tool_call :instrument
   #
   #     private
@@ -75,7 +79,7 @@ class Riffer::ToolRuntime
   #   end
   #
   #   # Block — for simple inline hooks:
-  #   class LoggingRuntime < Riffer::ToolRuntime
+  #   class LoggingRuntime < Riffer::ToolRuntime::Inline
   #     around_tool_call do |tool_call, context:, &block|
   #       puts "Executing #{tool_call.name}"
   #       block.call

--- a/lib/riffer/tool_runtime/inline.rb
+++ b/lib/riffer/tool_runtime/inline.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Executes tool calls sequentially in the current thread.
+#
+# This is the default tool runtime used when no runtime is configured.
+#
+class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+end

--- a/lib/riffer/tool_runtime/inline.rb
+++ b/lib/riffer/tool_runtime/inline.rb
@@ -6,4 +6,8 @@
 # This is the default tool runtime used when no runtime is configured.
 #
 class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+  #: () -> void
+  def initialize
+    super(runner: Riffer::Runner::Sequential.new)
+  end
 end

--- a/lib/riffer/tool_runtime/threaded.rb
+++ b/lib/riffer/tool_runtime/threaded.rb
@@ -4,7 +4,7 @@
 # Executes tool calls concurrently using threads.
 #
 #   class MyAgent < Riffer::Agent
-#     tool_runtime :threaded
+#     tool_runtime Riffer::ToolRuntime::Threaded
 #   end
 #
 class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime

--- a/lib/riffer/tool_runtime/threaded.rb
+++ b/lib/riffer/tool_runtime/threaded.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Executes tool calls concurrently using threads.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime :threaded
+#   end
+#
+class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
+  DEFAULT_MAX_CONCURRENCY = 5 #: Integer
+
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #
+  #: (?max_concurrency: Integer) -> void
+  def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
+    super(runner: Riffer::Runner::Threaded.new(max_concurrency: max_concurrency))
+  end
+end

--- a/sig/generated/riffer.rbs
+++ b/sig/generated/riffer.rbs
@@ -17,6 +17,10 @@ module Riffer
   class TimeoutError < Error
   end
 
+  # Raised when a tool encounters an expected execution error.
+  class ToolExecutionError < Error
+  end
+
   # Returns the Riffer configuration.
   #
   # : () -> Riffer::Config

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -74,9 +74,8 @@ class Riffer::Agent
   #
   # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
   #
-  # This setting is not inherited by subclasses — each agent class must
-  # configure its own tool runtime explicitly. When unset, falls back to
-  # the global +Riffer.config.tool_runtime+.
+  # Inherited by subclasses. When unset, walks the ancestor chain and
+  # falls back to the global +Riffer.config.tool_runtime+.
   #
   # : (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -72,13 +72,14 @@ class Riffer::Agent
 
   # Gets or sets the tool runtime for this agent.
   #
-  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
+  # or a Proc.
   #
   # Inherited by subclasses. When unset, walks the ancestor chain and
   # falls back to the global +Riffer.config.tool_runtime+.
   #
-  # : (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
-  def self.tool_runtime: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  # : (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
+  def self.tool_runtime: (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
 
   # Finds an agent class by identifier.
   #

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -70,6 +70,17 @@ class Riffer::Agent
   # : (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
 
+  # Gets or sets the tool runtime for this agent.
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance, or a Proc.
+  #
+  # This setting is not inherited by subclasses — each agent class must
+  # configure its own tool runtime explicitly. When unset, falls back to
+  # the global +Riffer.config.tool_runtime+.
+  #
+  # : (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+  def self.tool_runtime: (?(Symbol | Riffer::ToolRuntime | Proc)?) -> (Symbol | Riffer::ToolRuntime | Proc)?
+
   # Finds an agent class by identifier.
   #
   # : (String) -> singleton(Riffer::Agent)?
@@ -221,9 +232,6 @@ class Riffer::Agent
   # : () -> void
   def execute_pending_tool_calls: () -> void
 
-  # : (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-  def execute_tool_call: (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
-
   # : (untyped) -> void
   def parse_model_string!: (untyped) -> void
 
@@ -238,11 +246,8 @@ class Riffer::Agent
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]
 
-  # : (String) -> singleton(Riffer::Tool)?
-  def find_tool_class: (String) -> singleton(Riffer::Tool)?
-
-  # : (String?) -> Hash[Symbol, untyped]
-  def parse_tool_arguments: (String?) -> Hash[Symbol, untyped]
+  # : () -> Riffer::ToolRuntime
+  def resolve_tool_runtime: () -> Riffer::ToolRuntime
 
   # : () -> Riffer::Messages::Assistant?
   def extract_final_response: () -> Riffer::Messages::Assistant?

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -57,17 +57,17 @@ class Riffer::Config
 
   # Global tool runtime configuration (experimental).
   #
-  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
   # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
-  attr_reader tool_runtime: Symbol | Riffer::ToolRuntime | Proc
+  attr_reader tool_runtime: singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc
 
   # Sets the global tool runtime.
   #
   # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
-  # (Symbol, ToolRuntime instance, or Proc).
+  # (ToolRuntime subclass, ToolRuntime instance, or Proc).
   #
-  # : ((Symbol | Riffer::ToolRuntime | Proc)) -> void
-  def tool_runtime=: (Symbol | Riffer::ToolRuntime | Proc) -> void
+  # : ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
+  def tool_runtime=: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc) -> void
 
   # : () -> void
   def initialize: () -> void

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -55,6 +55,20 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader evals: Riffer::Config::Evals
 
+  # Global tool runtime configuration (experimental).
+  #
+  # Accepts +:inline+, +:threaded+, a Riffer::ToolRuntime instance,
+  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  attr_reader tool_runtime: Symbol | Riffer::ToolRuntime | Proc
+
+  # Sets the global tool runtime.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
+  # (Symbol, ToolRuntime instance, or Proc).
+  #
+  # : ((Symbol | Riffer::ToolRuntime | Proc)) -> void
+  def tool_runtime=: (Symbol | Riffer::ToolRuntime | Proc) -> void
+
   # : () -> void
   def initialize: () -> void
 end

--- a/sig/generated/riffer/runner.rbs
+++ b/sig/generated/riffer/runner.rbs
@@ -1,0 +1,20 @@
+# Generated from lib/riffer/runner.rb with RBS::Inline
+
+# Generic concurrency primitive for batch execution.
+#
+# Subclasses implement +map+ to control how items are processed
+# (sequentially, threaded, etc.).
+#
+#   runner = Riffer::Runner::Sequential.new
+#   runner.map([1, 2, 3]) { |n| n * 2 }
+#   # => [2, 4, 6]
+class Riffer::Runner
+  # Maps over items using the provided block.
+  #
+  # +items+ - the items to process.
+  #
+  # Raises NotImplementedError if not implemented by subclass.
+  #
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/sequential.rbs
+++ b/sig/generated/riffer/runner/sequential.rbs
@@ -1,0 +1,9 @@
+# Generated from lib/riffer/runner/sequential.rb with RBS::Inline
+
+# Processes items sequentially in the current thread.
+#
+# This is the default runner used when no concurrency is needed.
+class Riffer::Runner::Sequential < Riffer::Runner
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/threaded.rbs
+++ b/sig/generated/riffer/runner/threaded.rbs
@@ -1,0 +1,24 @@
+# Generated from lib/riffer/runner/threaded.rb with RBS::Inline
+
+# Processes items concurrently using a thread pool.
+#
+# Maintains up to +max_concurrency+ worker threads that pull items from
+# a shared queue. When a worker finishes one item it immediately picks
+# up the next, so a single slow item does not block other workers.
+#
+# If multiple workers raise, only the first exception is re-raised
+# after all workers finish; subsequent errors are discarded.
+#
+#   runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+#   runner.map(items) { |item| expensive_operation(item) }
+class Riffer::Runner::Threaded < Riffer::Runner
+  DEFAULT_MAX_CONCURRENCY: Integer
+
+  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  #
+  # : (?max_concurrency: Integer) -> void
+  def initialize: (?max_concurrency: Integer) -> void
+
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -29,49 +29,23 @@ class Riffer::ToolRuntime
   def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
 
   # Hook that wraps each tool call execution. Override in subclasses
-  # or use the +around_tool_call+ class method DSL to customize.
-  # Must +yield+ to continue execution.
+  # to customize. Must +yield+ to continue execution.
   #
   # The default implementation simply yields.
   #
-  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-
-  # Class-level DSL to define the +around_tool_call+ hook via a symbol
-  # or block. Both forms use +define_method+ to override the instance
-  # method, so inheritance works naturally.
-  #
-  # Accepts a symbol (naming an instance method to delegate to) or a
-  # block. Raises +Riffer::ArgumentError+ if both are given or if
-  # neither is given.
-  #
-  # Note: when overriding +around_tool_call+ directly you can use +yield+,
-  # but both DSL forms (symbol and block) receive the continuation as an
-  # explicit +&block+ parameter that must be called with +block.call+.
-  #
-  #   # Symbol — delegates to a named instance method:
   #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
-  #     around_tool_call :instrument
-  #
   #     private
   #
-  #     def instrument(tool_call, context:, &block)
-  #       result = block.call
-  #       Rails.logger.info("Tool #{tool_call.name} completed")
+  #     def around_tool_call(tool_call, context:)
+  #       start = Time.now
+  #       result = yield
+  #       Rails.logger.info("Tool #{tool_call.name} took #{Time.now - start}s")
   #       result
   #     end
   #   end
   #
-  #   # Block — for simple inline hooks:
-  #   class LoggingRuntime < Riffer::ToolRuntime::Inline
-  #     around_tool_call do |tool_call, context:, &block|
-  #       puts "Executing #{tool_call.name}"
-  #       block.call
-  #     end
-  #   end
-  #
-  # : (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
-  def self.around_tool_call: (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
 
   private
 

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -1,0 +1,87 @@
+# Generated from lib/riffer/tool_runtime.rb with RBS::Inline
+
+# Riffer::ToolRuntime handles tool call execution for an agent.
+#
+# Composes with a Riffer::Runner for concurrency control and provides
+# +execute+ as the sole public entry point.
+#
+# Subclass and override +dispatch_tool_call+ to customize how individual
+# tool calls are dispatched (e.g., HTTP, gRPC).
+#
+#   runtime = Riffer::ToolRuntime::Inline.new
+#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+class Riffer::ToolRuntime
+  # +runner+ - the concurrency runner to use for batch execution.
+  #
+  # : (?runner: Riffer::Runner) -> void
+  def initialize: (?runner: Riffer::Runner) -> void
+
+  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  #
+  # +tool_calls+ - the tool calls to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
+
+  # Hook that wraps each tool call execution. Override in subclasses
+  # or use the +around_tool_call+ class method DSL to customize.
+  # Must +yield+ to continue execution.
+  #
+  # The default implementation simply yields.
+  #
+  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+
+  # Class-level DSL to define the +around_tool_call+ hook via a symbol
+  # or block. Both forms use +define_method+ to override the instance
+  # method, so inheritance works naturally.
+  #
+  # Accepts a symbol (naming an instance method to delegate to) or a
+  # block. Raises +Riffer::ArgumentError+ if both are given or if
+  # neither is given.
+  #
+  # Note: when overriding +around_tool_call+ directly you can use +yield+,
+  # but both DSL forms (symbol and block) receive the continuation as an
+  # explicit +&block+ parameter that must be called with +block.call+.
+  #
+  #   # Symbol — delegates to a named instance method:
+  #   class InstrumentedRuntime < Riffer::ToolRuntime
+  #     around_tool_call :instrument
+  #
+  #     private
+  #
+  #     def instrument(tool_call, context:, &block)
+  #       result = block.call
+  #       Rails.logger.info("Tool #{tool_call.name} completed")
+  #       result
+  #     end
+  #   end
+  #
+  #   # Block — for simple inline hooks:
+  #   class LoggingRuntime < Riffer::ToolRuntime
+  #     around_tool_call do |tool_call, context:, &block|
+  #       puts "Executing #{tool_call.name}"
+  #       block.call
+  #     end
+  #   end
+  #
+  # : (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+  def self.around_tool_call: (?Symbol?) { (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response } -> void
+
+  private
+
+  # Dispatches a single tool call. Override in subclasses to change
+  # how individual tools are invoked (e.g., HTTP, gRPC).
+  #
+  # +tool_call+ - the tool call to execute.
+  # +tools+ - the resolved tool classes.
+  # +context+ - the tool context hash.
+  #
+  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+  def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+
+  # : (String?) -> Hash[Symbol, untyped]
+  def parse_arguments: (String?) -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -13,8 +13,11 @@
 class Riffer::ToolRuntime
   # +runner+ - the concurrency runner to use for batch execution.
   #
-  # : (?runner: Riffer::Runner) -> void
-  def initialize: (?runner: Riffer::Runner) -> void
+  # Subclasses must provide a runner; instantiating ToolRuntime directly
+  # raises +NotImplementedError+.
+  #
+  # : (runner: Riffer::Runner) -> void
+  def initialize: (runner: Riffer::Runner) -> void
 
   # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
   #
@@ -47,7 +50,7 @@ class Riffer::ToolRuntime
   # explicit +&block+ parameter that must be called with +block.call+.
   #
   #   # Symbol — delegates to a named instance method:
-  #   class InstrumentedRuntime < Riffer::ToolRuntime
+  #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   #     around_tool_call :instrument
   #
   #     private
@@ -60,7 +63,7 @@ class Riffer::ToolRuntime
   #   end
   #
   #   # Block — for simple inline hooks:
-  #   class LoggingRuntime < Riffer::ToolRuntime
+  #   class LoggingRuntime < Riffer::ToolRuntime::Inline
   #     around_tool_call do |tool_call, context:, &block|
   #       puts "Executing #{tool_call.name}"
   #       block.call

--- a/sig/generated/riffer/tool_runtime/inline.rbs
+++ b/sig/generated/riffer/tool_runtime/inline.rbs
@@ -1,0 +1,7 @@
+# Generated from lib/riffer/tool_runtime/inline.rb with RBS::Inline
+
+# Executes tool calls sequentially in the current thread.
+#
+# This is the default tool runtime used when no runtime is configured.
+class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+end

--- a/sig/generated/riffer/tool_runtime/inline.rbs
+++ b/sig/generated/riffer/tool_runtime/inline.rbs
@@ -4,4 +4,6 @@
 #
 # This is the default tool runtime used when no runtime is configured.
 class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+  # : () -> void
+  def initialize: () -> void
 end

--- a/sig/generated/riffer/tool_runtime/threaded.rbs
+++ b/sig/generated/riffer/tool_runtime/threaded.rbs
@@ -3,7 +3,7 @@
 # Executes tool calls concurrently using threads.
 #
 #   class MyAgent < Riffer::Agent
-#     tool_runtime :threaded
+#     tool_runtime Riffer::ToolRuntime::Threaded
 #   end
 class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
   DEFAULT_MAX_CONCURRENCY: Integer

--- a/sig/generated/riffer/tool_runtime/threaded.rbs
+++ b/sig/generated/riffer/tool_runtime/threaded.rbs
@@ -1,0 +1,15 @@
+# Generated from lib/riffer/tool_runtime/threaded.rb with RBS::Inline
+
+# Executes tool calls concurrently using threads.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime :threaded
+#   end
+class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
+  DEFAULT_MAX_CONCURRENCY: Integer
+
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #
+  # : (?max_concurrency: Integer) -> void
+  def initialize: (?max_concurrency: Integer) -> void
+end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1005,35 +1005,35 @@ describe Riffer::Agent do
       expect(agent_class.tool_runtime).must_be_nil
     end
 
-    it "sets the tool_runtime symbol" do
+    it "sets the tool_runtime class" do
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime :threaded
+        tool_runtime Riffer::ToolRuntime::Threaded
       end
-      expect(agent.tool_runtime).must_equal :threaded
+      expect(agent.tool_runtime).must_equal Riffer::ToolRuntime::Threaded
     end
 
     it "inherits tool_runtime from parent class" do
       parent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime :threaded
+        tool_runtime Riffer::ToolRuntime::Threaded
       end
       child = Class.new(parent)
 
-      expect(child.tool_runtime).must_equal :threaded
+      expect(child.tool_runtime).must_equal Riffer::ToolRuntime::Threaded
     end
 
     it "allows subclass to override inherited tool_runtime" do
       parent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime :threaded
+        tool_runtime Riffer::ToolRuntime::Threaded
       end
       child = Class.new(parent) do
-        tool_runtime :inline
+        tool_runtime Riffer::ToolRuntime::Inline
       end
 
-      expect(child.tool_runtime).must_equal :inline
-      expect(parent.tool_runtime).must_equal :threaded
+      expect(child.tool_runtime).must_equal Riffer::ToolRuntime::Inline
+      expect(parent.tool_runtime).must_equal Riffer::ToolRuntime::Threaded
     end
 
     it "defaults to inline when no config" do
@@ -1044,10 +1044,10 @@ describe Riffer::Agent do
       expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
     end
 
-    it "uses threaded runtime with :threaded symbol" do
+    it "resolves a ToolRuntime class to an instance" do
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime :threaded
+        tool_runtime Riffer::ToolRuntime::Threaded
       end
       runtime = agent.new.send(:resolve_tool_runtime)
       expect(runtime).must_be_instance_of Riffer::ToolRuntime::Threaded
@@ -1056,7 +1056,7 @@ describe Riffer::Agent do
     it "uses lambda resolution with zero arity" do
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime -> { :inline }
+        tool_runtime -> { Riffer::ToolRuntime::Inline.new }
       end
       runtime = agent.new.send(:resolve_tool_runtime)
       expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
@@ -1068,7 +1068,7 @@ describe Riffer::Agent do
         model "mock/riffer-1"
         tool_runtime ->(ctx) {
           received_context = ctx
-          :inline
+          Riffer::ToolRuntime::Inline.new
         }
       end
 
@@ -1082,7 +1082,7 @@ describe Riffer::Agent do
     it "uses global config as fallback" do
       original = Riffer.config.tool_runtime
       begin
-        Riffer.config.tool_runtime = :threaded
+        Riffer.config.tool_runtime = Riffer::ToolRuntime::Threaded
         agent = Class.new(Riffer::Agent) do
           model "mock/riffer-1"
         end
@@ -1096,10 +1096,10 @@ describe Riffer::Agent do
     it "per-agent config overrides global config" do
       original = Riffer.config.tool_runtime
       begin
-        Riffer.config.tool_runtime = :threaded
+        Riffer.config.tool_runtime = Riffer::ToolRuntime::Threaded
         agent = Class.new(Riffer::Agent) do
           model "mock/riffer-1"
-          tool_runtime :inline
+          tool_runtime Riffer::ToolRuntime::Inline
         end
         runtime = agent.new.send(:resolve_tool_runtime)
         expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
@@ -1132,7 +1132,7 @@ describe Riffer::Agent do
         model "mock/riffer-1"
         tool_runtime ->(ctx) {
           received_contexts << ctx
-          :inline
+          Riffer::ToolRuntime::Inline.new
         }
       end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1000,6 +1000,132 @@ describe Riffer::Agent do
     end
   end
 
+  describe ".tool_runtime" do
+    it "returns nil when not set" do
+      expect(agent_class.tool_runtime).must_be_nil
+    end
+
+    it "sets the tool_runtime symbol" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      expect(agent.tool_runtime).must_equal :threaded
+    end
+
+    it "defaults to inline when no config" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "uses threaded runtime with :threaded symbol" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Threaded
+    end
+
+    it "uses lambda resolution with zero arity" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime -> { :inline }
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "passes tool_context to lambda with arity 1" do
+      received_context = nil
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime ->(ctx) {
+          received_context = ctx
+          :inline
+        }
+      end
+
+      instance = agent.new
+      instance.instance_variable_set(:@tool_context, {user_id: 42})
+      instance.send(:resolve_tool_runtime)
+
+      expect(received_context).must_equal({user_id: 42})
+    end
+
+    it "uses global config as fallback" do
+      original = Riffer.config.tool_runtime
+      begin
+        Riffer.config.tool_runtime = :threaded
+        agent = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+        end
+        runtime = agent.new.send(:resolve_tool_runtime)
+        expect(runtime).must_be_instance_of Riffer::ToolRuntime::Threaded
+      ensure
+        Riffer.config.tool_runtime = original
+      end
+    end
+
+    it "per-agent config overrides global config" do
+      original = Riffer.config.tool_runtime
+      begin
+        Riffer.config.tool_runtime = :threaded
+        agent = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          tool_runtime :inline
+        end
+        runtime = agent.new.send(:resolve_tool_runtime)
+        expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+      ensure
+        Riffer.config.tool_runtime = original
+      end
+    end
+
+    it "accepts a ToolRuntime instance" do
+      custom_runtime = Riffer::ToolRuntime::Inline.new
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime custom_runtime
+      end
+      runtime = agent.new.send(:resolve_tool_runtime)
+      expect(runtime).must_equal custom_runtime
+    end
+
+    it "raises for invalid tool_runtime" do
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime "invalid"
+      end
+      expect { agent.new.send(:resolve_tool_runtime) }.must_raise Riffer::ArgumentError
+    end
+
+    it "clears resolved tool runtime between generate calls" do
+      received_contexts = []
+      agent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime ->(ctx) {
+          received_contexts << ctx
+          :inline
+        }
+      end
+
+      instance = agent.new
+      instance.instance_variable_set(:@tool_context, {a: 1})
+      instance.send(:resolve_tool_runtime)
+
+      # Simulate what generate does: reset and resolve again
+      instance.instance_variable_set(:@resolved_tool_runtime, nil)
+      instance.instance_variable_set(:@tool_context, {b: 2})
+      instance.send(:resolve_tool_runtime)
+
+      expect(received_contexts).must_equal [{a: 1}, {b: 2}]
+    end
+  end
+
   describe "dynamic model selection" do
     it "resolves lambda for generate" do
       dynamic_agent_class = Class.new(Riffer::Agent) do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -1013,6 +1013,29 @@ describe Riffer::Agent do
       expect(agent.tool_runtime).must_equal :threaded
     end
 
+    it "inherits tool_runtime from parent class" do
+      parent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      child = Class.new(parent)
+
+      expect(child.tool_runtime).must_equal :threaded
+    end
+
+    it "allows subclass to override inherited tool_runtime" do
+      parent = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        tool_runtime :threaded
+      end
+      child = Class.new(parent) do
+        tool_runtime :inline
+      end
+
+      expect(child.tool_runtime).must_equal :inline
+      expect(parent.tool_runtime).must_equal :threaded
+    end
+
     it "defaults to inline when no config" do
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -23,6 +23,29 @@ describe Riffer::Config do
     end
   end
 
+  describe "tool_runtime" do
+    it "defaults to Inline instance" do
+      config = Riffer::Config.new
+      expect(config.tool_runtime).must_be_instance_of Riffer::ToolRuntime::Inline
+    end
+
+    it "allows setting tool_runtime" do
+      config = Riffer::Config.new
+      config.tool_runtime = :threaded
+      expect(config.tool_runtime).must_equal :threaded
+    end
+
+    it "raises for invalid tool_runtime" do
+      config = Riffer::Config.new
+      expect { config.tool_runtime = nil }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises for string tool_runtime" do
+      config = Riffer::Config.new
+      expect { config.tool_runtime = "invalid" }.must_raise Riffer::ArgumentError
+    end
+  end
+
   describe "evals namespace" do
     it "initializes with nil judge_model" do
       config = Riffer::Config.new

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -31,8 +31,8 @@ describe Riffer::Config do
 
     it "allows setting tool_runtime" do
       config = Riffer::Config.new
-      config.tool_runtime = :threaded
-      expect(config.tool_runtime).must_equal :threaded
+      config.tool_runtime = Riffer::ToolRuntime::Threaded
+      expect(config.tool_runtime).must_equal Riffer::ToolRuntime::Threaded
     end
 
     it "raises for invalid tool_runtime" do

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Runner do
+  describe "#map" do
+    it "raises NotImplementedError" do
+      runner = Riffer::Runner.new
+      expect { runner.map([1, 2, 3]) { |n| n } }.must_raise NotImplementedError
+    end
+  end
+end
+
+describe Riffer::Runner::Sequential do
+  describe "#map" do
+    it "returns results in order" do
+      runner = Riffer::Runner::Sequential.new
+      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      expect(results).must_equal [2, 4, 6]
+    end
+
+    it "handles empty items" do
+      runner = Riffer::Runner::Sequential.new
+      results = runner.map([]) { |n| n }
+      expect(results).must_equal []
+    end
+  end
+end
+
+describe Riffer::Runner::Threaded do
+  describe "#map" do
+    it "returns results in order" do
+      runner = Riffer::Runner::Threaded.new
+      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      expect(results).must_equal [2, 4, 6]
+    end
+
+    it "executes concurrently" do
+      runner = Riffer::Runner::Threaded.new(max_concurrency: 3)
+      thread_ids = Mutex.new
+      seen = []
+
+      runner.map([1, 2, 3]) do |n|
+        thread_ids.synchronize { seen << Thread.current.object_id }
+        sleep 0.01
+        n
+      end
+
+      # Each item runs in its own thread, so we should see distinct thread ids
+      expect(seen.uniq.length).must_equal 3
+    end
+
+    it "respects max_concurrency" do
+      runner = Riffer::Runner::Threaded.new(max_concurrency: 2)
+      mutex = Mutex.new
+      concurrent = 0
+      max_concurrent = 0
+
+      runner.map([1, 2, 3, 4]) do |n|
+        mutex.synchronize do
+          concurrent += 1
+          max_concurrent = [max_concurrent, concurrent].max
+        end
+        sleep 0.02
+        mutex.synchronize { concurrent -= 1 }
+        n
+      end
+
+      expect(max_concurrent).must_be :<=, 2
+    end
+
+    it "handles empty items" do
+      runner = Riffer::Runner::Threaded.new
+      results = runner.map([]) { |n| n }
+      expect(results).must_equal []
+    end
+
+    it "propagates exceptions from worker threads" do
+      runner = Riffer::Runner::Threaded.new(max_concurrency: 2)
+      expect {
+        runner.map([1, 2, 3]) do |n|
+          raise "boom" if n == 2
+          n
+        end
+      }.must_raise RuntimeError
+    end
+  end
+end

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -48,9 +48,17 @@ describe Riffer::ToolRuntime do
     results[0][1]
   end
 
+  describe "#initialize" do
+    it "raises NotImplementedError when instantiated directly" do
+      expect {
+        Riffer::ToolRuntime.new(runner: Riffer::Runner::Sequential.new)
+      }.must_raise NotImplementedError
+    end
+  end
+
   describe "#execute" do
     it "dispatches to correct tool and returns response" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
 
       result = execute_single(runtime, tool_call, tools: tools, context: context)
@@ -61,7 +69,7 @@ describe Riffer::ToolRuntime do
     end
 
     it "returns error response for unknown tool" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "nonexistent", arguments: "{}")
 
       result = execute_single(runtime, tool_call, tools: tools, context: context)
@@ -72,7 +80,7 @@ describe Riffer::ToolRuntime do
     end
 
     it "returns error response for validation failure" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "weather_tool", arguments: "{}")
 
       result = execute_single(runtime, tool_call, tools: tools, context: context)
@@ -82,7 +90,7 @@ describe Riffer::ToolRuntime do
     end
 
     it "returns error response for timeout" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "slow_tool", arguments: "{}")
 
       result = execute_single(runtime, tool_call, tools: [slow_tool_class], context: context)
@@ -101,7 +109,7 @@ describe Riffer::ToolRuntime do
         end
       end
 
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "error_tool", arguments: "{}")
 
       result = execute_single(runtime, tool_call, tools: [error_tool], context: context)
@@ -121,7 +129,7 @@ describe Riffer::ToolRuntime do
         end
       end
 
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "tool_exec_error_tool", arguments: "{}")
 
       result = execute_single(runtime, tool_call, tools: [error_tool], context: context)
@@ -141,7 +149,7 @@ describe Riffer::ToolRuntime do
         end
       end
 
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "buggy_tool", arguments: "{}")
 
       expect {
@@ -150,7 +158,7 @@ describe Riffer::ToolRuntime do
     end
 
     it "returns [tool_call, response] pairs in order" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tc1 = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', id: "1")
       tc2 = make_tool_call(name: "weather_tool", arguments: '{"city":"London"}', id: "2")
 
@@ -166,7 +174,7 @@ describe Riffer::ToolRuntime do
 
   describe "#around_tool_call" do
     it "yields by default" do
-      runtime = Riffer::ToolRuntime.new
+      runtime = Riffer::ToolRuntime::Inline.new
       tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
 
       results = runtime.execute([tool_call], tools: tools, context: context)
@@ -176,7 +184,7 @@ describe Riffer::ToolRuntime do
 
     it "can be overridden directly" do
       log = []
-      runtime_class = Class.new(Riffer::ToolRuntime) do
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
         define_method(:around_tool_call) do |tool_call, context:, &block|
           log << "before:#{tool_call.name}"
           result = block.call
@@ -193,7 +201,7 @@ describe Riffer::ToolRuntime do
 
     it "is inherited by subclasses" do
       log = []
-      parent = Class.new(Riffer::ToolRuntime) do
+      parent = Class.new(Riffer::ToolRuntime::Inline) do
         around_tool_call do |tool_call, context:, &block|
           log << "parent"
           block.call
@@ -209,7 +217,7 @@ describe Riffer::ToolRuntime do
 
     it "allows subclass to override" do
       log = []
-      parent = Class.new(Riffer::ToolRuntime) do
+      parent = Class.new(Riffer::ToolRuntime::Inline) do
         around_tool_call do |_, context:, &block|
           log << "parent"
           block.call
@@ -233,7 +241,7 @@ describe Riffer::ToolRuntime do
   describe ".around_tool_call" do
     it "defines around_tool_call with a block" do
       log = []
-      runtime_class = Class.new(Riffer::ToolRuntime) do
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
         around_tool_call do |tool_call, context:, &block|
           log << "before:#{tool_call.name}"
           result = block.call
@@ -250,7 +258,7 @@ describe Riffer::ToolRuntime do
 
     it "defines around_tool_call with a symbol" do
       log = []
-      runtime_class = Class.new(Riffer::ToolRuntime) do
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
         around_tool_call :instrument
 
         define_method(:instrument) do |tool_call, context:, &block|

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -182,7 +182,7 @@ describe Riffer::ToolRuntime do
       expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
     end
 
-    it "can be overridden directly" do
+    it "can be overridden in a subclass" do
       log = []
       runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
         define_method(:around_tool_call) do |tool_call, context:, &block|
@@ -202,7 +202,7 @@ describe Riffer::ToolRuntime do
     it "is inherited by subclasses" do
       log = []
       parent = Class.new(Riffer::ToolRuntime::Inline) do
-        around_tool_call do |tool_call, context:, &block|
+        define_method(:around_tool_call) do |tool_call, context:, &block|
           log << "parent"
           block.call
         end
@@ -218,14 +218,14 @@ describe Riffer::ToolRuntime do
     it "allows subclass to override" do
       log = []
       parent = Class.new(Riffer::ToolRuntime::Inline) do
-        around_tool_call do |_, context:, &block|
+        define_method(:around_tool_call) do |_, context:, &block|
           log << "parent"
           block.call
         end
       end
 
       child = Class.new(parent) do
-        around_tool_call do |_, context:, &block|
+        define_method(:around_tool_call) do |_, context:, &block|
           log << "child"
           block.call
         end
@@ -235,62 +235,6 @@ describe Riffer::ToolRuntime do
       child.new.execute([tool_call], tools: tools, context: context)
 
       expect(log).must_equal ["child"]
-    end
-  end
-
-  describe ".around_tool_call" do
-    it "defines around_tool_call with a block" do
-      log = []
-      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
-        around_tool_call do |tool_call, context:, &block|
-          log << "before:#{tool_call.name}"
-          result = block.call
-          log << "after:#{tool_call.name}"
-          result
-        end
-      end
-
-      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
-      runtime_class.new.execute([tool_call], tools: tools, context: context)
-
-      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
-    end
-
-    it "defines around_tool_call with a symbol" do
-      log = []
-      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
-        around_tool_call :instrument
-
-        define_method(:instrument) do |tool_call, context:, &block|
-          log << "before:#{tool_call.name}"
-          result = block.call
-          log << "after:#{tool_call.name}"
-          result
-        end
-      end
-
-      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
-      runtime_class.new.execute([tool_call], tools: tools, context: context)
-
-      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
-    end
-
-    it "raises when given both a symbol and a block" do
-      expect {
-        Class.new(Riffer::ToolRuntime) do
-          around_tool_call(:instrument) do |_, context:, &block|
-            block.call
-          end
-        end
-      }.must_raise Riffer::ArgumentError
-    end
-
-    it "raises when given neither a symbol nor a block" do
-      expect {
-        Class.new(Riffer::ToolRuntime) do
-          around_tool_call
-        end
-      }.must_raise Riffer::ArgumentError
     end
   end
 end

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -1,0 +1,350 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::ToolRuntime do
+  let(:weather_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "weather_tool"
+      description "Gets the weather"
+
+      params do
+        required :city, String
+      end
+
+      def call(context:, city:)
+        text("Weather in #{city}: 20 degrees")
+      end
+    end
+  end
+
+  let(:slow_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "slow_tool"
+      description "A slow tool"
+      timeout 0.01
+
+      def call(context:, **)
+        sleep 0.02
+        text("done")
+      end
+    end
+  end
+
+  let(:tools) { [weather_tool_class] }
+  let(:context) { nil }
+
+  def make_tool_call(name:, arguments:, id: "call_1")
+    Riffer::Messages::Assistant::ToolCall.new(
+      id: id,
+      call_id: "call_id_#{id}",
+      name: name,
+      arguments: arguments
+    )
+  end
+
+  def execute_single(runtime, tool_call, tools:, context:)
+    results = runtime.execute([tool_call], tools: tools, context: context)
+    results[0][1]
+  end
+
+  describe "#execute" do
+    it "dispatches to correct tool and returns response" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      result = execute_single(runtime, tool_call, tools: tools, context: context)
+
+      expect(result).must_be_instance_of Riffer::Tools::Response
+      expect(result.content).must_equal "Weather in Toronto: 20 degrees"
+      expect(result.success?).must_equal true
+    end
+
+    it "returns error response for unknown tool" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "nonexistent", arguments: "{}")
+
+      result = execute_single(runtime, tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :unknown_tool
+      expect(result.content).must_match(/Unknown tool 'nonexistent'/)
+    end
+
+    it "returns error response for validation failure" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: "{}")
+
+      result = execute_single(runtime, tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :validation_error
+    end
+
+    it "returns error response for timeout" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "slow_tool", arguments: "{}")
+
+      result = execute_single(runtime, tool_call, tools: [slow_tool_class], context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :timeout_error
+    end
+
+    it "returns error response for RuntimeError" do
+      error_tool = Class.new(Riffer::Tool) do
+        identifier "error_tool"
+        description "Raises an error"
+
+        def call(context:, **)
+          raise "Something went wrong"
+        end
+      end
+
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "error_tool", arguments: "{}")
+
+      result = execute_single(runtime, tool_call, tools: [error_tool], context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :execution_error
+      expect(result.content).must_match(/Something went wrong/)
+    end
+
+    it "returns error response for ToolExecutionError" do
+      error_tool = Class.new(Riffer::Tool) do
+        identifier "tool_exec_error_tool"
+        description "Raises a ToolExecutionError"
+
+        def call(context:, **)
+          raise Riffer::ToolExecutionError, "Expected failure"
+        end
+      end
+
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "tool_exec_error_tool", arguments: "{}")
+
+      result = execute_single(runtime, tool_call, tools: [error_tool], context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :execution_error
+      expect(result.content).must_equal "Expected failure"
+    end
+
+    it "propagates NoMethodError (programming bugs are not swallowed)" do
+      buggy_tool = Class.new(Riffer::Tool) do
+        identifier "buggy_tool"
+        description "Has a bug"
+
+        def call(context:, **)
+          nil.nonexistent_method
+        end
+      end
+
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "buggy_tool", arguments: "{}")
+
+      expect {
+        runtime.execute([tool_call], tools: [buggy_tool], context: context)
+      }.must_raise NoMethodError
+    end
+
+    it "returns [tool_call, response] pairs in order" do
+      runtime = Riffer::ToolRuntime.new
+      tc1 = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', id: "1")
+      tc2 = make_tool_call(name: "weather_tool", arguments: '{"city":"London"}', id: "2")
+
+      results = runtime.execute([tc1, tc2], tools: tools, context: context)
+
+      expect(results.length).must_equal 2
+      expect(results[0][0]).must_equal tc1
+      expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+      expect(results[1][0]).must_equal tc2
+      expect(results[1][1].content).must_equal "Weather in London: 20 degrees"
+    end
+  end
+
+  describe "#around_tool_call" do
+    it "yields by default" do
+      runtime = Riffer::ToolRuntime.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      results = runtime.execute([tool_call], tools: tools, context: context)
+
+      expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+    end
+
+    it "can be overridden directly" do
+      log = []
+      runtime_class = Class.new(Riffer::ToolRuntime) do
+        define_method(:around_tool_call) do |tool_call, context:, &block|
+          log << "before:#{tool_call.name}"
+          result = block.call
+          log << "after:#{tool_call.name}"
+          result
+        end
+      end
+
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
+    end
+
+    it "is inherited by subclasses" do
+      log = []
+      parent = Class.new(Riffer::ToolRuntime) do
+        around_tool_call do |tool_call, context:, &block|
+          log << "parent"
+          block.call
+        end
+      end
+
+      child = Class.new(parent)
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      child.new.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["parent"]
+    end
+
+    it "allows subclass to override" do
+      log = []
+      parent = Class.new(Riffer::ToolRuntime) do
+        around_tool_call do |_, context:, &block|
+          log << "parent"
+          block.call
+        end
+      end
+
+      child = Class.new(parent) do
+        around_tool_call do |_, context:, &block|
+          log << "child"
+          block.call
+        end
+      end
+
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      child.new.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["child"]
+    end
+  end
+
+  describe ".around_tool_call" do
+    it "defines around_tool_call with a block" do
+      log = []
+      runtime_class = Class.new(Riffer::ToolRuntime) do
+        around_tool_call do |tool_call, context:, &block|
+          log << "before:#{tool_call.name}"
+          result = block.call
+          log << "after:#{tool_call.name}"
+          result
+        end
+      end
+
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
+    end
+
+    it "defines around_tool_call with a symbol" do
+      log = []
+      runtime_class = Class.new(Riffer::ToolRuntime) do
+        around_tool_call :instrument
+
+        define_method(:instrument) do |tool_call, context:, &block|
+          log << "before:#{tool_call.name}"
+          result = block.call
+          log << "after:#{tool_call.name}"
+          result
+        end
+      end
+
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context)
+
+      expect(log).must_equal ["before:weather_tool", "after:weather_tool"]
+    end
+
+    it "raises when given both a symbol and a block" do
+      expect {
+        Class.new(Riffer::ToolRuntime) do
+          around_tool_call(:instrument) do |_, context:, &block|
+            block.call
+          end
+        end
+      }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises when given neither a symbol nor a block" do
+      expect {
+        Class.new(Riffer::ToolRuntime) do
+          around_tool_call
+        end
+      }.must_raise Riffer::ArgumentError
+    end
+  end
+end
+
+describe Riffer::ToolRuntime::Inline do
+  it "behaves identically to base" do
+    runtime = Riffer::ToolRuntime::Inline.new
+    expect(runtime).must_be_kind_of Riffer::ToolRuntime
+  end
+
+  it "executes tool calls sequentially" do
+    weather_tool = Class.new(Riffer::Tool) do
+      identifier "weather_tool"
+      description "Gets the weather"
+
+      params do
+        required :city, String
+      end
+
+      def call(context:, city:)
+        text("Weather in #{city}: 20 degrees")
+      end
+    end
+
+    runtime = Riffer::ToolRuntime::Inline.new
+    tool_call = Riffer::Messages::Assistant::ToolCall.new(
+      id: "1", call_id: "cid_1", name: "weather_tool", arguments: '{"city":"Toronto"}'
+    )
+
+    results = runtime.execute([tool_call], tools: [weather_tool], context: nil)
+
+    expect(results.length).must_equal 1
+    expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+  end
+end
+
+describe Riffer::ToolRuntime::Threaded do
+  it "executes tool calls in parallel" do
+    thread_ids = Mutex.new
+    seen = []
+
+    tracking_tool = Class.new(Riffer::Tool) do
+      identifier "tracking_tool"
+      description "Tracks threads"
+
+      define_method(:call) do |context:, **|
+        thread_ids.synchronize { seen << Thread.current.object_id }
+        sleep 0.01
+        text("done")
+      end
+    end
+
+    runtime = Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
+    tool_calls = 3.times.map do |i|
+      Riffer::Messages::Assistant::ToolCall.new(
+        id: i.to_s, call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
+      )
+    end
+
+    results = runtime.execute(tool_calls, tools: [tracking_tool], context: nil)
+
+    expect(results.length).must_equal 3
+    expect(seen.uniq.length).must_equal 3
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ToolRuntime` abstraction with `Inline` (sequential) and `Threaded` (thread pool) implementations
- Add `Runner` abstraction (`Sequential` and `Threaded`) used by tool runtimes for concurrency control
- New `tool_runtime` DSL on agents and global config
- `around_tool_call` callback for wrapping individual tool call execution
- Refactor `execute_tool_calls` / `execute_pending_tool_calls` to delegate to the resolved runtime

Split from #145 for independent review.

## Test plan

- [x] ToolRuntime inline and threaded modes execute tool calls correctly
- [x] Runner sequential and threaded modes work correctly
- [x] `around_tool_call` callbacks compose properly (block, symbol, inheritance)
- [x] DSL resolves symbol, instance, and Proc configurations
- [x] `bundle exec rake` passes (tests + lint + type check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)