### PR TITLE
feat: add support for dynamic instructions

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -16,6 +16,17 @@ agent = EchoAgent.new
 puts agent.generate('Hello world')
 ```
 
+`instructions` also accepts a Proc for dynamic instructions resolved at generate time. The Proc receives the `context` hash:
+
+```ruby
+class PersonalAgent < Riffer::Agent
+  model 'openai/gpt-5-mini'
+  instructions ->(context) { "You are assisting #{context[:name]}" }
+end
+
+PersonalAgent.generate('Hello!', context: { name: 'Jane' })
+```
+
 ### Providers (`lib/riffer/providers/`)
 
 Adapters for LLM APIs. The base class uses a template-method pattern — `generate_text` and `stream_text` orchestrate the flow, delegating to five hook methods each provider implements:

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -60,6 +60,28 @@ class MyAgent < Riffer::Agent
 end
 ```
 
+Instructions can also be resolved dynamically with a lambda:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  instructions -> { "Today is #{Date.today}. You are a helpful assistant." }
+end
+```
+
+When the lambda accepts a parameter, it receives the `context`:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-4o'
+  instructions ->(ctx) { "You are assisting #{ctx[:name]}" }
+end
+
+MyAgent.generate('Hello!', context: { name: 'Jane' })
+```
+
+The lambda is re-evaluated on each `generate` or `stream` call, so instructions can change between calls based on runtime context.
+
 ### identifier
 
 Sets a custom identifier (defaults to snake_case class name):

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -50,11 +50,26 @@ class Riffer::Agent
 
   # Gets or sets the agent instructions.
   #
-  #: (?String?) -> String?
-  def self.instructions(instructions_text = nil)
-    return @instructions if instructions_text.nil?
-    validate_is_string!(instructions_text, "instructions")
-    @instructions = instructions_text
+  # Accepts a static string or a Proc for dynamic instructions.
+  # When a Proc is given, it is called at generate time and receives
+  # the +context+ hash (which may be +nil+).
+  #
+  #   instructions "You are a helpful assistant."
+  #
+  #   instructions -> (context) {
+  #     "You are assisting #{context[:name]}"
+  #   }
+  #
+  #: (?(String | Proc)?) -> (String | Proc)?
+  def self.instructions(instructions_or_proc = nil)
+    return @instructions if instructions_or_proc.nil?
+
+    if instructions_or_proc.is_a?(Proc)
+      @instructions = instructions_or_proc
+    else
+      validate_is_string!(instructions_or_proc, "instructions")
+      @instructions = instructions_or_proc
+    end
   end
 
   # Gets or sets provider options passed to the provider client.
@@ -214,7 +229,7 @@ class Riffer::Agent
     @token_usage = nil
     @interrupted = false
     @model_config = self.class.model
-    @instructions_text = self.class.instructions
+    @instructions_config = self.class.instructions
 
     if @model_config.is_a?(Proc)
       @provider_name = nil
@@ -381,7 +396,8 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages(prompt_or_messages, files: nil)
     @messages = []
-    @messages << Riffer::Messages::System.new(@instructions_text) if @instructions_text
+    instructions_text = generate_instructions
+    @messages << Riffer::Messages::System.new(instructions_text) if instructions_text
 
     if prompt_or_messages.is_a?(Array)
       if files && !files.empty?
@@ -590,6 +606,15 @@ class Riffer::Agent
   def clear_resolved_model
     @resolved_model = nil
     @provider_instance = nil if @model_config.is_a?(Proc)
+  end
+
+  #: () -> String?
+  def generate_instructions
+    if @instructions_config.is_a?(Proc)
+      (@instructions_config.arity == 0) ? @instructions_config.call : @instructions_config.call(@context)
+    else
+      @instructions_config
+    end
   end
 
   attr_reader :resolved_model #: String?

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -37,8 +37,18 @@ class Riffer::Agent
 
   # Gets or sets the agent instructions.
   #
-  # : (?String?) -> String?
-  def self.instructions: (?String?) -> String?
+  # Accepts a static string or a Proc for dynamic instructions.
+  # When a Proc is given, it is called at generate time and receives
+  # the +context+ hash (which may be +nil+).
+  #
+  #   instructions "You are a helpful assistant."
+  #
+  #   instructions -> (context) {
+  #     "You are assisting #{context[:name]}"
+  #   }
+  #
+  # : (?(String | Proc)?) -> (String | Proc)?
+  def self.instructions: (?(String | Proc)?) -> (String | Proc)?
 
   # Gets or sets provider options passed to the provider client.
   #
@@ -237,6 +247,9 @@ class Riffer::Agent
 
   # : () -> void
   def clear_resolved_model: () -> void
+
+  # : () -> String?
+  def generate_instructions: () -> String?
 
   attr_reader resolved_model: String?
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -63,6 +63,14 @@ describe Riffer::Agent do
       error = expect { agent_class.instructions("   ") }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/instructions cannot be empty/)
     end
+
+    it "accepts a Proc" do
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions -> { "Dynamic instructions" }
+      end
+      expect(klass.instructions).must_be_instance_of Proc
+    end
   end
 
   describe ".provider_options" do
@@ -356,6 +364,57 @@ describe Riffer::Agent do
       end
     end
 
+    describe "with dynamic instructions" do
+      it "resolves the Proc at generate time" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          instructions -> { "Dynamic instructions" }
+        end
+
+        agent = klass.new
+        agent.generate("Hello")
+        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        expect(system_message.content).must_equal "Dynamic instructions"
+      end
+
+      it "passes context to the Proc" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          instructions ->(context) { "You are assisting #{context[:name]}" }
+        end
+
+        agent = klass.new
+        agent.generate("Hello", context: {name: "Jane"})
+        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        expect(system_message.content).must_equal "You are assisting Jane"
+      end
+
+      it "passes nil context when not provided" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          instructions ->(context) { context ? "With context" : "No context" }
+        end
+
+        agent = klass.new
+        agent.generate("Hello")
+        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        expect(system_message.content).must_equal "No context"
+      end
+
+      it "does not add system message when Proc returns nil" do
+        returner = ->(_tool_context) {}
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          instructions returner
+        end
+
+        agent = klass.new
+        agent.generate("Hello")
+        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        expect(system_message).must_be_nil
+      end
+    end
+
     describe "with invalid provider" do
       it "raises error when provider is not found" do
         invalid_agent_class = Class.new(Riffer::Agent) do
@@ -570,6 +629,20 @@ describe Riffer::Agent do
         agent.stream("Hello").each { |_| }
         system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).must_be_nil
+      end
+    end
+
+    describe "with dynamic instructions" do
+      it "resolves the Proc with context" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          instructions ->(context) { "You are assisting #{context[:name]}" }
+        end
+
+        agent = klass.new
+        agent.stream("Hello", context: {name: "Jane"}).each { |_| }
+        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        expect(system_message.content).must_equal "You are assisting Jane"
       end
     end
 


### PR DESCRIPTION
- The `instructions` DSL now accepts a Proc for dynamic instructions, matching the existing `model` pattern. The Proc is resolved at generate/stream time and receives `tool_context`.

```ruby
class MyAgent < Riffer::Agent
  model 'openai/gpt-4o'
  instructions ->(ctx) { "You are assisting #{ctx[:name]}" }
end

MyAgent.generate('Hello!', tool_context: { name: 'Jane' })
```