### PR TITLE
refactor!: rename `tool_context` to `context`

### DIFF
--- a/.agents/rbs-inline.md
+++ b/.agents/rbs-inline.md
@@ -64,8 +64,8 @@ def evaluate(input:, output:)
 def evaluate(input:, output:, context: nil)
 
 # Positional + keyword parameters
-#: (String, ?tool_context: Hash[Symbol, untyped]?) -> String
-def generate(prompt, tool_context: nil)
+#: (String, ?context: Hash[Symbol, untyped]?) -> String
+def generate(prompt, context: nil)
 
 # Splat/double-splat
 #: (**untyped) -> void

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -37,12 +37,12 @@ class MyAgent < Riffer::Agent
 end
 ```
 
-When the lambda accepts a parameter, it receives the `tool_context`:
+When the lambda accepts a parameter, it receives the `context`:
 
 ```ruby
 class MyAgent < Riffer::Agent
-  model ->(ctx) {
-    ctx&.dig(:premium) ? "anthropic/claude-sonnet-4-20250514" : "anthropic/claude-haiku-4-5-20251001"
+  model ->(context) {
+    context&.dig(:premium) ? "anthropic/claude-sonnet-4-20250514" : "anthropic/claude-haiku-4-5-20251001"
   }
 end
 ```
@@ -282,8 +282,8 @@ response = MyAgent.generate([
   {role: 'user', content: 'How are you?'}
 ])
 
-# With tool context
-response = MyAgent.generate('Look up my orders', tool_context: {user_id: 123})
+# With context
+response = MyAgent.generate('Look up my orders', context: {user_id: 123})
 
 # With files (string prompt + files shorthand)
 response = MyAgent.generate('What is in this image?', files: [
@@ -426,7 +426,7 @@ For cross-process resume (e.g., after a process restart or async approval), pass
 # Persist messages during generation (e.g., via on_message callback)
 # Later, in a new process:
 agent = MyAgent.new
-response = agent.resume(messages: persisted_messages, tool_context: {user_id: 123})
+response = agent.resume(messages: persisted_messages, context: {user_id: 123})
 
 # Or resume in streaming mode:
 agent.resume_stream(messages: persisted_messages).each do |event|
@@ -445,7 +445,7 @@ Continues an agent loop synchronously. Returns a `Riffer::Agent::Response` objec
 response = agent.resume
 
 # Cross-process resume from persisted messages
-response = agent.resume(messages: persisted_messages, tool_context: {user_id: 123})
+response = agent.resume(messages: persisted_messages, context: {user_id: 123})
 ```
 
 ### resume_stream

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -145,7 +145,7 @@ Every tool must implement the `call` method and return a `Riffer::Tools::Respons
 
 ```ruby
 def call(context:, **kwargs)
-  # context - The tool_context passed to agent.generate()
+  # context - The context passed to agent.generate()
   # kwargs  - Validated parameters
   #
   # Must return a Riffer::Tools::Response
@@ -154,7 +154,7 @@ end
 
 ### Accessing Context
 
-The `context` argument receives whatever was passed to `tool_context`:
+The `context` argument receives whatever was passed as `context:` to `generate`:
 
 ```ruby
 class UserOrdersTool < Riffer::Tool
@@ -172,7 +172,7 @@ class UserOrdersTool < Riffer::Tool
 end
 
 # Usage
-agent.generate("Show my orders", tool_context: {user_id: 123})
+agent.generate("Show my orders", context: {user_id: 123})
 ```
 
 ## Response Objects
@@ -417,10 +417,10 @@ class MyAgent < Riffer::Agent
   }
 end
 
-agent.generate("Do work", tool_context: {parallel: true})
+agent.generate("Do work", context: {parallel: true})
 ```
 
-When the lambda accepts a parameter, it receives the `tool_context`. Zero-arity lambdas are also supported.
+When the lambda accepts a parameter, it receives the `context`. Zero-arity lambdas are also supported.
 
 ### Global Configuration
 

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -81,23 +81,23 @@ result = Riffer::Evals::EvaluatorRunner.run(
 )
 ```
 
