### PR TITLE
feat: add fibers tool runtime using async gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       cgi
       connection_pool
     ast (2.4.3)
-    async (2.38.1)
+    async (2.37.0)
       console (~> 1.29)
       fiber-annotation
       io-event (~> 1.11)
@@ -252,7 +252,7 @@ PLATFORMS
 
 DEPENDENCIES
   anthropic (~> 1.25.0)
-  async
+  async (~> 2.25, < 2.38)
   aws-sdk-bedrockruntime (~> 1.42)
   dotenv
   guard

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    io-event (1.14.5)
+    io-event (1.13.0)
     irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -257,6 +257,7 @@ DEPENDENCIES
   dotenv
   guard
   guard-shell
+  io-event (< 1.14)
   irb
   minitest (~> 6.0)
   openai (~> 0.56.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,12 @@ GEM
       cgi
       connection_pool
     ast (2.4.3)
+    async (2.38.1)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     aws-eventstream (1.4.0)
     aws-partitions (1.1230.0)
     aws-sdk-bedrockruntime (1.74.0)
@@ -47,6 +53,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    console (1.34.3)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     crack (1.0.1)
       bigdecimal
       rexml
@@ -66,6 +76,10 @@ GEM
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     fileutils (1.8.0)
     formatador (1.2.3)
       reline
@@ -87,6 +101,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
+    io-event (1.14.5)
     irb (1.17.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -103,6 +118,7 @@ GEM
     logger (1.7.0)
     lumberjack (1.4.2)
     method_source (1.1.0)
+    metrics (0.15.0)
     minitest (6.0.2)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -206,6 +222,7 @@ GEM
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
+    traces (0.18.2)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -235,6 +252,7 @@ PLATFORMS
 
 DEPENDENCIES
   anthropic (~> 1.25.0)
+  async
   aws-sdk-bedrockruntime (~> 1.42)
   dotenv
   guard

--- a/docs/04_TOOLS.md
+++ b/docs/04_TOOLS.md
@@ -384,6 +384,7 @@ By default, tool calls are executed sequentially in the current thread using `Ri
 | ------------------------------- | ---------------------------------------------- |
 | `Riffer::ToolRuntime::Inline`   | Executes tool calls sequentially (default)     |
 | `Riffer::ToolRuntime::Threaded` | Executes tool calls concurrently using threads |
+| `Riffer::ToolRuntime::Fibers`   | Executes tool calls concurrently using fibers  |
 
 ### Per-Agent Configuration
 
@@ -449,6 +450,35 @@ class MyAgent < Riffer::Agent
   tool_runtime Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
 end
 ```
+
+### Fibers Runtime
+
+The fibers runtime uses the [async](https://github.com/socketry/async) gem for lightweight, cooperative concurrency. It requires the `async` gem to be installed:
+
+```ruby
+# Gemfile
+gem "async"
+```
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-5-mini'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime Riffer::ToolRuntime::Fibers
+end
+```
+
+By default, all tool calls run as fibers without a concurrency limit. You can optionally set a limit:
+
+```ruby
+class MyAgent < Riffer::Agent
+  model 'openai/gpt-5-mini'
+  uses_tools [WeatherTool, SearchTool]
+  tool_runtime Riffer::ToolRuntime::Fibers.new(max_concurrency: 10)
+end
+```
+
+Fibers use cooperative scheduling — they yield control at I/O boundaries (network calls, file reads, sleep). CPU-bound tools will not benefit from the fibers runtime. Be mindful of fiber-local state (`Fiber.[]`) and note that `Thread.current[]` values are shared across all fibers in the same thread.
 
 ### Custom Runtimes
 

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -4,7 +4,7 @@
 # Processes items concurrently using fibers via the +async+ gem.
 #
 # All items run as fibers simultaneously by default. When
-# +max_concurrency+ is set, an +Async::Semaphore+ limits how many
+# +max_concurrency+ is set, an <tt>Async::Semaphore</tt> limits how many
 # fibers execute at once.
 #
 # If multiple fibers raise, only the first exception is re-raised
@@ -16,9 +16,10 @@
 class Riffer::Runner::Fibers < Riffer::Runner
   include Riffer::Helpers::Dependencies
 
-  # +max_concurrency+ - maximum number of fibers to run simultaneously.
+  # [max_concurrency] maximum number of fibers to run simultaneously.
   #   When +nil+, all fibers run without limit.
   #
+  #--
   #: (?max_concurrency: Integer?) -> void
   def initialize(max_concurrency: nil)
     depends_on "async"
@@ -26,6 +27,7 @@ class Riffer::Runner::Fibers < Riffer::Runner
     @max_concurrency = max_concurrency
   end
 
+  #--
   #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     return [] if items.empty?

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -26,8 +26,8 @@ class Riffer::Runner::Fibers < Riffer::Runner
     @max_concurrency = max_concurrency
   end
 
-  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
-  def map(items, &block)
+  #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, context:, &block)
     return [] if items.empty?
 
     results = Array.new(items.size)

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Processes items concurrently using fibers via the +async+ gem.
+#
+# All items run as fibers simultaneously by default. When
+# +max_concurrency+ is set, an +Async::Semaphore+ limits how many
+# fibers execute at once.
+#
+# If multiple fibers raise, only the first exception is re-raised
+# after all fibers finish; subsequent errors are discarded.
+#
+#   runner = Riffer::Runner::Fibers.new
+#   runner.map(items) { |item| expensive_operation(item) }
+#
+class Riffer::Runner::Fibers < Riffer::Runner
+  include Riffer::Helpers::Dependencies
+
+  # +max_concurrency+ - maximum number of fibers to run simultaneously.
+  #   When +nil+, all fibers run without limit.
+  #
+  #: (?max_concurrency: Integer?) -> void
+  def initialize(max_concurrency: nil)
+    depends_on "async"
+    require "async/semaphore" if max_concurrency
+    @max_concurrency = max_concurrency
+  end
+
+  #: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map(items, &block)
+    return [] if items.empty?
+
+    results = Array.new(items.size)
+    errors = Array.new(items.size)
+
+    Async do
+      barrier = Async::Barrier.new
+      parent = if @max_concurrency
+        Async::Semaphore.new(@max_concurrency, parent: barrier)
+      else
+        barrier
+      end
+
+      items.each_with_index do |item, index|
+        parent.async do
+          results[index] = block.call(item)
+        rescue => e
+          errors[index] = e
+        end
+      end
+
+      barrier.wait
+    end
+
+    first_error = errors.compact.first
+    raise first_error if first_error
+
+    results
+  end
+end

--- a/lib/riffer/tool_runtime/fibers.rb
+++ b/lib/riffer/tool_runtime/fibers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Executes tool calls concurrently using fibers via the +async+ gem.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime Riffer::ToolRuntime::Fibers
+#   end
+#
+class Riffer::ToolRuntime::Fibers < Riffer::ToolRuntime
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #   When +nil+, all tool calls run as fibers without limit.
+  #
+  #: (?max_concurrency: Integer?) -> void
+  def initialize(max_concurrency: nil)
+    super(runner: Riffer::Runner::Fibers.new(max_concurrency: max_concurrency))
+  end
+end

--- a/lib/riffer/tool_runtime/fibers.rb
+++ b/lib/riffer/tool_runtime/fibers.rb
@@ -8,9 +8,10 @@
 #   end
 #
 class Riffer::ToolRuntime::Fibers < Riffer::ToolRuntime
-  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  # [max_concurrency] maximum number of tool calls to execute simultaneously.
   #   When +nil+, all tool calls run as fibers without limit.
   #
+  #--
   #: (?max_concurrency: Integer?) -> void
   def initialize(max_concurrency: nil)
     super(runner: Riffer::Runner::Fibers.new(max_concurrency: max_concurrency))

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "anthropic", "~> 1.25.0"
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.42"
   spec.add_development_dependency "openai", "~> 0.56.0"
-  spec.add_development_dependency "async"
+  spec.add_development_dependency "async", "~> 2.25", "< 2.38"
   spec.add_development_dependency "io-event", "< 1.14"
 
   # Testing

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "anthropic", "~> 1.25.0"
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.42"
   spec.add_development_dependency "openai", "~> 0.56.0"
+  spec.add_development_dependency "async"
 
   # Testing
   spec.add_development_dependency "minitest", "~> 6.0"

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.42"
   spec.add_development_dependency "openai", "~> 0.56.0"
   spec.add_development_dependency "async"
+  spec.add_development_dependency "io-event", "< 1.14"
 
   # Testing
   spec.add_development_dependency "minitest", "~> 6.0"

--- a/sig/generated/riffer/runner/fibers.rbs
+++ b/sig/generated/riffer/runner/fibers.rbs
@@ -1,0 +1,25 @@
+# Generated from lib/riffer/runner/fibers.rb with RBS::Inline
+
+# Processes items concurrently using fibers via the +async+ gem.
+#
+# All items run as fibers simultaneously by default. When
+# +max_concurrency+ is set, an +Async::Semaphore+ limits how many
+# fibers execute at once.
+#
+# If multiple fibers raise, only the first exception is re-raised
+# after all fibers finish; subsequent errors are discarded.
+#
+#   runner = Riffer::Runner::Fibers.new
+#   runner.map(items) { |item| expensive_operation(item) }
+class Riffer::Runner::Fibers < Riffer::Runner
+  include Riffer::Helpers::Dependencies
+
+  # +max_concurrency+ - maximum number of fibers to run simultaneously.
+  #   When +nil+, all fibers run without limit.
+  #
+  # : (?max_concurrency: Integer?) -> void
+  def initialize: (?max_concurrency: Integer?) -> void
+
+  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+end

--- a/sig/generated/riffer/runner/fibers.rbs
+++ b/sig/generated/riffer/runner/fibers.rbs
@@ -20,6 +20,6 @@ class Riffer::Runner::Fibers < Riffer::Runner
   # : (?max_concurrency: Integer?) -> void
   def initialize: (?max_concurrency: Integer?) -> void
 
-  # : (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
-  def map: (Array[untyped]) { (untyped) -> untyped } -> Array[untyped]
+  # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/fibers.rbs
+++ b/sig/generated/riffer/runner/fibers.rbs
@@ -3,7 +3,7 @@
 # Processes items concurrently using fibers via the +async+ gem.
 #
 # All items run as fibers simultaneously by default. When
-# +max_concurrency+ is set, an +Async::Semaphore+ limits how many
+# +max_concurrency+ is set, an <tt>Async::Semaphore</tt> limits how many
 # fibers execute at once.
 #
 # If multiple fibers raise, only the first exception is re-raised
@@ -14,12 +14,14 @@
 class Riffer::Runner::Fibers < Riffer::Runner
   include Riffer::Helpers::Dependencies
 
-  # +max_concurrency+ - maximum number of fibers to run simultaneously.
+  # [max_concurrency] maximum number of fibers to run simultaneously.
   #   When +nil+, all fibers run without limit.
   #
+  # --
   # : (?max_concurrency: Integer?) -> void
   def initialize: (?max_concurrency: Integer?) -> void
 
+  # --
   # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/tool_runtime/fibers.rbs
+++ b/sig/generated/riffer/tool_runtime/fibers.rbs
@@ -6,9 +6,10 @@
 #     tool_runtime Riffer::ToolRuntime::Fibers
 #   end
 class Riffer::ToolRuntime::Fibers < Riffer::ToolRuntime
-  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  # [max_concurrency] maximum number of tool calls to execute simultaneously.
   #   When +nil+, all tool calls run as fibers without limit.
   #
+  # --
   # : (?max_concurrency: Integer?) -> void
   def initialize: (?max_concurrency: Integer?) -> void
 end

--- a/sig/generated/riffer/tool_runtime/fibers.rbs
+++ b/sig/generated/riffer/tool_runtime/fibers.rbs
@@ -1,0 +1,14 @@
+# Generated from lib/riffer/tool_runtime/fibers.rb with RBS::Inline
+
+# Executes tool calls concurrently using fibers via the +async+ gem.
+#
+#   class MyAgent < Riffer::Agent
+#     tool_runtime Riffer::ToolRuntime::Fibers
+#   end
+class Riffer::ToolRuntime::Fibers < Riffer::ToolRuntime
+  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  #   When +nil+, all tool calls run as fibers without limit.
+  #
+  # : (?max_concurrency: Integer?) -> void
+  def initialize: (?max_concurrency: Integer?) -> void
+end

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -48,6 +48,63 @@ describe Riffer::Runner::Sequential do
   end
 end
 
+describe Riffer::Runner::Fibers do
+  describe "#map" do
+    it "returns results in order" do
+      runner = Riffer::Runner::Fibers.new
+      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      expect(results).must_equal [2, 4, 6]
+    end
+
+    it "executes concurrently" do
+      runner = Riffer::Runner::Fibers.new
+      seen = []
+
+      runner.map([1, 2, 3]) do |n|
+        seen << Fiber.current.object_id
+        n
+      end
+
+      expect(seen.uniq.length).must_equal 3
+    end
+
+    it "respects max_concurrency" do
+      runner = Riffer::Runner::Fibers.new(max_concurrency: 2)
+      concurrent = 0
+      max_concurrent = 0
+      mutex = Mutex.new
+
+      runner.map([1, 2, 3, 4]) do |n|
+        mutex.synchronize do
+          concurrent += 1
+          max_concurrent = [max_concurrent, concurrent].max
+        end
+        sleep 0.02
+        mutex.synchronize { concurrent -= 1 }
+        n
+      end
+
+      expect(max_concurrent).must_be :<=, 2
+    end
+
+    it "handles empty items" do
+      runner = Riffer::Runner::Fibers.new
+      results = runner.map([]) { |n| n }
+      expect(results).must_equal []
+    end
+
+    it "propagates exceptions" do
+      runner = Riffer::Runner::Fibers.new
+      expect {
+        runner.map([1, 2, 3]) do |n|
+          raise "boom" if n == 2
+          n
+        end
+      }.must_raise RuntimeError
+    end
+  end
+end
+
 describe Riffer::Runner::Threaded do
   describe "#map" do
     it "returns results in order" do

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -52,7 +52,7 @@ describe Riffer::Runner::Fibers do
   describe "#map" do
     it "returns results in order" do
       runner = Riffer::Runner::Fibers.new
-      results = runner.map([1, 2, 3]) { |n| n * 2 }
+      results = runner.map([1, 2, 3], context: nil) { |n| n * 2 }
       expect(results).must_equal [2, 4, 6]
     end
 
@@ -60,7 +60,7 @@ describe Riffer::Runner::Fibers do
       runner = Riffer::Runner::Fibers.new
       seen = []
 
-      runner.map([1, 2, 3]) do |n|
+      runner.map([1, 2, 3], context: nil) do |n|
         seen << Fiber.current.object_id
         n
       end
@@ -74,7 +74,7 @@ describe Riffer::Runner::Fibers do
       max_concurrent = 0
       mutex = Mutex.new
 
-      runner.map([1, 2, 3, 4]) do |n|
+      runner.map([1, 2, 3, 4], context: nil) do |n|
         mutex.synchronize do
           concurrent += 1
           max_concurrent = [max_concurrent, concurrent].max
@@ -89,14 +89,14 @@ describe Riffer::Runner::Fibers do
 
     it "handles empty items" do
       runner = Riffer::Runner::Fibers.new
-      results = runner.map([]) { |n| n }
+      results = runner.map([], context: nil) { |n| n }
       expect(results).must_equal []
     end
 
     it "propagates exceptions" do
       runner = Riffer::Runner::Fibers.new
       expect {
-        runner.map([1, 2, 3]) do |n|
+        runner.map([1, 2, 3], context: nil) do |n|
           raise "boom" if n == 2
           n
         end

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -271,6 +271,35 @@ describe Riffer::ToolRuntime::Inline do
   end
 end
 
+describe Riffer::ToolRuntime::Fibers do
+  it "executes tool calls concurrently" do
+    seen = []
+
+    tracking_tool = Class.new(Riffer::Tool) do
+      identifier "tracking_tool"
+      description "Tracks fibers"
+
+      define_method(:call) do |context:, **|
+        seen << Fiber.current.object_id
+        sleep 0.01
+        text("done")
+      end
+    end
+
+    runtime = Riffer::ToolRuntime::Fibers.new
+    tool_calls = 3.times.map do |i|
+      Riffer::Messages::Assistant::ToolCall.new(
+        id: i.to_s, call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
+      )
+    end
+
+    results = runtime.execute(tool_calls, tools: [tracking_tool], context: nil)
+
+    expect(results.length).must_equal 3
+    expect(seen.uniq.length).must_equal 3
+  end
+end
+
 describe Riffer::ToolRuntime::Threaded do
   it "executes tool calls in parallel" do
     thread_ids = Mutex.new


### PR DESCRIPTION
## Summary

- Add `Riffer::ToolRuntime::Fibers` — a new built-in tool runtime that executes tool calls concurrently using fibers via the `async` gem
- Add `Riffer::Runner::Fibers` — the underlying runner that uses `Async::Barrier` for concurrency and optional `Async::Semaphore` for limiting max concurrency
- No concurrency limit by default (fibers are lightweight); users can opt in via `max_concurrency:`
- Uses `Riffer::Helpers::Dependencies#depends_on` for lazy loading the `async` gem with clear error messages if missing
- Pin `async < 2.38` and `io-event < 1.14` to maintain Ruby 3.2 compatibility
- Fix missing `context:` keyword on `Fibers#map` to match the updated runner interface
- Fix RDoc formatting to match conventions from #182: labeled list params, `#--` stop directives, `<tt>` for multi-word inline code

## Test plan

- [x] `Riffer::Runner::Fibers` tests: order preservation, concurrent execution, max_concurrency enforcement, empty items, exception propagation
- [x] `Riffer::ToolRuntime::Fibers` test: concurrent tool call execution verified via fiber identity tracking
- [x] All existing tests pass (`bundle exec rake` — 1170 runs, 1795 assertions, 0 failures)
- [x] Type checking passes (`bundle exec steep check`)
- [x] RBS signatures generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)