### PR TITLE
feat: Unify generate/stream API with multi-turn support, remove resume methods

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -81,6 +81,10 @@ Structured events for streaming responses:
 - `WebSearchDone` - web search completion with query and sources
 - `Interrupt` - callback interrupted the agent loop
 
+### Per-Call State Reset
+
+Each call to `generate` or `stream` resets `context`, tools, tool runtime, model, skills state, and the interrupted flag via `prepare_run`. Only the message history and cumulative `token_usage` persist across calls. This means `context:` must be passed on every call.
+
 ### Stopping the Loop Early
 
 Two mechanisms can stop the agent loop before the LLM finishes naturally:

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -91,11 +91,14 @@ Two mechanisms can stop the agent loop before the LLM finishes naturally:
 
 ### Resuming After an Interrupt
 
-Pass the message array back to `generate` or `stream` to resume an interrupted loop. Array input is treated as resume mode: messages are used as-is (no system message prepend), and pending tool calls are automatically executed.
+Two resume paths:
+
+- **In-memory** — call `generate` or `stream` again with a string on the same agent instance. The message history is preserved and the new user message is appended.
+- **Cross-process** — pass persisted messages as an array to a new agent instance. Array input uses messages as-is (no system message prepend). Passing an array to an agent that already has messages raises `Riffer::ArgumentError`.
 
 ```ruby
-agent.generate(agent.messages)          # in-memory resume
-agent.stream(persisted_messages)        # cross-process resume
+agent.generate('Continue')              # in-memory resume
+MyAgent.new.stream(persisted_messages)  # cross-process resume
 ```
 
 On resume, `execute_pending_tool_calls` detects tool calls from the last assistant message that lack corresponding tool result messages and executes them before entering the LLM loop. This handles the case where an interrupt fired mid-way through tool execution.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -91,7 +91,12 @@ Two mechanisms can stop the agent loop before the LLM finishes naturally:
 
 ### Resuming After an Interrupt
 
-`agent.resume` or `agent.resume_stream` continues an interrupted loop. Both accept `messages:` for cross-process resume from persisted data.
+Pass the message array back to `generate` or `stream` to resume an interrupted loop. Array input is treated as resume mode: messages are used as-is (no system message prepend), and pending tool calls are automatically executed.
+
+```ruby
+agent.generate(agent.messages)          # in-memory resume
+agent.stream(persisted_messages)        # cross-process resume
+```
 
 On resume, `execute_pending_tool_calls` detects tool calls from the last assistant message that lack corresponding tool result messages and executes them before entering the LLM loop. This handles the case where an interrupt fired mid-way through tool execution.
 

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -293,6 +293,14 @@ The behavior depends on what you pass and the agent's current state:
 | **Array** | No prior messages | **Restore from persisted data.** Uses the array as-is (no system messages added). Pending tool calls are executed. This is for cross-process resume. |
 | **Array** | Has messages from a prior call | **Raises `Riffer::ArgumentError`.** Use a string to continue, or a new agent instance to start from a persisted array. |
 
+**State reset per call:** Each call to `generate` or `stream` resets `context`, tools, tool runtime, model, skills state, and the interrupted flag. This means `context:` must be passed on every call — it is not carried over from a previous call. The only state that persists across calls is the message history and cumulative `token_usage`.
+
+```ruby
+agent.generate('Hello', context: {user_id: 123})
+agent.generate('Follow up')  # context is nil here — pass it again if needed
+agent.generate('More', context: {user_id: 123})  # context is restored
+```
+
 ```ruby
 # New conversation (class method — recommended for simple calls)
 response = MyAgent.generate('Hello')

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -282,27 +282,38 @@ See [Guardrails](09_GUARDRAILS.md) for detailed documentation.
 
 ### generate
 
-Generates a response synchronously. Returns a `Riffer::Agent::Response` object:
+Generates a response synchronously. Returns a `Riffer::Agent::Response` object.
+
+The behavior depends on what you pass and the agent's current state:
+
+| Input | Agent state | Behavior |
+|---|---|---|
+| **String** | No prior messages | **New conversation.** Builds system messages (instructions + skills), adds user message, calls the LLM. |
+| **String** | Has messages from a prior call | **Continue conversation.** Appends the user message to the existing history and re-enters the LLM loop. Pending tool calls from a prior interrupt are executed first. |
+| **Array** | No prior messages | **Restore from persisted data.** Uses the array as-is (no system messages added). Pending tool calls are executed. This is for cross-process resume. |
+| **Array** | Has messages from a prior call | **Raises `Riffer::ArgumentError`.** Use a string to continue, or a new agent instance to start from a persisted array. |
 
 ```ruby
-# Class method (recommended for simple calls)
+# New conversation (class method — recommended for simple calls)
 response = MyAgent.generate('Hello')
 puts response.content       # Access the response text
 puts response.blocked?      # Check if guardrail blocked (always false without guardrails)
 puts response.interrupted?  # Check if a callback interrupted the loop
 
-# Instance method (when you need message history or callbacks)
+# New conversation (instance method — when you need message history or callbacks)
 agent = MyAgent.new
 agent.on_message { |msg| log(msg) }
 response = agent.generate('Hello')
 agent.messages  # Access message history
 
-# With message objects/hashes
-response = MyAgent.generate([
-  {role: 'user', content: 'Hello'},
-  {role: 'assistant', content: 'Hi there!'},
-  {role: 'user', content: 'How are you?'}
-])
+# Multi-turn conversation
+agent = MyAgent.new
+agent.generate('Hello')
+agent.generate('Tell me more')   # continues with full history
+
+# Restore from persisted messages (cross-process resume)
+agent = MyAgent.new
+response = agent.generate(persisted_messages, context: {user_id: 123})
 
 # With context
 response = MyAgent.generate('Look up my orders', context: {user_id: 123})