-### Tool Context
+### Context
 
-Pass `tool_context:` to provide context that agents use for dynamic model selection, tool resolution, or tool execution:
+Pass `context:` to provide context that agents use for dynamic model selection, tool resolution, or tool execution:
 
 ```ruby
 result = Riffer::Evals::EvaluatorRunner.run(
   agent: MyAgent,
   scenarios: [
     { input: "What is Ruby?" },
-    { input: "Premium question", tool_context: { premium: true } }
+    { input: "Premium question", context: { premium: true } }
   ],
   evaluators: [AnswerRelevancyEvaluator],
-  tool_context: { premium: false }
+  context: { premium: false }
 )
 ```
 
-Per-scenario `tool_context` overrides the top-level value. Scenarios without their own `tool_context` inherit the top-level value.
+Per-scenario `context` overrides the top-level value. Scenarios without their own `context` inherit the top-level value.
 
 ### RunResult
 

--- a/docs_providers/05_MOCK_PROVIDER.md
+++ b/docs_providers/05_MOCK_PROVIDER.md
@@ -121,7 +121,7 @@ class MyAgentTest < Minitest::Test
     ])
     @provider.stub_response("Done.")
 
-    @agent.generate("Do something", tool_context: {user_id: 123})
+    @agent.generate("Do something", context: {user_id: 123})
 
     # Tool receives the context
   end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -226,9 +226,9 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, files: nil, tool_context: nil)
-    @tool_context = tool_context
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate(prompt_or_messages, files: nil, context: nil)
+    @context = context
     @resolved_tools = nil
     @resolved_tool_runtime = nil
     clear_resolved_model
@@ -249,11 +249,11 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, files: nil, tool_context: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt_or_messages, files: nil, context: nil)
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
-    @tool_context = tool_context
+    @context = context
     @resolved_tools = nil
     @resolved_tool_runtime = nil
     clear_resolved_model
@@ -283,9 +283,9 @@ class Riffer::Agent
   # The step offset is derived automatically from the number of assistant
   # messages so +max_steps+ is enforced across the full session.
   #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def resume(messages: nil, tool_context: nil)
-    restore_state(messages: messages, tool_context: tool_context)
+  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def resume(messages: nil, context: nil)
+    restore_state(messages: messages, context: context)
     run_generate_loop(resume: true)
   end
 
@@ -293,9 +293,9 @@ class Riffer::Agent
   #
   # Same as +resume+ but returns an Enumerator yielding stream events.
   #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def resume_stream(messages: nil, tool_context: nil)
-    restore_state(messages: messages, tool_context: tool_context)
+  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def resume_stream(messages: nil, context: nil)
+    restore_state(messages: messages, context: context)
 
     Enumerator.new do |yielder|
       run_stream_loop(yielder, resume: true)
@@ -397,10 +397,10 @@ class Riffer::Agent
     end
   end
 
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> void
-  def restore_state(messages: nil, tool_context: nil)
+  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
+  def restore_state(messages: nil, context: nil)
     @messages = messages.map { |item| convert_to_message_object(item) } if messages
-    @tool_context = tool_context if tool_context
+    @context = context if context
     @interrupted = false
     @resolved_tools = nil
     @resolved_tool_runtime = nil
@@ -523,7 +523,7 @@ class Riffer::Agent
   #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
     runtime = resolve_tool_runtime
-    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @tool_context)
+    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @context)
 
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
@@ -564,7 +564,7 @@ class Riffer::Agent
     return if pending.empty?
 
     runtime = resolve_tool_runtime
-    results = runtime.execute(pending, tools: resolved_tools, context: @tool_context)
+    results = runtime.execute(pending, tools: resolved_tools, context: @context)
 
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
@@ -597,7 +597,7 @@ class Riffer::Agent
   #: () -> String
   def resolve_model
     @resolved_model ||= if @model_config.is_a?(Proc)
