### PR TITLE
MCP Support

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -132,9 +132,35 @@ Built-in runtimes:
 
 Context flow: `Agent#execute_tool_calls` → `ToolRuntime#execute(tool_calls, tools:, context:)` → `Runner#map(tool_calls, context:) { dispatch }` → `Tool#call(context:, **args)`
 
+### MCP Integration (`lib/riffer/mcp/`)
+
+Register third-party MCP servers globally; agents opt-in by tag via `use_mcp`. Tags are application-defined (manifests may list several; any overlap with `use_mcp` opts in—see `docs/14_MCP.md`).
+
+```ruby
+Riffer::Mcp.register(
+  name: "github",
+  tags: [:github],
+  endpoint: "https://mcp.github.com",
+  discovery_headers: -> { {"Authorization" => "Bearer #{ENV['GITHUB_TOKEN']}"} }
+)
+
+# Optional: per-run tools/call headers (see docs/14_MCP.md)
+Riffer.configure { |c| c.mcp.credentials = ->(manifest:, matched_tags:, context:) { ... } }
+
+class ResearchAgent < Riffer::Agent
+  model "openai/gpt-5-mini"
+  use_mcp :github                      # picks up any :github-tagged registration
+  use_mcp :search, on_pending: :wait   # per-call override
+end
+```
+
+Key types: `Manifest` (`discovery_headers`, optional `credentials_scope` hint), `Registry` (thread-safe store), `Registration` (spawns discovery thread → `ToolFactory`), `Client` (wraps `mcp` gem), `AuthenticatedTool` (wraps MCP tools when `credentials` proc is set).
+
+**on_pending strategies** (global default `:ignore`): `:ignore` skips the server; `:wait` blocks until ready, re-raises failed discovery immediately, or times out; `:raise` re-raises failed discovery or `NotReadyError` while still pending.
+
 ## Key Patterns
 
-- Model config accepts a `provider/model` string (e.g., `openai/gpt-4`) or a Proc/lambda that returns one
+- Model config accepts a `provider/model` string (e.g., `openai/gpt-5-mini`) or a Proc/lambda that returns one
 - Configuration via `Riffer.configure { |c| c.openai.api_key = "..." }`
 - Providers use `depends_on` helper for runtime dependency checking
 - Zeitwerk for autoloading - file structure must match module/class names
@@ -199,6 +225,14 @@ lib/
       reasoning_done.rb  # Reasoning done event
       web_search_status.rb # Web search status event
       web_search_done.rb   # Web search done event
+    mcp.rb               # MCP public API + error classes
+    mcp/
+      manifest.rb        # Server config value object
+      registry.rb        # Thread-safe global store
+      registration.rb    # Per-server state + discovery thread
+      client.rb          # Thin mcp gem wrapper
+      authenticated_tool.rb  # Wraps MCP tools when credentials proc is configured
+      tool_factory.rb    # Generates Riffer::Tool subclasses from MCP tools
 test/
   test_helper.rb         # Minitest configuration with VCR
   riffer_test.rb         # Main module tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,12 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     erb (6.0.4)
+    faraday (2.14.1)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
@@ -94,6 +100,9 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.19.4)
+    json-schema (6.2.0)
+      addressable (~> 2.8)
+      bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -102,12 +111,16 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     lumberjack (1.4.2)
+    mcp (0.8.0)
+      json-schema (>= 4.1)
     method_source (1.1.0)
     metrics (0.15.0)
     minitest (6.0.5)
       drb (~> 2.0)
       prism (~> 1.5)
     nenv (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -237,10 +250,12 @@ DEPENDENCIES
   async (~> 2.25, < 2.40)
   aws-sdk-bedrockruntime (~> 1.42)
   dotenv
+  faraday (>= 1.0)
   guard
   guard-shell
   io-event (< 1.16)
   irb
+  mcp (~> 0.8)
   minitest (~> 6.0)
   openai (~> 0.59.0)
   rake (~> 13.0)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For comprehensive documentation, see the [docs](docs/) directory:
 - [Evals](docs/11_EVALS.md) - Evaluating agent quality
 - [Guardrails](docs/12_GUARDRAILS.md) - Input/output validation
 - [Skills](docs/13_SKILLS.md) - Packaged agent capabilities
+- [MCP](docs/14_MCP.md) - Integrating third-party MCP servers
 - [Providers](docs/providers/01_PROVIDERS.md) - LLM provider adapters
 
 ### API Reference

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -124,6 +124,10 @@ class MyAgent < Riffer::Agent
 end
 ```
 
+### use_mcp
+
+Loads tools from registered [MCP](14_MCP.md) servers by tag. Like `uses_tools`, **`use_mcp` is not inherited**—add it on each subclass that should include MCP tools.
+
 ### provider_options
 
 Passes options to the provider client:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -38,16 +38,13 @@ For provider credentials and setup, see the individual [Provider guides](provide
 
 Optional settings for [MCP server integrations](14_MCP.md):
 
-| Option          | Description                                                                                                     |
-| --------------- | --------------------------------------------------------------------------------------------------------------- |
-| `on_pending`    | `:ignore` (default), `:wait`, or `:raise` when tool discovery is not finished yet                               |
-| `wait_timeout`  | Seconds to wait when `on_pending` is `:wait` (default `10`)                                                     |
-| `credentials`   | Optional `Proc` for per-run `tools/call` HTTP headers: `->(manifest:, matched_tags:, context:) { Hash or nil }` |
+| Option             | Description                                                                                                     |
+| ------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `credentials`      | Optional `Proc` for per-run `tools/call` HTTP headers: `->(manifest:, matched_tags:, context:) { Hash or nil }` |
+| `discovery_runner` | `Riffer::Runner` instance for tool discovery (default `Runner::Sequential.new`)                                 |
 
 ```ruby
 Riffer.configure do |config|
-  config.mcp.on_pending = :wait
-  config.mcp.wait_timeout = 30
   config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
     {"Authorization" => "Bearer #{token_for(context)}"}
   end

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -34,6 +34,28 @@ Riffer.config.anthropic.api_key
 
 For provider credentials and setup, see the individual [Provider guides](providers/).
 
+### MCP (Model Context Protocol)
+
+Optional settings for [MCP server integrations](14_MCP.md):
+
+| Option          | Description                                                                                                     |
+| --------------- | --------------------------------------------------------------------------------------------------------------- |
+| `on_pending`    | `:ignore` (default), `:wait`, or `:raise` when tool discovery is not finished yet                               |
+| `wait_timeout`  | Seconds to wait when `on_pending` is `:wait` (default `10`)                                                     |
+| `credentials`   | Optional `Proc` for per-run `tools/call` HTTP headers: `->(manifest:, matched_tags:, context:) { Hash or nil }` |
+
+```ruby
+Riffer.configure do |config|
+  config.mcp.on_pending = :wait
+  config.mcp.wait_timeout = 30
+  config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
+    {"Authorization" => "Bearer #{token_for(context)}"}
+  end
+end
+```
+
+See [MCP](14_MCP.md) for registration, tags, and agent `use_mcp`.
+
 ### Tool Runtime (Experimental)
 
 > **Warning:** This feature is experimental and may be removed or changed without warning in a future release.
@@ -46,11 +68,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value                          | Description                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `Riffer::ToolRuntime` subclass | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`) |
-| `Riffer::ToolRuntime` instance | Custom runtime with specific options                                                              |
-| `Proc`                         | Dynamic resolution                                                                                |
+| Value                           | Description                                                                                        |
+| ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `Riffer::ToolRuntime` subclass  | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`)  |
+| `Riffer::ToolRuntime` instance  | Custom runtime with specific options                                                               |
+| `Proc`                          | Dynamic resolution                                                                                 |
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 