@@ -322,10 +333,10 @@ response = MyAgent.generate([
 
 ### stream
 
-Streams a response as an Enumerator:
+Streams a response as an Enumerator. Follows the same input rules as `generate` — a string starts a new conversation or continues an existing one, an array restores from persisted data.
 
 ```ruby
-# Class method (recommended for simple calls)
+# New conversation (class method — recommended for simple calls)
 MyAgent.stream('Tell me a story').each do |event|
   case event
   when Riffer::StreamEvents::TextDelta
@@ -337,11 +348,16 @@ MyAgent.stream('Tell me a story').each do |event|
   end
 end
 
-# Instance method (when you need message history or callbacks)
+# New conversation (instance method — when you need message history or callbacks)
 agent = MyAgent.new
 agent.on_message { |msg| persist_message(msg) }
 agent.stream('Tell me a story').each { |event| handle(event) }
 agent.messages  # Access message history
+
+# Multi-turn conversation
+agent = MyAgent.new
+agent.stream('Hello').each { |event| handle(event) }
+agent.stream('Tell me more').each { |event| handle(event) }
 
 # With files
 MyAgent.stream('What is in this image?', files: [{data: base64_data, media_type: 'image/jpeg'}]).each do |event|
@@ -428,7 +444,9 @@ end
 
 #### Resuming an Interrupted Loop
 
-Pass the message array back to `generate` (or `stream`) to resume after an interrupt. When `generate`/`stream` receives an Array, it treats it as resume mode: messages are used as-is (no system message prepend), and pending tool calls are automatically executed before re-entering the LLM loop.
+There are two ways to resume after an interrupt, depending on whether the agent is still in memory or you're restoring from persisted data.
+
+**In-memory resume** — call `generate` (or `stream`) again with a string. The agent keeps its message history, so a new string appends a user message and continues the loop. Pending tool calls from the interrupt are automatically executed first.
 
 ```ruby
 agent = MyAgent.new
@@ -438,38 +456,43 @@ response = agent.generate('Do something risky')
 
 if response.interrupted?
   approve_action(agent.messages)
-  response = agent.generate(agent.messages)  # executes pending tools, then calls the LLM
+  response = agent.generate('Approved, go ahead')  # executes pending tools, then calls the LLM
 end
 ```
 
-For cross-process resume (e.g., after a process restart or async approval), pass persisted messages as an array. Accepts both message objects and hashes:
+You can also resume without adding a new user message by passing a continuation like `'Continue'` — the LLM will pick up from the existing context.
+
+**Cross-process resume** — when the agent is gone (process restart, async approval, etc.), create a new agent and pass the persisted messages as an array. Array input uses messages as-is (no system messages added) and executes any pending tool calls.
 
 ```ruby
-# Persist messages during generation (e.g., via on_message callback)
+# During generation, persist messages via on_message callback
 # Later, in a new process:
 agent = MyAgent.new
 response = agent.generate(persisted_messages, context: {user_id: 123})
 
 # Or resume in streaming mode:
+agent = MyAgent.new
 agent.stream(persisted_messages).each do |event|
   # handle stream events
 end
 ```
 
-No prior interruption is required — any Array input triggers resume mode.
+**Important:** You cannot pass an array to an agent that already has messages. This raises `Riffer::ArgumentError` because it would silently discard the existing history. Use a string to continue, or create a new agent instance for cross-process resume.
 
 #### Building System Messages for Persistence
 
-Use `instruction_message` and `skills_message` to generate system messages independently. This is useful for database persistence workflows where you store and reconstruct message histories:
+Use `instruction_message` and `skills_message` to generate system messages independently. This is useful for database persistence workflows where you need to store and later reconstruct message histories.
+
+Both methods return a `Riffer::Messages::System` or `nil` (when unconfigured). They accept an optional `context:` keyword, just like `generate`.
 
 ```ruby
 agent = MyAgent.new
 sys = agent.instruction_message(context: ctx)     # => Riffer::Messages::System or nil
 skills = agent.skills_message(context: ctx)        # => Riffer::Messages::System or nil
 
-# Store in DB, then later resume:
+# Store in DB, then later resume in a new process:
 messages = [sys, skills, user_msg].compact
-agent.generate(messages, context: ctx)
+MyAgent.new.generate(messages, context: ctx)
 ```
 
 ### interrupt!
@@ -614,7 +637,7 @@ Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :r
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
 - **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
 - **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
-- **Resumable:** Yes. Call `generate(agent.messages)` or `stream(agent.messages)` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Resumable:** Yes. Call `generate('Continue')` or `stream('Continue')` on the same agent instance to resume. For cross-process resume, pass persisted messages as an array to a new agent. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 agent = MyAgent.new
@@ -625,7 +648,7 @@ end
 response = agent.generate('Do something risky')
 response.interrupted?      # => true
 response.interrupt_reason  # => "approval needed"
-response = agent.generate(agent.messages)  # continues where it left off
+response = agent.generate('Approved, continue')  # continues where it left off
 ```
 
 ### Max Steps Limit
@@ -635,7 +658,7 @@ The `max_steps` class method caps the number of LLM call steps in the tool-use l
 - **When to use:** Safety net to prevent runaway tool-use loops — useful when agents have access to many tools or operate autonomously.
 - **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` is `:max_steps`.
 - **Streaming:** Yields an `Interrupt` event with `reason: :max_steps`.
-- **Resumable:** Yes. Call `generate(agent.messages)` or `stream(agent.messages)` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Resumable:** Yes. Call `generate('Continue')` or `stream('Continue')` on the same agent instance to resume. For cross-process resume, pass persisted messages as an array to a new agent. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 class MyAgent < Riffer::Agent
@@ -658,7 +681,7 @@ If a guardrail, provider call, or other internal code raises an exception, it pr
 | ------------- | ------------------------------------ | -------------------------------- | -------------------------------- |
 | Defined       | At class level (`guardrail :before`) | At instance level (`on_message`) | At class level (`max_steps 8`)   |
 | Fires         | Automatically on every request       | When callback logic decides      | When step count reaches limit    |
-| Resumable     | No                                   | Yes (pass array to `generate`/`stream`) | Yes (pass array to `generate`/`stream`) |
+| Resumable     | No                                   | Yes (call `generate`/`stream` again)    | Yes (call `generate`/`stream` again)    |
 | Response flag | `blocked?`                           | `interrupted?`                   | `interrupted?`                   |
 | Stream event  | `GuardrailTripwire`                  | `Interrupt`                      | `Interrupt`                      |
 | Purpose       | Policy enforcement                   | Flow control                     | Runaway loop prevention          |

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -428,7 +428,7 @@ end
 
 #### Resuming an Interrupted Loop
 
-Use `resume` (or `resume_stream`) to continue after an interrupt. On resume, the agent automatically detects and executes any pending tool calls (tool calls from the last assistant message that lack a corresponding tool result) before re-entering the LLM loop.
+Pass the message array back to `generate` (or `stream`) to resume after an interrupt. When `generate`/`stream` receives an Array, it treats it as resume mode: messages are used as-is (no system message prepend), and pending tool calls are automatically executed before re-entering the LLM loop.
 
 ```ruby
 agent = MyAgent.new
@@ -438,53 +438,38 @@ response = agent.generate('Do something risky')
 
 if response.interrupted?
   approve_action(agent.messages)
-  response = agent.resume   # executes pending tools, then calls the LLM
+  response = agent.generate(agent.messages)  # executes pending tools, then calls the LLM
 end
 ```
 
-For cross-process resume (e.g., after a process restart or async approval), pass persisted messages via the `messages:` keyword. Accepts both message objects and hashes:
+For cross-process resume (e.g., after a process restart or async approval), pass persisted messages as an array. Accepts both message objects and hashes:
 
 ```ruby
 # Persist messages during generation (e.g., via on_message callback)
 # Later, in a new process:
 agent = MyAgent.new
-response = agent.resume(messages: persisted_messages, context: {user_id: 123})
+response = agent.generate(persisted_messages, context: {user_id: 123})
 
 # Or resume in streaming mode:
-agent.resume_stream(messages: persisted_messages).each do |event|
+agent.stream(persisted_messages).each do |event|
   # handle stream events
 end
 ```
 
-When called without `messages:`, resumes from in-memory state. When called with `messages:`, reconstructs state from persisted data. No prior interruption is required in either case.
+No prior interruption is required — any Array input triggers resume mode.
 
-### resume
+#### Building System Messages for Persistence
 
-Continues an agent loop synchronously. Returns a `Riffer::Agent::Response` object:
-
-```ruby
-# In-memory resume after an interrupt
-response = agent.resume
-
-# Cross-process resume from persisted messages
-response = agent.resume(messages: persisted_messages, context: {user_id: 123})
-```
-
-### resume_stream
-
-Continues an agent loop as a streaming Enumerator. Accepts the same arguments as `resume`:
+Use `instruction_message` and `skills_message` to generate system messages independently. This is useful for database persistence workflows where you store and reconstruct message histories:
 
 ```ruby
-# In-memory resume
-agent.resume_stream.each do |event|
-  # handle stream events
-end
-
-# Cross-process resume
 agent = MyAgent.new
-agent.resume_stream(messages: persisted_messages).each do |event|
-  # handle stream events
-end
+sys = agent.instruction_message(context: ctx)     # => Riffer::Messages::System or nil
+skills = agent.skills_message(context: ctx)        # => Riffer::Messages::System or nil
+
+# Store in DB, then later resume:
+messages = [sys, skills, user_msg].compact
+agent.generate(messages, context: ctx)
 ```
 
 ### interrupt!
@@ -516,7 +501,7 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 ## Response Attributes
 
-`Riffer::Agent::Response` is returned by `generate` and `resume`:
+`Riffer::Agent::Response` is returned by `generate`:
 
 | Attribute          | Type                        | Description                                        |
 | ------------------ | --------------------------- | -------------------------------------------------- |
@@ -629,7 +614,7 @@ Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :r
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
 - **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
 - **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
-- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Resumable:** Yes. Call `generate(agent.messages)` or `stream(agent.messages)` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 agent = MyAgent.new
@@ -640,7 +625,7 @@ end
 response = agent.generate('Do something risky')
 response.interrupted?      # => true
 response.interrupt_reason  # => "approval needed"
-response = agent.resume    # continues where it left off
+response = agent.generate(agent.messages)  # continues where it left off
 ```
 
 ### Max Steps Limit
@@ -650,7 +635,7 @@ The `max_steps` class method caps the number of LLM call steps in the tool-use l
 - **When to use:** Safety net to prevent runaway tool-use loops — useful when agents have access to many tools or operate autonomously.
 - **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` is `:max_steps`.
 - **Streaming:** Yields an `Interrupt` event with `reason: :max_steps`.
-- **Resumable:** Yes. Call `resume` or `resume_stream` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
+- **Resumable:** Yes. Call `generate(agent.messages)` or `stream(agent.messages)` to continue. Pending tool calls are automatically executed before the LLM loop resumes.
 
 ```ruby
 class MyAgent < Riffer::Agent
@@ -673,7 +658,7 @@ If a guardrail, provider call, or other internal code raises an exception, it pr
 | ------------- | ------------------------------------ | -------------------------------- | -------------------------------- |
 | Defined       | At class level (`guardrail :before`) | At instance level (`on_message`) | At class level (`max_steps 8`)   |
 | Fires         | Automatically on every request       | When callback logic decides      | When step count reaches limit    |
-| Resumable     | No                                   | Yes (`resume` / `resume_stream`) | Yes (`resume` / `resume_stream`) |
+| Resumable     | No                                   | Yes (pass array to `generate`/`stream`) | Yes (pass array to `generate`/`stream`) |
 | Response flag | `blocked?`                           | `interrupted?`                   | `interrupted?`                   |
 | Stream event  | `GuardrailTripwire`                  | `Interrupt`                      | `Interrupt`                      |
 | Purpose       | Policy enforcement                   | Flow control                     | Runaway loop prevention          |

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -286,12 +286,12 @@ Generates a response synchronously. Returns a `Riffer::Agent::Response` object.
 
 The behavior depends on what you pass and the agent's current state:
 
-| Input | Agent state | Behavior |
-|---|---|---|
-| **String** | No prior messages | **New conversation.** Builds system messages (instructions + skills), adds user message, calls the LLM. |
+| Input      | Agent state                    | Behavior                                                                                                                                                              |
+| ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **String** | No prior messages              | **New conversation.** Builds system messages (instructions + skills), adds user message, calls the LLM.                                                               |
 | **String** | Has messages from a prior call | **Continue conversation.** Appends the user message to the existing history and re-enters the LLM loop. Pending tool calls from a prior interrupt are executed first. |
-| **Array** | No prior messages | **Restore from persisted data.** Uses the array as-is (no system messages added). Pending tool calls are executed. This is for cross-process resume. |
-| **Array** | Has messages from a prior call | **Raises `Riffer::ArgumentError`.** Use a string to continue, or a new agent instance to start from a persisted array. |
+| **Array**  | No prior messages              | **Restore from persisted data.** Uses the array as-is (no system messages added). Pending tool calls are executed. This is for cross-process resume.                  |
+| **Array**  | Has messages from a prior call | **Raises `Riffer::ArgumentError`.** Use a string to continue, or a new agent instance to start from a persisted array.                                                |
 
 **State reset per call:** Each call to `generate` or `stream` resets `context`, tools, tool runtime, model, skills state, and the interrupted flag. This means `context:` must be passed on every call — it is not carried over from a previous call. The only state that persists across calls is the message history and cumulative `token_usage`.
 
@@ -534,16 +534,16 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 `Riffer::Agent::Response` is returned by `generate`:
 
-| Attribute          | Type                        | Description                                        |
-| ------------------ | --------------------------- | -------------------------------------------------- |
-| `content`          | `String`                    | The response text                                  |
+| Attribute           | Type                        | Description                                        |
+| ------------------- | --------------------------- | -------------------------------------------------- |
+| `content`           | `String`                    | The response text                                  |
 | `structured_output` | `Hash` / `nil`              | Parsed and validated structured output (see below) |
-| `blocked?`         | `Boolean`                   | `true` if a guardrail tripwire fired               |
-| `tripwire`         | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request    |
-| `modified?`        | `Boolean`                   | `true` if a guardrail modified the content         |
-| `modifications`    | `Array`                     | List of guardrail modifications applied            |
-| `interrupted?`     | `Boolean`                   | `true` if the loop was interrupted                 |
-| `interrupt_reason` | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
+| `blocked?`          | `Boolean`                   | `true` if a guardrail tripwire fired               |
+| `tripwire`          | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request    |
+| `modified?`         | `Boolean`                   | `true` if a guardrail modified the content         |
+| `modifications`     | `Array`                     | List of guardrail modifications applied            |
+| `interrupted?`      | `Boolean`                   | `true` if the loop was interrupted                 |
+| `interrupt_reason`  | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
 
 ### response.structured_output
 
@@ -685,11 +685,11 @@ If a guardrail, provider call, or other internal code raises an exception, it pr
 
 ### Comparison
 
-|               | Guardrail Tripwire                   | Callback Interrupt               | Max Steps Limit                  |
-| ------------- | ------------------------------------ | -------------------------------- | -------------------------------- |
-| Defined       | At class level (`guardrail :before`) | At instance level (`on_message`) | At class level (`max_steps 8`)   |
-| Fires         | Automatically on every request       | When callback logic decides      | When step count reaches limit    |
-| Resumable     | No                                   | Yes (call `generate`/`stream` again)    | Yes (call `generate`/`stream` again)    |
-| Response flag | `blocked?`                           | `interrupted?`                   | `interrupted?`                   |
-| Stream event  | `GuardrailTripwire`                  | `Interrupt`                      | `Interrupt`                      |
-| Purpose       | Policy enforcement                   | Flow control                     | Runaway loop prevention          |
+|               | Guardrail Tripwire                   | Callback Interrupt                   | Max Steps Limit                      |
+| ------------- | ------------------------------------ | ------------------------------------ | ------------------------------------ |
+| Defined       | At class level (`guardrail :before`) | At instance level (`on_message`)     | At class level (`max_steps 8`)       |
+| Fires         | Automatically on every request       | When callback logic decides          | When step count reaches limit        |
+| Resumable     | No                                   | Yes (call `generate`/`stream` again) | Yes (call `generate`/`stream` again) |
+| Response flag | `blocked?`                           | `interrupted?`                       | `interrupted?`                       |
+| Stream event  | `GuardrailTripwire`                  | `Interrupt`                          | `Interrupt`                          |
+| Purpose       | Policy enforcement                   | Flow control                         | Runaway loop prevention              |

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -489,14 +489,14 @@ end
 
 #### Building System Messages for Persistence
 
-Use `instruction_message` and `skills_message` to generate system messages independently. This is useful for database persistence workflows where you need to store and later reconstruct message histories.
+Use `generate_instruction_message` and `generate_skills_message` to generate system messages independently. This is useful for database persistence workflows where you need to store and later reconstruct message histories.
 
 Both methods return a `Riffer::Messages::System` or `nil` (when unconfigured). They accept an optional `context:` keyword, just like `generate`.
 
 ```ruby
 agent = MyAgent.new
-sys = agent.instruction_message(context: ctx)     # => Riffer::Messages::System or nil
-skills = agent.skills_message(context: ctx)        # => Riffer::Messages::System or nil
+sys = agent.generate_instruction_message(context: ctx)     # => Riffer::Messages::System or nil
+skills = agent.generate_skills_message(context: ctx)        # => Riffer::Messages::System or nil
 
 # Store in DB, then later resume in a new process:
 messages = [sys, skills, user_msg].compact

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -380,9 +380,9 @@ By default, tool calls are executed sequentially in the current thread using `Ri
 
 ### Built-in Runtimes
 
-| Runtime | Description |
-|---------|-------------|
-| `Riffer::ToolRuntime::Inline` | Executes tool calls sequentially (default) |
+| Runtime                         | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `Riffer::ToolRuntime::Inline`   | Executes tool calls sequentially (default)     |
 | `Riffer::ToolRuntime::Threaded` | Executes tool calls concurrently using threads |
 
 ### Per-Agent Configuration

--- a/docs/06_STREAM_EVENTS.md
+++ b/docs/06_STREAM_EVENTS.md
@@ -218,7 +218,7 @@ agent.stream("Hello").each do |event|
 end
 ```
 
-After an interrupt, pass the message array back to `stream` to continue the loop. See [Agents - Resuming an Interrupted Loop](03_AGENTS.md#resuming-an-interrupted-loop) for details.
+After an interrupt, call `stream` again with a string to continue the loop. See [Agents — Resuming an Interrupted Loop](03_AGENTS.md#resuming-an-interrupted-loop) for details.
 
 ### TokenUsageDone
 

--- a/docs/06_STREAM_EVENTS.md
+++ b/docs/06_STREAM_EVENTS.md
@@ -218,7 +218,7 @@ agent.stream("Hello").each do |event|
 end
 ```
 
-After an interrupt, use `resume_stream` to continue the loop. See [Agents - Interrupting the Agent Loop](03_AGENTS.md#interrupting-the-agent-loop) for details.
+After an interrupt, pass the message array back to `stream` to continue the loop. See [Agents - Resuming an Interrupted Loop](03_AGENTS.md#resuming-an-interrupted-loop) for details.
 
 ### TokenUsageDone
 

--- a/docs/07_CONFIGURATION.md
+++ b/docs/07_CONFIGURATION.md
@@ -84,11 +84,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value | Description |
-|-------|-------------|
+| Value                          | Description                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
 | `Riffer::ToolRuntime` subclass | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`) |
-| `Riffer::ToolRuntime` instance | Custom runtime with specific options |
-| `Proc` | Dynamic resolution |
+| `Riffer::ToolRuntime` instance | Custom runtime with specific options                                                              |
+| `Proc`                         | Dynamic resolution                                                                                |
 
 Per-agent configuration overrides this global default. See [Tools — Tool Runtime](04_TOOLS.md#tool-runtime-experimental) for details.
 
@@ -145,10 +145,10 @@ end
 
 Options are passed through to the [Bedrock Converse API](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/BedrockRuntime/Client.html#converse-instance_method).
 
-| Option                               | Description                                                       |
-| ------------------------------------ | ----------------------------------------------------------------- |
-| `inference_config`                   | Hash with `max_tokens`, `temperature`, `top_p`, `stop_sequences`  |
-| `additional_model_request_fields`    | Hash for model-specific params (e.g., `top_k` for Claude)        |
+| Option                            | Description                                                      |
+| --------------------------------- | ---------------------------------------------------------------- |
+| `inference_config`                | Hash with `max_tokens`, `temperature`, `top_p`, `stop_sequences` |
+| `additional_model_request_fields` | Hash for model-specific params (e.g., `top_k` for Claude)        |
 
 ```ruby
 class MyAgent < Riffer::Agent

--- a/docs/10_SKILLS.md
+++ b/docs/10_SKILLS.md
@@ -21,9 +21,11 @@ Each `SKILL.md` has YAML frontmatter and a Markdown body:
 name: code-review
 description: Reviews code for quality, style, and potential issues.
 ---
+
 You are a code review assistant.
 
 Review the code for:
+
 - Style issues
 - Potential bugs
 - Performance problems

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -267,13 +267,15 @@ class Riffer::Agent
     @structured_output = resolve_structured_output
     initialize_messages(prompt_or_messages, files: files)
 
+    resume_mode = prompt_or_messages.is_a?(Array)
+
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
 
     tripwire, modifications = run_before_guardrails
     all_modifications.concat(modifications)
     return build_response("", tripwire: tripwire, modifications: all_modifications) if tripwire
 
-    run_generate_loop(all_modifications)
+    run_generate_loop(all_modifications, resume: resume_mode)
   end
 
   # Streams a response from the agent.
@@ -288,6 +290,8 @@ class Riffer::Agent
     prepare_run
     initialize_messages(prompt_or_messages, files: files)
 
+    resume_mode = prompt_or_messages.is_a?(Array)
+
     Enumerator.new do |yielder|
       tripwire, modifications = run_before_guardrails
       modifications.each { |m| yielder << Riffer::StreamEvents::GuardrailModification.new(m) }
@@ -297,39 +301,7 @@ class Riffer::Agent
         next
       end
 
-      run_stream_loop(yielder)
-    end
-  end
-
-  # Resumes an agent loop.
-  #
-  # When called without +messages+, continues using the existing in-memory
-  # message history. When called with +messages+, reconstructs the agent
-  # state from persisted data (useful for cross-process resume).
-  #
-  # Skips message initialization and before guardrails in both cases.
-  # The step offset is derived automatically from the number of assistant
-  # messages so +max_steps+ is enforced across the full session.
-  #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def resume(messages: nil, context: nil)
-    restore_state(messages: messages, context: context)
-    @structured_output = resolve_structured_output
-    run_generate_loop(resume: true)
-  end
-
-  # Resumes an agent loop in streaming mode.
-  #
-  # Same as +resume+ but returns an Enumerator yielding stream events.
-  #
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def resume_stream(messages: nil, context: nil)
-    raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #resume instead." if self.class.structured_output
-
-    restore_state(messages: messages, context: context)
-
-    Enumerator.new do |yielder|
-      run_stream_loop(yielder, resume: true)
+      run_stream_loop(yielder, resume: resume_mode)
     end
   end
 
@@ -342,6 +314,34 @@ class Riffer::Agent
     raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
     @message_callbacks << block
     self
+  end
+
+  # Returns the instruction system message for this agent.
+  #
+  # Useful for database persistence workflows where the system messages
+  # need to be stored independently.
+  #
+  # Returns +nil+ when no instructions are configured.
+  #
+  #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def instruction_message(context: nil)
+    @context = context
+    prepare_run
+    build_instruction_message
+  end
+
+  # Returns the skills catalog system message for this agent.
+  #
+  # Useful for database persistence workflows where the system messages
+  # need to be stored independently.
+  #
+  # Returns +nil+ when no skills are configured or the catalog is empty.
+  #
+  #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def skills_message(context: nil)
+    @context = context
+    prepare_run
+    build_skills_message
   end
 
   # Interrupts the agent loop.
@@ -411,34 +411,32 @@ class Riffer::Agent
 
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages(prompt_or_messages, files: nil)
-    @messages = []
-
-    system_content = [
-      generate_instructions,
-      @skills_state&.system_prompt
-    ].compact.join("\n\n")
-
-    @messages << Riffer::Messages::System.new(system_content) unless system_content.empty?
-
     if prompt_or_messages.is_a?(Array)
-      if files && !files.empty?
-        raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead"
-      end
-
-      prompt_or_messages.each do |item|
-        @messages << convert_to_message_object(item)
-      end
+      raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
+      @messages = prompt_or_messages.map { |item| convert_to_message_object(item) }
     else
+      @messages = []
+      sys = build_instruction_message
+      @messages << sys if sys
+      skills = build_skills_message
+      @messages << skills if skills
       file_parts = (files || []).map { |f| convert_to_file_part(f) }
       @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
     end
   end
 
-  #: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
-  def restore_state(messages: nil, context: nil)
-    @messages = messages.map { |item| convert_to_message_object(item) } if messages
-    @context = context
-    prepare_run
+  #: () -> Riffer::Messages::System?
+  def build_instruction_message
+    content = generate_instructions
+    return nil if content.nil? || content.empty?
+    Riffer::Messages::System.new(content)
+  end
+
+  #: () -> Riffer::Messages::System?
+  def build_skills_message
+    content = @skills_state&.system_prompt
+    return nil if content.nil? || content.empty?
+    Riffer::Messages::System.new(content)
   end
 
   #: () -> Integer

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -263,7 +263,6 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def generate(prompt_or_messages, files: nil, context: nil)
     @context = context
-    continuation = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     @structured_output = resolve_structured_output
     initialize_messages(prompt_or_messages, files: files)
@@ -274,7 +273,7 @@ class Riffer::Agent
     all_modifications.concat(modifications)
     return build_response("", tripwire: tripwire, modifications: all_modifications) if tripwire
 
-    run_generate_loop(all_modifications, resume: continuation)
+    run_generate_loop(all_modifications)
   end
 
   # Streams a response from the agent.
@@ -286,7 +285,6 @@ class Riffer::Agent
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @context = context
-    continuation = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     initialize_messages(prompt_or_messages, files: files)
 
@@ -299,7 +297,7 @@ class Riffer::Agent
         next
       end
 
-      run_stream_loop(yielder, resume: continuation)
+      run_stream_loop(yielder)
     end
   end
 
@@ -350,12 +348,12 @@ class Riffer::Agent
 
   private
 
-  #: (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response
-  def run_generate_loop(all_modifications = [], resume: false)
-    step = resume ? count_assistant_messages : 0
+  #: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
+  def run_generate_loop(all_modifications = [])
+    step = count_assistant_messages
 
     reason = catch(:riffer_interrupt) do
-      execute_pending_tool_calls if resume
+      execute_pending_tool_calls
 
       loop do
         response = call_llm
@@ -442,16 +440,16 @@ class Riffer::Agent
     @messages.count { |m| m.is_a?(Riffer::Messages::Assistant) }
   end
 
-  #: (Enumerator::Yielder, ?resume: bool) -> void
-  def run_stream_loop(yielder, resume: false)
-    step = resume ? count_assistant_messages : 0
+  #: (Enumerator::Yielder) -> void
+  def run_stream_loop(yielder)
+    step = count_assistant_messages
 
     if @skills_state
       @skills_state.on_activate = ->(name) { yielder << Riffer::StreamEvents::SkillActivation.new(name) }
     end
 
     completed = catch(:riffer_interrupt) do
-      execute_pending_tool_calls if resume
+      execute_pending_tool_calls
 
       loop do
         accumulated_content = ""
@@ -573,22 +571,11 @@ class Riffer::Agent
   # then executes any that are missing.
   #
   #: () -> void
+  # Executes tool calls from the last assistant message that don't yet
+  # have a corresponding tool result. Safe to call unconditionally —
+  # returns immediately when there is nothing pending.
   def execute_pending_tool_calls
-    # Find the most recent assistant message (the one whose tool calls
-    # may be partially executed).
-    last_assistant_idx = @messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
-    return unless last_assistant_idx
-
-    assistant = @messages[last_assistant_idx]
-    return if assistant.tool_calls.empty?
-
-    # Collect ids of tool calls that already have a result message
-    # after the assistant message.
-    executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
-      m.is_a?(Riffer::Messages::Tool)
-    }.map(&:tool_call_id)
-
-    pending = assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
+    pending = pending_tool_calls
     return if pending.empty?
 
     runtime = resolve_tool_runtime
@@ -603,6 +590,20 @@ class Riffer::Agent
         error_type: result.error_type
       ))
     end
+  end
+
+  def pending_tool_calls
+    last_assistant_idx = @messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
+    return [] unless last_assistant_idx
+
+    assistant = @messages[last_assistant_idx]
+    return [] if assistant.tool_calls.empty?
+
+    executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
+      m.is_a?(Riffer::Messages::Tool)
+    }.map(&:tool_call_id)
+
+    assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
   end
 
   #: () -> void

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -263,7 +263,7 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def generate(prompt_or_messages, files: nil, context: nil)
     @context = context
