### PR TITLE
feat: expose message history in eval results

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -544,6 +544,7 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 | `modifications`     | `Array`                     | List of guardrail modifications applied            |
 | `interrupted?`      | `Boolean`                   | `true` if the loop was interrupted                 |
 | `interrupt_reason`  | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
+| `messages`          | `Array`                     | Full message history from the conversation         |
 
 ### response.structured_output
 

--- a/docs/08_EVALS.md
+++ b/docs/08_EVALS.md
@@ -120,6 +120,7 @@ scenario.output       # => "The capital of France is Paris."
 scenario.ground_truth # => "Paris"
 scenario.scores       # => { EvaluatorClass => score } for this scenario
 scenario.results      # => Array of Result objects
+scenario.messages     # => Array of Message objects (system, user, assistant, tool)
 scenario.to_h         # => Hash representation
 ```
 
@@ -183,7 +184,7 @@ Class methods:
 
 Instance methods:
 
-- `evaluate(input:, output:, ground_truth:)` - Override for custom logic; default calls judge with `instructions`
+- `evaluate(input:, output:, ground_truth:, messages:)` - Override for custom logic; default calls judge with `instructions`
 - `judge` - Returns a Judge instance for LLM-as-judge calls
 - `result(score:, reason:, metadata:)` - Helper to build Result objects
 
@@ -196,7 +197,7 @@ class CustomEvaluator < Riffer::Evals::Evaluator
   higher_is_better true
   judge_model "anthropic/claude-opus-4-5-20251101"
 
-  def evaluate(input:, output:, ground_truth: nil)
+  def evaluate(input:, output:, ground_truth: nil, messages: [])
     evaluation = judge.evaluate(
       instructions: "Custom evaluation criteria...",
       input: input,
@@ -217,7 +218,7 @@ Evaluators don't have to use LLM-as-judge:
 class LengthEvaluator < Riffer::Evals::Evaluator
   higher_is_better true
 
-  def evaluate(input:, output:, ground_truth: nil)
+  def evaluate(input:, output:, ground_truth: nil, messages: [])
     min_length = 50
     max_length = 500
 

--- a/examples/evaluators/keyword_coverage.rb
+++ b/examples/evaluators/keyword_coverage.rb
@@ -31,7 +31,7 @@ class KeywordCoverageEvaluator < Riffer::Evals::Evaluator
 
   higher_is_better true
 
-  def evaluate(input:, output:, ground_truth: nil)
+  def evaluate(input:, output:, ground_truth: nil, messages: [])
     raise ArgumentError, "ground_truth is required for KeywordCoverageEvaluator" unless ground_truth
 
     truth_keywords = extract_keywords(ground_truth)

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -788,6 +788,6 @@ class Riffer::Agent
 
   #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output)
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze)
   end
 end

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -28,6 +28,9 @@ class Riffer::Agent::Response
   # The parsed structured output, if structured output was configured.
   attr_reader :structured_output #: Hash[Symbol, untyped]?
 
+  # The full message history from the agent conversation.
+  attr_reader :messages #: Array[Riffer::Messages::Base]
+
   # Creates a new response.
   #
   # +content+ - the response content.
@@ -36,15 +39,17 @@ class Riffer::Agent::Response
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
   # +structured_output+ - parsed structured output when structured output is configured.
+  # +messages+ - the full message history from the agent conversation.
   #
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [])
     @content = content
     @tripwire = tripwire
     @modifications = modifications
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output
+    @messages = messages
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -50,11 +50,12 @@ class Riffer::Evals::Evaluator
   # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
   # +output+ - the agent's response to evaluate.
   # +ground_truth+ - optional reference answer for comparison.
+  # +messages+ - the full message history from the agent conversation.
   #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
-  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
-  def evaluate(input:, output:, ground_truth: nil)
+  #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
+  def evaluate(input:, output:, ground_truth: nil, messages: [])
     instr = self.class.instructions
     raise NotImplementedError, "#{self.class} must set instructions or implement #evaluate" unless instr
 

--- a/lib/riffer/evals/evaluator_runner.rb
+++ b/lib/riffer/evals/evaluator_runner.rb
@@ -65,16 +65,18 @@ class Riffer::Evals::EvaluatorRunner
 
     response = agent.generate(input, context: resolved_context)
     output = response.content
+    messages = response.messages
 
     results = evaluators.map do |evaluator_class|
-      evaluator_class.new.evaluate(input: input, output: output, ground_truth: ground_truth)
+      evaluator_class.new.evaluate(input: input, output: output, ground_truth: ground_truth, messages: messages)
     end
 
     Riffer::Evals::ScenarioResult.new(
       input: input,
       output: output,
       ground_truth: ground_truth,
-      results: results
+      results: results,
+      messages: messages
     )
   end
 end

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -27,14 +27,18 @@ class Riffer::Evals::ScenarioResult
   # Individual evaluation results.
   attr_reader :results #: Array[Riffer::Evals::Result]
 
+  # The full message history from the agent conversation.
+  attr_reader :messages #: Array[Riffer::Messages::Base]
+
   # Initializes a new scenario result.
   #
-  #: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result]) -> void
-  def initialize(input:, output:, ground_truth:, results:)
+  #: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize(input:, output:, ground_truth:, results:, messages: [])
     @input = input
     @output = output
     @ground_truth = ground_truth
     @results = results
+    @messages = messages
   end
 
   # Returns scores keyed by evaluator class.
@@ -55,7 +59,8 @@ class Riffer::Evals::ScenarioResult
       output: output,
       ground_truth: ground_truth,
       scores: scores.transform_keys(&:name),
-      results: results.map(&:to_h)
+      results: results.map(&:to_h),
+      messages: messages.map { |m| {role: m.role, content: m.content} }
     }
   end
 end

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -60,7 +60,7 @@ class Riffer::Evals::ScenarioResult
       ground_truth: ground_truth,
       scores: scores.transform_keys(&:name),
       results: results.map(&:to_h),
-      messages: messages.map { |m| {role: m.role, content: m.content} }
+      messages: messages.map(&:to_h)
     }
   end
 end

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -27,6 +27,9 @@ class Riffer::Agent::Response
   # The parsed structured output, if structured output was configured.
   attr_reader structured_output: Hash[Symbol, untyped]?
 
+  # The full message history from the agent conversation.
+  attr_reader messages: Array[Riffer::Messages::Base]
+
   # Creates a new response.
   #
   # +content+ - the response content.
@@ -35,9 +38,10 @@ class Riffer::Agent::Response
   # +interrupted+ - whether the agent loop was interrupted by a callback.
   # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
   # +structured_output+ - parsed structured output when structured output is configured.
+  # +messages+ - the full message history from the agent conversation.
   #
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -37,11 +37,12 @@ class Riffer::Evals::Evaluator
   # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
   # +output+ - the agent's response to evaluate.
   # +ground_truth+ - optional reference answer for comparison.
+  # +messages+ - the full message history from the agent conversation.
   #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
-  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
-  def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?) -> Riffer::Evals::Result
+  # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
+  def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
 
   private
 

--- a/sig/generated/riffer/evals/scenario_result.rbs
+++ b/sig/generated/riffer/evals/scenario_result.rbs
@@ -25,10 +25,13 @@ class Riffer::Evals::ScenarioResult
   # Individual evaluation results.
   attr_reader results: Array[Riffer::Evals::Result]
 
+  # The full message history from the agent conversation.
+  attr_reader messages: Array[Riffer::Messages::Base]
+
   # Initializes a new scenario result.
   #
-  # : (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result]) -> void
-  def initialize: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result]) -> void
+  # : (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
 
   # Returns scores keyed by evaluator class.
   #

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -88,6 +88,19 @@ describe Riffer::Agent::Response do
     end
   end
 
+  describe "#messages" do
+    it "defaults to empty array" do
+      response = Riffer::Agent::Response.new("Hello!")
+      expect(response.messages).must_equal []
+    end
+
+    it "stores the messages" do
+      messages = [Riffer::Messages::User.new("Hi"), Riffer::Messages::Assistant.new("Hello")]
+      response = Riffer::Agent::Response.new("Hello!", messages: messages)
+      expect(response.messages).must_equal messages
+    end
+  end
+
   describe "#interrupted?" do
     it "returns false by default" do
       response = Riffer::Agent::Response.new("Hello!")

--- a/test/riffer/evals/evaluator_runner_test.rb
+++ b/test/riffer/evals/evaluator_runner_test.rb
@@ -7,7 +7,7 @@ describe Riffer::Evals::EvaluatorRunner do
     Class.new(Riffer::Evals::Evaluator) do
       higher_is_better true
 
-      def evaluate(input:, output:, ground_truth: nil)
+      def evaluate(input:, output:, ground_truth: nil, messages: [])
         score = [output.length / 100.0, 1.0].min
         result(score: score, reason: "Based on output length")
       end
@@ -18,7 +18,7 @@ describe Riffer::Evals::EvaluatorRunner do
     Class.new(Riffer::Evals::Evaluator) do
       higher_is_better true
 
-      def evaluate(input:, output:, ground_truth: nil)
+      def evaluate(input:, output:, ground_truth: nil, messages: [])
         score = (ground_truth == output) ? 1.0 : 0.5
         result(score: score, reason: "Ground truth match")
       end
@@ -88,6 +88,41 @@ describe Riffer::Evals::EvaluatorRunner do
       )
 
       expect(result.scenario_results.first.output).must_equal "Mock response"
+    end
+
+    it "includes message history in scenario results" do
+      result = Riffer::Evals::EvaluatorRunner.run(
+        agent: agent_class,
+        scenarios: [{input: "Hello"}],
+        evaluators: [evaluator_class]
+      )
+
+      messages = result.scenario_results.first.messages
+      expect(messages).wont_be_empty
+      expect(messages.any? { |m| m.is_a?(Riffer::Messages::System) }).must_equal true
+      expect(messages.any? { |m| m.is_a?(Riffer::Messages::User) }).must_equal true
+      expect(messages.any? { |m| m.is_a?(Riffer::Messages::Assistant) }).must_equal true
+    end
+
+    it "passes messages to evaluators" do
+      received_messages = nil
+      messages_evaluator = Class.new(Riffer::Evals::Evaluator) do
+        higher_is_better true
+
+        define_method(:evaluate) do |input:, output:, ground_truth: nil, messages: []|
+          received_messages = messages
+          result(score: 1.0, reason: "ok")
+        end
+      end
+
+      Riffer::Evals::EvaluatorRunner.run(
+        agent: agent_class,
+        scenarios: [{input: "Hello"}],
+        evaluators: [messages_evaluator]
+      )
+
+      expect(received_messages).wont_be_nil
+      expect(received_messages).wont_be_empty
     end
 
     it "returns aggregate scores" do

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -127,7 +127,7 @@ describe Riffer::Evals::Evaluator do
       klass = Class.new(Riffer::Evals::Evaluator) do
         higher_is_better true
 
-        def evaluate(input:, output:, ground_truth: nil)
+        def evaluate(input:, output:, ground_truth: nil, messages: [])
           result(score: 0.9, reason: "Good")
         end
       end
@@ -146,7 +146,7 @@ describe Riffer::Evals::Evaluator do
       klass = Class.new(Riffer::Evals::Evaluator) do
         higher_is_better false
 
-        def evaluate(input:, output:, ground_truth: nil)
+        def evaluate(input:, output:, ground_truth: nil, messages: [])
           result(score: 0.1, reason: "Low toxicity")
         end
       end

--- a/test/riffer/evals/scenario_result_test.rb
+++ b/test/riffer/evals/scenario_result_test.rb
@@ -39,6 +39,32 @@ describe Riffer::Evals::ScenarioResult do
     end
   end
 
+  describe "#messages" do
+    it "defaults to empty array" do
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: []
+      )
+
+      expect(scenario.messages).must_equal []
+    end
+
+    it "stores provided messages" do
+      messages = [Riffer::Messages::User.new("Hi"), Riffer::Messages::Assistant.new("Hello")]
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: [],
+        messages: messages
+      )
+
+      expect(scenario.messages).must_equal messages
+    end
+  end
+
   describe "#scores" do
     it "returns scores keyed by evaluator class" do
       scenario = Riffer::Evals::ScenarioResult.new(
@@ -79,6 +105,7 @@ describe Riffer::Evals::ScenarioResult do
       expect(hash[:ground_truth]).must_equal "A programming language"
       expect(hash[:results].length).must_equal 1
       expect(hash[:scores]).must_be_instance_of Hash
+      expect(hash[:messages]).must_be_instance_of Array
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `messages` attribute to `Agent::Response` so the full conversation history is preserved after `generate`
- Add `messages` attribute to `ScenarioResult` and forward from `EvaluatorRunner.run_scenario`
- Add `messages:` keyword to `Evaluator#evaluate` so custom evaluators can inspect intermediate agent steps (system messages, tool calls, etc.)
- Use `to_h` on messages in `ScenarioResult#to_h` to preserve full message data (tool calls, etc.)
- Update docs: agent response attributes table, evals guide, and example evaluators
- Update RBS type signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)