-      model_string = (@model_config.arity == 0) ? @model_config.call : @model_config.call(@tool_context)
+      model_string = (@model_config.arity == 0) ? @model_config.call : @model_config.call(@context)
       parse_model_string!(model_string)
       model_string
     else
@@ -612,7 +612,7 @@ class Riffer::Agent
       return [] if config.nil?
 
       if config.is_a?(Proc)
-        (config.arity == 0) ? config.call : config.call(@tool_context)
+        (config.arity == 0) ? config.call : config.call(@context)
       else
         config
       end
@@ -625,7 +625,7 @@ class Riffer::Agent
       config = self.class.tool_runtime || Riffer.config.tool_runtime
 
       runtime = if config.is_a?(Proc)
-        (config.arity == 0) ? config.call : config.call(@tool_context)
+        (config.arity == 0) ? config.call : config.call(@context)
       else
         config
       end
@@ -648,7 +648,7 @@ class Riffer::Agent
     guardrails = self.class.guardrails_for(:before)
     return [nil, []] if guardrails.empty?
 
-    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :before, context: @tool_context)
+    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :before, context: @context)
     processed_messages, tripwire, modifications = runner.run(@messages)
     @messages = processed_messages unless tripwire
     [tripwire, modifications]
@@ -659,7 +659,7 @@ class Riffer::Agent
     guardrails = self.class.guardrails_for(:after)
     return [response, nil, []] if guardrails.empty?
 
-    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :after, context: @tool_context)
+    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :after, context: @context)
     processed_response, tripwire, modifications = runner.run(response, messages: @messages)
 
     response_index = @messages.length

--- a/lib/riffer/evals/evaluator_runner.rb
+++ b/lib/riffer/evals/evaluator_runner.rb
@@ -22,20 +22,20 @@ class Riffer::Evals::EvaluatorRunner
   # Runs evaluators against an agent for the given scenarios.
   #
   # +agent+ - an Agent subclass (not an instance).
-  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:tool_context+.
+  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
   # +evaluators+ - array of Evaluator subclasses to run against each scenario.
-  # +tool_context+ - optional hash passed to +agent.generate+. Per-scenario +:tool_context+ takes precedence.
+  # +context+ - optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
   #
   # Raises Riffer::ArgumentError if agent is not a Riffer::Agent subclass
   # or any eval is not a Riffer::Evals::Evaluator subclass.
   #
-  #: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-  def self.run(agent:, scenarios:, evaluators:, tool_context: nil)
+  #: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  def self.run(agent:, scenarios:, evaluators:, context: nil)
     validate_agent!(agent)
     validate_evaluators!(evaluators)
 
     scenario_results = scenarios.map do |scenario|
-      run_scenario(agent: agent, scenario: scenario, evaluators: evaluators, tool_context: tool_context)
+      run_scenario(agent: agent, scenario: scenario, evaluators: evaluators, context: context)
     end
 
     Riffer::Evals::RunResult.new(scenario_results: scenario_results)
@@ -57,13 +57,13 @@ class Riffer::Evals::EvaluatorRunner
     end
   end
 
-  #: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
-  private_class_method def self.run_scenario(agent:, scenario:, evaluators:, tool_context: nil)
+  #: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
+  private_class_method def self.run_scenario(agent:, scenario:, evaluators:, context: nil)
     input = scenario[:input]
     ground_truth = scenario[:ground_truth]
-    context = scenario[:tool_context] || tool_context
+    resolved_context = scenario[:context] || context
 
-    response = agent.generate(input, tool_context: context)
+    response = agent.generate(input, context: resolved_context)
     output = response.content
 
     results = evaluators.map do |evaluator_class|

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -7,7 +7,7 @@
 # to the next. If any guardrail blocks, execution stops and a tripwire
 # is returned.
 #