-    resume_mode = prompt_or_messages.is_a?(Array) || @messages.any?
+    continuation = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     @structured_output = resolve_structured_output
     initialize_messages(prompt_or_messages, files: files)
@@ -274,7 +274,7 @@ class Riffer::Agent
     all_modifications.concat(modifications)
     return build_response("", tripwire: tripwire, modifications: all_modifications) if tripwire
 
-    run_generate_loop(all_modifications, resume: resume_mode)
+    run_generate_loop(all_modifications, resume: continuation)
   end
 
   # Streams a response from the agent.
@@ -286,7 +286,7 @@ class Riffer::Agent
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @context = context
-    resume_mode = prompt_or_messages.is_a?(Array) || @messages.any?
+    continuation = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     initialize_messages(prompt_or_messages, files: files)
 
@@ -299,7 +299,7 @@ class Riffer::Agent
         next
       end
 
-      run_stream_loop(yielder, resume: resume_mode)
+      run_stream_loop(yielder, resume: continuation)
     end
   end
 
@@ -323,9 +323,7 @@ class Riffer::Agent
   #
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def instruction_message(context: nil)
-    @context = context
-    prepare_run
-    build_instruction_message
+    build_instruction_message(context)
   end
 
   # Returns the skills catalog system message for this agent.
@@ -337,9 +335,7 @@ class Riffer::Agent
   #
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def skills_message(context: nil)
-    @context = context
-    prepare_run
-    build_skills_message
+    build_skills_message(resolve_skills(context))
   end
 
   # Interrupts the agent loop.