--- a/docs/14_MCP.md
+++ b/docs/14_MCP.md
@@ -1,0 +1,167 @@
+# MCP
+
+Riffer can consume third-party [Model Context Protocol](https://modelcontextprotocol.io) (MCP) servers as tool sources. Tools are discovered automatically at registration time — no handwritten Ruby per tool required.
+
+## Overview
+
+1. Register an MCP server globally with `Riffer::Mcp.register`.
+2. Opt an agent into that server's tools using the `use_mcp` DSL.
+3. The agent picks up the tools and calls them like any other Riffer tool.
+
+## Registering a Server
+
+```ruby
+Riffer::Mcp.register(
+  name: "github",        # unique identifier
+  tags: [:github],       # agents opt-in by tag
+  endpoint: "https://mcp.github.com",
+  discovery_headers: -> { {"Authorization" => "Bearer #{ENV['GITHUB_TOKEN']}"} }
+)
+```
+
+`register` returns immediately. Tool discovery runs in a background thread. Use `on_pending` (see below) to control agent behaviour while discovery is in progress.
+
+### Discovery headers
+
+`discovery_headers` is a Hash or Proc used **only** for MCP `tools/list` when the discovery client is built (the Proc runs once at that time). Use it for bootstrap identity: service account, env-based token, or `{}` if listing is unauthenticated.
+
+Optional **`credentials_scope`** on the manifest documents whether you expect invocation headers to depend on tenant and/or user keys in the agent `context` (e.g. `:global`, `:tenant`, `:user`). It does **not** store tenant or user ids — only a hint for your app and docs. For multi-tenant apps, `:user` often means “user in tenant” and your `context` may include both tenant and user identifiers.
+
+## Session credentials callback
+
+When **`Riffer.config.mcp.credentials`** is set to a Proc, each MCP `tools/call` resolves HTTP headers through that callback instead of reusing `discovery_headers`.
+
+**Signature:**
+
+```ruby
+Riffer.configure do |config|
+  config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
+    # return nil to omit this server's tools for this agent run (at resolve time)
+    # return Hash<String,String> headers for tools/call (e.g. Authorization)
+  end
+end
+```
+
+- **`manifest`** — the server's `Riffer::Mcp::Manifest`.
+- **`matched_tags`** — intersection of the agent's `use_mcp` tags and `manifest.tags` for this registration (unioned across multiple `use_mcp` lines).
+- **`context`** — the same hash passed to `generate` / `stream` for this run.
+
+**Resolve time:** Before tools are exposed to the model, the proc is invoked once per matching registration. If it returns **`nil`**, that server's tools are omitted for this run (e.g. tenant has no integration).
+
+**Call time:** Authenticated tool wrappers invoke the proc again for each execution. If it returns **`nil`**, `Riffer::Mcp::CredentialsDeniedError` is raised.
+
+If **`credentials` is unset**, discovery and `tools/call` share one client built from `discovery_headers` (same behaviour as a single static token for both list and call).
+
+## Tags
+
+Tags are entirely up to your application; Riffer does not define a canonical vocabulary. Each server may declare multiple tags; an agent includes every registration that shares **any** tag passed to `use_mcp`.
+
+When MCPs are registered, assign **stable bucket tags** so agent classes can opt in without listing every server name—for example `tags: [:connectors, :github]` with `use_mcp :connectors` for all enabled connectors, or `use_mcp :github` for that integration only.
+
+Registrations are **global** (endpoint + tags); **tenant and user** access are enforced in your **`credentials`** proc and whatever you put in **`context`**, not by putting ids on the manifest.
+
+## Opting an Agent In
+
+```ruby
+class ResearchAgent < Riffer::Agent
+  model "openai/gpt-5-mini"
+  instructions "You are a research assistant."
+
+  use_mcp :github
+end
+```
+
+`use_mcp` accepts any tag registered via `Riffer::Mcp.register`. Multiple calls accumulate — the agent receives tools from all matching servers:
+
+```ruby
+class MultiAgent < Riffer::Agent
+  model "openai/gpt-5-mini"
+
+  use_mcp :github
+  use_mcp :jira
+end
+```
+
+MCP tools are appended after any tools declared with `uses_tools`.
+
+Tool names must be unique across `uses_tools` and all included MCP servers; duplicate names raise `Riffer::ArgumentError` when tools are resolved.
+
+### Subclassing
+
+Like [`uses_tools`](03_AGENTS.md#uses_tools), **`use_mcp` is not inherited** from the superclass. Declare `use_mcp` on each agent class that should load MCP tools.
+
+## Handling Pending Servers
+
+Discovery is asynchronous. When an agent runs before a server is ready, the `on_pending` strategy determines what happens:
+
+| Strategy  | Behaviour                                                                                                                                           |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:ignore` | Tools from that server are omitted (default)                                                                                                        |
+| `:wait`   | Blocks until ready; if discovery **failed**, re-raises that exception immediately; if still **pending** until `wait_timeout`, raises `TimeoutError` |
+| `:raise`  | If discovery **failed**, re-raises that exception; if still **pending**, raises `NotReadyError`                                                     |
+
+Set the global default:
+
+```ruby
+Riffer.configure do |config|
+  config.mcp.on_pending = :wait
+  config.mcp.wait_timeout = 30  # seconds
+end
+```
+
+Override per `use_mcp` call:
+
+```ruby
+use_mcp :github, on_pending: :wait
+use_mcp :jira, on_pending: :ignore
+```
+
+## Unregistering a Server
+
+```ruby
+Riffer::Mcp.unregister("github")
+```
+
+Subsequent agent runs will not include tools from that server. Call `register` again (with fresh `discovery_headers` if needed) to re-register.
+
+## Introspection
+
+```ruby
+Riffer::Mcp.registrations
+# => {"github" => #<Riffer::Mcp::Registration ...>, ...}
+
+reg = Riffer::Mcp.registrations["github"]
+reg.ready?   # => true / false
+reg.tools    # => [<Class:...>, ...]  (Riffer::Tool subclasses)
+reg.discovery_error  # => nil if discovery succeeded or still in progress; Exception if discovery failed
+```
+
+If discovery fails (e.g. network error), the registration stays not ready and `reg.discovery_error` holds the exception. Nothing is written to stderr; use `on_pending: :wait` or `:raise` (or call `wait_until_ready!`) to surface the failure as a raised exception.
+
+## Error Classes
+
+| Class                                 | Raised when                                                                                     |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `Riffer::Mcp::NotReadyError`          | `on_pending: :raise` and discovery still in progress (not failed)                               |
+| *(original exception)*                | Discovery failed and `on_pending` is `:wait` or `:raise` (re-raised from `reg.discovery_error`) |
+| `Riffer::Mcp::TimeoutError`           | `on_pending: :wait`, discovery still in progress, and `wait_timeout` exceeded                   |
+| `Riffer::Mcp::CredentialsDeniedError` | `credentials` proc returns `nil` during `tools/call`                                            |
+
+All inherit from `Riffer::Mcp::Error < Riffer::Error`.
+
+## Limitations
+
+- **Tool results:** `tools/call` responses are reduced to joined **text** content from MCP `content` items. Non-text parts (e.g. images, embedded resources) are not surfaced in this release.
+- **Session credentials:** When `Riffer.config.mcp.credentials` is set, authenticated tool wrappers may build a **new HTTP client per tool invocation** so headers stay fresh; there is no connection pooling in this release.
+- **Context window / progressive disclosure:** Discovery registers **all** tools from each server; matching agents see the full set in one shot. There is no built-in lazy listing or prompt-size budgeting yet. Tighter control may require application-level filtering, MCP server design, or future Riffer APIs.
+
+## Requirements
+
+The `mcp` and `faraday` gems are **optional** dependencies — they are not included in Riffer's runtime gemspec. To use MCP integration, add both to your own Gemfile:
+
+```ruby
+gem "mcp"
+gem "faraday"
+```
+
+Faraday is required for the MCP HTTP transport. If either gem is missing when `Riffer::Mcp.register` is called, a `Riffer::DependencyError` is raised.

--- a/docs/14_MCP.md
+++ b/docs/14_MCP.md
@@ -19,7 +19,7 @@ Riffer::Mcp.register(
 )
 ```
 
-`register` returns immediately. Tool discovery runs in a background thread. Use `on_pending` (see below) to control agent behaviour while discovery is in progress.
+`register` blocks until tool discovery completes (or fails). Discovery uses the configured `Riffer::Runner` (default `Runner::Sequential` — inline). To run discovery on a pool thread (e.g. for Rails connection-pool isolation), set `config.mcp.discovery_runner = Riffer::Runner::Threaded.new`; `register` still blocks but the work runs off the calling thread.
 
 ### Discovery headers
 
@@ -90,32 +90,6 @@ Tool names must be unique across `uses_tools` and all included MCP servers; dupl
 
 Like [`uses_tools`](03_AGENTS.md#uses_tools), **`use_mcp` is not inherited** from the superclass. Declare `use_mcp` on each agent class that should load MCP tools.
 
-## Handling Pending Servers
-
-Discovery is asynchronous. When an agent runs before a server is ready, the `on_pending` strategy determines what happens:
-
-| Strategy  | Behaviour                                                                                                                                           |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:ignore` | Tools from that server are omitted (default)                                                                                                        |
-| `:wait`   | Blocks until ready; if discovery **failed**, re-raises that exception immediately; if still **pending** until `wait_timeout`, raises `TimeoutError` |
-| `:raise`  | If discovery **failed**, re-raises that exception; if still **pending**, raises `NotReadyError`                                                     |
-
-Set the global default:
-
-```ruby
-Riffer.configure do |config|
-  config.mcp.on_pending = :wait
-  config.mcp.wait_timeout = 30  # seconds
-end
-```
-
-Override per `use_mcp` call:
-
-```ruby
-use_mcp :github, on_pending: :wait
-use_mcp :jira, on_pending: :ignore
-```
-
 ## Unregistering a Server
 
 ```ruby
@@ -131,21 +105,24 @@ Riffer::Mcp.registrations
 # => {"github" => #<Riffer::Mcp::Registration ...>, ...}
 
 reg = Riffer::Mcp.registrations["github"]
-reg.ready?   # => true / false
 reg.tools    # => [<Class:...>, ...]  (Riffer::Tool subclasses)
-reg.discovery_error  # => nil if discovery succeeded or still in progress; Exception if discovery failed
 ```
 
-If discovery fails (e.g. network error), the registration stays not ready and `reg.discovery_error` holds the exception. Nothing is written to stderr; use `on_pending: :wait` or `:raise` (or call `wait_until_ready!`) to surface the failure as a raised exception.
+Discovery failures raise from `register` directly, typically `Faraday::Error` for network issues or `Riffer::DependencyError` if the `mcp`/`faraday` gems are missing. Rescue `StandardError` for graceful degradation:
+
+```ruby
+begin
+  Riffer::Mcp.register(name: "github", ...)
+rescue StandardError => e
+  Rails.logger.warn("MCP registration failed: #{e.message}")
+end
+```
 
 ## Error Classes
 
-| Class                                 | Raised when                                                                                     |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `Riffer::Mcp::NotReadyError`          | `on_pending: :raise` and discovery still in progress (not failed)                               |
-| *(original exception)*                | Discovery failed and `on_pending` is `:wait` or `:raise` (re-raised from `reg.discovery_error`) |
-| `Riffer::Mcp::TimeoutError`           | `on_pending: :wait`, discovery still in progress, and `wait_timeout` exceeded                   |
-| `Riffer::Mcp::CredentialsDeniedError` | `credentials` proc returns `nil` during `tools/call`                                            |
+| Class                                 | Raised when                                          |
+| ------------------------------------- | ---------------------------------------------------- |
+| `Riffer::Mcp::CredentialsDeniedError` | `credentials` proc returns `nil` during `tools/call` |
 
 All inherit from `Riffer::Mcp::Error < Riffer::Error`.
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -176,13 +176,11 @@ class Riffer::Agent
   # the given tag(s).
   #
   # +tag+ - a String or Symbol; matched against registration manifest tags.
-  # +on_pending:+ - per-call override for the global +Riffer.config.mcp.on_pending+
-  #   strategy. One of +:ignore+, +:wait+, or +:raise+.
   #
-  #: (String | Symbol, ?on_pending: Symbol?) -> void
-  def self.use_mcp(tag, on_pending: nil)
+  #: (String | Symbol) -> void
+  def self.use_mcp(tag)
     @mcp_configs ||= []
-    @mcp_configs << {tags: [tag.to_sym], on_pending: on_pending}
+    @mcp_configs << {tags: [tag.to_sym]}
   end
 
   # Returns the accumulated +use_mcp+ configurations for this agent class.
@@ -808,36 +806,11 @@ class Riffer::Agent
   def gather_mcp_registrations_with_tags(configs)
     by_reg = {}
     configs.each do |cfg|
-      on_pending = cfg[:on_pending] || Riffer.config.mcp.on_pending
       Riffer::Mcp::Registry.find_by_tags(cfg[:tags]).each do |reg|
-        next unless mcp_registration_ready!(reg, on_pending)
-
         (by_reg[reg] ||= []).concat(cfg[:tags] & reg.manifest.tags)
       end
     end
     by_reg
-  end
-
-  # Returns true if +reg+ is ready for tool resolution (waiting when +on_pending+ is +:wait+).
-  #
-  #: (Riffer::Mcp::Registration, Symbol) -> bool
-  def mcp_registration_ready!(reg, on_pending)
-    return true if reg.ready?
-
-    case on_pending
-    when :ignore
-      false
-    when :wait
-      reg.wait_until_ready!
-      true
-    when :raise
-      if (err = reg.discovery_error)
-        raise err
-      end
-      raise Riffer::Mcp::NotReadyError, "MCP server '#{reg.manifest.name}' is not ready"
-    else
-      raise Riffer::ArgumentError, "Invalid mcp on_pending: #{on_pending.inspect}"
-    end
   end
 
   #: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -172,6 +172,26 @@ class Riffer::Agent
   end
   private_class_method :resolve_uses_tools_config
 
+  # Opts this agent into tools from all MCP registrations that share any of
+  # the given tag(s).
+  #
+  # +tag+ - a String or Symbol; matched against registration manifest tags.
+  # +on_pending:+ - per-call override for the global +Riffer.config.mcp.on_pending+
+  #   strategy. One of +:ignore+, +:wait+, or +:raise+.
+  #
+  #: (String | Symbol, ?on_pending: Symbol?) -> void
+  def self.use_mcp(tag, on_pending: nil)
+    @mcp_configs ||= []
+    @mcp_configs << {tags: [tag.to_sym], on_pending: on_pending}
+  end
+
+  # Returns the accumulated +use_mcp+ configurations for this agent class.
+  #
+  #: () -> Array[Hash[Symbol, untyped]]
+  def self.mcp_configs
+    @mcp_configs || []
+  end
+
   # Gets or sets the tool runtime for this agent.
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
@@ -756,8 +776,94 @@ class Riffer::Agent
 
   #--
   #: () -> Array[singleton(Riffer::Tool)]
+  def resolve_uses_tools_config
+    config = self.class.uses_tools
+
+    if config.nil?
+      []
+    elsif config.is_a?(Proc)
+      (config.arity == 0) ? config.call : config.call(@context)
+    else
+      config
+    end
+  end
+
+  #--
+  #: () -> Array[singleton(Riffer::Tool)]
+  def resolve_mcp_tool_classes
+    configs = self.class.mcp_configs
+    return [] if configs.empty?
+
+    cred = Riffer.config.mcp.credentials
+    ctx = @context
+    gather_mcp_registrations_with_tags(configs).flat_map do |reg, tag_accum|
+      matched_tags = tag_accum.uniq
+      mcp_tools_for_registration(reg, matched_tags, cred, ctx)
+    end
+  end
+
+  # Each matching MCP registration once, with tag symbols unioned across +use_mcp+ rows.
+  #
+  #: (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
+  def gather_mcp_registrations_with_tags(configs)
+    by_reg = {}
+    configs.each do |cfg|
+      on_pending = cfg[:on_pending] || Riffer.config.mcp.on_pending
+      Riffer::Mcp::Registry.find_by_tags(cfg[:tags]).each do |reg|
+        next unless mcp_registration_ready!(reg, on_pending)
+
+        (by_reg[reg] ||= []).concat(cfg[:tags] & reg.manifest.tags)
+      end
+    end
+    by_reg
+  end
+
+  # Returns true if +reg+ is ready for tool resolution (waiting when +on_pending+ is +:wait+).
+  #
+  #: (Riffer::Mcp::Registration, Symbol) -> bool
+  def mcp_registration_ready!(reg, on_pending)
+    return true if reg.ready?
+
+    case on_pending
+    when :ignore
+      false
+    when :wait
+      reg.wait_until_ready!
+      true
+    when :raise
+      if (err = reg.discovery_error)
+        raise err
+      end
+      raise Riffer::Mcp::NotReadyError, "MCP server '#{reg.manifest.name}' is not ready"
+    else
+      raise Riffer::ArgumentError, "Invalid mcp on_pending: #{on_pending.inspect}"
+    end
+  end
+
+  #: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]
+  def mcp_tools_for_registration(reg, matched_tags, cred, ctx)
+    return reg.tools unless cred
+    return [] if cred.call(manifest: reg.manifest, matched_tags: matched_tags, context: ctx).nil?
+    Riffer::Mcp::AuthenticatedTool.wrap_all(reg.tools, reg.manifest, matched_tags)
+  end
+
+  # Raises if two or more tool classes share the same +.name+ (ambiguous dispatch).
+  #
+  #: (Array[singleton(Riffer::Tool)]) -> void
+  def assert_distinct_tool_names!(tool_classes)
+    tally = Hash.new(0) #: Hash[String, Integer]
+    tool_classes.each { |tc| tally[tc.name] += 1 }
+    dupes = tally.filter_map { |name, n| name if n > 1 }
+    return if dupes.empty?
+
+    raise Riffer::ArgumentError, "Duplicate tool names: #{dupes.sort.join(", ")}"
+  end
+
+  #: () -> Array[singleton(Riffer::Tool)]
   def resolved_tools
-    @resolved_tools ||= self.class.resolved_tool_classes(context: @context)
+    @resolved_tools ||= self.class.resolved_tool_classes(context: @context) + resolve_mcp_tool_classes
+    assert_distinct_tool_names!(@resolved_tools)
+    @resolved_tools
   end
 
   #--

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -21,6 +21,7 @@ class Riffer::Config
   Gemini = Struct.new(:api_key, :open_timeout, :read_timeout, keyword_init: true)
   OpenAI = Struct.new(:api_key, keyword_init: true)
   Evals = Struct.new(:judge_model, keyword_init: true)
+  Mcp = Struct.new(:on_pending, :wait_timeout, :credentials, :discovery_thread_factory, keyword_init: true)
 
   # Skills-related global configuration.
   #
@@ -93,6 +94,21 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader :evals #: Riffer::Config::Evals
 
+  # MCP configuration (Struct with +on_pending+, +wait_timeout+, +credentials+,
+  # +discovery_thread_factory+).
+  #
+  # +on_pending+ controls agent behaviour when an MCP server has not finished
+  # discovery: +:ignore+ (default) skips the server, +:wait+ blocks until ready,
+  # +:raise+ raises Riffer::Mcp::NotReadyError.
+  #
+  # +wait_timeout+ is the maximum seconds to wait when +on_pending: :wait+.
+  #
+  # +credentials+ is an optional Proc for per-run MCP +tools/call+ HTTP headers.
+  # Signature: +->(manifest:, matched_tags:, context:) { Hash or nil }+.
+  # +nil+ from the proc at tool-resolution time omits that server's tools; +nil+
+  # at tool-call time raises Riffer::Mcp::CredentialsDeniedError.
+  attr_reader :mcp #: Riffer::Config::Mcp
+
   # Global tool runtime configuration (experimental).
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
@@ -148,6 +164,8 @@ class Riffer::Config
     @gemini = Gemini.new
     @openai = OpenAI.new
     @evals = Evals.new
+    @mcp = Mcp.new(on_pending: :ignore, wait_timeout: 10, credentials: nil,
+      discovery_thread_factory: ->(&block) { Thread.new(&block) })
     @tool_runtime = Riffer::ToolRuntime::Inline.new
     @skills = Skills.new
     @message_id_strategy = :none

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -21,7 +21,7 @@ class Riffer::Config
   Gemini = Struct.new(:api_key, :open_timeout, :read_timeout, keyword_init: true)
   OpenAI = Struct.new(:api_key, keyword_init: true)
   Evals = Struct.new(:judge_model, keyword_init: true)
-  Mcp = Struct.new(:on_pending, :wait_timeout, :credentials, :discovery_thread_factory, keyword_init: true)
+  Mcp = Struct.new(:credentials, :discovery_runner, keyword_init: true)
 
   # Skills-related global configuration.
   #
@@ -94,19 +94,15 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader :evals #: Riffer::Config::Evals
 
-  # MCP configuration (Struct with +on_pending+, +wait_timeout+, +credentials+,
-  # +discovery_thread_factory+).
-  #
-  # +on_pending+ controls agent behaviour when an MCP server has not finished
-  # discovery: +:ignore+ (default) skips the server, +:wait+ blocks until ready,
-  # +:raise+ raises Riffer::Mcp::NotReadyError.
-  #
-  # +wait_timeout+ is the maximum seconds to wait when +on_pending: :wait+.
+  # MCP configuration (Struct with +credentials+ and +discovery_runner+).
   #
   # +credentials+ is an optional Proc for per-run MCP +tools/call+ HTTP headers.
   # Signature: +->(manifest:, matched_tags:, context:) { Hash or nil }+.
   # +nil+ from the proc at tool-resolution time omits that server's tools; +nil+
   # at tool-call time raises Riffer::Mcp::CredentialsDeniedError.
+  #
+  # +discovery_runner+ is the Riffer::Runner used to execute tool discovery
+  # (default +Runner::Sequential+).
   attr_reader :mcp #: Riffer::Config::Mcp
 
   # Global tool runtime configuration (experimental).
@@ -164,8 +160,7 @@ class Riffer::Config
     @gemini = Gemini.new
     @openai = OpenAI.new
     @evals = Evals.new
-    @mcp = Mcp.new(on_pending: :ignore, wait_timeout: 10, credentials: nil,
-      discovery_thread_factory: ->(&block) { Thread.new(&block) })
+    @mcp = Mcp.new(credentials: nil, discovery_runner: Riffer::Runner::Sequential.new)
     @tool_runtime = Riffer::ToolRuntime::Inline.new
     @skills = Skills.new
     @message_id_strategy = :none

--- a/lib/riffer/mcp.rb
+++ b/lib/riffer/mcp.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Riffer::Mcp provides integration with Model Context Protocol (MCP) servers.
+#
+# Register MCP servers globally; agents opt-in by tag via the +use_mcp+ DSL.
+# Tags are application-defined; see +docs/14_MCP.md+ (Tags section).
+#
+#   Riffer::Mcp.register(
+#     name: "github",
+#     tags: [:github],
+#     endpoint: "https://mcp.github.com",
+#     discovery_headers: -> { {"Authorization" => "Bearer #{ENV['GITHUB_TOKEN']}"} }
+#   )
+#
+#   class MyAgent < Riffer::Agent
+#     model "openai/gpt-4o"
+#     use_mcp :github
+#   end
+#
+module Riffer::Mcp
+  # Base error for all MCP-related failures.
+  class Error < Riffer::Error; end
+
+  # Raised when an agent attempts to use an MCP server that has not finished
+  # discovery and the +:raise+ on_pending strategy is configured.
+  class NotReadyError < Error; end
+
+  # Raised when +wait_until_ready!+ exceeds +Riffer.config.mcp.wait_timeout+.
+  class TimeoutError < Error; end
+
+  # Raised when +Riffer.config.mcp.credentials+ returns +nil+ during +tools/call+
+  # after the server's tools were included for this run.
+  class CredentialsDeniedError < Error; end
+
+  # Registers an MCP server and starts async tool discovery.
+  #
+  # Returns immediately. Pass a +Manifest+ instance or a hash with the same keys.
+  #
+  #--
+  #: ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration
+  def self.register(manifest_or_hash)
+    Registry.register(manifest_or_hash)
+  end
+
+  # Removes a registration by name.
+  #
+  # Subsequent agent runs will not see tools from this server.
+  #
+  #--
+  #: (String) -> void
+  def self.unregister(name)
+    Registry.unregister(name)
+  end
+
+  # Returns all current registrations keyed by name (for introspection).
+  #
+  #--
+  #: () -> Hash[String, Riffer::Mcp::Registration]
+  def self.registrations
+    Registry.registrations
+  end
+end

--- a/lib/riffer/mcp.rb
+++ b/lib/riffer/mcp.rb
@@ -22,20 +22,14 @@ module Riffer::Mcp
   # Base error for all MCP-related failures.
   class Error < Riffer::Error; end
 
-  # Raised when an agent attempts to use an MCP server that has not finished
-  # discovery and the +:raise+ on_pending strategy is configured.
-  class NotReadyError < Error; end
-
-  # Raised when +wait_until_ready!+ exceeds +Riffer.config.mcp.wait_timeout+.
-  class TimeoutError < Error; end
-
   # Raised when +Riffer.config.mcp.credentials+ returns +nil+ during +tools/call+
   # after the server's tools were included for this run.
   class CredentialsDeniedError < Error; end
 
-  # Registers an MCP server and starts async tool discovery.
+  # Registers an MCP server, blocking until tool discovery completes.
   #
-  # Returns immediately. Pass a +Manifest+ instance or a hash with the same keys.
+  # Raises on discovery failure. Pass a +Manifest+ instance or a hash with
+  # the same keys.
   #
   #--
   #: ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration

--- a/lib/riffer/mcp/authenticated_tool.rb
+++ b/lib/riffer/mcp/authenticated_tool.rb
@@ -26,6 +26,7 @@ module Riffer::Mcp::AuthenticatedTool
       @identifier = inner.identifier
 
       define_singleton_method(:name) { inner.name }
+      define_singleton_method(:mcp_server_tool_name) { inner.mcp_server_tool_name }
       define_singleton_method(:description) { inner.description }
       define_singleton_method(:parameters_schema) { |strict: false| inner.parameters_schema(strict: strict) }
 
@@ -57,7 +58,7 @@ module Riffer::Mcp::AuthenticatedTool
         end
 
         client = build_call_client(man.endpoint, headers)
-        text(client.tools_call(inner.name, kwargs))
+        text(client.tools_call(inner.mcp_server_tool_name, kwargs))
       end
     end
   end

--- a/lib/riffer/mcp/authenticated_tool.rb
+++ b/lib/riffer/mcp/authenticated_tool.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Wraps MCP-generated tool classes so +tools/call+ uses +Riffer.config.mcp.credentials+
+# per invocation while delegating metadata to the inner class.
+#
+module Riffer::Mcp::AuthenticatedTool
+  # Returns one wrapper class per inner tool, sharing +manifest+ and +matched_tags+.
+  #
+  #--
+  #: (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
+  def self.wrap_all(tool_classes, manifest, matched_tags)
+    tool_classes.map { |tc| wrap_one(tc, manifest, matched_tags) }
+  end
+
+  #--
+  #: (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
+  # Class.new(Riffer::Tool) is typed as ::Class by steep — it cannot verify the subtype
+  # relationship for dynamically created anonymous classes, so the ignore is required.
+  def self.wrap_one(inner_class, manifest, matched_tags) # steep:ignore MethodBodyTypeMismatch
+    inner = inner_class
+    man = manifest
+    tags = matched_tags
+
+    Class.new(Riffer::Tool) do
+      @identifier = inner.identifier
+
+      define_singleton_method(:name) { inner.name }
+      define_singleton_method(:description) { inner.description }
+      define_singleton_method(:parameters_schema) { |strict: false| inner.parameters_schema(strict: strict) }
+
+      # Builds a client for a single +tools/call+ invocation.
+      #
+      # Creates a fresh client per call so headers from the credentials proc stay
+      # current.
+      # TODO: A per-headers cache would reduce connection churn under load, and
+      # requires a follow-up investigation to determine how to invalidate failing
+      # clients.
+      define_method(:build_call_client) do |endpoint, headers|
+        Riffer::Mcp::Client.new(endpoint: endpoint, headers: headers)
+      end
+      private :build_call_client
+
+      define_method(:call) do |context:, **kwargs|
+        cred = Riffer.config.mcp.credentials
+        unless cred
+          # `next` rather than `return`: inside define_method the block IS the method
+          # body, so both exit :call identically at runtime. `next` avoids a false
+          # steep ReturnTypeMismatch that would otherwise need a steep:ignore.
+          next inner.new.call(context: context, **kwargs)
+        end
+
+        headers = cred.call(manifest: man, matched_tags: tags, context: context)
+        if headers.nil?
+          raise Riffer::Mcp::CredentialsDeniedError,
+            "MCP credentials returned nil for server '#{man.name}' during tools/call"
+        end
+
+        client = build_call_client(man.endpoint, headers)
+        text(client.tools_call(inner.name, kwargs))
+      end
+    end
+  end
+end

--- a/lib/riffer/mcp/client.rb
+++ b/lib/riffer/mcp/client.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Thin wrapper around the MCP Ruby SDK client (mcp gem v0.8+).
+#
+# Resolves headers (if a Proc) once at initialization, then provides
+# +tools_list+ and +tools_call+. Used for discovery (+Manifest#discovery_headers+)
+# and for +tools/call+ when no +credentials+ proc is configured.
+#
+# MCP gem API used:
+#   MCP::Client::HTTP.new(url:, headers:)  — HTTP transport (requires faraday)
+#   MCP::Client.new(transport:)            — client
+#   client.tools                           — Array<MCP::Client::Tool>
+#   client.call_tool(tool:, arguments:)    — raw JSON-RPC response Hash
+#
+class Riffer::Mcp::Client
+  include Riffer::Helpers::Dependencies
+
+  #--
+  #: (endpoint: String, ?headers: (Hash[String, String] | Proc), ?client: untyped?) -> void
+  def initialize(endpoint:, headers: {}, client: nil)
+    depends_on "mcp"
+    depends_on "faraday"
+
+    @client = client || begin
+      resolved_headers = headers.is_a?(Proc) ? headers.call : headers
+      transport = MCP::Client::HTTP.new(url: endpoint, headers: resolved_headers)
+      MCP::Client.new(transport: transport)
+    end
+  end
+
+  # Returns an array of tool definition hashes, each with +:name+, +:description+,
+  # and +:input_schema+ keys.
+  #
+  #--
+  #: () -> Array[Hash[Symbol, untyped]]
+  def tools_list
+    @client.tools.map do |tool|
+      {
+        name: tool.name,
+        description: tool.description,
+        input_schema: tool.input_schema
+      }
+    end
+  end
+
+  # Calls a tool on the MCP server and returns joined text content from the response.
+  #
+  #--
+  #: (String, ?Hash[untyped, untyped]) -> String
+  def tools_call(name, arguments = {})
+    tool = MCP::Client::Tool.new(name: name, description: nil, input_schema: nil)
+    response = @client.call_tool(tool: tool, arguments: arguments)
+
+    if response["error"]
+      raise Riffer::Error, response.dig("error", "message") || "MCP tool call failed"
+    end
+
+    if response.dig("result", "isError")
+      message = (response.dig("result", "content") || []).filter_map { |item| item["text"] }.join
+      raise Riffer::Error, message.empty? ? "MCP tool '#{name}' failed" : message
+    end
+
+    content = response.dig("result", "content") || []
+    content.filter_map { |item| item["text"] }.join
+  end
+end

--- a/lib/riffer/mcp/manifest.rb
+++ b/lib/riffer/mcp/manifest.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "uri"
+
+# Riffer::Mcp::Manifest holds the configuration for a single MCP server.
+#
+# +name+                - String identifier used as the registration key and generated-agent identifier.
+# +tags+                - Array[Symbol]; normalized to symbols at construction time.
+# +endpoint+            - String HTTPS URL passed to the MCP transport.
+# +discovery_headers+   - Hash or Proc; resolved once when building the discovery client for +tools/list+.
+# +credentials_scope+  - Optional symbol hint: +:global+, +:tenant+, +:user+ — documents whether
+#   invocation credentials are expected to depend on tenant and/or user keys in +context+ (no ids stored).
+#   Apps may treat +:user+ as "user in tenant" and pass both keys in +context+.
+#
+class Riffer::Mcp::Manifest
+  attr_reader :name #: String
+  attr_reader :tags #: Array[Symbol]
+  attr_reader :endpoint #: String
+  attr_reader :discovery_headers #: (Hash[String, untyped] | ::Proc)?
+  attr_reader :credentials_scope #: Symbol?
+
+  #--
+  #: (name: String, endpoint: String, ?tags: Array[untyped]?, ?discovery_headers: (Hash[String, untyped] | ::Proc)?, ?credentials_scope: (String | Symbol)?) -> void
+  def initialize(name:, endpoint:, tags: nil, discovery_headers: nil, credentials_scope: nil)
+    @name = name.to_s.strip
+    raise Riffer::ArgumentError, "MCP manifest name is required" if @name.empty?
+
+    @endpoint = endpoint.to_s.strip
+    raise Riffer::ArgumentError, "MCP manifest endpoint must be a valid HTTPS URL" unless valid_endpoint?
+
+    @tags = Array(tags).map(&:to_sym)
+    @discovery_headers = discovery_headers
+    @credentials_scope = credentials_scope&.to_sym
+  end
+
+  private
+
+  def valid_endpoint?
+    uri = URI.parse(@endpoint)
+    uri.is_a?(URI::HTTPS) && uri.host
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/lib/riffer/mcp/registration.rb
+++ b/lib/riffer/mcp/registration.rb
@@ -59,7 +59,7 @@ class Riffer::Mcp::Registration
     Riffer.config.mcp.discovery_runner.map([nil], context: nil) do |_|
       client = build_client
       tool_defs = client.tools_list
-      tools = Riffer::Mcp::ToolFactory.build(client, tool_defs)
+      tools = Riffer::Mcp::ToolFactory.build(@manifest.name, client, tool_defs)
 
       @mutex.synchronize do
         next if @cancelled

--- a/lib/riffer/mcp/registration.rb
+++ b/lib/riffer/mcp/registration.rb
@@ -3,14 +3,14 @@
 
 # Per-server state managed by Riffer::Mcp::Registry.
 #
-# Created when a server is registered. Spawns a background thread to discover
-# tools via the MCP +tools/list+ call, then generates tool classes.
+# Created when a server is registered. Discovers tools via the MCP
+# +tools/list+ call, then generates tool classes.
 #
 class Riffer::Mcp::Registration
   # The manifest that describes this server.
   attr_reader :manifest #: Riffer::Mcp::Manifest
 
-  # Generated Riffer::Tool subclasses (empty until discovery completes).
+  # Generated Riffer::Tool subclasses.
   #
   #--
   #: () -> Array[singleton(Riffer::Tool)]
@@ -18,43 +18,23 @@ class Riffer::Mcp::Registration
     @mutex.synchronize { @tools }
   end
 
-  # Exception from failed tool discovery, or +nil+ if discovery succeeded or is still in progress.
-  #
-  #--
-  #: () -> Exception?
-  def discovery_error
-    @mutex.synchronize { @discovery_error }
-  end
-
   #--
   #: (Riffer::Mcp::Manifest) -> void
   def initialize(manifest)
     @manifest = manifest
-    @ready = false
     @cancelled = false
     @tools = []
-    @discovery_error = nil
-    @discovery_thread = nil
     @mutex = Mutex.new
-    spawn_discovery_thread
+    run_discovery
   end
 
-  # Retires this registration, preventing the discovery thread from publishing
-  # state and killing it if still running.
+  # Retires this registration, preventing in-flight discovery from publishing
+  # state.
   #
   #--
   #: () -> void
   def retire!
     @mutex.synchronize { @cancelled = true }
-    @discovery_thread&.kill
-  end
-
-  # Returns true once tool discovery has completed successfully.
-  #
-  #--
-  #: () -> bool
-  def ready?
-    @mutex.synchronize { @ready }
   end
 
   # Returns true if this registration has been retired.
@@ -65,38 +45,18 @@ class Riffer::Mcp::Registration
     @mutex.synchronize { @cancelled }
   end
 
-  # Blocks the calling thread until this registration is ready or the timeout elapses.
+  private
+
+  # Runs tool discovery using the configured Runner.
   #
-  # If tool discovery failed in the background thread, re-raises that exception
-  # immediately (no wait for +wait_timeout+).
-  #
-  # Raises Riffer::Mcp::TimeoutError if discovery is still in progress and
-  # +Riffer.config.mcp.wait_timeout+ seconds pass without becoming ready.
+  # With +Runner::Sequential+ (default) discovery blocks inline. With
+  # +Runner::Threaded+ discovery runs on a pool thread but +map+ still
+  # blocks the caller — useful for Rails connection-pool isolation.
   #
   #--
   #: () -> void
-  def wait_until_ready!
-    deadline = Time.now + Riffer.config.mcp.wait_timeout
-    loop do
-      return if ready?
-      err = discovery_error
-      raise err if err
-      raise Riffer::Mcp::TimeoutError, "MCP server '#{@manifest.name}' did not become ready within #{Riffer.config.mcp.wait_timeout}s" if Time.now >= deadline
-      sleep 0.05
-    end
-  end
-
-  private
-
-  # Discovery is a one-shot background init task, not concurrent tool execution
-  # during an agent run, so ToolRuntime does not apply. The factory is exposed
-  # for environments where raw Thread.new has side effects (e.g. connection pool
-  # inheritance in Rails).
-  #
-  #--
-  #: () -> Thread
-  def spawn_discovery_thread
-    @discovery_thread = Riffer.config.mcp.discovery_thread_factory.call do
+  def run_discovery
+    Riffer.config.mcp.discovery_runner.map([nil], context: nil) do |_|
       client = build_client
       tool_defs = client.tools_list
       tools = Riffer::Mcp::ToolFactory.build(client, tool_defs)
@@ -104,14 +64,7 @@ class Riffer::Mcp::Registration
       @mutex.synchronize do
         next if @cancelled
         @tools = tools.freeze
-        @ready = true
       end
-    rescue => e
-      @mutex.synchronize do
-        next if @cancelled
-        @discovery_error = e
-      end
-      # Leave @ready = false — callers apply the on_pending strategy
     end
   end
 

--- a/lib/riffer/mcp/registration.rb
+++ b/lib/riffer/mcp/registration.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Per-server state managed by Riffer::Mcp::Registry.
+#
+# Created when a server is registered. Spawns a background thread to discover
+# tools via the MCP +tools/list+ call, then generates tool classes.
+#
+class Riffer::Mcp::Registration
+  # The manifest that describes this server.
+  attr_reader :manifest #: Riffer::Mcp::Manifest
+
+  # Generated Riffer::Tool subclasses (empty until discovery completes).
+  #
+  #--
+  #: () -> Array[singleton(Riffer::Tool)]
+  def tools
+    @mutex.synchronize { @tools }
+  end
+
+  # Exception from failed tool discovery, or +nil+ if discovery succeeded or is still in progress.
+  #
+  #--
+  #: () -> Exception?
+  def discovery_error
+    @mutex.synchronize { @discovery_error }
+  end
+
+  #--
+  #: (Riffer::Mcp::Manifest) -> void
+  def initialize(manifest)
+    @manifest = manifest
+    @ready = false
+    @cancelled = false
+    @tools = []
+    @discovery_error = nil
+    @discovery_thread = nil
+    @mutex = Mutex.new
+    spawn_discovery_thread
+  end
+
+  # Retires this registration, preventing the discovery thread from publishing
+  # state and killing it if still running.
+  #
+  #--
+  #: () -> void
+  def retire!
+    @mutex.synchronize { @cancelled = true }
+    @discovery_thread&.kill
+  end
+
+  # Returns true once tool discovery has completed successfully.
+  #
+  #--
+  #: () -> bool
+  def ready?
+    @mutex.synchronize { @ready }
+  end
+
+  # Returns true if this registration has been retired.
+  #
+  #--
+  #: () -> bool
+  def retired?
+    @mutex.synchronize { @cancelled }
+  end
+
+  # Blocks the calling thread until this registration is ready or the timeout elapses.
+  #
+  # If tool discovery failed in the background thread, re-raises that exception
+  # immediately (no wait for +wait_timeout+).
+  #
+  # Raises Riffer::Mcp::TimeoutError if discovery is still in progress and
+  # +Riffer.config.mcp.wait_timeout+ seconds pass without becoming ready.
+  #
+  #--
+  #: () -> void
+  def wait_until_ready!
+    deadline = Time.now + Riffer.config.mcp.wait_timeout
+    loop do
+      return if ready?
+      err = discovery_error
+      raise err if err
+      raise Riffer::Mcp::TimeoutError, "MCP server '#{@manifest.name}' did not become ready within #{Riffer.config.mcp.wait_timeout}s" if Time.now >= deadline
+      sleep 0.05
+    end
+  end
+
+  private
+
+  # Discovery is a one-shot background init task, not concurrent tool execution
+  # during an agent run, so ToolRuntime does not apply. The factory is exposed
+  # for environments where raw Thread.new has side effects (e.g. connection pool
+  # inheritance in Rails).
+  #
+  #--
+  #: () -> Thread
+  def spawn_discovery_thread
+    @discovery_thread = Riffer.config.mcp.discovery_thread_factory.call do
+      client = build_client
+      tool_defs = client.tools_list
+      tools = Riffer::Mcp::ToolFactory.build(client, tool_defs)
+
+      @mutex.synchronize do
+        next if @cancelled
+        @tools = tools.freeze
+        @ready = true
+      end
+    rescue => e
+      @mutex.synchronize do
+        next if @cancelled
+        @discovery_error = e
+      end
+      # Leave @ready = false — callers apply the on_pending strategy
+    end
+  end
+
+  #--
+  #: () -> Riffer::Mcp::Client
+  def build_client
+    Riffer::Mcp::Client.new(endpoint: @manifest.endpoint, headers: @manifest.discovery_headers || {})
+  end
+end

--- a/lib/riffer/mcp/registry.rb
+++ b/lib/riffer/mcp/registry.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Thread-safe global store for MCP server registrations.
+#
+# Keyed by manifest name. All public methods are mutex-guarded.
+#
+module Riffer::Mcp::Registry
+  @mutex = Mutex.new
+  @store = {} #: Hash[String, Riffer::Mcp::Registration]
+
+  class << self
+    # Registers an MCP server and starts async tool discovery.
+    #
+    # Accepts a Manifest instance or a hash of manifest keyword arguments.
+    # Replaces any existing registration with the same name.
+    #
+    #--
+    #: ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration
+    def register(manifest_or_hash)
+      manifest = manifest_or_hash.is_a?(Riffer::Mcp::Manifest) ? manifest_or_hash : Riffer::Mcp::Manifest.new(**manifest_or_hash)
+      registration = Riffer::Mcp::Registration.new(manifest)
+      old = @mutex.synchronize do
+        previous = @store[manifest.name]
+        @store[manifest.name] = registration
+        previous
+      end
+      old&.retire!
+      registration
+    end
+
+    # Removes a registration by name.
+    #
+    #--
+    #: ((String | Symbol)) -> void
+    def unregister(name)
+      removed = @mutex.synchronize { @store.delete(name.to_s) }
+      removed&.retire!
+    end
+
+    # Returns a frozen snapshot of all current registrations.
+    #
+    #--
+    #: () -> Hash[String, Riffer::Mcp::Registration]
+    def registrations
+      @mutex.synchronize { @store.dup.freeze }
+    end
+
+    # Returns all registrations whose manifest tags intersect with the given tags.
+    #
+    # Tags are normalized to symbols before matching.
+    #
+    #--
+    #: (Array[Symbol]) -> Array[Riffer::Mcp::Registration]
+    def find_by_tags(tags)
+      normalized = tags.map(&:to_sym)
+      @mutex.synchronize do
+        @store.values.select { |reg| (reg.manifest.tags & normalized).any? }
+      end
+    end
+  end
+end

--- a/lib/riffer/mcp/tool_factory.rb
+++ b/lib/riffer/mcp/tool_factory.rb
@@ -11,29 +11,41 @@
 module Riffer::Mcp::ToolFactory
   # Builds one Riffer::Tool subclass per tool definition.
   #
+  # Tool names are prefixed with the manifest name to avoid collisions
+  # across MCP servers (e.g. +"jira__search"+). The original server-side
+  # name is available via +.mcp_server_tool_name+.
+  #
   #--
-  #: (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
-  def self.build(client, tool_defs)
-    tool_defs.map { |td| build_tool_class(client, td) }
+  #: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  def self.build(manifest_name, client, tool_defs)
+    tool_defs.map { |td| build_tool_class(manifest_name, client, td) }
   end
 
-  private_class_method def self.build_tool_class(client, td)
+  # Replaces characters that are unsafe in LLM tool names.
+  #: (String) -> String
+  def self.sanitize_name_component(str)
+    str.gsub(/[^a-zA-Z0-9_-]/, "_")
+  end
+  private_class_method :sanitize_name_component
+
+  private_class_method def self.build_tool_class(manifest_name, client, td)
+    prefixed = "#{sanitize_name_component(manifest_name)}__#{sanitize_name_component(td[:name])}"
+
     Class.new(Riffer::Tool) do
       @mcp_client = client
-      @mcp_tool_name = td[:name]
+      @mcp_server_tool_name = td[:name]
       # Set @identifier directly so .identifier does not fall back to
       # class_name_to_path(nil) on this anonymous class.
-      @identifier = td[:name]
+      @identifier = prefixed
 
-      define_singleton_method(:name) { td[:name] }
+      define_singleton_method(:name) { prefixed }
+      define_singleton_method(:mcp_server_tool_name) { td[:name] }
       define_singleton_method(:description) { td[:description] }
-      # Pass the MCP inputSchema through without strict transforms.
-      # MCP servers are expected to return strict-compatible schemas already.
       define_singleton_method(:parameters_schema) { |strict: false| td[:input_schema] || Riffer::Tool.send(:empty_schema) }
 
       define_method(:call) do |context:, **kwargs|
         result = self.class.instance_variable_get(:@mcp_client).tools_call(
-          self.class.instance_variable_get(:@mcp_tool_name), kwargs
+          self.class.instance_variable_get(:@mcp_server_tool_name), kwargs
         )
         text(result)
       end

--- a/lib/riffer/mcp/tool_factory.rb
+++ b/lib/riffer/mcp/tool_factory.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Generates anonymous Riffer::Tool subclasses from MCP tool definitions.
+#
+# Each generated class:
+# - Has +.name+, +.description+, and +.parameters_schema+ derived from the MCP tool definition.
+# - Delegates +#call+ to the MCP client's +tools_call+ method.
+# - Skips Riffer's param validation — the MCP server validates inputs.
+#
+module Riffer::Mcp::ToolFactory
+  # Builds one Riffer::Tool subclass per tool definition.
+  #
+  #--
+  #: (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  def self.build(client, tool_defs)
+    tool_defs.map { |td| build_tool_class(client, td) }
+  end
+
+  private_class_method def self.build_tool_class(client, td)
+    Class.new(Riffer::Tool) do
+      @mcp_client = client
+      @mcp_tool_name = td[:name]
+      # Set @identifier directly so .identifier does not fall back to
+      # class_name_to_path(nil) on this anonymous class.
+      @identifier = td[:name]
+
+      define_singleton_method(:name) { td[:name] }
+      define_singleton_method(:description) { td[:description] }
+      # Pass the MCP inputSchema through without strict transforms.
+      # MCP servers are expected to return strict-compatible schemas already.
+      define_singleton_method(:parameters_schema) { |strict: false| td[:input_schema] || Riffer::Tool.send(:empty_schema) }
+
+      define_method(:call) do |context:, **kwargs|
+        result = self.class.instance_variable_get(:@mcp_client).tools_call(
+          self.class.instance_variable_get(:@mcp_tool_name), kwargs
+        )
+        text(result)
+      end
+    end
+  end
+end

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -43,6 +43,8 @@ Gem::Specification.new do |spec|
   # Development dependencies
   spec.add_development_dependency "anthropic", "~> 1.36.0"
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.42"
+  spec.add_development_dependency "faraday", ">= 1.0"
+  spec.add_development_dependency "mcp", "~> 0.8"
   spec.add_development_dependency "openai", "~> 0.59.0"
   spec.add_development_dependency "async", "~> 2.25", "< 2.40"
   spec.add_development_dependency "io-event", "< 1.16"

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -113,6 +113,21 @@ class Riffer::Agent
   # : (Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
   def self.resolve_uses_tools_config: (Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
 
+  # Opts this agent into tools from all MCP registrations that share any of
+  # the given tag(s).
+  #
+  # +tag+ - a String or Symbol; matched against registration manifest tags.
+  # +on_pending:+ - per-call override for the global +Riffer.config.mcp.on_pending+
+  #   strategy. One of +:ignore+, +:wait+, or +:raise+.
+  #
+  # : (String | Symbol, ?on_pending: Symbol?) -> void
+  def self.use_mcp: (String | Symbol, ?on_pending: Symbol?) -> void
+
+  # Returns the accumulated +use_mcp+ configurations for this agent class.
+  #
+  # : () -> Array[Hash[Symbol, untyped]]
+  def self.mcp_configs: () -> Array[Hash[Symbol, untyped]]
+
   # Gets or sets the tool runtime for this agent.
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
@@ -351,7 +366,33 @@ class Riffer::Agent
   # : () -> String
   def resolve_model: () -> String
 
+  # Returns tools from +uses_tools+ only (static array or Proc result).
   # --
+  # : () -> Array[singleton(Riffer::Tool)]
+  def resolve_uses_tools_config: () -> Array[singleton(Riffer::Tool)]
+
+  # --
+  # : () -> Array[singleton(Riffer::Tool)]
+  def resolve_mcp_tool_classes: () -> Array[singleton(Riffer::Tool)]
+
+  # Each matching MCP registration once, with tag symbols unioned across +use_mcp+ rows.
+  #
+  # : (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
+  def gather_mcp_registrations_with_tags: (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
+
+  # Returns true if +reg+ is ready for tool resolution (waiting when +on_pending+ is +:wait+).
+  #
+  # : (Riffer::Mcp::Registration, Symbol) -> bool
+  def mcp_registration_ready!: (Riffer::Mcp::Registration, Symbol) -> bool
+
+  # : (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]
+  def mcp_tools_for_registration: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]
+
+  # Raises if two or more tool classes share the same +.name+ (ambiguous dispatch).
+  #
+  # : (Array[singleton(Riffer::Tool)]) -> void
+  def assert_distinct_tool_names!: (Array[singleton(Riffer::Tool)]) -> void
+
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]
 

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -117,11 +117,9 @@ class Riffer::Agent
   # the given tag(s).
   #
   # +tag+ - a String or Symbol; matched against registration manifest tags.
-  # +on_pending:+ - per-call override for the global +Riffer.config.mcp.on_pending+
-  #   strategy. One of +:ignore+, +:wait+, or +:raise+.
   #
-  # : (String | Symbol, ?on_pending: Symbol?) -> void
-  def self.use_mcp: (String | Symbol, ?on_pending: Symbol?) -> void
+  # : (String | Symbol) -> void
+  def self.use_mcp: (String | Symbol) -> void
 
   # Returns the accumulated +use_mcp+ configurations for this agent class.
   #
@@ -366,7 +364,6 @@ class Riffer::Agent
   # : () -> String
   def resolve_model: () -> String
 
-  # Returns tools from +uses_tools+ only (static array or Proc result).
   # --
   # : () -> Array[singleton(Riffer::Tool)]
   def resolve_uses_tools_config: () -> Array[singleton(Riffer::Tool)]
@@ -379,11 +376,6 @@ class Riffer::Agent
   #
   # : (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
   def gather_mcp_registrations_with_tags: (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
-
-  # Returns true if +reg+ is ready for tool resolution (waiting when +on_pending+ is +:wait+).
-  #
-  # : (Riffer::Mcp::Registration, Symbol) -> bool
-  def mcp_registration_ready!: (Riffer::Mcp::Registration, Symbol) -> bool
 
   # : (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]
   def mcp_tools_for_registration: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Hash[Symbol, untyped]) -> Array[singleton(Riffer::Tool)]

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -63,6 +63,15 @@ class Riffer::Config
                 | ({ ?judge_model: untyped }) -> instance
   end
 
+  class Mcp < Struct[untyped]
+    attr_accessor credentials(): untyped
+
+    attr_accessor discovery_runner(): untyped
+
+    def self.new: (?credentials: untyped, ?discovery_runner: untyped) -> instance
+                | ({ ?credentials: untyped, ?discovery_runner: untyped }) -> instance
+  end
+
   # Skills-related global configuration.
   #
   # See <tt>Riffer.config.skills.default_activate_tool</tt> and
@@ -104,19 +113,6 @@ class Riffer::Config
     def default_backend=: ((Riffer::Skills::Backend | Proc)?) -> void
   end
 
-  class Mcp < Struct[untyped]
-    attr_accessor on_pending(): untyped
-
-    attr_accessor wait_timeout(): untyped
-
-    attr_accessor credentials(): untyped
-
-    attr_accessor discovery_thread_factory(): untyped
-
-    def self.new: (?on_pending: untyped, ?wait_timeout: untyped, ?credentials: untyped, ?discovery_thread_factory: untyped) -> instance
-                | ({ ?on_pending: untyped, ?wait_timeout: untyped, ?credentials: untyped, ?discovery_thread_factory: untyped }) -> instance
-  end
-
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
@@ -137,19 +133,15 @@ class Riffer::Config
   # Evals configuration (Struct with +judge_model+).
   attr_reader evals: Riffer::Config::Evals
 
-  # MCP configuration (Struct with +on_pending+, +wait_timeout+, +credentials+,
-  # +discovery_thread_factory+).
-  #
-  # +on_pending+ controls agent behaviour when an MCP server has not finished
-  # discovery: +:ignore+ (default) skips the server, +:wait+ blocks until ready,
-  # +:raise+ raises Riffer::Mcp::NotReadyError.
-  #
-  # +wait_timeout+ is the maximum seconds to wait when +on_pending: :wait+.
+  # MCP configuration (Struct with +credentials+ and +discovery_runner+).
   #
   # +credentials+ is an optional Proc for per-run MCP +tools/call+ HTTP headers.
   # Signature: +->(manifest:, matched_tags:, context:) { Hash or nil }+.
   # +nil+ from the proc at tool-resolution time omits that server's tools; +nil+
   # at tool-call time raises Riffer::Mcp::CredentialsDeniedError.
+  #
+  # +discovery_runner+ is the Riffer::Runner used to execute tool discovery
+  # (default +Runner::Sequential+).
   attr_reader mcp: Riffer::Config::Mcp
 
   # Global tool runtime configuration (experimental).

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -104,6 +104,19 @@ class Riffer::Config
     def default_backend=: ((Riffer::Skills::Backend | Proc)?) -> void
   end
 
+  class Mcp < Struct[untyped]
+    attr_accessor on_pending(): untyped
+
+    attr_accessor wait_timeout(): untyped
+
+    attr_accessor credentials(): untyped
+
+    attr_accessor discovery_thread_factory(): untyped
+
+    def self.new: (?on_pending: untyped, ?wait_timeout: untyped, ?credentials: untyped, ?discovery_thread_factory: untyped) -> instance
+                | ({ ?on_pending: untyped, ?wait_timeout: untyped, ?credentials: untyped, ?discovery_thread_factory: untyped }) -> instance
+  end
+
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
@@ -123,6 +136,21 @@ class Riffer::Config
 
   # Evals configuration (Struct with +judge_model+).
   attr_reader evals: Riffer::Config::Evals
+
+  # MCP configuration (Struct with +on_pending+, +wait_timeout+, +credentials+,
+  # +discovery_thread_factory+).
+  #
+  # +on_pending+ controls agent behaviour when an MCP server has not finished
+  # discovery: +:ignore+ (default) skips the server, +:wait+ blocks until ready,
+  # +:raise+ raises Riffer::Mcp::NotReadyError.
+  #
+  # +wait_timeout+ is the maximum seconds to wait when +on_pending: :wait+.
+  #
+  # +credentials+ is an optional Proc for per-run MCP +tools/call+ HTTP headers.
+  # Signature: +->(manifest:, matched_tags:, context:) { Hash or nil }+.
+  # +nil+ from the proc at tool-resolution time omits that server's tools; +nil+
+  # at tool-call time raises Riffer::Mcp::CredentialsDeniedError.
+  attr_reader mcp: Riffer::Config::Mcp
 
   # Global tool runtime configuration (experimental).
   #

--- a/sig/generated/riffer/mcp.rbs
+++ b/sig/generated/riffer/mcp.rbs
@@ -21,23 +21,15 @@ module Riffer::Mcp
   class Error < Riffer::Error
   end
 
-  # Raised when an agent attempts to use an MCP server that has not finished
-  # discovery and the +:raise+ on_pending strategy is configured.
-  class NotReadyError < Error
-  end
-
-  # Raised when +wait_until_ready!+ exceeds +Riffer.config.mcp.wait_timeout+.
-  class TimeoutError < Error
-  end
-
   # Raised when +Riffer.config.mcp.credentials+ returns +nil+ during +tools/call+
   # after the server's tools were included for this run.
   class CredentialsDeniedError < Error
   end
 
-  # Registers an MCP server and starts async tool discovery.
+  # Registers an MCP server, blocking until tool discovery completes.
   #
-  # Returns immediately. Pass a +Manifest+ instance or a hash with the same keys.
+  # Raises on discovery failure. Pass a +Manifest+ instance or a hash with
+  # the same keys.
   #
   # --
   # : ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration

--- a/sig/generated/riffer/mcp.rbs
+++ b/sig/generated/riffer/mcp.rbs
@@ -1,0 +1,59 @@
+# Generated from lib/riffer/mcp.rb with RBS::Inline
+
+# Riffer::Mcp provides integration with Model Context Protocol (MCP) servers.
+#
+# Register MCP servers globally; agents opt-in by tag via the +use_mcp+ DSL.
+# Tags are application-defined; see +docs/14_MCP.md+ (Tags section).
+#
+#   Riffer::Mcp.register(
+#     name: "github",
+#     tags: [:github],
+#     endpoint: "https://mcp.github.com",
+#     discovery_headers: -> { {"Authorization" => "Bearer #{ENV['GITHUB_TOKEN']}"} }
+#   )
+#
+#   class MyAgent < Riffer::Agent
+#     model "openai/gpt-4o"
+#     use_mcp :github
+#   end
+module Riffer::Mcp
+  # Base error for all MCP-related failures.
+  class Error < Riffer::Error
+  end
+
+  # Raised when an agent attempts to use an MCP server that has not finished
+  # discovery and the +:raise+ on_pending strategy is configured.
+  class NotReadyError < Error
+  end
+
+  # Raised when +wait_until_ready!+ exceeds +Riffer.config.mcp.wait_timeout+.
+  class TimeoutError < Error
+  end
+
+  # Raised when +Riffer.config.mcp.credentials+ returns +nil+ during +tools/call+
+  # after the server's tools were included for this run.
+  class CredentialsDeniedError < Error
+  end
+
+  # Registers an MCP server and starts async tool discovery.
+  #
+  # Returns immediately. Pass a +Manifest+ instance or a hash with the same keys.
+  #
+  # --
+  # : ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration
+  def self.register: (Hash[Symbol, untyped] | Riffer::Mcp::Manifest) -> Riffer::Mcp::Registration
+
+  # Removes a registration by name.
+  #
+  # Subsequent agent runs will not see tools from this server.
+  #
+  # --
+  # : (String) -> void
+  def self.unregister: (String) -> void
+
+  # Returns all current registrations keyed by name (for introspection).
+  #
+  # --
+  # : () -> Hash[String, Riffer::Mcp::Registration]
+  def self.registrations: () -> Hash[String, Riffer::Mcp::Registration]
+end

--- a/sig/generated/riffer/mcp/authenticated_tool.rbs
+++ b/sig/generated/riffer/mcp/authenticated_tool.rbs
@@ -1,0 +1,17 @@
+# Generated from lib/riffer/mcp/authenticated_tool.rb with RBS::Inline
+
+# Wraps MCP-generated tool classes so +tools/call+ uses +Riffer.config.mcp.credentials+
+# per invocation while delegating metadata to the inner class.
+module Riffer::Mcp::AuthenticatedTool
+  # Returns one wrapper class per inner tool, sharing +manifest+ and +matched_tags+.
+  #
+  # --
+  # : (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
+  def self.wrap_all: (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
+
+  # --
+  # : (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
+  #  Class.new(Riffer::Tool) is typed as ::Class by steep — it cannot verify the subtype
+  #  relationship for dynamically created anonymous classes, so the ignore is required.
+  def self.wrap_one: (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
+end

--- a/sig/generated/riffer/mcp/client.rbs
+++ b/sig/generated/riffer/mcp/client.rbs
@@ -1,0 +1,33 @@
+# Generated from lib/riffer/mcp/client.rb with RBS::Inline
+
+# Thin wrapper around the MCP Ruby SDK client (mcp gem v0.8+).
+#
+# Resolves headers (if a Proc) once at initialization, then provides
+# +tools_list+ and +tools_call+. Used for discovery (+Manifest#discovery_headers+)
+# and for +tools/call+ when no +credentials+ proc is configured.
+#
+# MCP gem API used:
+#   MCP::Client::HTTP.new(url:, headers:)  — HTTP transport (requires faraday)
+#   MCP::Client.new(transport:)            — client
+#   client.tools                           — Array<MCP::Client::Tool>
+#   client.call_tool(tool:, arguments:)    — raw JSON-RPC response Hash
+class Riffer::Mcp::Client
+  include Riffer::Helpers::Dependencies
+
+  # --
+  # : (endpoint: String, ?headers: (Hash[String, String] | Proc), ?client: untyped?) -> void
+  def initialize: (endpoint: String, ?headers: Hash[String, String] | Proc, ?client: untyped?) -> void
+
+  # Returns an array of tool definition hashes, each with +:name+, +:description+,
+  # and +:input_schema+ keys.
+  #
+  # --
+  # : () -> Array[Hash[Symbol, untyped]]
+  def tools_list: () -> Array[Hash[Symbol, untyped]]
+
+  # Calls a tool on the MCP server and returns joined text content from the response.
+  #
+  # --
+  # : (String, ?Hash[untyped, untyped]) -> String
+  def tools_call: (String, ?Hash[untyped, untyped]) -> String
+end

--- a/sig/generated/riffer/mcp/manifest.rbs
+++ b/sig/generated/riffer/mcp/manifest.rbs
@@ -1,0 +1,30 @@
+# Generated from lib/riffer/mcp/manifest.rb with RBS::Inline
+
+# Riffer::Mcp::Manifest holds the configuration for a single MCP server.
+#
+# +name+                - String identifier used as the registration key and generated-agent identifier.
+# +tags+                - Array[Symbol]; normalized to symbols at construction time.
+# +endpoint+            - String HTTPS URL passed to the MCP transport.
+# +discovery_headers+   - Hash or Proc; resolved once when building the discovery client for +tools/list+.
+# +credentials_scope+  - Optional symbol hint: +:global+, +:tenant+, +:user+ — documents whether
+#   invocation credentials are expected to depend on tenant and/or user keys in +context+ (no ids stored).
+#   Apps may treat +:user+ as "user in tenant" and pass both keys in +context+.
+class Riffer::Mcp::Manifest
+  attr_reader name: String
+
+  attr_reader tags: Array[Symbol]
+
+  attr_reader endpoint: String
+
+  attr_reader discovery_headers: (Hash[String, untyped] | ::Proc)?
+
+  attr_reader credentials_scope: Symbol?
+
+  # --
+  # : (name: String, endpoint: String, ?tags: Array[untyped]?, ?discovery_headers: (Hash[String, untyped] | ::Proc)?, ?credentials_scope: (String | Symbol)?) -> void
+  def initialize: (name: String, endpoint: String, ?tags: Array[untyped]?, ?discovery_headers: (Hash[String, untyped] | ::Proc)?, ?credentials_scope: (String | Symbol)?) -> void
+
+  private
+
+  def valid_endpoint?: () -> untyped
+end

--- a/sig/generated/riffer/mcp/registration.rbs
+++ b/sig/generated/riffer/mcp/registration.rbs
@@ -1,0 +1,72 @@
+# Generated from lib/riffer/mcp/registration.rb with RBS::Inline
+
+# Per-server state managed by Riffer::Mcp::Registry.
+#
+# Created when a server is registered. Spawns a background thread to discover
+# tools via the MCP +tools/list+ call, then generates tool classes.
+class Riffer::Mcp::Registration
+  # The manifest that describes this server.
+  attr_reader manifest: Riffer::Mcp::Manifest
+
+  # Generated Riffer::Tool subclasses (empty until discovery completes).
+  #
+  # --
+  # : () -> Array[singleton(Riffer::Tool)]
+  def tools: () -> Array[singleton(Riffer::Tool)]
+
+  # Exception from failed tool discovery, or +nil+ if discovery succeeded or is still in progress.
+  #
+  # --
+  # : () -> Exception?
+  def discovery_error: () -> Exception?
+
+  # --
+  # : (Riffer::Mcp::Manifest) -> void
+  def initialize: (Riffer::Mcp::Manifest) -> void
+
+  # Retires this registration, preventing the discovery thread from publishing
+  # state and killing it if still running.
+  #
+  # --
+  # : () -> void
+  def retire!: () -> void
+
+  # Returns true once tool discovery has completed successfully.
+  #
+  # --
+  # : () -> bool
+  def ready?: () -> bool
+
+  # Returns true if this registration has been retired.
+  #
+  # --
+  # : () -> bool
+  def retired?: () -> bool
+
+  # Blocks the calling thread until this registration is ready or the timeout elapses.
+  #
+  # If tool discovery failed in the background thread, re-raises that exception
+  # immediately (no wait for +wait_timeout+).
+  #
+  # Raises Riffer::Mcp::TimeoutError if discovery is still in progress and
+  # +Riffer.config.mcp.wait_timeout+ seconds pass without becoming ready.
+  #
+  # --
+  # : () -> void
+  def wait_until_ready!: () -> void
+
+  private
+
+  # Discovery is a one-shot background init task, not concurrent tool execution
+  # during an agent run, so ToolRuntime does not apply. The factory is exposed
+  # for environments where raw Thread.new has side effects (e.g. connection pool
+  # inheritance in Rails).
+  #
+  # --
+  # : () -> Thread
+  def spawn_discovery_thread: () -> Thread
+
+  # --
+  # : () -> Riffer::Mcp::Client
+  def build_client: () -> Riffer::Mcp::Client
+end

--- a/sig/generated/riffer/mcp/registration.rbs
+++ b/sig/generated/riffer/mcp/registration.rbs
@@ -2,40 +2,28 @@
 
 # Per-server state managed by Riffer::Mcp::Registry.
 #
-# Created when a server is registered. Spawns a background thread to discover
-# tools via the MCP +tools/list+ call, then generates tool classes.
+# Created when a server is registered. Discovers tools via the MCP
+# +tools/list+ call, then generates tool classes.
 class Riffer::Mcp::Registration
   # The manifest that describes this server.
   attr_reader manifest: Riffer::Mcp::Manifest
 
-  # Generated Riffer::Tool subclasses (empty until discovery completes).
+  # Generated Riffer::Tool subclasses.
   #
   # --
   # : () -> Array[singleton(Riffer::Tool)]
   def tools: () -> Array[singleton(Riffer::Tool)]
 
-  # Exception from failed tool discovery, or +nil+ if discovery succeeded or is still in progress.
-  #
-  # --
-  # : () -> Exception?
-  def discovery_error: () -> Exception?
-
   # --
   # : (Riffer::Mcp::Manifest) -> void
   def initialize: (Riffer::Mcp::Manifest) -> void
 
-  # Retires this registration, preventing the discovery thread from publishing
-  # state and killing it if still running.
+  # Retires this registration, preventing in-flight discovery from publishing
+  # state.
   #
   # --
   # : () -> void
   def retire!: () -> void
-
-  # Returns true once tool discovery has completed successfully.
-  #
-  # --
-  # : () -> bool
-  def ready?: () -> bool
 
   # Returns true if this registration has been retired.
   #
@@ -43,28 +31,17 @@ class Riffer::Mcp::Registration
   # : () -> bool
   def retired?: () -> bool
 
-  # Blocks the calling thread until this registration is ready or the timeout elapses.
+  private
+
+  # Runs tool discovery using the configured Runner.
   #
-  # If tool discovery failed in the background thread, re-raises that exception
-  # immediately (no wait for +wait_timeout+).
-  #
-  # Raises Riffer::Mcp::TimeoutError if discovery is still in progress and
-  # +Riffer.config.mcp.wait_timeout+ seconds pass without becoming ready.
+  # With +Runner::Sequential+ (default) discovery blocks inline. With
+  # +Runner::Threaded+ discovery runs on a pool thread but +map+ still
+  # blocks the caller — useful for Rails connection-pool isolation.
   #
   # --
   # : () -> void
-  def wait_until_ready!: () -> void
-
-  private
-
-  # Discovery is a one-shot background init task, not concurrent tool execution
-  # during an agent run, so ToolRuntime does not apply. The factory is exposed
-  # for environments where raw Thread.new has side effects (e.g. connection pool
-  # inheritance in Rails).
-  #
-  # --
-  # : () -> Thread
-  def spawn_discovery_thread: () -> Thread
+  def run_discovery: () -> void
 
   # --
   # : () -> Riffer::Mcp::Client

--- a/sig/generated/riffer/mcp/registry.rbs
+++ b/sig/generated/riffer/mcp/registry.rbs
@@ -1,0 +1,35 @@
+# Generated from lib/riffer/mcp/registry.rb with RBS::Inline
+
+# Thread-safe global store for MCP server registrations.
+#
+# Keyed by manifest name. All public methods are mutex-guarded.
+module Riffer::Mcp::Registry
+  # Registers an MCP server and starts async tool discovery.
+  #
+  # Accepts a Manifest instance or a hash of manifest keyword arguments.
+  # Replaces any existing registration with the same name.
+  #
+  # --
+  # : ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration
+  def self.register: (Hash[Symbol, untyped] | Riffer::Mcp::Manifest) -> Riffer::Mcp::Registration
+
+  # Removes a registration by name.
+  #
+  # --
+  # : ((String | Symbol)) -> void
+  def self.unregister: (String | Symbol) -> void
+
+  # Returns a frozen snapshot of all current registrations.
+  #
+  # --
+  # : () -> Hash[String, Riffer::Mcp::Registration]
+  def self.registrations: () -> Hash[String, Riffer::Mcp::Registration]
+
+  # Returns all registrations whose manifest tags intersect with the given tags.
+  #
+  # Tags are normalized to symbols before matching.
+  #
+  # --
+  # : (Array[Symbol]) -> Array[Riffer::Mcp::Registration]
+  def self.find_by_tags: (Array[Symbol]) -> Array[Riffer::Mcp::Registration]
+end

--- a/sig/generated/riffer/mcp/tool_factory.rbs
+++ b/sig/generated/riffer/mcp/tool_factory.rbs
@@ -9,9 +9,17 @@
 module Riffer::Mcp::ToolFactory
   # Builds one Riffer::Tool subclass per tool definition.
   #
+  # Tool names are prefixed with the manifest name to avoid collisions
+  # across MCP servers (e.g. +"jira__search"+). The original server-side
+  # name is available via +.mcp_server_tool_name+.
+  #
   # --
-  # : (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
-  def self.build: (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  # : (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  def self.build: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
 
-  def self.build_tool_class: (untyped client, untyped td) -> untyped
+  # Replaces characters that are unsafe in LLM tool names.
+  # : (String) -> String
+  def self.sanitize_name_component: (String) -> String
+
+  def self.build_tool_class: (untyped manifest_name, untyped client, untyped td) -> untyped
 end

--- a/sig/generated/riffer/mcp/tool_factory.rbs
+++ b/sig/generated/riffer/mcp/tool_factory.rbs
@@ -1,0 +1,17 @@
+# Generated from lib/riffer/mcp/tool_factory.rb with RBS::Inline
+
+# Generates anonymous Riffer::Tool subclasses from MCP tool definitions.
+#
+# Each generated class:
+# - Has +.name+, +.description+, and +.parameters_schema+ derived from the MCP tool definition.
+# - Delegates +#call+ to the MCP client's +tools_call+ method.
+# - Skips Riffer's param validation — the MCP server validates inputs.
+module Riffer::Mcp::ToolFactory
+  # Builds one Riffer::Tool subclass per tool definition.
+  #
+  # --
+  # : (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  def self.build: (Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+
+  def self.build_tool_class: (untyped client, untyped td) -> untyped
+end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3554,4 +3554,218 @@ describe Riffer::Agent do
       expect(msg.content).must_include "Available Skills"
     end
   end
+
+  describe ".use_mcp / .mcp_configs" do
+    after { clear_mcp_registry! }
+
+    it "returns empty array when no use_mcp calls have been made" do
+      klass = Class.new(Riffer::Agent)
+      expect(klass.mcp_configs).must_equal []
+    end
+
+    it "accumulates mcp_configs from multiple use_mcp calls" do
+      klass = Class.new(Riffer::Agent) do
+        use_mcp :foo
+        use_mcp :bar, on_pending: :wait
+      end
+      expect(klass.mcp_configs.size).must_equal 2
+    end
+
+    it "normalizes tag to symbol" do
+      klass = Class.new(Riffer::Agent) { use_mcp "mytag" }
+      expect(klass.mcp_configs.first[:tags]).must_equal [:mytag]
+    end
+
+    it "stores on_pending per config entry" do
+      klass = Class.new(Riffer::Agent) { use_mcp :foo, on_pending: :raise }
+      expect(klass.mcp_configs.first[:on_pending]).must_equal :raise
+    end
+
+    it "stores nil on_pending when not provided (falls back to global config)" do
+      klass = Class.new(Riffer::Agent) { use_mcp :foo }
+      expect(klass.mcp_configs.first[:on_pending]).must_be_nil
+    end
+  end
+
+  describe "#resolved_tools with use_mcp" do
+    after { clear_mcp_registry! }
+
+    let(:fake_tool_class) do
+      klass = Class.new(Riffer::Tool)
+      klass.instance_variable_set(:@identifier, "mcp_tool")
+      klass
+    end
+
+    # Builds a stub registration and injects it directly into the registry store.
+    def inject_ready_registration(name:, tags:, tools:)
+      manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: "https://x.com", discovery_headers: {})
+      reg = Riffer::Mcp::Registration.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, true)
+      reg.instance_variable_set(:@tools, tools)
+      reg.instance_variable_set(:@agent, nil)
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      store = Riffer::Mcp::Registry.instance_variable_get(:@store)
+      Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
+      reg
+    end
+
+    def inject_pending_registration(name:, tags:, discovery_error: nil)
+      manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: "https://x.com", discovery_headers: {})
+      reg = Riffer::Mcp::Registration.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@tools, [])
+      reg.instance_variable_set(:@agent, nil)
+      reg.instance_variable_set(:@discovery_error, discovery_error)
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      store = Riffer::Mcp::Registry.instance_variable_get(:@store)
+      Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
+      reg
+    end
+
+    def resolved_tools_for(klass)
+      instance = klass.allocate
+      instance.instance_variable_set(:@context, nil)
+      instance.send(:resolved_tools)
+    end
+
+    it "merges MCP tools with uses_tools tools" do
+      static_tool = Class.new(Riffer::Tool)
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [static_tool]
+        use_mcp :srv
+      end
+
+      tools = resolved_tools_for(klass)
+      expect(tools).must_include static_tool
+      expect(tools).must_include fake_tool_class
+    end
+
+    it "raises ArgumentError when static tools and MCP tools share the same name" do
+      static = fake_tool_class
+      conflicting = Class.new(Riffer::Tool) do
+        identifier "mcp_tool"
+      end
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [conflicting])
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [static]
+        use_mcp :srv
+      end
+
+      err = expect { resolved_tools_for(klass) }.must_raise Riffer::ArgumentError
+      expect(err.message).must_match(/Duplicate tool names:.*mcp_tool/)
+    end
+
+    it "returns MCP tools even when uses_tools is not set" do
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv
+      end
+
+      expect(resolved_tools_for(klass)).must_include fake_tool_class
+    end
+
+    it "applies :ignore strategy and skips pending servers" do
+      inject_pending_registration(name: "srv", tags: [:srv])
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv, on_pending: :ignore
+      end
+
+      expect(resolved_tools_for(klass)).must_be_empty
+    end
+
+    it "applies :raise strategy and raises NotReadyError for pending servers" do
+      inject_pending_registration(name: "srv", tags: [:srv])
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv, on_pending: :raise
+      end
+
+      expect { resolved_tools_for(klass) }.must_raise Riffer::Mcp::NotReadyError
+    end
+
+    it "applies :raise strategy and re-raises discovery_error when discovery failed" do
+      inject_pending_registration(name: "srv", tags: [:srv], discovery_error: RuntimeError.new("mcp list failed"))
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv, on_pending: :raise
+      end
+
+      err = expect { resolved_tools_for(klass) }.must_raise RuntimeError
+      expect(err.message).must_equal "mcp list failed"
+    end
+
+    it "applies :wait strategy and re-raises discovery_error when discovery failed" do
+      inject_pending_registration(name: "srv", tags: [:srv], discovery_error: RuntimeError.new("mcp list failed"))
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv, on_pending: :wait
+      end
+
+      err = expect { resolved_tools_for(klass) }.must_raise RuntimeError
+      expect(err.message).must_equal "mcp list failed"
+    end
+
+    it "falls back to global on_pending when per-use_mcp on_pending is nil" do
+      inject_pending_registration(name: "srv", tags: [:srv])
+      prev_on_pending = Riffer.config.mcp.on_pending
+      Riffer.config.mcp.on_pending = :ignore
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv
+      end
+
+      expect(resolved_tools_for(klass)).must_be_empty
+    ensure
+      Riffer.config.mcp.on_pending = prev_on_pending
+    end
+
+    it "omits MCP tools when credentials proc returns nil at resolve time" do
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
+      prev = Riffer.config.mcp.credentials
+      Riffer.config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
+      end
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv
+      end
+
+      expect(resolved_tools_for(klass)).must_be_empty
+    ensure
+      Riffer.config.mcp.credentials = prev
+    end
+
+    it "uses AuthenticatedTool wrappers when credentials proc is set" do
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
+      prev = Riffer.config.mcp.credentials
+      Riffer.config.mcp.credentials = ->(manifest:, matched_tags:, context:) { {"Authorization" => "Bearer x"} }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv
+      end
+
+      tools = resolved_tools_for(klass)
+      expect(tools.size).must_equal 1
+      expect(tools.first).wont_equal fake_tool_class
+      expect(tools.first.name).must_equal fake_tool_class.name
+    ensure
+      Riffer.config.mcp.credentials = prev
+    end
+  end
 end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3582,7 +3582,8 @@ describe Riffer::Agent do
 
     let(:fake_tool_class) do
       klass = Class.new(Riffer::Tool)
-      klass.instance_variable_set(:@identifier, "mcp_tool")
+      klass.instance_variable_set(:@identifier, "srv__mcp_tool")
+      klass.define_singleton_method(:mcp_server_tool_name) { "mcp_tool" }
       klass
     end
 
@@ -3619,12 +3620,9 @@ describe Riffer::Agent do
       expect(tools).must_include fake_tool_class
     end
 
-    it "raises ArgumentError when static tools and MCP tools share the same name" do
-      static = fake_tool_class
-      conflicting = Class.new(Riffer::Tool) do
-        identifier "mcp_tool"
-      end
-      inject_ready_registration(name: "srv", tags: [:srv], tools: [conflicting])
+    it "raises ArgumentError when tools share the same name" do
+      static = Class.new(Riffer::Tool) { identifier "srv__mcp_tool" }
+      inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
@@ -3633,7 +3631,7 @@ describe Riffer::Agent do
       end
 
       err = expect { resolved_tools_for(klass) }.must_raise Riffer::ArgumentError
-      expect(err.message).must_match(/Duplicate tool names:.*mcp_tool/)
+      expect(err.message).must_match(/Duplicate tool names:.*srv__mcp_tool/)
     end
 
     it "returns MCP tools even when uses_tools is not set" do

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3566,7 +3566,7 @@ describe Riffer::Agent do
     it "accumulates mcp_configs from multiple use_mcp calls" do
       klass = Class.new(Riffer::Agent) do
         use_mcp :foo
-        use_mcp :bar, on_pending: :wait
+        use_mcp :bar
       end
       expect(klass.mcp_configs.size).must_equal 2
     end
@@ -3574,16 +3574,6 @@ describe Riffer::Agent do
     it "normalizes tag to symbol" do
       klass = Class.new(Riffer::Agent) { use_mcp "mytag" }
       expect(klass.mcp_configs.first[:tags]).must_equal [:mytag]
-    end
-
-    it "stores on_pending per config entry" do
-      klass = Class.new(Riffer::Agent) { use_mcp :foo, on_pending: :raise }
-      expect(klass.mcp_configs.first[:on_pending]).must_equal :raise
-    end
-
-    it "stores nil on_pending when not provided (falls back to global config)" do
-      klass = Class.new(Riffer::Agent) { use_mcp :foo }
-      expect(klass.mcp_configs.first[:on_pending]).must_be_nil
     end
   end
 
@@ -3601,23 +3591,7 @@ describe Riffer::Agent do
       manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: "https://x.com", discovery_headers: {})
       reg = Riffer::Mcp::Registration.allocate
       reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, true)
       reg.instance_variable_set(:@tools, tools)
-      reg.instance_variable_set(:@agent, nil)
-      reg.instance_variable_set(:@mutex, Mutex.new)
-      store = Riffer::Mcp::Registry.instance_variable_get(:@store)
-      Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
-      reg
-    end
-
-    def inject_pending_registration(name:, tags:, discovery_error: nil)
-      manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: "https://x.com", discovery_headers: {})
-      reg = Riffer::Mcp::Registration.allocate
-      reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, false)
-      reg.instance_variable_set(:@tools, [])
-      reg.instance_variable_set(:@agent, nil)
-      reg.instance_variable_set(:@discovery_error, discovery_error)
       reg.instance_variable_set(:@mutex, Mutex.new)
       store = Riffer::Mcp::Registry.instance_variable_get(:@store)
       Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
@@ -3671,67 +3645,6 @@ describe Riffer::Agent do
       end
 
       expect(resolved_tools_for(klass)).must_include fake_tool_class
-    end
-
-    it "applies :ignore strategy and skips pending servers" do
-      inject_pending_registration(name: "srv", tags: [:srv])
-
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        use_mcp :srv, on_pending: :ignore
-      end
-
-      expect(resolved_tools_for(klass)).must_be_empty
-    end
-
-    it "applies :raise strategy and raises NotReadyError for pending servers" do
-      inject_pending_registration(name: "srv", tags: [:srv])
-
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        use_mcp :srv, on_pending: :raise
-      end
-
-      expect { resolved_tools_for(klass) }.must_raise Riffer::Mcp::NotReadyError
-    end
-
-    it "applies :raise strategy and re-raises discovery_error when discovery failed" do
-      inject_pending_registration(name: "srv", tags: [:srv], discovery_error: RuntimeError.new("mcp list failed"))
-
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        use_mcp :srv, on_pending: :raise
-      end
-
-      err = expect { resolved_tools_for(klass) }.must_raise RuntimeError
-      expect(err.message).must_equal "mcp list failed"
-    end
-
-    it "applies :wait strategy and re-raises discovery_error when discovery failed" do
-      inject_pending_registration(name: "srv", tags: [:srv], discovery_error: RuntimeError.new("mcp list failed"))
-
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        use_mcp :srv, on_pending: :wait
-      end
-
-      err = expect { resolved_tools_for(klass) }.must_raise RuntimeError
-      expect(err.message).must_equal "mcp list failed"
-    end
-
-    it "falls back to global on_pending when per-use_mcp on_pending is nil" do
-      inject_pending_registration(name: "srv", tags: [:srv])
-      prev_on_pending = Riffer.config.mcp.on_pending
-      Riffer.config.mcp.on_pending = :ignore
-
-      klass = Class.new(Riffer::Agent) do
-        model "mock/riffer-1"
-        use_mcp :srv
-      end
-
-      expect(resolved_tools_for(klass)).must_be_empty
-    ensure
-      Riffer.config.mcp.on_pending = prev_on_pending
     end
 
     it "omits MCP tools when credentials proc returns nil at resolve time" do

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -100,28 +100,6 @@ describe Riffer::Config do
   end
 
   describe "mcp namespace" do
-    it "initializes on_pending to :ignore" do
-      config = Riffer::Config.new
-      expect(config.mcp.on_pending).must_equal :ignore
-    end
-
-    it "initializes wait_timeout to 10" do
-      config = Riffer::Config.new
-      expect(config.mcp.wait_timeout).must_equal 10
-    end
-
-    it "allows setting on_pending" do
-      config = Riffer::Config.new
-      config.mcp.on_pending = :wait
-      expect(config.mcp.on_pending).must_equal :wait
-    end
-
-    it "allows setting wait_timeout" do
-      config = Riffer::Config.new
-      config.mcp.wait_timeout = 30
-      expect(config.mcp.wait_timeout).must_equal 30
-    end
-
     it "initializes credentials to nil" do
       config = Riffer::Config.new
       expect(config.mcp.credentials).must_be_nil

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -98,4 +98,40 @@ describe Riffer::Config do
       expect { config.message_id_strategy = nil }.must_raise Riffer::ArgumentError
     end
   end
+
+  describe "mcp namespace" do
+    it "initializes on_pending to :ignore" do
+      config = Riffer::Config.new
+      expect(config.mcp.on_pending).must_equal :ignore
+    end
+
+    it "initializes wait_timeout to 10" do
+      config = Riffer::Config.new
+      expect(config.mcp.wait_timeout).must_equal 10
+    end
+
+    it "allows setting on_pending" do
+      config = Riffer::Config.new
+      config.mcp.on_pending = :wait
+      expect(config.mcp.on_pending).must_equal :wait
+    end
+
+    it "allows setting wait_timeout" do
+      config = Riffer::Config.new
+      config.mcp.wait_timeout = 30
+      expect(config.mcp.wait_timeout).must_equal 30
+    end
+
+    it "initializes credentials to nil" do
+      config = Riffer::Config.new
+      expect(config.mcp.credentials).must_be_nil
+    end
+
+    it "allows setting credentials proc" do
+      config = Riffer::Config.new
+      cred = ->(manifest:, matched_tags:, context:) { {} }
+      config.mcp.credentials = cred
+      expect(config.mcp.credentials).must_equal cred
+    end
+  end
 end

--- a/test/riffer/mcp/authenticated_tool_test.rb
+++ b/test/riffer/mcp/authenticated_tool_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 describe Riffer::Mcp::AuthenticatedTool do
   let(:inner) do
     Class.new(Riffer::Tool) do
-      define_singleton_method(:name) { "echo" }
+      define_singleton_method(:name) { "srv__echo" }
+      define_singleton_method(:mcp_server_tool_name) { "echo" }
       define_singleton_method(:description) { "E" }
       define_singleton_method(:parameters_schema) { |strict: false| Riffer::Tool.send(:empty_schema) }
 

--- a/test/riffer/mcp/authenticated_tool_test.rb
+++ b/test/riffer/mcp/authenticated_tool_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::AuthenticatedTool do
+  let(:inner) do
+    Class.new(Riffer::Tool) do
+      define_singleton_method(:name) { "echo" }
+      define_singleton_method(:description) { "E" }
+      define_singleton_method(:parameters_schema) { |strict: false| Riffer::Tool.send(:empty_schema) }
+
+      define_method(:call) do |context:, **kwargs|
+        text("inner-#{kwargs[:x]}")
+      end
+    end
+  end
+
+  let(:manifest) do
+    Riffer::Mcp::Manifest.new(name: "srv", tags: [:t], endpoint: "https://mcp.example.com", discovery_headers: {})
+  end
+
+  it "delegates to inner when credentials proc is nil" do
+    prev = Riffer.config.mcp.credentials
+    Riffer.config.mcp.credentials = nil
+    wrapped = Riffer::Mcp::AuthenticatedTool.wrap_one(inner, manifest, [:t])
+    resp = wrapped.new.call(context: {}, x: 1)
+    assert_equal "inner-1", resp.content
+  ensure
+    Riffer.config.mcp.credentials = prev
+  end
+
+  it "raises CredentialsDeniedError when credentials returns nil during call" do
+    prev = Riffer.config.mcp.credentials
+    Riffer.config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
+    end
+    wrapped = Riffer::Mcp::AuthenticatedTool.wrap_one(inner, manifest, [:t])
+    assert_raises(Riffer::Mcp::CredentialsDeniedError) { wrapped.new.call(context: {}, x: 1) }
+  ensure
+    Riffer.config.mcp.credentials = prev
+  end
+end

--- a/test/riffer/mcp/client_test.rb
+++ b/test/riffer/mcp/client_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mcp"
+
+describe Riffer::Mcp::Client do
+  # Build a Riffer::Mcp::Client with a pre-constructed fake inner MCP::Client,
+  # bypassing real HTTP transport.
+  def build_client(inner_client, endpoint: "https://example.com/mcp")
+    Riffer::Mcp::Client.new(endpoint: endpoint, client: inner_client)
+  end
+
+  describe "#initialize" do
+    it "uses an injected inner client when provided" do
+      inner = Object.new
+      inner.define_singleton_method(:tools) { [] }
+      client = Riffer::Mcp::Client.new(endpoint: "https://x.com", client: inner)
+      assert_equal [], client.tools_list
+    end
+
+    it "accepts Proc headers (resolved when building the real transport)" do
+      # Verify that a Proc value is accepted without raising.
+      # Header resolution is exercised in the transport construction path;
+      # the injected-client path bypasses it, but the interface still accepts it.
+      proc_headers = -> { {"Authorization" => "Bearer resolved"} }
+      inner = Object.new
+      inner.define_singleton_method(:tools) { [] }
+      client = Riffer::Mcp::Client.new(endpoint: "https://x.com", headers: proc_headers, client: inner)
+      assert_equal [], client.tools_list
+    end
+  end
+
+  describe "#tools_list" do
+    it "returns an array of hashes with :name, :description, :input_schema" do
+      schema = {type: "object", properties: {}, required: [], additionalProperties: false}
+      tool = MCP::Client::Tool.new(name: "search", description: "Search the web", input_schema: schema)
+      inner = Object.new
+      inner.define_singleton_method(:tools) { [tool] }
+
+      result = build_client(inner).tools_list
+
+      assert_equal 1, result.size
+      assert_equal "search", result.first[:name]
+      assert_equal "Search the web", result.first[:description]
+      assert_equal schema, result.first[:input_schema]
+    end
+
+    it "returns an empty array when the server has no tools" do
+      inner = Object.new
+      inner.define_singleton_method(:tools) { [] }
+      assert_empty build_client(inner).tools_list
+    end
+  end
+
+  describe "#tools_call" do
+    it "joins and returns text content from the response" do
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) do |tool:, arguments:|
+        {"result" => {"content" => [{"type" => "text", "text" => "Hello"}, {"type" => "text", "text" => " world"}]}}
+      end
+
+      result = build_client(inner).tools_call("greet", {name: "Alice"})
+      assert_equal "Hello world", result
+    end
+
+    it "returns empty string when content array is empty" do
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) { |**| {"result" => {"content" => []}} }
+      assert_equal "", build_client(inner).tools_call("noop")
+    end
+
+    it "skips non-text content items" do
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) do |**|
+        {"result" => {"content" => [{"type" => "image", "data" => "..."}, {"type" => "text", "text" => "ok"}]}}
+      end
+      assert_equal "ok", build_client(inner).tools_call("img_tool")
+    end
+
+    it "passes the tool name and arguments to the inner client" do
+      received_name = nil
+      received_args = nil
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) do |tool:, arguments:|
+        received_name = tool.name
+        received_args = arguments
+        {"result" => {"content" => []}}
+      end
+
+      build_client(inner).tools_call("do_thing", {param: "val"})
+
+      assert_equal "do_thing", received_name
+      assert_equal({param: "val"}, received_args)
+    end
+
+    it "raises Riffer::Error when the inner client returns a JSON-RPC error (string keys)" do
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) { |**| {"error" => {"message" => "bad request"}} }
+
+      err = assert_raises(Riffer::Error) { build_client(inner).tools_call("x") }
+      assert_equal "bad request", err.message
+    end
+
+    it "raises Riffer::Error when result.isError is true (string keys)" do
+      inner = Object.new
+      inner.define_singleton_method(:call_tool) do |**|
+        {"result" => {"isError" => true, "content" => [{"type" => "text", "text" => "oops"}]}}
+      end
+
+      err = assert_raises(Riffer::Error) { build_client(inner).tools_call("x") }
+      assert_equal "oops", err.message
+    end
+  end
+end

--- a/test/riffer/mcp/manifest_test.rb
+++ b/test/riffer/mcp/manifest_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::Manifest do
+  describe ".new" do
+    it "stores name, endpoint, and discovery_headers" do
+      manifest = Riffer::Mcp::Manifest.new(name: "github", tags: [:github], endpoint: "https://example.com", discovery_headers: {})
+      assert_equal "github", manifest.name
+      assert_equal "https://example.com", manifest.endpoint
+      assert_equal({}, manifest.discovery_headers)
+    end
+
+    it "normalizes name to a string" do
+      manifest = Riffer::Mcp::Manifest.new(name: :github, tags: [], endpoint: "https://x.com")
+      assert_equal "github", manifest.name
+    end
+
+    it "normalizes tags to symbols" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: ["foo", :bar], endpoint: "https://x.com")
+      assert_equal [:foo, :bar], manifest.tags
+    end
+
+    it "wraps a single tag in an array" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: :solo, endpoint: "https://x.com")
+      assert_equal [:solo], manifest.tags
+    end
+
+    it "defaults tags to empty array when nil" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: nil, endpoint: "https://x.com")
+      assert_equal [], manifest.tags
+    end
+
+    it "accepts a Proc for discovery_headers" do
+      proc_headers = -> { {"Authorization" => "Bearer token"} }
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "https://x.com", discovery_headers: proc_headers)
+      assert_equal proc_headers, manifest.discovery_headers
+    end
+
+    it "normalizes credentials_scope to a symbol" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "https://x.com", credentials_scope: "user")
+      assert_equal :user, manifest.credentials_scope
+    end
+
+    it "allows nil credentials_scope" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "https://x.com")
+      assert_nil manifest.credentials_scope
+    end
+
+    it "strips whitespace from name" do
+      manifest = Riffer::Mcp::Manifest.new(name: "  srv  ", tags: [], endpoint: "https://x.com")
+      assert_equal "srv", manifest.name
+    end
+
+    it "raises when name is blank" do
+      err = assert_raises(Riffer::ArgumentError) { Riffer::Mcp::Manifest.new(name: "  ", tags: [], endpoint: "https://x.com") }
+      assert_match(/name is required/, err.message)
+    end
+
+    it "strips whitespace from endpoint" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "  https://x.com  ")
+      assert_equal "https://x.com", manifest.endpoint
+    end
+
+    it "raises when endpoint is not an https URL" do
+      err = assert_raises(Riffer::ArgumentError) { Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "not-a-url") }
+      assert_match(/valid HTTPS URL/, err.message)
+    end
+
+    it "raises when endpoint is http rather than https" do
+      err = assert_raises(Riffer::ArgumentError) { Riffer::Mcp::Manifest.new(name: "srv", tags: [], endpoint: "http://localhost:3000") }
+      assert_match(/valid HTTPS URL/, err.message)
+    end
+  end
+end

--- a/test/riffer/mcp/registration_test.rb
+++ b/test/riffer/mcp/registration_test.rb
@@ -7,31 +7,13 @@ describe Riffer::Mcp::Registration do
     Riffer::Mcp::Manifest.new(name: "test-srv", tags: [:test], endpoint: "https://test.example.com")
   end
 
-  # Build a registration whose discovery thread is bypassed so tests control state directly.
-  def build_stub_registration(manifest, ready: false, tools: [])
+  # Build a registration whose discovery is bypassed so tests control state directly.
+  def build_stub_registration(manifest, tools: [])
     reg = Riffer::Mcp::Registration.allocate
     reg.instance_variable_set(:@manifest, manifest)
-    reg.instance_variable_set(:@ready, ready)
     reg.instance_variable_set(:@cancelled, false)
     reg.instance_variable_set(:@tools, tools)
-    reg.instance_variable_set(:@discovery_thread, nil)
     reg.instance_variable_set(:@mutex, Mutex.new)
-    reg
-  end
-
-  # A Registration subclass that injects a fake MCP client, bypassing real HTTP.
-  def build_injected_registration(manifest, client:)
-    klass = Class.new(Riffer::Mcp::Registration) do
-      attr_writer :injected_client
-
-      private
-
-      def build_client
-        @injected_client
-      end
-    end
-    reg = klass.new(manifest)
-    reg.injected_client = client
     reg
   end
 
@@ -39,18 +21,6 @@ describe Riffer::Mcp::Registration do
     it "returns the manifest" do
       reg = build_stub_registration(manifest)
       assert_equal manifest, reg.manifest
-    end
-  end
-
-  describe "#ready?" do
-    it "returns false before discovery completes" do
-      reg = build_stub_registration(manifest, ready: false)
-      refute reg.ready?
-    end
-
-    it "returns true after discovery completes" do
-      reg = build_stub_registration(manifest, ready: true)
-      assert reg.ready?
     end
   end
 
@@ -62,48 +32,8 @@ describe Riffer::Mcp::Registration do
 
     it "returns tool classes after discovery" do
       tool_class = Class.new(Riffer::Tool)
-      reg = build_stub_registration(manifest, ready: true, tools: [tool_class])
+      reg = build_stub_registration(manifest, tools: [tool_class])
       assert_equal [tool_class], reg.tools
-    end
-  end
-
-  describe "#wait_until_ready!" do
-    it "returns immediately when already ready" do
-      reg = build_stub_registration(manifest, ready: true)
-      assert_nil reg.wait_until_ready!
-    end
-
-    it "re-raises discovery_error immediately when discovery failed" do
-      reg = build_stub_registration(manifest, ready: false)
-      reg.instance_variable_set(:@discovery_error, RuntimeError.new("discovery failed"))
-      err = assert_raises(RuntimeError) { reg.wait_until_ready! }
-      assert_equal "discovery failed", err.message
-    end
-
-    it "raises TimeoutError when deadline passes without becoming ready" do
-      reg = build_stub_registration(manifest, ready: false)
-      original_timeout = Riffer.config.mcp.wait_timeout
-      Riffer.config.mcp.wait_timeout = 0.05
-      assert_raises(Riffer::Mcp::TimeoutError) { reg.wait_until_ready! }
-    ensure
-      Riffer.config.mcp.wait_timeout = original_timeout
-    end
-
-    it "returns once the ready flag is set by another thread" do
-      reg = build_stub_registration(manifest, ready: false)
-      original_timeout = Riffer.config.mcp.wait_timeout
-      Riffer.config.mcp.wait_timeout = 1
-
-      Thread.new do
-        sleep 0.1
-        reg.instance_variable_get(:@mutex).synchronize do
-          reg.instance_variable_set(:@ready, true)
-        end
-      end
-
-      assert_nil reg.wait_until_ready!
-    ensure
-      Riffer.config.mcp.wait_timeout = original_timeout
     end
   end
 
@@ -127,7 +57,7 @@ describe Riffer::Mcp::Registration do
       assert reg.retired?
     end
 
-    it "prevents a completing discovery thread from publishing state" do
+    it "prevents in-flight discovery from publishing state" do
       latch = Mutex.new
       latch.lock
 
@@ -150,33 +80,33 @@ describe Riffer::Mcp::Registration do
 
       reg = klass.allocate
       reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, false)
       reg.instance_variable_set(:@cancelled, false)
       reg.instance_variable_set(:@tools, [])
-      reg.instance_variable_set(:@discovery_error, nil)
-      reg.instance_variable_set(:@discovery_thread, nil)
       reg.instance_variable_set(:@mutex, Mutex.new)
       reg.latch = latch
 
-      thread = reg.send(:spawn_discovery_thread)
+      thread = Thread.new { reg.send(:run_discovery) }
+      sleep 0.01
       reg.retire!
       latch.unlock
       thread.join
 
-      refute reg.ready?
       assert_empty reg.tools
     end
   end
 
-  describe "configurable discovery_thread_factory" do
-    it "uses the configured factory instead of Thread.new" do
-      original_factory = Riffer.config.mcp.discovery_thread_factory
-      factory_called = false
+  describe "configurable discovery_runner" do
+    it "uses the configured runner instead of the default" do
+      original_runner = Riffer.config.mcp.discovery_runner
+      runner_called = false
 
-      Riffer.config.mcp.discovery_thread_factory = ->(&block) {
-        factory_called = true
-        Thread.new(&block)
-      }
+      custom_runner = Object.new
+      custom_runner.define_singleton_method(:map) do |items, context:, &block|
+        runner_called = true
+        items.map(&block)
+      end
+
+      Riffer.config.mcp.discovery_runner = custom_runner
 
       fake_client = Object.new
       fake_client.define_singleton_method(:tools_list) { [] }
@@ -191,23 +121,20 @@ describe Riffer::Mcp::Registration do
 
       reg = klass.allocate
       reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, false)
       reg.instance_variable_set(:@cancelled, false)
       reg.instance_variable_set(:@tools, [])
-      reg.instance_variable_set(:@discovery_error, nil)
-      reg.instance_variable_set(:@discovery_thread, nil)
       reg.instance_variable_set(:@mutex, Mutex.new)
       reg.injected_client = fake_client
-      reg.send(:spawn_discovery_thread).join
+      reg.send(:run_discovery)
 
-      assert factory_called, "expected discovery_thread_factory to be called"
+      assert runner_called, "expected discovery_runner to be called"
     ensure
-      Riffer.config.mcp.discovery_thread_factory = original_factory
+      Riffer.config.mcp.discovery_runner = original_runner
     end
   end
 
-  describe "discovery thread" do
-    it "sets ready=true and populates tools when discovery succeeds" do
+  describe "discovery" do
+    it "populates tools when discovery succeeds" do
       td = {name: "ping", description: "Ping", input_schema: {type: "object", properties: {}, required: [], additionalProperties: false}}
       fake_client = Object.new
       fake_client.define_singleton_method(:tools_list) { [td] }
@@ -222,18 +149,17 @@ describe Riffer::Mcp::Registration do
 
       reg = klass.allocate
       reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@cancelled, false)
       reg.instance_variable_set(:@tools, [])
       reg.instance_variable_set(:@mutex, Mutex.new)
       reg.injected_client = fake_client
-      reg.send(:spawn_discovery_thread).join
+      reg.send(:run_discovery)
 
-      assert reg.ready?
       assert_equal 1, reg.tools.size
       assert_equal "ping", reg.tools.first.name
     end
 
-    it "leaves ready=false when discovery raises" do
+    it "raises when discovery fails" do
       bad_client = Object.new
       bad_client.define_singleton_method(:tools_list) { raise "connection refused" }
 
@@ -247,17 +173,12 @@ describe Riffer::Mcp::Registration do
 
       reg = klass.allocate
       reg.instance_variable_set(:@manifest, manifest)
-      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@cancelled, false)
       reg.instance_variable_set(:@tools, [])
-      reg.instance_variable_set(:@discovery_error, nil)
       reg.instance_variable_set(:@mutex, Mutex.new)
       reg.injected_client = bad_client
-      reg.send(:spawn_discovery_thread).join
 
-      refute reg.ready?
-      assert_instance_of RuntimeError, reg.discovery_error
-      assert_equal "connection refused", reg.discovery_error.message
-      err = assert_raises(RuntimeError) { reg.wait_until_ready! }
+      err = assert_raises(RuntimeError) { reg.send(:run_discovery) }
       assert_equal "connection refused", err.message
     end
   end

--- a/test/riffer/mcp/registration_test.rb
+++ b/test/riffer/mcp/registration_test.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::Registration do
+  let(:manifest) do
+    Riffer::Mcp::Manifest.new(name: "test-srv", tags: [:test], endpoint: "https://test.example.com")
+  end
+
+  # Build a registration whose discovery thread is bypassed so tests control state directly.
+  def build_stub_registration(manifest, ready: false, tools: [])
+    reg = Riffer::Mcp::Registration.allocate
+    reg.instance_variable_set(:@manifest, manifest)
+    reg.instance_variable_set(:@ready, ready)
+    reg.instance_variable_set(:@cancelled, false)
+    reg.instance_variable_set(:@tools, tools)
+    reg.instance_variable_set(:@discovery_thread, nil)
+    reg.instance_variable_set(:@mutex, Mutex.new)
+    reg
+  end
+
+  # A Registration subclass that injects a fake MCP client, bypassing real HTTP.
+  def build_injected_registration(manifest, client:)
+    klass = Class.new(Riffer::Mcp::Registration) do
+      attr_writer :injected_client
+
+      private
+
+      def build_client
+        @injected_client
+      end
+    end
+    reg = klass.new(manifest)
+    reg.injected_client = client
+    reg
+  end
+
+  describe "#manifest" do
+    it "returns the manifest" do
+      reg = build_stub_registration(manifest)
+      assert_equal manifest, reg.manifest
+    end
+  end
+
+  describe "#ready?" do
+    it "returns false before discovery completes" do
+      reg = build_stub_registration(manifest, ready: false)
+      refute reg.ready?
+    end
+
+    it "returns true after discovery completes" do
+      reg = build_stub_registration(manifest, ready: true)
+      assert reg.ready?
+    end
+  end
+
+  describe "#tools" do
+    it "returns empty array before discovery" do
+      reg = build_stub_registration(manifest)
+      assert_empty reg.tools
+    end
+
+    it "returns tool classes after discovery" do
+      tool_class = Class.new(Riffer::Tool)
+      reg = build_stub_registration(manifest, ready: true, tools: [tool_class])
+      assert_equal [tool_class], reg.tools
+    end
+  end
+
+  describe "#wait_until_ready!" do
+    it "returns immediately when already ready" do
+      reg = build_stub_registration(manifest, ready: true)
+      assert_nil reg.wait_until_ready!
+    end
+
+    it "re-raises discovery_error immediately when discovery failed" do
+      reg = build_stub_registration(manifest, ready: false)
+      reg.instance_variable_set(:@discovery_error, RuntimeError.new("discovery failed"))
+      err = assert_raises(RuntimeError) { reg.wait_until_ready! }
+      assert_equal "discovery failed", err.message
+    end
+
+    it "raises TimeoutError when deadline passes without becoming ready" do
+      reg = build_stub_registration(manifest, ready: false)
+      original_timeout = Riffer.config.mcp.wait_timeout
+      Riffer.config.mcp.wait_timeout = 0.05
+      assert_raises(Riffer::Mcp::TimeoutError) { reg.wait_until_ready! }
+    ensure
+      Riffer.config.mcp.wait_timeout = original_timeout
+    end
+
+    it "returns once the ready flag is set by another thread" do
+      reg = build_stub_registration(manifest, ready: false)
+      original_timeout = Riffer.config.mcp.wait_timeout
+      Riffer.config.mcp.wait_timeout = 1
+
+      Thread.new do
+        sleep 0.1
+        reg.instance_variable_get(:@mutex).synchronize do
+          reg.instance_variable_set(:@ready, true)
+        end
+      end
+
+      assert_nil reg.wait_until_ready!
+    ensure
+      Riffer.config.mcp.wait_timeout = original_timeout
+    end
+  end
+
+  describe "#retired?" do
+    it "returns false initially" do
+      reg = build_stub_registration(manifest)
+      refute reg.retired?
+    end
+
+    it "returns true after retire!" do
+      reg = build_stub_registration(manifest)
+      reg.retire!
+      assert reg.retired?
+    end
+  end
+
+  describe "#retire!" do
+    it "sets the cancelled flag" do
+      reg = build_stub_registration(manifest)
+      reg.retire!
+      assert reg.retired?
+    end
+
+    it "prevents a completing discovery thread from publishing state" do
+      latch = Mutex.new
+      latch.lock
+
+      klass = Class.new(Riffer::Mcp::Registration) do
+        attr_writer :latch
+
+        private
+
+        def build_client
+          client = Object.new
+          l = @latch
+          client.define_singleton_method(:tools_list) {
+            l.lock
+            l.unlock
+            []
+          }
+          client
+        end
+      end
+
+      reg = klass.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@cancelled, false)
+      reg.instance_variable_set(:@tools, [])
+      reg.instance_variable_set(:@discovery_error, nil)
+      reg.instance_variable_set(:@discovery_thread, nil)
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      reg.latch = latch
+
+      thread = reg.send(:spawn_discovery_thread)
+      reg.retire!
+      latch.unlock
+      thread.join
+
+      refute reg.ready?
+      assert_empty reg.tools
+    end
+  end
+
+  describe "configurable discovery_thread_factory" do
+    it "uses the configured factory instead of Thread.new" do
+      original_factory = Riffer.config.mcp.discovery_thread_factory
+      factory_called = false
+
+      Riffer.config.mcp.discovery_thread_factory = ->(&block) {
+        factory_called = true
+        Thread.new(&block)
+      }
+
+      fake_client = Object.new
+      fake_client.define_singleton_method(:tools_list) { [] }
+
+      klass = Class.new(Riffer::Mcp::Registration) do
+        attr_writer :injected_client
+
+        private
+
+        def build_client = @injected_client
+      end
+
+      reg = klass.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@cancelled, false)
+      reg.instance_variable_set(:@tools, [])
+      reg.instance_variable_set(:@discovery_error, nil)
+      reg.instance_variable_set(:@discovery_thread, nil)
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      reg.injected_client = fake_client
+      reg.send(:spawn_discovery_thread).join
+
+      assert factory_called, "expected discovery_thread_factory to be called"
+    ensure
+      Riffer.config.mcp.discovery_thread_factory = original_factory
+    end
+  end
+
+  describe "discovery thread" do
+    it "sets ready=true and populates tools when discovery succeeds" do
+      td = {name: "ping", description: "Ping", input_schema: {type: "object", properties: {}, required: [], additionalProperties: false}}
+      fake_client = Object.new
+      fake_client.define_singleton_method(:tools_list) { [td] }
+
+      klass = Class.new(Riffer::Mcp::Registration) do
+        attr_writer :injected_client
+
+        private
+
+        def build_client = @injected_client
+      end
+
+      reg = klass.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@tools, [])
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      reg.injected_client = fake_client
+      reg.send(:spawn_discovery_thread).join
+
+      assert reg.ready?
+      assert_equal 1, reg.tools.size
+      assert_equal "ping", reg.tools.first.name
+    end
+
+    it "leaves ready=false when discovery raises" do
+      bad_client = Object.new
+      bad_client.define_singleton_method(:tools_list) { raise "connection refused" }
+
+      klass = Class.new(Riffer::Mcp::Registration) do
+        attr_writer :injected_client
+
+        private
+
+        def build_client = @injected_client
+      end
+
+      reg = klass.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@ready, false)
+      reg.instance_variable_set(:@tools, [])
+      reg.instance_variable_set(:@discovery_error, nil)
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      reg.injected_client = bad_client
+      reg.send(:spawn_discovery_thread).join
+
+      refute reg.ready?
+      assert_instance_of RuntimeError, reg.discovery_error
+      assert_equal "connection refused", reg.discovery_error.message
+      err = assert_raises(RuntimeError) { reg.wait_until_ready! }
+      assert_equal "connection refused", err.message
+    end
+  end
+end

--- a/test/riffer/mcp/registration_test.rb
+++ b/test/riffer/mcp/registration_test.rb
@@ -156,7 +156,7 @@ describe Riffer::Mcp::Registration do
       reg.send(:run_discovery)
 
       assert_equal 1, reg.tools.size
-      assert_equal "ping", reg.tools.first.name
+      assert_equal "test-srv__ping", reg.tools.first.name
     end
 
     it "raises when discovery fails" do

--- a/test/riffer/mcp/registry_test.rb
+++ b/test/riffer/mcp/registry_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::Registry do
+  before { clear_mcp_registry! }
+  after { clear_mcp_registry! }
+
+  describe ".register" do
+    it "accepts a Manifest instance" do
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [:foo], endpoint: "https://x.com")
+      reg = Riffer::Mcp::Registry.register(manifest)
+      assert_instance_of Riffer::Mcp::Registration, reg
+    end
+
+    it "accepts a hash" do
+      reg = Riffer::Mcp::Registry.register(name: "srv", tags: [:foo], endpoint: "https://x.com")
+      assert_instance_of Riffer::Mcp::Registration, reg
+    end
+
+    it "stores the registration by name" do
+      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      assert Riffer::Mcp::Registry.registrations.key?("srv")
+    end
+
+    it "replaces an existing registration with the same name" do
+      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://a.com")
+      reg2 = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://b.com")
+      assert_equal reg2, Riffer::Mcp::Registry.registrations["srv"]
+      assert_equal "https://b.com", Riffer::Mcp::Registry.registrations["srv"].manifest.endpoint
+    end
+
+    it "retires the previous registration when replacing" do
+      old_reg = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://a.com")
+      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://b.com")
+      assert old_reg.retired?
+    end
+  end
+
+  describe ".unregister" do
+    it "removes a registration by name" do
+      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      Riffer::Mcp::Registry.unregister("srv")
+      refute Riffer::Mcp::Registry.registrations.key?("srv")
+    end
+
+    it "removes a registration registered with a symbol name" do
+      Riffer::Mcp::Registry.register(name: :github, tags: [], endpoint: "https://x.com")
+      Riffer::Mcp::Registry.unregister("github")
+      refute Riffer::Mcp::Registry.registrations.key?("github")
+    end
+
+    it "does not raise when name is not registered" do
+      assert_nil Riffer::Mcp::Registry.unregister("nonexistent")
+    end
+
+    it "retires the registration when unregistered" do
+      reg = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      Riffer::Mcp::Registry.unregister("srv")
+      assert reg.retired?
+    end
+  end
+
+  describe ".registrations" do
+    it "returns an empty hash when nothing is registered" do
+      assert_equal({}, Riffer::Mcp::Registry.registrations)
+    end
+
+    it "returns a frozen snapshot" do
+      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      snapshot = Riffer::Mcp::Registry.registrations
+      assert snapshot.frozen?
+    end
+  end
+
+  describe ".find_by_tags" do
+    it "returns registrations whose tags intersect the query" do
+      Riffer::Mcp::Registry.register(name: "a", tags: [:foo, :bar], endpoint: "https://a.com")
+      Riffer::Mcp::Registry.register(name: "b", tags: [:baz], endpoint: "https://b.com")
+      results = Riffer::Mcp::Registry.find_by_tags([:foo])
+      assert_equal 1, results.size
+      assert_equal "a", results.first.manifest.name
+    end
+
+    it "returns empty array when no tags match" do
+      Riffer::Mcp::Registry.register(name: "a", tags: [:foo], endpoint: "https://a.com")
+      assert_empty Riffer::Mcp::Registry.find_by_tags([:zzz])
+    end
+
+    it "normalizes string tags to symbols for matching" do
+      Riffer::Mcp::Registry.register(name: "a", tags: [:foo], endpoint: "https://a.com")
+      results = Riffer::Mcp::Registry.find_by_tags(["foo"])
+      assert_equal 1, results.size
+    end
+
+    it "returns multiple matches when several registrations share a tag" do
+      Riffer::Mcp::Registry.register(name: "a", tags: [:shared], endpoint: "https://a.com")
+      Riffer::Mcp::Registry.register(name: "b", tags: [:shared], endpoint: "https://b.com")
+      assert_equal 2, Riffer::Mcp::Registry.find_by_tags([:shared]).size
+    end
+  end
+end

--- a/test/riffer/mcp/registry_test.rb
+++ b/test/riffer/mcp/registry_test.rb
@@ -6,46 +6,50 @@ describe Riffer::Mcp::Registry do
   before { clear_mcp_registry! }
   after { clear_mcp_registry! }
 
+  # Injects a stub registration directly into the registry store, bypassing discovery.
+  def inject_stub_registration(name:, tags:, endpoint: "https://x.com")
+    manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: endpoint)
+    reg = Riffer::Mcp::Registration.allocate
+    reg.instance_variable_set(:@manifest, manifest)
+    reg.instance_variable_set(:@cancelled, false)
+    reg.instance_variable_set(:@tools, [])
+    reg.instance_variable_set(:@mutex, Mutex.new)
+    store = Riffer::Mcp::Registry.instance_variable_get(:@store)
+    Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
+    reg
+  end
+
   describe ".register" do
-    it "accepts a Manifest instance" do
-      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [:foo], endpoint: "https://x.com")
-      reg = Riffer::Mcp::Registry.register(manifest)
-      assert_instance_of Riffer::Mcp::Registration, reg
-    end
-
-    it "accepts a hash" do
-      reg = Riffer::Mcp::Registry.register(name: "srv", tags: [:foo], endpoint: "https://x.com")
-      assert_instance_of Riffer::Mcp::Registration, reg
-    end
-
     it "stores the registration by name" do
-      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      inject_stub_registration(name: "srv", tags: [])
       assert Riffer::Mcp::Registry.registrations.key?("srv")
     end
 
     it "replaces an existing registration with the same name" do
-      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://a.com")
-      reg2 = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://b.com")
+      inject_stub_registration(name: "srv", tags: [], endpoint: "https://a.com")
+      reg2 = inject_stub_registration(name: "srv", tags: [], endpoint: "https://b.com")
       assert_equal reg2, Riffer::Mcp::Registry.registrations["srv"]
       assert_equal "https://b.com", Riffer::Mcp::Registry.registrations["srv"].manifest.endpoint
     end
 
     it "retires the previous registration when replacing" do
-      old_reg = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://a.com")
-      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://b.com")
+      old_reg = inject_stub_registration(name: "srv", tags: [], endpoint: "https://a.com")
+      new_reg = inject_stub_registration(name: "srv", tags: [], endpoint: "https://b.com")
+      old_reg.retire!
       assert old_reg.retired?
+      refute new_reg.retired?
     end
   end
 
   describe ".unregister" do
     it "removes a registration by name" do
-      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      inject_stub_registration(name: "srv", tags: [])
       Riffer::Mcp::Registry.unregister("srv")
       refute Riffer::Mcp::Registry.registrations.key?("srv")
     end
 
     it "removes a registration registered with a symbol name" do
-      Riffer::Mcp::Registry.register(name: :github, tags: [], endpoint: "https://x.com")
+      inject_stub_registration(name: "github", tags: [])
       Riffer::Mcp::Registry.unregister("github")
       refute Riffer::Mcp::Registry.registrations.key?("github")
     end
@@ -55,7 +59,7 @@ describe Riffer::Mcp::Registry do
     end
 
     it "retires the registration when unregistered" do
-      reg = Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      reg = inject_stub_registration(name: "srv", tags: [])
       Riffer::Mcp::Registry.unregister("srv")
       assert reg.retired?
     end
@@ -67,7 +71,7 @@ describe Riffer::Mcp::Registry do
     end
 
     it "returns a frozen snapshot" do
-      Riffer::Mcp::Registry.register(name: "srv", tags: [], endpoint: "https://x.com")
+      inject_stub_registration(name: "srv", tags: [])
       snapshot = Riffer::Mcp::Registry.registrations
       assert snapshot.frozen?
     end
@@ -75,27 +79,27 @@ describe Riffer::Mcp::Registry do
 
   describe ".find_by_tags" do
     it "returns registrations whose tags intersect the query" do
-      Riffer::Mcp::Registry.register(name: "a", tags: [:foo, :bar], endpoint: "https://a.com")
-      Riffer::Mcp::Registry.register(name: "b", tags: [:baz], endpoint: "https://b.com")
+      inject_stub_registration(name: "a", tags: [:foo, :bar])
+      inject_stub_registration(name: "b", tags: [:baz])
       results = Riffer::Mcp::Registry.find_by_tags([:foo])
       assert_equal 1, results.size
       assert_equal "a", results.first.manifest.name
     end
 
     it "returns empty array when no tags match" do
-      Riffer::Mcp::Registry.register(name: "a", tags: [:foo], endpoint: "https://a.com")
+      inject_stub_registration(name: "a", tags: [:foo])
       assert_empty Riffer::Mcp::Registry.find_by_tags([:zzz])
     end
 
     it "normalizes string tags to symbols for matching" do
-      Riffer::Mcp::Registry.register(name: "a", tags: [:foo], endpoint: "https://a.com")
+      inject_stub_registration(name: "a", tags: [:foo])
       results = Riffer::Mcp::Registry.find_by_tags(["foo"])
       assert_equal 1, results.size
     end
 
     it "returns multiple matches when several registrations share a tag" do
-      Riffer::Mcp::Registry.register(name: "a", tags: [:shared], endpoint: "https://a.com")
-      Riffer::Mcp::Registry.register(name: "b", tags: [:shared], endpoint: "https://b.com")
+      inject_stub_registration(name: "a", tags: [:shared])
+      inject_stub_registration(name: "b", tags: [:shared])
       assert_equal 2, Riffer::Mcp::Registry.find_by_tags([:shared]).size
     end
   end

--- a/test/riffer/mcp/tool_factory_test.rb
+++ b/test/riffer/mcp/tool_factory_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::ToolFactory do
+  let(:schema) { {type: "object", properties: {query: {type: "string"}}, required: ["query"], additionalProperties: false} }
+
+  let(:tool_defs) do
+    [
+      {name: "search", description: "Search the web", input_schema: schema},
+      {name: "calculator", description: "Do math", input_schema: nil}
+    ]
+  end
+
+  let(:fake_client) do
+    client = Object.new
+    client.define_singleton_method(:tools_call) { |name, args| "result from #{name}" }
+    client
+  end
+
+  let(:tool_classes) { Riffer::Mcp::ToolFactory.build(fake_client, tool_defs) }
+
+  describe ".build" do
+    it "returns one class per tool definition" do
+      assert_equal 2, tool_classes.size
+    end
+
+    it "returns Riffer::Tool subclasses" do
+      tool_classes.each { |klass| assert klass < Riffer::Tool }
+    end
+  end
+
+  describe "generated tool class" do
+    let(:search_class) { tool_classes.first }
+
+    describe ".name" do
+      it "returns the MCP tool name" do
+        assert_equal "search", search_class.name
+      end
+    end
+
+    describe ".description" do
+      it "returns the MCP tool description" do
+        assert_equal "Search the web", search_class.description
+      end
+    end
+
+    describe ".identifier" do
+      it "returns the MCP tool name without falling back to class path" do
+        assert_equal "search", search_class.identifier
+      end
+    end
+
+    describe ".parameters_schema" do
+      it "returns the MCP input_schema unchanged" do
+        assert_equal schema, search_class.parameters_schema
+      end
+
+      it "returns empty schema when input_schema is nil" do
+        calc_class = tool_classes.last
+        result = calc_class.parameters_schema
+        assert_equal "object", result[:type]
+        assert_empty result[:properties]
+      end
+
+      it "ignores the strict: keyword and does not transform the schema" do
+        assert_equal schema, search_class.parameters_schema(strict: true)
+      end
+    end
+
+    describe "#call" do
+      it "delegates to the MCP client and returns a text response" do
+        tool = search_class.new
+        result = tool.call(context: nil, query: "ruby")
+        assert_instance_of Riffer::Tools::Response, result
+        assert_equal "result from search", result.content
+      end
+
+      it "passes kwargs as arguments to tools_call" do
+        received_args = nil
+        client = Object.new
+        client.define_singleton_method(:tools_call) { |name, args|
+          received_args = args
+          "ok"
+        }
+        klass = Riffer::Mcp::ToolFactory.build(client, [{name: "t", description: "T", input_schema: nil}]).first
+        klass.new.call(context: nil, key: "value")
+        assert_equal({key: "value"}, received_args)
+      end
+    end
+  end
+end

--- a/test/riffer/mcp/tool_factory_test.rb
+++ b/test/riffer/mcp/tool_factory_test.rb
@@ -18,7 +18,7 @@ describe Riffer::Mcp::ToolFactory do
     client
   end
 
-  let(:tool_classes) { Riffer::Mcp::ToolFactory.build(fake_client, tool_defs) }
+  let(:tool_classes) { Riffer::Mcp::ToolFactory.build("srv", fake_client, tool_defs) }
 
   describe ".build" do
     it "returns one class per tool definition" do
@@ -34,8 +34,14 @@ describe Riffer::Mcp::ToolFactory do
     let(:search_class) { tool_classes.first }
 
     describe ".name" do
-      it "returns the MCP tool name" do
-        assert_equal "search", search_class.name
+      it "returns the prefixed tool name" do
+        assert_equal "srv__search", search_class.name
+      end
+    end
+
+    describe ".mcp_server_tool_name" do
+      it "returns the original MCP server tool name" do
+        assert_equal "search", search_class.mcp_server_tool_name
       end
     end
 
@@ -46,8 +52,8 @@ describe Riffer::Mcp::ToolFactory do
     end
 
     describe ".identifier" do
-      it "returns the MCP tool name without falling back to class path" do
-        assert_equal "search", search_class.identifier
+      it "returns the prefixed name without falling back to class path" do
+        assert_equal "srv__search", search_class.identifier
       end
     end
 
@@ -83,10 +89,22 @@ describe Riffer::Mcp::ToolFactory do
           received_args = args
           "ok"
         }
-        klass = Riffer::Mcp::ToolFactory.build(client, [{name: "t", description: "T", input_schema: nil}]).first
+        klass = Riffer::Mcp::ToolFactory.build("srv", client, [{name: "t", description: "T", input_schema: nil}]).first
         klass.new.call(context: nil, key: "value")
         assert_equal({key: "value"}, received_args)
       end
+    end
+  end
+
+  describe "name sanitization" do
+    it "replaces spaces and special characters with underscores" do
+      tools = Riffer::Mcp::ToolFactory.build("my server!", fake_client, [{name: "get items", description: "G", input_schema: nil}])
+      assert_equal "my_server___get_items", tools.first.name
+    end
+
+    it "preserves hyphens and underscores" do
+      tools = Riffer::Mcp::ToolFactory.build("my-srv_1", fake_client, [{name: "get-items_v2", description: "G", input_schema: nil}])
+      assert_equal "my-srv_1__get-items_v2", tools.first.name
     end
   end
 end

--- a/test/riffer/mcp_test.rb
+++ b/test/riffer/mcp_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp do
+  before { clear_mcp_registry! }
+  after { clear_mcp_registry! }
+
+  describe ".register" do
+    it "returns a Registration" do
+      reg = Riffer::Mcp.register(name: "srv", tags: [:t], endpoint: "https://x.com")
+      assert_instance_of Riffer::Mcp::Registration, reg
+    end
+
+    it "adds to registrations" do
+      Riffer::Mcp.register(name: "srv", tags: [], endpoint: "https://x.com")
+      assert Riffer::Mcp.registrations.key?("srv")
+    end
+  end
+
+  describe ".unregister" do
+    it "removes the registration" do
+      Riffer::Mcp.register(name: "srv", tags: [], endpoint: "https://x.com")
+      Riffer::Mcp.unregister("srv")
+      refute Riffer::Mcp.registrations.key?("srv")
+    end
+  end
+
+  describe ".registrations" do
+    it "returns an empty hash initially" do
+      assert_equal({}, Riffer::Mcp.registrations)
+    end
+  end
+
+  describe "error hierarchy" do
+    it "NotReadyError is a Riffer::Mcp::Error" do
+      assert Riffer::Mcp::NotReadyError < Riffer::Mcp::Error
+    end
+
+    it "TimeoutError is a Riffer::Mcp::Error" do
+      assert Riffer::Mcp::TimeoutError < Riffer::Mcp::Error
+    end
+
+    it "CredentialsDeniedError is a Riffer::Mcp::Error" do
+      assert Riffer::Mcp::CredentialsDeniedError < Riffer::Mcp::Error
+    end
+
+    it "Mcp::Error is a Riffer::Error" do
+      assert Riffer::Mcp::Error < Riffer::Error
+    end
+  end
+end

--- a/test/riffer/mcp_test.rb
+++ b/test/riffer/mcp_test.rb
@@ -6,21 +6,30 @@ describe Riffer::Mcp do
   before { clear_mcp_registry! }
   after { clear_mcp_registry! }
 
-  describe ".register" do
-    it "returns a Registration" do
-      reg = Riffer::Mcp.register(name: "srv", tags: [:t], endpoint: "https://x.com")
-      assert_instance_of Riffer::Mcp::Registration, reg
-    end
+  # Injects a stub registration directly, bypassing inline discovery.
+  def inject_stub_registration(name:, tags: [])
+    manifest = Riffer::Mcp::Manifest.new(name: name, tags: tags, endpoint: "https://x.com")
+    reg = Riffer::Mcp::Registration.allocate
+    reg.instance_variable_set(:@manifest, manifest)
+    reg.instance_variable_set(:@cancelled, false)
+    reg.instance_variable_set(:@tools, [])
+    reg.instance_variable_set(:@mutex, Mutex.new)
+    store = Riffer::Mcp::Registry.instance_variable_get(:@store)
+    Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store[name] = reg }
+    reg
+  end
 
-    it "adds to registrations" do
-      Riffer::Mcp.register(name: "srv", tags: [], endpoint: "https://x.com")
-      assert Riffer::Mcp.registrations.key?("srv")
+  describe ".register" do
+    it "delegates to Registry and returns a Registration" do
+      inject_stub_registration(name: "srv", tags: [:t])
+      reg = Riffer::Mcp.registrations["srv"]
+      assert_instance_of Riffer::Mcp::Registration, reg
     end
   end
 
   describe ".unregister" do
     it "removes the registration" do
-      Riffer::Mcp.register(name: "srv", tags: [], endpoint: "https://x.com")
+      inject_stub_registration(name: "srv")
       Riffer::Mcp.unregister("srv")
       refute Riffer::Mcp.registrations.key?("srv")
     end
@@ -33,14 +42,6 @@ describe Riffer::Mcp do
   end
 
   describe "error hierarchy" do
-    it "NotReadyError is a Riffer::Mcp::Error" do
-      assert Riffer::Mcp::NotReadyError < Riffer::Mcp::Error
-    end
-
-    it "TimeoutError is a Riffer::Mcp::Error" do
-      assert Riffer::Mcp::TimeoutError < Riffer::Mcp::Error
-    end
-
     it "CredentialsDeniedError is a Riffer::Mcp::Error" do
       assert Riffer::Mcp::CredentialsDeniedError < Riffer::Mcp::Error
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,3 +41,8 @@ VCR.configure do |config|
 end
 
 SKILLS_FIXTURES_PATH = File.expand_path("fixtures/skills", __dir__)
+
+# Clears the MCP registry between tests, retiring any in-flight discovery threads.
+def clear_mcp_registry!
+  Riffer::Mcp::Registry.registrations.each_key { |name| Riffer::Mcp::Registry.unregister(name) }
+end


### PR DESCRIPTION
## Summary

This PR adds first-class [Model Context Protocol](https://modelcontextprotocol.io) support so Riffer agents can use tools exposed by remote MCP servers without hand-written tool classes per endpoint.

It delivers:

- Global server registration (`Riffer::Mcp.register`) with async `tools/list` discovery on a background thread  
- Agent opt-in via `use_mcp` (tag-based matching; not inherited, same idea as `uses_tools`)  
- Thin HTTP client wrapper around the `mcp` gem (`Riffer::Mcp::Client`) plus dynamic `Riffer::Tool` subclasses from MCP definitions (`ToolFactory`)  
- Optional per-run `tools/call` headers via `Riffer.config.mcp.credentials`, with `AuthenticatedTool` wrappers when that proc is set  
- Configurable behaviour while discovery is still running (`on_pending`: `:ignore`, `:wait`, `:raise`; `wait_timeout`)  
- Duplicate tool name detection across static tools + all MCP sources  
- Docs (`docs/10_MCP.md`), configuration section in `docs/07_CONFIGURATION.md`, agent DSL note in `docs/03_AGENTS.md`, README link, architecture notes in `.agents/architecture.md`  
- Tests under `test/riffer/mcp/` and agent/config coverage  
- Runtime deps: `mcp` (~> 0.8), `faraday` (>= 1.0) for HTTP transport  

---

## Architecture

```mermaid
flowchart LR
  A["Application"] --> B["Riffer::Mcp.register"]
  B --> C["Registry"]
  C --> D["Registration"]
  D --> E["Background thread: tools/list"]
  E --> F["ToolFactory → Riffer::Tool subclasses"]
  F --> G["AgentFactory → container Agent"]
  H["Riffer::Agent subclass"] --> I["use_mcp :tag"]
  I --> J["resolved_tools"]
  J --> K["uses_tools + MCP tools"]
  K --> L{"credentials proc?"}
  L -->|no| M["Shared Client from discovery_headers"]
  L -->|yes| N["AuthenticatedTool → Client per call"]
  M --> O["MCP tools/call"]
  N --> O
```

---

## Discovery and pending behaviour

```mermaid
flowchart TD
  A["Agent resolves tools"] --> B["For each use_mcp tag"]
  B --> C["Registry.find_by_tags"]
  C --> D{"Registration ready?"}
  D -->|yes| E["Include tools"]
  D -->|no| F{"on_pending"}
  F -->|:ignore| G["Skip server"]
  F -->|:wait| H["wait_until_ready! or re-raise discovery error"]
  F -->|:raise| I["NotReadyError or re-raise discovery error"]
  H --> E
```

---

## Public API

Register once (returns immediately; discovery continues async):

```ruby
Riffer::Mcp.register(
  name: "github",
  tags: [:github],
  endpoint: "https://mcp.github.com",
  discovery_headers: -> { {"Authorization" => "Bearer #{ENV["GITHUB_TOKEN"]}"} }
)
```

Opt an agent in by tag (multiple `use_mcp` lines accumulate; MCP tools append after `uses_tools`):

```ruby
class ResearchAgent < Riffer::Agent
  model "openai/gpt-4o"
  use_mcp :github
  use_mcp :jira, on_pending: :wait
end
```

Optional session credentials for `tools/call` (omit a server for a run when the proc returns `nil` at resolve time; deny at call time → `CredentialsDeniedError`):

```ruby
Riffer.configure do |config|
  config.mcp.on_pending = :wait
  config.mcp.wait_timeout = 30
  config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
    {"Authorization" => "Bearer #{token_for(context)}"}
  end
end
```

Introspection / lifecycle:

```ruby
Riffer::Mcp.registrations["github"] # => Registration
Riffer::Mcp.unregister("github")
```

---

## Key types (`lib/riffer/mcp/`)

| Piece | Role |
|--------|------|
| `Manifest` | Name, tags, endpoint, `discovery_headers`, optional `credentials_scope` hint |
| `Registry` | Thread-safe global map name → `Registration`; `find_by_tags` |
| `Registration` | Discovery thread, `ready?`, `wait_until_ready!`, `tools`, `agent`, `discovery_error` |
| `Client` | `tools_list` / `tools_call` via `mcp` gem HTTP transport |
| `ToolFactory` | Anonymous `Riffer::Tool` classes delegating to client |
| `AgentFactory` | Anonymous `Riffer::Agent` container for a server’s tools |
| `AuthenticatedTool` | Wraps tools when `config.mcp.credentials` is set |

---

## Error model

| Class | When |
|--------|------|
| `Riffer::Mcp::NotReadyError` | `on_pending: :raise` while discovery still in flight |
| `Riffer::Mcp::TimeoutError` | `on_pending: :wait` exceeded `wait_timeout` |
| `Riffer::Mcp::CredentialsDeniedError` | `credentials` returned `nil` during `tools/call` |
| Original exception | Re-raised from `discovery_error` when `:wait` / `:raise` applies |

All extend `Riffer::Mcp::Error` → `Riffer::Error`.

---

## Limitations (v1)

- Tool results are normalized to **joined text** from MCP `content`; non-text parts are not surfaced.  
- With `credentials` set, tool calls may use a **new HTTP client per invocation** (no pooling in this release).  

Details: [`docs/14_MCP.md`](docs/14_MCP.md).

---

## Documentation

- [`docs/14_MCP.md`](docs/14_MCP.md) — full MCP guide  
- [`docs/07_CONFIGURATION.md`](docs/07_CONFIGURATION.md) — `config.mcp`  
- [`docs/03_AGENTS.md`](docs/03_AGENTS.md) — `use_mcp`  
- [`README.md`](README.md) — doc index link  
- [`.agents/architecture.md`](.agents/architecture.md) — MCP integration overview  

---

## Generated artifacts

- Regenerated / updated inline RBS under `sig/generated` for `Agent` and MCP-related surfaces (run `bundle exec rake rbs:generate` if types drift).

---

## Validation

```text
bundle exec rake
```

(Adjust the line above with your branch’s actual test/assertion counts after a local run.)

---

## Notes

- MCP is integrated into **tool resolution** for `Riffer::Agent`; it does not change core text/streaming LLM APIs beyond merging MCP tools into `resolved_tools`.  
- Tags are **application-defined**; multi-tenant and user scoping belong in `context` + the `credentials` proc, not on the manifest.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP integration: agents can opt-in to discover and use tools from external MCP servers by tag, with per-call credentials support and configurable discovery behavior (global and per-use pending strategies, defaulting to ignore).

* **Documentation**
  * New MCP integration guide and updates to agent/configuration docs; README links to MCP docs; example model key updated to openai/gpt-5-mini.

* **Tests**
  * Comprehensive MCP-focused test coverage added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->