-#   runner = Runner.new(guardrail_configs, phase: :before, context: tool_context)
+#   runner = Runner.new(guardrail_configs, phase: :before, context: context)
 #   data, tripwire, modifications = runner.run(messages)
 class Riffer::Guardrails::Runner
   # The guardrail configs to execute.

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -12,7 +12,7 @@ require "json"
 # tool calls are dispatched (e.g., HTTP, gRPC).
 #
 #   runtime = Riffer::ToolRuntime::Inline.new
-#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+#   results = runtime.execute(tool_calls, tools: tools, context: context)
 #
 class Riffer::ToolRuntime
   # +runner+ - the concurrency runner to use for batch execution.
@@ -30,7 +30,7 @@ class Riffer::ToolRuntime
   #
   # +tool_calls+ - the tool calls to execute.
   # +tools+ - the resolved tool classes.
-  # +context+ - the tool context hash.
+  # +context+ - the context hash.
   #
   #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute(tool_calls, tools:, context:)
@@ -70,7 +70,7 @@ class Riffer::ToolRuntime
   #
   # +tool_call+ - the tool call to execute.
   # +tools+ - the resolved tool classes.
-  # +context+ - the tool context hash.
+  # +context+ - the context hash.
   #
   #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
   def dispatch_tool_call(tool_call, tools:, context:)

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -138,15 +138,15 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Resumes an agent loop.
   #
@@ -158,15 +158,15 @@ class Riffer::Agent
   # The step offset is derived automatically from the number of assistant
   # messages so +max_steps+ is enforced across the full session.
   #
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def resume: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def resume: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
   # Resumes an agent loop in streaming mode.
   #
   # Same as +resume+ but returns an Enumerator yielding stream events.
   #
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def resume_stream: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def resume_stream: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a callback to be invoked when messages are added during generation.
   #
@@ -197,8 +197,8 @@ class Riffer::Agent
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> void
-  def restore_state: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?tool_context: Hash[Symbol, untyped]?) -> void
+  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
+  def restore_state: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
 
   # : () -> Integer
   def count_assistant_messages: () -> Integer

--- a/sig/generated/riffer/evals/evaluator_runner.rbs
+++ b/sig/generated/riffer/evals/evaluator_runner.rbs
@@ -20,15 +20,15 @@ class Riffer::Evals::EvaluatorRunner
   # Runs evaluators against an agent for the given scenarios.
   #
   # +agent+ - an Agent subclass (not an instance).
-  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:tool_context+.
+  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
   # +evaluators+ - array of Evaluator subclasses to run against each scenario.
-  # +tool_context+ - optional hash passed to +agent.generate+. Per-scenario +:tool_context+ takes precedence.
+  # +context+ - optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
   #
   # Raises Riffer::ArgumentError if agent is not a Riffer::Agent subclass
   # or any eval is not a Riffer::Evals::Evaluator subclass.
   #
-  # : (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
-  def self.run: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  # : (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
+  def self.run: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
 
   # : (singleton(Riffer::Agent)) -> void
   def self.validate_agent!: (singleton(Riffer::Agent)) -> void
@@ -36,6 +36,6 @@ class Riffer::Evals::EvaluatorRunner
   # : (Array[singleton(Riffer::Evals::Evaluator)]) -> void
   def self.validate_evaluators!: (Array[singleton(Riffer::Evals::Evaluator)]) -> void
 
-  # : (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
-  def self.run_scenario: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?tool_context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
+  # : (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
+  def self.run_scenario: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
 end

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -6,7 +6,7 @@
 # to the next. If any guardrail blocks, execution stops and a tripwire
 # is returned.
 #
-#   runner = Runner.new(guardrail_configs, phase: :before, context: tool_context)
+#   runner = Runner.new(guardrail_configs, phase: :before, context: context)
 #   data, tripwire, modifications = runner.run(messages)
 class Riffer::Guardrails::Runner
   # The guardrail configs to execute.

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -9,7 +9,7 @@
 # tool calls are dispatched (e.g., HTTP, gRPC).
 #
 #   runtime = Riffer::ToolRuntime::Inline.new