@@ -427,16 +423,16 @@ class Riffer::Agent
     end
   end
 
-  #: () -> Riffer::Messages::System?
-  def build_instruction_message
-    content = generate_instructions
+  #: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def build_instruction_message(context = @context)
+    content = generate_instructions(context)
     return nil if content.nil? || content.empty?
     Riffer::Messages::System.new(content)
   end
 
-  #: () -> Riffer::Messages::System?
-  def build_skills_message
-    content = @skills_state&.system_prompt
+  #: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
+  def build_skills_message(skills_state = @skills_state)
+    content = skills_state&.system_prompt
     return nil if content.nil? || content.empty?
     Riffer::Messages::System.new(content)
   end
@@ -617,6 +613,7 @@ class Riffer::Agent
     @interrupted = false
     resolve_model
     @skills_state = resolve_skills
+    @context = (@context || {}).merge(skills: @skills_state) if @skills_state
   end
 
   #: (untyped) -> void
@@ -634,10 +631,10 @@ class Riffer::Agent
     @provider_instance = nil if @model_config.is_a?(Proc)
   end
 
-  #: () -> String?
-  def generate_instructions
+  #: (?Hash[Symbol, untyped]?) -> String?
+  def generate_instructions(context = @context)
     if @instructions_config.is_a?(Proc)
-      (@instructions_config.arity == 0) ? @instructions_config.call : @instructions_config.call(@context)
+      (@instructions_config.arity == 0) ? @instructions_config.call : @instructions_config.call(context)
     else
       @instructions_config
     end
@@ -701,15 +698,17 @@ class Riffer::Agent
   # Resolves the skills backend, lists skills, and selects an adapter.
   #
   # Returns nil if skills are not configured or empty.
+  # Does not mutate instance state — callers are responsible for
+  # assigning the returned context.
   #
-  #: () -> Riffer::Skills::Context?
-  def resolve_skills
+  #: (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
+  def resolve_skills(context = @context)
     return nil unless self.class.skills
 
     backend = self.class.skills.backend
     return nil unless backend
 
-    backend = backend.is_a?(Proc) ? backend.call(@context) : backend
+    backend = backend.is_a?(Proc) ? backend.call(context) : backend
     skills_list = backend.list_skills
     return nil if skills_list.empty?
 
