### PR TITLE
fix: resolve edge cases in generate/resume and streaming

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -295,6 +295,7 @@ class Riffer::Agent
   #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def resume(messages: nil, context: nil)
     restore_state(messages: messages, context: context)
+    @structured_output = resolve_structured_output
     run_generate_loop(resume: true)
   end
 
@@ -304,6 +305,8 @@ class Riffer::Agent
   #
   #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def resume_stream(messages: nil, context: nil)
+    raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #resume instead." if self.class.structured_output
+
     restore_state(messages: messages, context: context)
 
     Enumerator.new do |yielder|
@@ -410,7 +413,7 @@ class Riffer::Agent
   #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
   def restore_state(messages: nil, context: nil)
     @messages = messages.map { |item| convert_to_message_object(item) } if messages
-    @context = context if context
+    @context = context
     prepare_run
   end
 
@@ -507,7 +510,7 @@ class Riffer::Agent
       messages: @messages,
       model: @model_name,
       tools: resolved_tools,
-      **self.class.model_options
+      **merged_model_options
     )
   end
 

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -67,7 +67,9 @@ module Riffer::Messages::Converter
       files = (hash[:files] || []).map { |f| convert_to_file_part(f) }
       Riffer::Messages::User.new(content, files: files)
     when :assistant
-      tool_calls = hash[:tool_calls] || []
+      tool_calls = (hash[:tool_calls] || []).map { |tc|
+        tc.is_a?(Riffer::Messages::Assistant::ToolCall) ? tc : Riffer::Messages::Assistant::ToolCall.new(**tc)
+      }
       structured_output = hash[:structured_output]
       Riffer::Messages::Assistant.new(content, tool_calls: tool_calls, structured_output: structured_output)
     when :system

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2387,6 +2387,44 @@ describe Riffer::Agent do
         expect(system_messages.length).must_equal 1
         expect(system_messages.first.content).must_equal "Custom instructions."
       end
+
+      it "executes pending tool calls from hash-serialized messages" do
+        tc = Class.new(Riffer::Tool) do
+          description "Simple tool"
+          def call(context:)
+            text("done")
+          end
+        end.tap { |t| t.identifier("cross_process_pending_tool") }
+
+        tool = tc
+        custom_agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          uses_tools [tool]
+        end
+
+        agent = custom_agent_class.new
+        provider = agent.send(:provider_instance)
+        provider.stub_response("All done!")
+
+        messages = [
+          {role: "user", content: "Call tool"},
+          {role: "assistant", content: "", tool_calls: [{id: "tc_1", call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}"}]}
+        ]
+        result = agent.resume(messages: messages)
+        expect(result.interrupted?).must_equal false
+
+        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        expect(tool_messages.length).must_equal 1
+        expect(tool_messages.first.content).must_equal "done"
+      end
+
+      it "clears context when not provided on cross-process resume" do
+        agent = agent_class.new
+        agent.generate("Hello", context: {user: "Alice"})
+
+        agent.resume(messages: [Riffer::Messages::User.new("Hello")])
+        expect(agent.send(:instance_variable_get, :@context)).must_be_nil
+      end
     end
 
     describe "auto-derived step offset" do
@@ -2453,6 +2491,52 @@ describe Riffer::Agent do
         )
         expect(result.interrupted?).must_equal true
         expect(result.interrupt_reason).must_equal :max_steps
+      end
+    end
+
+    describe "with structured_output" do
+      it "returns parsed structured_output on in-memory resume" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          structured_output do
+            required :sentiment, String
+          end
+        end
+
+        agent = klass.new
+        provider = agent.send(:provider_instance)
+        provider.stub_response('{"sentiment":"positive"}')
+
+        interrupted_once = false
+        agent.on_message do |_msg|
+          unless interrupted_once
+            interrupted_once = true
+            throw :riffer_interrupt
+          end
+        end
+
+        agent.generate("Analyze sentiment")
+
+        provider.stub_response('{"sentiment":"negative"}')
+        result = agent.resume
+        expect(result.structured_output).must_equal({sentiment: "negative"})
+      end
+
+      it "returns parsed structured_output on cross-process resume" do
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          structured_output do
+            required :sentiment, String
+          end
+        end
+
+        agent = klass.new
+        provider = agent.send(:provider_instance)
+        provider.stub_response('{"sentiment":"positive"}')
+
+        messages = [Riffer::Messages::User.new("Analyze sentiment")]
+        result = agent.resume(messages: messages)
+        expect(result.structured_output).must_equal({sentiment: "positive"})
       end
     end
   end
@@ -2539,6 +2623,18 @@ describe Riffer::Agent do
         interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
         expect(interrupt_event).must_be_nil
       end
+    end
+
+    it "raises when structured_output is configured" do
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        structured_output do
+          required :sentiment, String
+        end
+      end
+      agent = klass.new
+      error = expect { agent.resume_stream }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/Structured output is not supported with streaming/)
     end
   end
 

--- a/test/riffer/messages/converter_test.rb
+++ b/test/riffer/messages/converter_test.rb
@@ -105,6 +105,20 @@ describe Riffer::Messages::Converter do
         result = instance.convert_to_message_object(assistant_message)
         expect(result.tool_calls).must_equal [tool_call]
       end
+
+      it "converts tool_call hashes to ToolCall structs" do
+        result = instance.convert_to_message_object({
+          role: "assistant",
+          content: "Let me search",
+          tool_calls: [{id: "1", call_id: "c1", name: "search", arguments: "{}"}]
+        })
+        tc = result.tool_calls.first
+        expect(tc).must_be_instance_of Riffer::Messages::Assistant::ToolCall
+        expect(tc.id).must_equal "1"
+        expect(tc.call_id).must_equal "c1"
+        expect(tc.name).must_equal "search"
+        expect(tc.arguments).must_equal "{}"
+      end
     end
 
     describe "with user message with files" do


### PR DESCRIPTION
## Summary

- **Critical**: Convert tool_call hashes to `ToolCall` structs in message converter, fixing a `NoMethodError` crash on cross-process resume with pending tool calls
- **Moderate**: Guard `resume_stream` against structured output (matching `stream` behavior)
- **Moderate**: Always reset `@context` in `restore_state` so cross-process resume gets a clean slate when no context is provided
- **Minor**: Use `merged_model_options` in `call_llm_stream` for consistency with `call_llm`

## Test plan

- [x] New test: converter converts tool_call hashes to ToolCall structs
- [x] New test: cross-process resume executes pending tool calls from hash-serialized messages
- [x] New test: context is cleared when not provided on cross-process resume
- [x] New test: `resume_stream` raises when structured output is configured
- [x] Full suite passes (1066 tests, 0 failures)
- [x] StandardRB lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)