-#   results = runtime.execute(tool_calls, tools: tools, context: ctx)
+#   results = runtime.execute(tool_calls, tools: tools, context: context)
 class Riffer::ToolRuntime
   # +runner+ - the concurrency runner to use for batch execution.
   #
@@ -23,7 +23,7 @@ class Riffer::ToolRuntime
   #
   # +tool_calls+ - the tool calls to execute.
   # +tools+ - the resolved tool classes.
-  # +context+ - the tool context hash.
+  # +context+ - the context hash.
   #
   # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
@@ -54,7 +54,7 @@ class Riffer::ToolRuntime
   #
   # +tool_call+ - the tool call to execute.
   # +tools+ - the resolved tool classes.
-  # +context+ - the tool context hash.
+  # +context+ - the context hash.
   #
   # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
   def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -894,7 +894,7 @@ describe Riffer::Agent do
       expect(result).must_be_instance_of Riffer::Agent::Response
     end
 
-    it "passes tool_context to tools" do
+    it "passes context to tools" do
       context_tool = Class.new(Riffer::Tool) do
         description "Gets user info"
         params do
@@ -910,13 +910,13 @@ describe Riffer::Agent do
       received_context = nil
       custom_agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        uses_tools ->(ctx) {
-          received_context = ctx
+        uses_tools ->(context) {
+          received_context = context
           [tool]
         }
       end
 
-      custom_agent_class.generate("Hello", tool_context: {user_name: "Bob"})
+      custom_agent_class.generate("Hello", context: {user_name: "Bob"})
       expect(received_context).must_equal({user_name: "Bob"})
     end
   end
@@ -932,7 +932,7 @@ describe Riffer::Agent do
       expect(events).wont_be_empty
     end
 
-    it "passes tool_context to tools" do
+    it "passes context to tools" do
       context_tool = Class.new(Riffer::Tool) do
         description "Gets user info"
         params do
@@ -948,13 +948,13 @@ describe Riffer::Agent do
       received_context = nil
       custom_agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        uses_tools ->(ctx) {
-          received_context = ctx
+        uses_tools ->(context) {
+          received_context = context
           [tool]
         }
       end
 
-      custom_agent_class.stream("Hello", tool_context: {user_id: "42"}).each { |_| }
+      custom_agent_class.stream("Hello", context: {user_id: "42"}).each { |_| }
       expect(received_context).must_equal({user_id: "42"})
     end
   end
@@ -1062,18 +1062,18 @@ describe Riffer::Agent do
       expect(runtime).must_be_instance_of Riffer::ToolRuntime::Inline
     end
 
-    it "passes tool_context to lambda with arity 1" do
+    it "passes context to lambda with arity 1" do
       received_context = nil
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime ->(ctx) {
-          received_context = ctx
+        tool_runtime ->(context) {
+          received_context = context
           Riffer::ToolRuntime::Inline.new
         }
       end
 
       instance = agent.new
-      instance.instance_variable_set(:@tool_context, {user_id: 42})
+      instance.instance_variable_set(:@context, {user_id: 42})
       instance.send(:resolve_tool_runtime)
 
       expect(received_context).must_equal({user_id: 42})
@@ -1130,19 +1130,19 @@ describe Riffer::Agent do
       received_contexts = []
       agent = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
-        tool_runtime ->(ctx) {
-          received_contexts << ctx
+        tool_runtime ->(context) {
+          received_contexts << context
           Riffer::ToolRuntime::Inline.new
         }
       end
 
       instance = agent.new
-      instance.instance_variable_set(:@tool_context, {a: 1})
+      instance.instance_variable_set(:@context, {a: 1})
       instance.send(:resolve_tool_runtime)
 
       # Simulate what generate does: reset and resolve again
       instance.instance_variable_set(:@resolved_tool_runtime, nil)
-      instance.instance_variable_set(:@tool_context, {b: 2})
+      instance.instance_variable_set(:@context, {b: 2})
       instance.send(:resolve_tool_runtime)
 
       expect(received_contexts).must_equal [{a: 1}, {b: 2}]
@@ -1168,16 +1168,16 @@ describe Riffer::Agent do
       expect(events).wont_be_empty
     end
 
-    it "passes tool_context to lambda with arity 1" do
+    it "passes context to lambda with arity 1" do
       received_context = nil
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model ->(ctx) {
-          received_context = ctx
+        model ->(context) {
+          received_context = context
           "mock/riffer-1"
         }
       end
 
-      dynamic_agent_class.generate("Hello", tool_context: {premium: true})
+      dynamic_agent_class.generate("Hello", context: {premium: true})
       expect(received_context).must_equal({premium: true})
     end
 
@@ -1220,19 +1220,19 @@ describe Riffer::Agent do
       expect(call_count).must_equal 2
     end
 
-    it "can change model between calls based on tool_context" do
+    it "can change model between calls based on context" do
       models_used = []
       dynamic_agent_class = Class.new(Riffer::Agent) do
-        model ->(ctx) {
-          model = ctx&.dig(:premium) ? "mock/riffer-premium" : "mock/riffer-basic"
+        model ->(context) {
+          model = context&.dig(:premium) ? "mock/riffer-premium" : "mock/riffer-basic"
           models_used << model
           model
         }
       end
 
       agent = dynamic_agent_class.new
-      agent.generate("Hello", tool_context: {premium: false})
-      agent.generate("Hello", tool_context: {premium: true})
+      agent.generate("Hello", context: {premium: false})
+      agent.generate("Hello", context: {premium: true})
       expect(models_used).must_equal ["mock/riffer-basic", "mock/riffer-premium"]
     end
 
@@ -1370,7 +1370,7 @@ describe Riffer::Agent do
         expect(result.content).must_equal "The weather in Toronto is nice!"
       end
 
-      it "passes tool_context to tools" do
+      it "passes context to tools" do
         tool_class = context_tool_class
         tool_class.identifier("context_tool")
         agent_class = Class.new(Riffer::Agent) do
@@ -1385,7 +1385,7 @@ describe Riffer::Agent do
         ])
         provider.stub_response("Your name is Alice!")
 
-        agent.generate("Get my name", tool_context: {user_name: "Alice"})
+        agent.generate("Get my name", context: {user_name: "Alice"})
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Alice"
@@ -1571,7 +1571,7 @@ describe Riffer::Agent do
         expect(tool_messages.length).must_equal 1
       end
 
-      it "passes tool_context in streaming mode" do
+      it "passes context in streaming mode" do
         tool_class = context_tool_class
         tool_class.identifier("context_tool")
         agent_class = Class.new(Riffer::Agent) do
@@ -1586,7 +1586,7 @@ describe Riffer::Agent do
         ])
         provider.stub_response("Your ID is 12345!")
 
-        agent.stream("Get my id", tool_context: {user_id: "12345"}).each { |_| }
+        agent.stream("Get my id", context: {user_id: "12345"}).each { |_| }
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "12345"
@@ -1728,7 +1728,7 @@ describe Riffer::Agent do
         expect(call_count).must_be :>, 0
       end
 
-      it "passes tool_context to lambda when it accepts a parameter" do
+      it "passes context to lambda when it accepts a parameter" do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         received_context = nil
@@ -1743,7 +1743,7 @@ describe Riffer::Agent do
 
         agent = agent_class.new
         context = {user_id: 123, admin: true}
-        agent.generate("Hello", tool_context: context)
+        agent.generate("Hello", context: context)
 
         expect(received_context).must_equal context
       end
@@ -1773,13 +1773,13 @@ describe Riffer::Agent do
         admin_agent = agent_class.new
         provider = admin_agent.send(:provider_instance)
         provider.stub_response("Done")
-        admin_agent.generate("Hello", tool_context: {admin: true})
+        admin_agent.generate("Hello", context: {admin: true})
         admin_tools = provider.calls.last[:tools]
 
         regular_agent = agent_class.new
         provider2 = regular_agent.send(:provider_instance)
         provider2.stub_response("Done")
-        regular_agent.generate("Hello", tool_context: {admin: false})
+        regular_agent.generate("Hello", context: {admin: false})
         regular_tools = provider2.calls.last[:tools]
 
         expect(admin_tools.length).must_equal 2
@@ -1800,8 +1800,8 @@ describe Riffer::Agent do
         end
 
         agent = agent_class.new
-        agent.generate("Hello", tool_context: {call: 1})
-        agent.generate("Hello again", tool_context: {call: 2})
+        agent.generate("Hello", context: {call: 1})
+        agent.generate("Hello again", context: {call: 2})
 
         expect(contexts_received.length).must_equal 2
         expect(contexts_received[0]).must_equal({call: 1})
@@ -2272,7 +2272,7 @@ describe Riffer::Agent do
         expect(result.interrupted?).must_equal false
       end
 
-      it "sets tool_context" do
+      it "sets context" do
         context_tool = Class.new(Riffer::Tool) do
           description "Gets user info"
           params do
@@ -2297,7 +2297,7 @@ describe Riffer::Agent do
         provider.stub_response("Your name is Alice!")
 
         messages = [Riffer::Messages::User.new("Get my name")]
-        agent.resume(messages: messages, tool_context: {user_name: "Alice"})
+        agent.resume(messages: messages, context: {user_name: "Alice"})
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Alice"

--- a/test/riffer/evals/evaluator_runner_test.rb
+++ b/test/riffer/evals/evaluator_runner_test.rb
@@ -104,12 +104,12 @@ describe Riffer::Evals::EvaluatorRunner do
     end
   end
 
-  describe "tool_context" do
-    it "passes tool_context to agent" do
+  describe "context" do
+    it "passes context to agent" do
       received_context = nil
       context_agent = Class.new(Riffer::Agent) do
-        model ->(ctx) {
-          received_context = ctx
+        model ->(context) {
+          received_context = context
           "mock/mock-model"
         }
         instructions "You are a helpful assistant."
@@ -119,17 +119,17 @@ describe Riffer::Evals::EvaluatorRunner do
         agent: context_agent,
         scenarios: [{input: "Hello"}],
         evaluators: [evaluator_class],
-        tool_context: {user_id: 42}
+        context: {user_id: 42}
       )
 
       expect(received_context).must_equal({user_id: 42})
     end
 
-    it "allows per-scenario tool_context to override top-level" do
+    it "allows per-scenario context to override top-level" do
       received_contexts = []
       context_agent = Class.new(Riffer::Agent) do
-        model ->(ctx) {
-          received_contexts << ctx
+        model ->(context) {
+          received_contexts << context
           "mock/mock-model"
         }
         instructions "You are a helpful assistant."
@@ -138,11 +138,11 @@ describe Riffer::Evals::EvaluatorRunner do
       Riffer::Evals::EvaluatorRunner.run(
         agent: context_agent,
         scenarios: [
-          {input: "Hello", tool_context: {user_id: 99}},
+          {input: "Hello", context: {user_id: 99}},
           {input: "Hi"}
         ],
         evaluators: [evaluator_class],
-        tool_context: {user_id: 42}
+        context: {user_id: 42}
       )
 
       expect(received_contexts[0]).must_equal({user_id: 99})


### PR DESCRIPTION
`tool_context` stopped being "context for tools" once we started passing it around for doing dynamic model selection and guardrails. We have even more features in the works that would use this "context" for dynamic behavior, namely dynamic instructions https://github.com/janeapp/riffer/pull/158 and skills https://github.com/janeapp/riffer/pull/151. So I think we're due for renaming this object `context`, to avoid confusion and simplify things. It's a breaking change, but better now than later.