@@ -717,11 +716,11 @@ class Riffer::Agent
     adapter_class = self.class.skills.adapter || provider_class.skills_adapter
 
     skills_context = Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: adapter_class.new)
-    @context = (@context || {}).merge(skills: skills_context)
+    ctx = (context || {}).merge(skills: skills_context)
 
     activate = self.class.skills.activate
     if activate
-      names = activate.is_a?(Proc) ? activate.call(@context) : Array(activate)
+      names = activate.is_a?(Proc) ? activate.call(ctx) : Array(activate)
       names.each { |name| skills_context.activate(name) }
     end
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -314,7 +314,7 @@ class Riffer::Agent
     self
   end
 
-  # Returns the instruction system message for this agent.
+  # Generates the instruction system message for this agent.
   #
   # Useful for database persistence workflows where the system messages
   # need to be stored independently.
@@ -322,11 +322,11 @@ class Riffer::Agent
   # Returns +nil+ when no instructions are configured.
   #
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def instruction_message(context: nil)
+  def generate_instruction_message(context: nil)
     build_instruction_message(context)
   end
 
-  # Returns the skills catalog system message for this agent.
+  # Generates the skills catalog system message for this agent.
   #
   # Useful for database persistence workflows where the system messages
   # need to be stored independently.
@@ -334,7 +334,7 @@ class Riffer::Agent
   # Returns +nil+ when no skills are configured or the catalog is empty.
   #
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def skills_message(context: nil)
+  def generate_skills_message(context: nil)
     build_skills_message(resolve_skills(context))
   end
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -263,11 +263,10 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def generate(prompt_or_messages, files: nil, context: nil)
     @context = context
+    resume_mode = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     @structured_output = resolve_structured_output
     initialize_messages(prompt_or_messages, files: files)
-
-    resume_mode = prompt_or_messages.is_a?(Array)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
 
@@ -287,10 +286,9 @@ class Riffer::Agent
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @context = context
+    resume_mode = prompt_or_messages.is_a?(Array) || @messages.any?
     prepare_run
     initialize_messages(prompt_or_messages, files: files)
-
-    resume_mode = prompt_or_messages.is_a?(Array)
 
     Enumerator.new do |yielder|
       tripwire, modifications = run_before_guardrails
@@ -412,8 +410,12 @@ class Riffer::Agent
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages(prompt_or_messages, files: nil)
     if prompt_or_messages.is_a?(Array)
+      raise Riffer::ArgumentError, "cannot pass an array of messages on an agent with existing messages; use a string to continue the conversation or a new agent instance to start fresh" if @messages.any?
       raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
       @messages = prompt_or_messages.map { |item| convert_to_message_object(item) }
+    elsif @messages.any?
+      file_parts = (files || []).map { |f| convert_to_file_part(f) }
+      @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
     else
       @messages = []
       sys = build_instruction_message

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -171,32 +171,32 @@ class Riffer::Agent
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # Resumes an agent loop.
-  #
-  # When called without +messages+, continues using the existing in-memory
-  # message history. When called with +messages+, reconstructs the agent
-  # state from persisted data (useful for cross-process resume).
-  #
-  # Skips message initialization and before guardrails in both cases.
-  # The step offset is derived automatically from the number of assistant
-  # messages so +max_steps+ is enforced across the full session.
-  #
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def resume: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-
-  # Resumes an agent loop in streaming mode.
-  #
-  # Same as +resume+ but returns an Enumerator yielding stream events.
-  #
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def resume_stream: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-
   # Registers a callback to be invoked when messages are added during generation.
   #
   # Raises Riffer::ArgumentError if no block is given.
   #
   # : () { (Riffer::Messages::Base) -> void } -> self
   def on_message: () { (Riffer::Messages::Base) -> void } -> self
+
+  # Returns the instruction system message for this agent.
+  #
+  # Useful for database persistence workflows where the system messages
+  # need to be stored independently.
+  #
+  # Returns +nil+ when no instructions are configured.
+  #
+  # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def instruction_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+
+  # Returns the skills catalog system message for this agent.
+  #
+  # Useful for database persistence workflows where the system messages
+  # need to be stored independently.
+  #
+  # Returns +nil+ when no skills are configured or the catalog is empty.
+  #
+  # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def skills_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
   # Interrupts the agent loop.
   #
@@ -220,8 +220,11 @@ class Riffer::Agent
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
-  # : (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
-  def restore_state: (?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?context: Hash[Symbol, untyped]?) -> void
+  # : () -> Riffer::Messages::System?
+  def build_instruction_message: () -> Riffer::Messages::System?
+
+  # : () -> Riffer::Messages::System?
+  def build_skills_message: () -> Riffer::Messages::System?
 
   # : () -> Integer
   def count_assistant_messages: () -> Integer

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -178,7 +178,7 @@ class Riffer::Agent
   # : () { (Riffer::Messages::Base) -> void } -> self
   def on_message: () { (Riffer::Messages::Base) -> void } -> self
 
-  # Returns the instruction system message for this agent.
+  # Generates the instruction system message for this agent.
   #
   # Useful for database persistence workflows where the system messages
   # need to be stored independently.
@@ -186,9 +186,9 @@ class Riffer::Agent
   # Returns +nil+ when no instructions are configured.
   #
   # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def instruction_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def generate_instruction_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
-  # Returns the skills catalog system message for this agent.
+  # Generates the skills catalog system message for this agent.
   #
   # Useful for database persistence workflows where the system messages
   # need to be stored independently.
@@ -196,7 +196,7 @@ class Riffer::Agent
   # Returns +nil+ when no skills are configured or the catalog is empty.
   #
   # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def skills_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def generate_skills_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
   # Interrupts the agent loop.
   #

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -220,11 +220,11 @@ class Riffer::Agent
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
-  # : () -> Riffer::Messages::System?
-  def build_instruction_message: () -> Riffer::Messages::System?
+  # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  def build_instruction_message: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
-  # : () -> Riffer::Messages::System?
-  def build_skills_message: () -> Riffer::Messages::System?
+  # : (?Riffer::Skills::Context?) -> Riffer::Messages::System?
+  def build_skills_message: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
 
   # : () -> Integer
   def count_assistant_messages: () -> Integer
@@ -267,8 +267,8 @@ class Riffer::Agent
   # : () -> void
   def clear_resolved_model: () -> void
 
-  # : () -> String?
-  def generate_instructions: () -> String?
+  # : (?Hash[Symbol, untyped]?) -> String?
+  def generate_instructions: (?Hash[Symbol, untyped]?) -> String?
 
   attr_reader resolved_model: String?
 
@@ -284,9 +284,11 @@ class Riffer::Agent
   # Resolves the skills backend, lists skills, and selects an adapter.
   #
   # Returns nil if skills are not configured or empty.
+  # Does not mutate instance state — callers are responsible for
+  # assigning the returned context.
   #
-  # : () -> Riffer::Skills::Context?
-  def resolve_skills: () -> Riffer::Skills::Context?
+  # : (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
+  def resolve_skills: (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
 
   # : () -> singleton(Riffer::Providers::Base)
   def provider_class: () -> singleton(Riffer::Providers::Base)

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -208,8 +208,8 @@ class Riffer::Agent
 
   private
 
-  # : (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response
-  def run_generate_loop: (?Array[Riffer::Guardrails::Modification], ?resume: bool) -> Riffer::Agent::Response
+  # : (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
+  def run_generate_loop: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
 
   # : (Riffer::Messages::Base) -> void
   def add_message: (Riffer::Messages::Base) -> void
@@ -229,8 +229,8 @@ class Riffer::Agent
   # : () -> Integer
   def count_assistant_messages: () -> Integer
 
-  # : (Enumerator::Yielder, ?resume: bool) -> void
-  def run_stream_loop: (Enumerator::Yielder, ?resume: bool) -> void
+  # : (Enumerator::Yielder) -> void
+  def run_stream_loop: (Enumerator::Yielder) -> void
 
   # : () -> Riffer::Messages::Assistant
   def call_llm: () -> Riffer::Messages::Assistant
@@ -256,7 +256,12 @@ class Riffer::Agent
   # then executes any that are missing.
   #
   # : () -> void
+  # Executes tool calls from the last assistant message that don't yet
+  # have a corresponding tool result. Safe to call unconditionally —
+  # returns immediately when there is nothing pending.
   def execute_pending_tool_calls: () -> void
+
+  def pending_tool_calls: () -> untyped
 
   # : () -> void
   def prepare_run: () -> void

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2,8 +2,6 @@
 
 require "test_helper"
 
-SKILLS_FIXTURES_PATH = File.expand_path("../fixtures/skills", __dir__) unless defined?(SKILLS_FIXTURES_PATH)
-
 describe Riffer::Agent do
   let(:agent_class) do
     Class.new(Riffer::Agent) do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3428,10 +3428,10 @@ describe Riffer::Agent do
     end
   end
 
-  describe "#instruction_message" do
+  describe "#generate_instruction_message" do
     it "returns a System message with instructions" do
       agent = agent_class.new
-      msg = agent.instruction_message
+      msg = agent.generate_instruction_message
       expect(msg).must_be_instance_of Riffer::Messages::System
       expect(msg.content).must_equal "You are a helpful assistant."
     end
@@ -3441,7 +3441,7 @@ describe Riffer::Agent do
         model "mock/riffer-1"
       end
       agent = klass.new
-      expect(agent.instruction_message).must_be_nil
+      expect(agent.generate_instruction_message).must_be_nil
     end
 
     it "resolves dynamic instructions with context" do
@@ -3450,7 +3450,7 @@ describe Riffer::Agent do
         instructions ->(context) { "Helping #{context[:name]}" }
       end
       agent = klass.new
-      msg = agent.instruction_message(context: {name: "Alice"})
+      msg = agent.generate_instruction_message(context: {name: "Alice"})
       expect(msg.content).must_equal "Helping Alice"
     end
 
@@ -3461,14 +3461,14 @@ describe Riffer::Agent do
         instructions returner
       end
       agent = klass.new
-      expect(agent.instruction_message).must_be_nil
+      expect(agent.generate_instruction_message).must_be_nil
     end
   end
 
-  describe "#skills_message" do
+  describe "#generate_skills_message" do
     it "returns nil when no skills configured" do
       agent = agent_class.new
-      expect(agent.skills_message).must_be_nil
+      expect(agent.generate_skills_message).must_be_nil
     end
 
     it "returns a System message when skills are configured" do
@@ -3479,7 +3479,7 @@ describe Riffer::Agent do
         end
       end
       agent = klass.new
-      msg = agent.skills_message
+      msg = agent.generate_skills_message
       expect(msg).must_be_instance_of Riffer::Messages::System
       expect(msg.content).must_include "Available Skills"
     end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -317,6 +317,15 @@ describe Riffer::Agent do
         user_messages = agent.messages.select { |msg| msg.is_a?(Riffer::Messages::User) }
         expect(user_messages.length).must_be :>=, 2
       end
+
+      it "raises when passing an array on an agent with existing messages" do
+        agent = agent_class.new
+        agent.generate("Hello")
+        error = expect {
+          agent.generate([Riffer::Messages::User.new("Follow up")])
+        }.must_raise(Riffer::ArgumentError)
+        expect(error.message).must_match(/cannot pass an array/)
+      end
     end
 
     describe "with an array of hashes" do
@@ -2099,7 +2108,7 @@ describe Riffer::Agent do
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
 
-        result = agent.generate(agent.messages)
+        result = agent.generate("Continue")
         expect(result.interrupted?).must_equal false
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
@@ -2134,7 +2143,7 @@ describe Riffer::Agent do
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 0
 
-        result = agent.generate(agent.messages)
+        result = agent.generate("Continue")
         expect(result.interrupted?).must_equal false
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
@@ -2176,11 +2185,11 @@ describe Riffer::Agent do
     end
   end
 
-  describe "resume via generate with array input" do
+  describe "resume via generate" do
     it "re-enters loop without prior interruption" do
       agent = agent_class.new
       agent.generate("Hello")
-      result = agent.generate(agent.messages)
+      result = agent.generate("Continue")
       expect(result).must_be_instance_of Riffer::Agent::Response
       expect(result.interrupted?).must_equal false
     end
@@ -2195,7 +2204,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.generate(agent.messages)
+      result = agent.generate("Continue")
       expect(result).must_be_instance_of Riffer::Agent::Response
     end
 
@@ -2209,7 +2218,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.generate(agent.messages)
+      result = agent.generate("Continue")
       expect(result.interrupted?).must_equal false
     end
 
@@ -2223,7 +2232,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.generate(agent.messages)
+      result = agent.generate("Continue")
       expect(result.interrupt_reason).must_be_nil
     end
 
@@ -2238,7 +2247,7 @@ describe Riffer::Agent do
       end
       agent.generate("Hello")
       messages_before = agent.messages.length
-      agent.generate(agent.messages)
+      agent.generate("Continue")
       expect(agent.messages.length).must_be :>, messages_before
     end
 
@@ -2252,7 +2261,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      agent.generate(agent.messages)
+      agent.generate("Continue")
       system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       expect(system_messages.length).must_equal 1
     end
@@ -2295,7 +2304,7 @@ describe Riffer::Agent do
         result = agent.generate("What's the weather?")
         expect(result.interrupted?).must_equal true
 
-        result = agent.generate(agent.messages)
+        result = agent.generate("Continue")
         expect(result.interrupted?).must_equal false
         expect(result.content).must_equal "The weather is nice!"
       end
@@ -2408,10 +2417,11 @@ describe Riffer::Agent do
 
       it "clears context when not provided on cross-process resume" do
         agent = agent_class.new
-        agent.generate("Hello", context: {user: "Alice"})
+        agent.generate([Riffer::Messages::User.new("Hello")], context: {user: "Alice"})
 
-        agent.generate([Riffer::Messages::User.new("Hello")])
-        expect(agent.send(:instance_variable_get, :@context)).must_be_nil
+        fresh_agent = agent_class.new
+        fresh_agent.generate([Riffer::Messages::User.new("Hello")])
+        expect(fresh_agent.send(:instance_variable_get, :@context)).must_be_nil
       end
     end
 
@@ -2450,7 +2460,7 @@ describe Riffer::Agent do
         expect(result.interrupted?).must_equal true
 
         # Resume via generate with array: step offset is auto-derived from assistant messages
-        result = agent.generate(agent.messages)
+        result = agent.generate("Continue")
         expect(result.interrupted?).must_equal true
         expect(result.interrupt_reason).must_equal :max_steps
       end
@@ -2504,7 +2514,7 @@ describe Riffer::Agent do
         agent.generate("Analyze sentiment")
 
         provider.stub_response('{"sentiment":"negative"}')
-        result = agent.generate(agent.messages)
+        result = agent.generate("Continue")
         expect(result.structured_output).must_equal({sentiment: "negative"})
       end
 
@@ -2527,11 +2537,11 @@ describe Riffer::Agent do
     end
   end
 
-  describe "resume via stream with array input" do
+  describe "resume via stream" do
     it "re-enters loop without prior interruption" do
       agent = agent_class.new
       agent.generate("Hello")
-      events = agent.stream(agent.messages).to_a
+      events = agent.stream("Continue").to_a
       text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
       expect(text_events).wont_be_empty
     end
@@ -2546,7 +2556,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.stream(agent.messages)
+      result = agent.stream("Continue")
       expect(result).must_be_instance_of Enumerator
     end
 
@@ -2560,7 +2570,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      events = agent.stream(agent.messages).to_a
+      events = agent.stream("Continue").to_a
       text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
       expect(text_events).wont_be_empty
     end
@@ -2575,7 +2585,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      events = agent.stream(agent.messages).to_a
+      events = agent.stream("Continue").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).must_be_nil
     end
@@ -2609,6 +2619,142 @@ describe Riffer::Agent do
         interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
         expect(interrupt_event).must_be_nil
       end
+    end
+  end
+
+  describe "multi-turn string continuation" do
+    it "continues conversation when calling generate with a string on an agent with existing messages" do
+      agent = agent_class.new
+      agent.generate("Hello")
+      messages_before = agent.messages.length
+
+      result = agent.generate("Follow up")
+      expect(result).must_be_instance_of Riffer::Agent::Response
+      expect(agent.messages.length).must_be :>, messages_before
+    end
+
+    it "does not duplicate system messages on continuation" do
+      agent = agent_class.new
+      agent.generate("Hello")
+      agent.generate("Follow up")
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      expect(system_messages.length).must_equal 1
+    end
+
+    it "appends new user message to existing history" do
+      agent = agent_class.new
+      agent.generate("Hello")
+      agent.generate("Follow up")
+      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      expect(user_messages.length).must_equal 2
+      expect(user_messages.last.content).must_equal "Follow up"
+    end
+
+    it "resumes after interrupt with a new user message" do
+      agent = agent_class.new
+      interrupted_once = false
+      agent.on_message do |_msg|
+        unless interrupted_once
+          interrupted_once = true
+          throw :riffer_interrupt
+        end
+      end
+
+      result = agent.generate("Hello")
+      expect(result.interrupted?).must_equal true
+
+      result = agent.generate("Continue please")
+      expect(result.interrupted?).must_equal false
+      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      expect(user_messages.length).must_equal 2
+    end
+
+    it "executes pending tool calls on string continuation" do
+      tc = Class.new(Riffer::Tool) do
+        description "Simple tool"
+        def call(context:)
+          text("done")
+        end
+      end.tap { |t| t.identifier("continuation_pending_tool") }
+
+      tool = tc
+      custom_agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tool]
+      end
+
+      agent = custom_agent_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("", tool_calls: [
+        {name: "continuation_pending_tool", arguments: "{}"},
+        {name: "continuation_pending_tool", arguments: "{}"}
+      ])
+      provider.stub_response("Done!")
+
+      tool_count = 0
+      agent.on_message do |msg|
+        if msg.is_a?(Riffer::Messages::Tool)
+          tool_count += 1
+          throw :riffer_interrupt if tool_count == 1
+        end
+      end
+
+      result = agent.generate("Call tools")
+      expect(result.interrupted?).must_equal true
+      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      expect(tool_messages.length).must_equal 1
+
+      result = agent.generate("Go ahead")
+      expect(result.interrupted?).must_equal false
+      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      expect(tool_messages.length).must_equal 2
+    end
+
+    it "enforces max_steps across continuations" do
+      tc = Class.new(Riffer::Tool) do
+        description "Simple tool"
+        def call(context:)
+          text("done")
+        end
+      end.tap { |t| t.identifier("continuation_step_tool") }
+
+      tool = tc
+      custom_agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        max_steps 3
+        uses_tools [tool]
+      end
+
+      agent = custom_agent_class.new
+      provider = agent.send(:provider_instance)
+      3.times { provider.stub_response("", tool_calls: [{name: "continuation_step_tool", arguments: "{}"}]) }
+
+      interrupted_once = false
+      agent.on_message do |msg|
+        if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
+          interrupted_once = true
+          throw :riffer_interrupt
+        end
+      end
+
+      result = agent.generate("Do stuff")
+      expect(result.interrupted?).must_equal true
+
+      result = agent.generate("Continue")
+      expect(result.interrupted?).must_equal true
+      expect(result.interrupt_reason).must_equal :max_steps
+    end
+
+    it "continues conversation with stream" do
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      events = agent.stream("Follow up").to_a
+      text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
+      expect(text_events).wont_be_empty
+
+      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      expect(user_messages.length).must_equal 2
     end
   end
 
@@ -2678,7 +2824,7 @@ describe Riffer::Agent do
       tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 1
 
-      events = agent.stream(agent.messages).to_a
+      events = agent.stream("Continue").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).must_be_nil
       tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2,6 +2,8 @@
 
 require "test_helper"
 
+SKILLS_FIXTURES_PATH = File.expand_path("../fixtures/skills", __dir__) unless defined?(SKILLS_FIXTURES_PATH)
+
 describe Riffer::Agent do
   let(:agent_class) do
     Class.new(Riffer::Agent) do
@@ -297,18 +299,11 @@ describe Riffer::Agent do
         expect(result).must_be_instance_of Riffer::Agent::Response
       end
 
-      it "adds system message before the provided messages when instructions are present" do
+      it "uses messages as-is without prepending system message" do
         agent = agent_class.new
         messages = [Riffer::Messages::User.new("Hello")]
         agent.generate(messages)
-        expect(agent.messages.first).must_be_instance_of Riffer::Messages::System
-      end
-
-      it "preserves message order with system message first" do
-        agent = agent_class.new
-        messages = [Riffer::Messages::User.new("Hello")]
-        agent.generate(messages)
-        expect(agent.messages[1]).must_be_instance_of Riffer::Messages::User
+        expect(agent.messages.first).must_be_instance_of Riffer::Messages::User
       end
 
       it "preserves all provided messages" do
@@ -589,18 +584,11 @@ describe Riffer::Agent do
         expect(result).must_be_instance_of Enumerator
       end
 
-      it "adds system message before the provided messages when instructions are present" do
+      it "uses messages as-is without prepending system message" do
         agent = agent_class.new
         messages = [Riffer::Messages::User.new("Hello")]
         agent.stream(messages).each { |_| }
-        expect(agent.messages.first).must_be_instance_of Riffer::Messages::System
-      end
-
-      it "preserves message order with system message first" do
-        agent = agent_class.new
-        messages = [Riffer::Messages::User.new("Hello")]
-        agent.stream(messages).each { |_| }
-        expect(agent.messages[1]).must_be_instance_of Riffer::Messages::User
+        expect(agent.messages.first).must_be_instance_of Riffer::Messages::User
       end
     end
 
@@ -2111,7 +2099,7 @@ describe Riffer::Agent do
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
 
-        result = agent.resume
+        result = agent.generate(agent.messages)
         expect(result.interrupted?).must_equal false
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
@@ -2146,7 +2134,7 @@ describe Riffer::Agent do
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 0
 
-        result = agent.resume
+        result = agent.generate(agent.messages)
         expect(result.interrupted?).must_equal false
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
@@ -2188,11 +2176,11 @@ describe Riffer::Agent do
     end
   end
 
-  describe "#resume" do
+  describe "resume via generate with array input" do
     it "re-enters loop without prior interruption" do
       agent = agent_class.new
       agent.generate("Hello")
-      result = agent.resume
+      result = agent.generate(agent.messages)
       expect(result).must_be_instance_of Riffer::Agent::Response
       expect(result.interrupted?).must_equal false
     end
@@ -2207,7 +2195,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.resume
+      result = agent.generate(agent.messages)
       expect(result).must_be_instance_of Riffer::Agent::Response
     end
 
@@ -2221,7 +2209,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.resume
+      result = agent.generate(agent.messages)
       expect(result.interrupted?).must_equal false
     end
 
@@ -2235,7 +2223,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.resume
+      result = agent.generate(agent.messages)
       expect(result.interrupt_reason).must_be_nil
     end
 
@@ -2250,7 +2238,7 @@ describe Riffer::Agent do
       end
       agent.generate("Hello")
       messages_before = agent.messages.length
-      agent.resume
+      agent.generate(agent.messages)
       expect(agent.messages.length).must_be :>, messages_before
     end
 
@@ -2264,7 +2252,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      agent.resume
+      agent.generate(agent.messages)
       system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       expect(system_messages.length).must_equal 1
     end
@@ -2307,7 +2295,7 @@ describe Riffer::Agent do
         result = agent.generate("What's the weather?")
         expect(result.interrupted?).must_equal true
 
-        result = agent.resume
+        result = agent.generate(agent.messages)
         expect(result.interrupted?).must_equal false
         expect(result.content).must_equal "The weather is nice!"
       end
@@ -2321,7 +2309,7 @@ describe Riffer::Agent do
           Riffer::Messages::User.new("Hello"),
           Riffer::Messages::Assistant.new("Hi there!")
         ]
-        result = agent.resume(messages: messages)
+        result = agent.generate(messages)
         expect(result).must_be_instance_of Riffer::Agent::Response
       end
 
@@ -2332,7 +2320,7 @@ describe Riffer::Agent do
           {role: "user", content: "Hello"},
           {role: "assistant", content: "Hi there!"}
         ]
-        result = agent.resume(messages: messages)
+        result = agent.generate(messages)
         expect(result).must_be_instance_of Riffer::Agent::Response
       end
 
@@ -2341,7 +2329,7 @@ describe Riffer::Agent do
         messages = [
           Riffer::Messages::User.new("Hello")
         ]
-        result = agent.resume(messages: messages)
+        result = agent.generate(messages)
         expect(result.interrupted?).must_equal false
       end
 
@@ -2370,7 +2358,7 @@ describe Riffer::Agent do
         provider.stub_response("Your name is Alice!")
 
         messages = [Riffer::Messages::User.new("Get my name")]
-        agent.resume(messages: messages, context: {user_name: "Alice"})
+        agent.generate(messages, context: {user_name: "Alice"})
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Alice"
@@ -2382,7 +2370,7 @@ describe Riffer::Agent do
           Riffer::Messages::System.new("Custom instructions."),
           Riffer::Messages::User.new("Hello")
         ]
-        agent.resume(messages: messages)
+        agent.generate(messages)
         system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
         expect(system_messages.length).must_equal 1
         expect(system_messages.first.content).must_equal "Custom instructions."
@@ -2410,7 +2398,7 @@ describe Riffer::Agent do
           {role: "user", content: "Call tool"},
           {role: "assistant", content: "", tool_calls: [{id: "tc_1", call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}"}]}
         ]
-        result = agent.resume(messages: messages)
+        result = agent.generate(messages)
         expect(result.interrupted?).must_equal false
 
         tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
@@ -2422,7 +2410,7 @@ describe Riffer::Agent do
         agent = agent_class.new
         agent.generate("Hello", context: {user: "Alice"})
 
-        agent.resume(messages: [Riffer::Messages::User.new("Hello")])
+        agent.generate([Riffer::Messages::User.new("Hello")])
         expect(agent.send(:instance_variable_get, :@context)).must_be_nil
       end
     end
@@ -2461,8 +2449,8 @@ describe Riffer::Agent do
         result = agent.generate("Do stuff")
         expect(result.interrupted?).must_equal true
 
-        # Resume: step offset is auto-derived from assistant messages
-        result = agent.resume
+        # Resume via generate with array: step offset is auto-derived from assistant messages
+        result = agent.generate(agent.messages)
         expect(result.interrupted?).must_equal true
         expect(result.interrupt_reason).must_equal :max_steps
       end
@@ -2480,15 +2468,13 @@ describe Riffer::Agent do
         # Only 1 more step fits before max_steps (3 prior + 1 = 4)
         provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}])
 
-        result = agent.resume(
-          messages: [
-            Riffer::Messages::User.new("Original prompt"),
-            Riffer::Messages::Assistant.new("Step 1", tool_calls: []),
-            Riffer::Messages::Assistant.new("Step 2", tool_calls: []),
-            Riffer::Messages::Assistant.new("Step 3", tool_calls: []),
-            Riffer::Messages::User.new("Continue")
-          ]
-        )
+        result = agent.generate([
+          Riffer::Messages::User.new("Original prompt"),
+          Riffer::Messages::Assistant.new("Step 1", tool_calls: []),
+          Riffer::Messages::Assistant.new("Step 2", tool_calls: []),
+          Riffer::Messages::Assistant.new("Step 3", tool_calls: []),
+          Riffer::Messages::User.new("Continue")
+        ])
         expect(result.interrupted?).must_equal true
         expect(result.interrupt_reason).must_equal :max_steps
       end
@@ -2518,7 +2504,7 @@ describe Riffer::Agent do
         agent.generate("Analyze sentiment")
 
         provider.stub_response('{"sentiment":"negative"}')
-        result = agent.resume
+        result = agent.generate(agent.messages)
         expect(result.structured_output).must_equal({sentiment: "negative"})
       end
 
@@ -2535,17 +2521,17 @@ describe Riffer::Agent do
         provider.stub_response('{"sentiment":"positive"}')
 
         messages = [Riffer::Messages::User.new("Analyze sentiment")]
-        result = agent.resume(messages: messages)
+        result = agent.generate(messages)
         expect(result.structured_output).must_equal({sentiment: "positive"})
       end
     end
   end
 
-  describe "#resume_stream" do
+  describe "resume via stream with array input" do
     it "re-enters loop without prior interruption" do
       agent = agent_class.new
       agent.generate("Hello")
-      events = agent.resume_stream.to_a
+      events = agent.stream(agent.messages).to_a
       text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
       expect(text_events).wont_be_empty
     end
@@ -2560,7 +2546,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      result = agent.resume_stream
+      result = agent.stream(agent.messages)
       expect(result).must_be_instance_of Enumerator
     end
 
@@ -2574,7 +2560,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      events = agent.resume_stream.to_a
+      events = agent.stream(agent.messages).to_a
       text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
       expect(text_events).wont_be_empty
     end
@@ -2589,7 +2575,7 @@ describe Riffer::Agent do
         end
       end
       agent.generate("Hello")
-      events = agent.resume_stream.to_a
+      events = agent.stream(agent.messages).to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).must_be_nil
     end
@@ -2601,7 +2587,7 @@ describe Riffer::Agent do
           Riffer::Messages::System.new("You are a helpful assistant."),
           Riffer::Messages::User.new("Hello")
         ]
-        events = agent.resume_stream(messages: messages).to_a
+        events = agent.stream(messages).to_a
         text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
         expect(text_events).wont_be_empty
       end
@@ -2612,29 +2598,17 @@ describe Riffer::Agent do
           {role: "system", content: "You are a helpful assistant."},
           {role: "user", content: "Hello"}
         ]
-        events = agent.resume_stream(messages: messages).to_a
+        events = agent.stream(messages).to_a
         expect(events).wont_be_empty
       end
 
       it "does not require prior interruption" do
         agent = agent_class.new
         messages = [Riffer::Messages::User.new("Hello")]
-        events = agent.resume_stream(messages: messages).to_a
+        events = agent.stream(messages).to_a
         interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
         expect(interrupt_event).must_be_nil
       end
-    end
-
-    it "raises when structured_output is configured" do
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        structured_output do
-          required :sentiment, String
-        end
-      end
-      agent = klass.new
-      error = expect { agent.resume_stream }.must_raise(Riffer::ArgumentError)
-      expect(error.message).must_match(/Structured output is not supported with streaming/)
     end
   end
 
@@ -2704,7 +2678,7 @@ describe Riffer::Agent do
       tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 1
 
-      events = agent.resume_stream.to_a
+      events = agent.stream(agent.messages).to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).must_be_nil
       tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
@@ -3307,6 +3281,63 @@ describe Riffer::Agent do
         mod_event = events.find { |e| e.is_a?(Riffer::StreamEvents::GuardrailModification) }
         expect(mod_event.guardrail).must_equal transform_guardrail_class
       end
+    end
+  end
+
+  describe "#instruction_message" do
+    it "returns a System message with instructions" do
+      agent = agent_class.new
+      msg = agent.instruction_message
+      expect(msg).must_be_instance_of Riffer::Messages::System
+      expect(msg.content).must_equal "You are a helpful assistant."
+    end
+
+    it "returns nil when no instructions configured" do
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+      end
+      agent = klass.new
+      expect(agent.instruction_message).must_be_nil
+    end
+
+    it "resolves dynamic instructions with context" do
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions ->(context) { "Helping #{context[:name]}" }
+      end
+      agent = klass.new
+      msg = agent.instruction_message(context: {name: "Alice"})
+      expect(msg.content).must_equal "Helping Alice"
+    end
+
+    it "returns nil when Proc returns nil" do
+      returner = ->(_ctx) {}
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        instructions returner
+      end
+      agent = klass.new
+      expect(agent.instruction_message).must_be_nil
+    end
+  end
+
+  describe "#skills_message" do
+    it "returns nil when no skills configured" do
+      agent = agent_class.new
+      expect(agent.skills_message).must_be_nil
+    end
+
+    it "returns a System message when skills are configured" do
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+      agent = klass.new
+      msg = agent.skills_message
+      expect(msg).must_be_instance_of Riffer::Messages::System
+      expect(msg.content).must_include "Available Skills"
     end
   end
 end

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -2,8 +2,6 @@
 
 require "test_helper"
 
-SKILLS_FIXTURES_PATH = File.expand_path("../../fixtures/skills", __dir__)
-
 describe "Agent skills integration" do
   let(:backend) { Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH) }
 

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -8,7 +8,7 @@ describe "Agent skills integration" do
   let(:backend) { Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH) }
 
   describe "generate with skills" do
-    it "injects skills catalog into system prompt" do
+    it "injects skills catalog into separate system message" do
       agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         instructions "You are helpful."
@@ -20,12 +20,12 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      refute_nil system_message
-      assert_includes system_message.content, "You are helpful."
-      assert_includes system_message.content, "Available Skills"
-      assert_includes system_message.content, "code-review"
-      assert_includes system_message.content, "data-analysis"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      assert_equal 2, system_messages.length
+      assert_includes system_messages[0].content, "You are helpful."
+      assert_includes system_messages[1].content, "Available Skills"
+      assert_includes system_messages[1].content, "code-review"
+      assert_includes system_messages[1].content, "data-analysis"
     end
 
     it "uses Markdown renderer for mock provider by default" do
@@ -39,9 +39,10 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      assert_includes system_message.content, "## Available Skills"
-      assert_includes system_message.content, "- **code-review**"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_message = system_messages.find { |m| m.content.include?("Available Skills") }
+      assert_includes skills_message.content, "## Available Skills"
+      assert_includes skills_message.content, "- **code-review**"
     end
 
     it "allows custom adapter override" do
@@ -56,8 +57,9 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      assert_includes system_message.content, "<available_skills>"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_message = system_messages.find { |m| m.content.include?("available_skills") }
+      assert_includes skills_message.content, "<available_skills>"
     end
 
     it "includes skill_activate tool in resolved tools" do
@@ -166,8 +168,9 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      assert_includes system_message.content, "code-review"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_msg = system_messages.find { |m| m.content.include?("code-review") }
+      refute_nil skills_msg
     end
 
     it "generates no system message when skills backend returns empty" do
@@ -189,7 +192,7 @@ describe "Agent skills integration" do
   end
 
   describe "activated skills" do
-    it "appends activated skill bodies to system prompt" do
+    it "appends activated skill bodies to skills system message" do
       agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         instructions "Base instructions."
@@ -202,13 +205,15 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      assert_includes system_message.content, "Base instructions."
-      assert_includes system_message.content, "code review assistant"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      assert_equal 2, system_messages.length
+      assert_includes system_messages[0].content, "Base instructions."
+      skills_msg = system_messages[1]
+      assert_includes skills_msg.content, "code review assistant"
       # Pre-activated skill should not appear in the catalog
-      refute_includes system_message.content, "- **code-review**"
+      refute_includes skills_msg.content, "- **code-review**"
       # Non-activated skill should still be in the catalog
-      assert_includes system_message.content, "- **data-analysis**"
+      assert_includes skills_msg.content, "- **data-analysis**"
     end
 
     it "omits catalog entirely when all skills are pre-activated" do
@@ -223,10 +228,12 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      refute_includes system_message.content, "Available Skills"
-      assert_includes system_message.content, "code review assistant"
-      assert_includes system_message.content, "data analysis assistant"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_msg = system_messages.find { |m| m.content.include?("code review assistant") }
+      refute_nil skills_msg
+      refute_includes skills_msg.content, "Available Skills"
+      assert_includes skills_msg.content, "code review assistant"
+      assert_includes skills_msg.content, "data analysis assistant"
     end
 
     it "raises on unknown activated skill" do
@@ -255,13 +262,14 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello", context: {activate_skills: ["data-analysis"]})
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      assert_includes system_message.content, "data analysis assistant"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_msg = system_messages.find { |m| m.content.include?("data analysis assistant") }
+      refute_nil skills_msg
     end
   end
 
   describe "stream with skills" do
-    it "injects skills catalog into system prompt" do
+    it "injects skills catalog into separate system message" do
       agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         instructions "You are helpful."
@@ -273,10 +281,11 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.stream("Hello").each { |_| }
 
-      system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
-      refute_nil system_message
-      assert_includes system_message.content, "Available Skills"
-      assert_includes system_message.content, "code-review"
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      assert_equal 2, system_messages.length
+      skills_msg = system_messages.find { |m| m.content.include?("Available Skills") }
+      refute_nil skills_msg
+      assert_includes skills_msg.content, "code-review"
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,3 +34,5 @@ VCR.configure do |config|
   config.filter_sensitive_data("<AWS_BEDROCK_API_TOKEN>") { ENV.fetch("AWS_BEDROCK_API_TOKEN", "test_api_token") }
   config.filter_sensitive_data("<OPENAI_API_KEY>") { ENV.fetch("OPENAI_API_KEY", "test_api_key") }
 end
+
+SKILLS_FIXTURES_PATH = File.expand_path("fixtures/skills", __dir__)


### PR DESCRIPTION
## Summary

- **Remove `resume` / `resume_stream` / `restore_state`** — these separate methods are replaced by unified behavior in `generate` and `stream`
- **Multi-turn string continuation** — calling `generate("Follow up")` on an agent with existing messages appends the user message and continues the conversation (no system message duplication, pending tool calls executed, step offset preserved)
- **Array input = cross-process resume** — passing an array to a fresh agent uses messages as-is (no system messages prepended). Passing an array to an agent that already has messages raises `Riffer::ArgumentError`
- **Split system messages** — instructions and skills catalog are now two separate system messages instead of one combined message
- **Public `instruction_message` / `skills_message`** — new methods for database persistence workflows where system messages need to be stored independently
- **Per-call state reset** — `context`, tools, tool runtime, model, skills state, and interrupted flag reset on each call. Only message history and cumulative `token_usage` persist across calls. Documentation makes this explicit.

### Input behavior matrix

| Input | Agent state | Behavior |
|---|---|---|
| String | Fresh agent | New conversation (builds system messages + user message) |
| String | Has messages | Continue conversation (appends user message, resume mode) |
| Array | Fresh agent | Cross-process resume (messages used as-is) |
| Array | Has messages | Raises `Riffer::ArgumentError` |

## Test plan

- [x] `bundle exec rake` passes (tests + lint + type checking)
- [ ] Verify multi-turn: `agent.generate("Hello"); agent.generate("Follow up")`
- [ ] Verify cross-process resume: `MyAgent.new.generate(persisted_messages)`
- [ ] Verify guard: `agent.generate("Hello"); agent.generate([...])` raises
- [ ] Verify context must be re-passed: `agent.generate("Hello", context: ctx); agent.generate("More", context: ctx)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)