### PR TITLE
fix: RDoc formatting

### DIFF
--- a/.agents/rdoc.md
+++ b/.agents/rdoc.md
@@ -4,16 +4,28 @@ Use RDoc prose comments for public API descriptions and RBS inline annotations f
 
 ## Parameters and Return Types
 
-Describe parameters in the RDoc prose comment. Use a single `#:` line for the RBS method signature (see [rbs-inline.md](rbs-inline.md) for the full type annotation syntax):
+Describe parameters using RDoc labeled list syntax. Use a single `#:` line for the RBS method signature (see [rbs-inline.md](rbs-inline.md) for the full type annotation syntax):
 
 ```ruby
 # Creates a new agent.
 #
-# +name+ - the agent name.
-# +options+ - optional configuration.
+# [name] the agent name.
+# [options] optional configuration.
 #
+#--
 #: (String, ?options: Hash[Symbol, untyped]) -> void
 def initialize(name, options: {})
+```
+
+Always add `#--` (RDoc stop directive) on the line before a standalone `#:` type annotation. Without it, RDoc treats `#:` as a label-list marker and corrupts the preceding comment into a `<pre>` block. Inline `#:` on the same line as code (e.g., `attr_reader :name #: String`) does not need this.
+
+## Inline Code
+
+Use `+word+` for single-word inline code. For multi-word expressions (containing spaces, colons, or brackets), use `<tt>multi word expression</tt>`:
+
+```ruby
+# Returns +nil+ when no instructions are configured.
+# Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
 ```
 
 ## Attributes and Constants
@@ -37,7 +49,7 @@ Document with prose:
 
 ## Examples
 
-Include usage examples as indented code blocks:
+Include usage examples as indented code blocks (2 extra spaces of indent):
 
 ```ruby
 # Creates a new agent.

--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,7 @@ RDoc::Task.new do |rdoc|
   rdoc.rdoc_files.include("README.md", "CHANGELOG.md", "LICENSE.txt", "docs/**/*.md", "docs_providers/**/*.md")
   rdoc.rdoc_files.include("lib/**/*.rb")
 
-  # Use Markdown where available and ensure UTF-8
-  rdoc.options << "--charset" << "utf-8" << "--markup" << "markdown"
+  rdoc.options << "--charset" << "utf-8"
 end
 
 task docs: :rdoc

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -33,6 +33,7 @@ module Riffer
 
   # Returns the Riffer configuration.
   #
+  #--
   #: () -> Riffer::Config
   def self.config
     @config ||= Config.new
@@ -44,11 +45,13 @@ module Riffer
   #     config.openai.api_key = ENV['OPENAI_API_KEY']
   #   end
   #
+  #--
   #: () ?{ (Riffer::Config) -> void } -> void
   def self.configure(&block)
     yield config if block_given?
   end
 
+  #--
   #: () -> String
   def self.version
     VERSION

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -28,6 +28,7 @@ class Riffer::Agent
 
   # Gets or sets the agent identifier.
   #
+  #--
   #: (?String?) -> String
   def self.identifier(value = nil)
     return @identifier || class_name_to_path(name) if value.nil?
@@ -36,6 +37,7 @@ class Riffer::Agent
 
   # Gets or sets the model string (e.g., "openai/gpt-4o") or Proc.
   #
+  #--
   #: (?(String | Proc)?) -> (String | Proc)?
   def self.model(model_string_or_proc = nil)
     return @model if model_string_or_proc.nil?
@@ -60,6 +62,7 @@ class Riffer::Agent
   #     "You are assisting #{context[:name]}"
   #   }
   #
+  #--
   #: (?(String | Proc)?) -> (String | Proc)?
   def self.instructions(instructions_or_proc = nil)
     return @instructions if instructions_or_proc.nil?
@@ -74,6 +77,7 @@ class Riffer::Agent
 
   # Gets or sets provider options passed to the provider client.
   #
+  #--
   #: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.provider_options(options = nil)
     return @provider_options || {} if options.nil?
@@ -82,6 +86,7 @@ class Riffer::Agent
 
   # Gets or sets model options passed to generate_text/stream_text.
   #
+  #--
   #: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.model_options(options = nil)
     return @model_options || {} if options.nil?
@@ -92,6 +97,7 @@ class Riffer::Agent
   #
   # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
+  #--
   #: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
   def self.structured_output(params = nil, &block)
     if block
@@ -110,6 +116,7 @@ class Riffer::Agent
   # Defaults to DEFAULT_MAX_STEPS (16). Set to +Float::INFINITY+ for
   # unlimited steps.
   #
+  #--
   #: (?Numeric?) -> Numeric
   def self.max_steps(value = nil)
     return @max_steps || DEFAULT_MAX_STEPS if value.nil?
@@ -118,6 +125,7 @@ class Riffer::Agent
 
   # Gets or sets the tools used by this agent.
   #
+  #--
   #: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools(tools_or_lambda = nil)
     return @tools_config if tools_or_lambda.nil?
@@ -130,8 +138,9 @@ class Riffer::Agent
   # or a Proc.
   #
   # Inherited by subclasses. When unset, walks the ancestor chain and
-  # falls back to the global +Riffer.config.tool_runtime+.
+  # falls back to the global <tt>Riffer.config.tool_runtime</tt>.
   #
+  #--
   #: (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime(value = nil)
     if value.nil?
@@ -152,6 +161,7 @@ class Riffer::Agent
   #     activate ["code-review"]
   #   end
   #
+  #--
   #: () ?{ () -> void } -> Riffer::Skills::Config?
   def self.skills(&block)
     if block
@@ -163,6 +173,7 @@ class Riffer::Agent
 
   # Finds an agent class by identifier.
   #
+  #--
   #: (String) -> singleton(Riffer::Agent)?
   def self.find(identifier)
     subclasses.find { |agent_class| agent_class.identifier == identifier.to_s }
@@ -170,6 +181,7 @@ class Riffer::Agent
 
   # Returns all agent subclasses.
   #
+  #--
   #: () -> Array[singleton(Riffer::Agent)]
   def self.all
     subclasses
@@ -179,6 +191,7 @@ class Riffer::Agent
   #
   # See #generate for parameters and return value.
   #
+  #--
   #: (*untyped, **untyped) -> Riffer::Agent::Response
   def self.generate(...)
     new.generate(...)
@@ -188,6 +201,7 @@ class Riffer::Agent
   #
   # See #stream for parameters and return value.
   #
+  #--
   #: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def self.stream(...)
     new.stream(...)
@@ -195,11 +209,12 @@ class Riffer::Agent
 
   # Registers a guardrail for input, output, or both phases.
   #
-  # +phase+ - :before, :after, or :around.
-  # +with+ - the guardrail class (must be subclass of Riffer::Guardrail).
-  # +options+ - additional options passed to the guardrail.
+  # [phase] :before, :after, or :around.
+  # [with] the guardrail class (must be subclass of Riffer::Guardrail).
+  # [options] additional options passed to the guardrail.
   #
   # Raises Riffer::ArgumentError if phase is invalid or guardrail is not a Guardrail class.
+  #--
   #: (Symbol, with: singleton(Riffer::Guardrail), **untyped) -> void
   def self.guardrail(phase, with:, **options)
     valid_phases = [*Riffer::Guardrails::PHASES, :around]
@@ -222,8 +237,9 @@ class Riffer::Agent
 
   # Returns the registered guardrail configs for a given phase.
   #
-  # +phase+ - :before or :after.
+  # [phase] :before or :after.
   #
+  #--
   #: (Symbol) -> Array[Hash[Symbol, untyped]]
   def self.guardrails_for(phase)
     @guardrails ||= {before: [], after: []}
@@ -241,6 +257,7 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
+  #--
   #: () -> void
   def initialize
     @messages = []
@@ -260,6 +277,7 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
+  #--
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def generate(prompt_or_messages, files: nil, context: nil)
     @context = context
@@ -280,6 +298,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
+  #--
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream(prompt_or_messages, files: nil, context: nil)
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
@@ -305,6 +324,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if no block is given.
   #
+  #--
   #: () { (Riffer::Messages::Base) -> void } -> self
   def on_message(&block)
     raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
@@ -319,6 +339,7 @@ class Riffer::Agent
   #
   # Returns +nil+ when no instructions are configured.
   #
+  #--
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def generate_instruction_message(context: nil)
     build_instruction_message(context)
@@ -331,6 +352,7 @@ class Riffer::Agent
   #
   # Returns +nil+ when no skills are configured or the catalog is empty.
   #
+  #--
   #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def generate_skills_message(context: nil)
     build_skills_message(resolve_skills(context))
@@ -339,8 +361,9 @@ class Riffer::Agent
   # Interrupts the agent loop.
   #
   # Call from an +on_message+ callback to cleanly interrupt the loop.
-  # Equivalent to +throw :riffer_interrupt, reason+.
+  # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
+  #--
   #: (?(String | Symbol)?) -> void
   def interrupt!(reason = nil)
     throw :riffer_interrupt, reason
@@ -348,6 +371,7 @@ class Riffer::Agent
 
   private
 
+  #--
   #: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
   def run_generate_loop(all_modifications = [])
     step = count_assistant_messages
@@ -388,12 +412,14 @@ class Riffer::Agent
     build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response))
   end
 
+  #--
   #: (Riffer::Messages::Base) -> void
   def add_message(message)
     @messages << message
     @message_callbacks.each { |callback| callback.call(message) }
   end
 
+  #--
   #: (Riffer::TokenUsage?) -> void
   def track_token_usage(usage)
     return unless usage
@@ -401,6 +427,7 @@ class Riffer::Agent
     @token_usage = @token_usage ? @token_usage + usage : usage
   end
 
+  #--
   #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages(prompt_or_messages, files: nil)
     if prompt_or_messages.is_a?(Array)
@@ -421,6 +448,7 @@ class Riffer::Agent
     end
   end
 
+  #--
   #: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def build_instruction_message(context = @context)
     content = generate_instructions(context)
@@ -428,6 +456,7 @@ class Riffer::Agent
     Riffer::Messages::System.new(content)
   end
 
+  #--
   #: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
   def build_skills_message(skills_state = @skills_state)
     content = skills_state&.system_prompt
@@ -435,11 +464,13 @@ class Riffer::Agent
     Riffer::Messages::System.new(content)
   end
 
+  #--
   #: () -> Integer
   def count_assistant_messages
     @messages.count { |m| m.is_a?(Riffer::Messages::Assistant) }
   end
 
+  #--
   #: (Enumerator::Yielder) -> void
   def run_stream_loop(yielder)
     step = count_assistant_messages
@@ -516,6 +547,7 @@ class Riffer::Agent
     end
   end
 
+  #--
   #: () -> Riffer::Messages::Assistant
   def call_llm
     provider_instance.generate_text(
@@ -526,6 +558,7 @@ class Riffer::Agent
     )
   end
 
+  #--
   #: () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream
     provider_instance.stream_text(
@@ -536,16 +569,19 @@ class Riffer::Agent
     )
   end
 
+  #--
   #: () -> Riffer::Providers::Base
   def provider_instance
     @provider_instance ||= provider_class.new(**self.class.provider_options)
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> bool
   def has_tool_calls?(response)
     response.is_a?(Riffer::Messages::Assistant) && !response.tool_calls.empty?
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
     runtime = resolve_tool_runtime
@@ -570,6 +606,7 @@ class Riffer::Agent
   # last assistant message against the tool result messages that follow it,
   # then executes any that are missing.
   #
+  #--
   #: () -> void
   # Executes tool calls from the last assistant message that don't yet
   # have a corresponding tool result. Safe to call unconditionally —
@@ -606,6 +643,7 @@ class Riffer::Agent
     assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
   end
 
+  #--
   #: () -> void
   def prepare_run
     @resolved_tools = nil
@@ -617,6 +655,7 @@ class Riffer::Agent
     @context = (@context || {}).merge(skills: @skills_state) if @skills_state
   end
 
+  #--
   #: (untyped) -> void
   def parse_model_string!(model_string)
     raise Riffer::ArgumentError, "Invalid model string: #{model_string}" unless model_string.is_a?(String)
@@ -626,12 +665,14 @@ class Riffer::Agent
     @model_name = model_name
   end
 
+  #--
   #: () -> void
   def clear_resolved_model
     @resolved_model = nil
     @provider_instance = nil if @model_config.is_a?(Proc)
   end
 
+  #--
   #: (?Hash[Symbol, untyped]?) -> String?
   def generate_instructions(context = @context)
     if @instructions_config.is_a?(Proc)
@@ -643,6 +684,7 @@ class Riffer::Agent
 
   attr_reader :resolved_model #: String?
 
+  #--
   #: () -> String
   def resolve_model
     @resolved_model ||= if @model_config.is_a?(Proc)
@@ -654,6 +696,7 @@ class Riffer::Agent
     end
   end
 
+  #--
   #: () -> Array[singleton(Riffer::Tool)]
   def resolved_tools
     @resolved_tools ||= begin
@@ -677,6 +720,7 @@ class Riffer::Agent
     end
   end
 
+  #--
   #: () -> Riffer::ToolRuntime
   def resolve_tool_runtime
     @resolved_tool_runtime ||= begin
@@ -702,6 +746,7 @@ class Riffer::Agent
   # Does not mutate instance state — callers are responsible for
   # assigning the returned context.
   #
+  #--
   #: (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
   def resolve_skills(context = @context)
     return nil unless self.class.skills
@@ -728,6 +773,7 @@ class Riffer::Agent
     skills_context
   end
 
+  #--
   #: () -> singleton(Riffer::Providers::Base)
   def provider_class
     klass = Riffer::Providers::Repository.find(@provider_name)
@@ -735,11 +781,13 @@ class Riffer::Agent
     klass
   end
 
+  #--
   #: () -> Riffer::Messages::Assistant?
   def extract_final_response
     @messages.reverse.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
   end
 
+  #--
   #: () -> [Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_before_guardrails
     guardrails = self.class.guardrails_for(:before)
@@ -751,6 +799,7 @@ class Riffer::Agent
     [tripwire, modifications]
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_after_guardrails(response)
     guardrails = self.class.guardrails_for(:after)
@@ -765,6 +814,7 @@ class Riffer::Agent
     [processed_response, tripwire, modifications]
   end
 
+  #--
   #: (Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
   def validate_structured_output(response)
     return unless response&.structured_output? && @structured_output
@@ -772,12 +822,14 @@ class Riffer::Agent
     @structured_output.parse_and_validate(response.content).object
   end
 
+  #--
   #: () -> Riffer::StructuredOutput?
   def resolve_structured_output
     params = self.class.structured_output
     params ? Riffer::StructuredOutput.new(params) : nil
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def merged_model_options
     opts = self.class.model_options.dup
@@ -785,6 +837,7 @@ class Riffer::Agent
     opts
   end
 
+  #--
   #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
     Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze)

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -33,14 +33,15 @@ class Riffer::Agent::Response
 
   # Creates a new response.
   #
-  # +content+ - the response content.
-  # +tripwire+ - optional tripwire for blocked responses.
-  # +modifications+ - guardrail modifications applied during processing.
-  # +interrupted+ - whether the agent loop was interrupted by a callback.
-  # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
-  # +structured_output+ - parsed structured output when structured output is configured.
-  # +messages+ - the full message history from the agent conversation.
+  # [content] the response content.
+  # [tripwire] optional tripwire for blocked responses.
+  # [modifications] guardrail modifications applied during processing.
+  # [interrupted] whether the agent loop was interrupted by a callback.
+  # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
+  # [structured_output] parsed structured output when structured output is configured.
+  # [messages] the full message history from the agent conversation.
   #
+  #--
   #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
   def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [])
     @content = content
@@ -54,6 +55,7 @@ class Riffer::Agent::Response
 
   # Returns true if the response was blocked by a guardrail.
   #
+  #--
   #: () -> bool
   def blocked?
     !tripwire.nil?
@@ -61,14 +63,16 @@ class Riffer::Agent::Response
 
   # Returns true if any guardrail modified data during processing.
   #
+  #--
   #: () -> bool
   def modified?
     modifications.any?
   end
 
   # Returns true if the agent loop was interrupted by a callback
-  # via +throw :riffer_interrupt+.
+  # via <tt>throw :riffer_interrupt</tt>.
   #
+  #--
   #: () -> bool
   def interrupted?
     @interrupted

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -39,7 +39,7 @@ class Riffer::Config
   # Global tool runtime configuration (experimental).
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
-  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  # or a Proc. Defaults to <tt>Riffer::ToolRuntime::Inline.new</tt>.
   attr_reader :tool_runtime #: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)
 
   # Sets the global tool runtime.
@@ -47,6 +47,7 @@ class Riffer::Config
   # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
   # (ToolRuntime subclass, ToolRuntime instance, or Proc).
   #
+  #--
   #: ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=(value)
     valid = (value.is_a?(Class) && value < Riffer::ToolRuntime) || value.is_a?(Riffer::ToolRuntime) || value.is_a?(Proc)
@@ -54,6 +55,7 @@ class Riffer::Config
     @tool_runtime = value
   end
 
+  #--
   #: () -> void
   def initialize
     @amazon_bedrock = AmazonBedrock.new

--- a/lib/riffer/core.rb
+++ b/lib/riffer/core.rb
@@ -10,6 +10,7 @@ class Riffer::Core
   # The logger instance for Riffer.
   attr_reader :logger #: Logger
 
+  #--
   #: () -> void
   def initialize
     @logger = Logger.new($stdout)
@@ -19,6 +20,7 @@ class Riffer::Core
 
   # Yields self for configuration.
   #
+  #--
   #: () ?{ (Riffer::Core) -> void } -> void
   def configure(&block)
     yield self if block_given?

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -19,6 +19,7 @@ class Riffer::Evals::Evaluator
   class << self
     # Gets or sets the evaluation instructions (criteria and scoring rubric).
     #
+    #--
     #: (?String?) -> String?
     def instructions(value = nil)
       return @instructions if value.nil?
@@ -27,6 +28,7 @@ class Riffer::Evals::Evaluator
 
     # Gets or sets whether higher scores are better.
     #
+    #--
     #: (?bool?) -> bool
     def higher_is_better(value = nil)
       return @higher_is_better.nil? || @higher_is_better if value.nil?
@@ -35,6 +37,7 @@ class Riffer::Evals::Evaluator
 
     # Gets or sets the judge model for LLM-as-judge evaluations.
     #
+    #--
     #: (?String?) -> String?
     def judge_model(value = nil)
       return @judge_model if value.nil?
@@ -47,13 +50,14 @@ class Riffer::Evals::Evaluator
   # The default implementation calls the judge with the class-level +instructions+.
   # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
-  # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
-  # +output+ - the agent's response to evaluate.
-  # +ground_truth+ - optional reference answer for comparison.
-  # +messages+ - the full message history from the agent conversation.
+  # [input] the input to evaluate; String or Array of message hashes/Message objects.
+  # [output] the agent's response to evaluate.
+  # [ground_truth] optional reference answer for comparison.
+  # [messages] the full message history from the agent conversation.
   #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
+  #--
   #: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
   def evaluate(input:, output:, ground_truth: nil, messages: [])
     instr = self.class.instructions
@@ -77,6 +81,7 @@ class Riffer::Evals::Evaluator
   # Array inputs (message hashes or Message objects) are formatted
   # as labeled role/content pairs separated by blank lines.
   #
+  #--
   #: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
   def format_input(input)
     return input if input.is_a?(String)
@@ -92,6 +97,7 @@ class Riffer::Evals::Evaluator
 
   # Returns a Judge instance configured for this evaluator.
   #
+  #--
   #: () -> Riffer::Evals::Judge
   def judge
     @judge ||= begin
@@ -103,6 +109,7 @@ class Riffer::Evals::Evaluator
 
   # Helper to build a Result object.
   #
+  #--
   #: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
   def result(score:, reason: nil, metadata: {})
     Riffer::Evals::Result.new(

--- a/lib/riffer/evals/evaluator_runner.rb
+++ b/lib/riffer/evals/evaluator_runner.rb
@@ -21,14 +21,15 @@
 class Riffer::Evals::EvaluatorRunner
   # Runs evaluators against an agent for the given scenarios.
   #
-  # +agent+ - an Agent subclass (not an instance).
-  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
-  # +evaluators+ - array of Evaluator subclasses to run against each scenario.
-  # +context+ - optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
+  # [agent] an Agent subclass (not an instance).
+  # [scenarios] array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
+  # [evaluators] array of Evaluator subclasses to run against each scenario.
+  # [context] optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
   #
   # Raises Riffer::ArgumentError if agent is not a Riffer::Agent subclass
   # or any eval is not a Riffer::Evals::Evaluator subclass.
   #
+  #--
   #: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   def self.run(agent:, scenarios:, evaluators:, context: nil)
     validate_agent!(agent)
@@ -41,6 +42,7 @@ class Riffer::Evals::EvaluatorRunner
     Riffer::Evals::RunResult.new(scenario_results: scenario_results)
   end
 
+  #--
   #: (singleton(Riffer::Agent)) -> void
   private_class_method def self.validate_agent!(agent)
     return if agent.is_a?(Class) && agent < Riffer::Agent
@@ -48,6 +50,7 @@ class Riffer::Evals::EvaluatorRunner
     raise Riffer::ArgumentError, "agent must be a subclass of Riffer::Agent, got #{agent.inspect}"
   end
 
+  #--
   #: (Array[singleton(Riffer::Evals::Evaluator)]) -> void
   private_class_method def self.validate_evaluators!(evaluators)
     evaluators.each do |evaluator_class|
@@ -57,6 +60,7 @@ class Riffer::Evals::EvaluatorRunner
     end
   end
 
+  #--
   #: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
   private_class_method def self.run_scenario(agent:, scenario:, evaluators:, context: nil)
     input = scenario[:input]

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -29,6 +29,7 @@ class Riffer::Evals::Judge
       required :reason, String, description: "Brief explanation for the score"
     end
 
+    #--
     #: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
     def call(context:, score:, reason:)
       json({score: score, reason: reason})
@@ -40,6 +41,7 @@ class Riffer::Evals::Judge
 
   # Initializes a new judge.
   #
+  #--
   #: (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
   def initialize(model:, provider_options: {})
     provider_name, model_name = model.split("/", 2)
@@ -54,11 +56,12 @@ class Riffer::Evals::Judge
   # Evaluates using the configured LLM.
   #
   # Composes system and user messages from the semantic fields:
-  # +instructions+ - evaluation criteria and scoring rubric.
-  # +input+ - the original input/question.
-  # +output+ - the agent's response to evaluate.
-  # +ground_truth+ - optional reference answer for comparison.
+  # [instructions] evaluation criteria and scoring rubric.
+  # [input] the original input/question.
+  # [output] the agent's response to evaluate.
+  # [ground_truth] optional reference answer for comparison.
   #
+  #--
   #: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
   def evaluate(instructions:, input:, output:, ground_truth: nil)
     system_message = build_system_message(instructions)
@@ -76,6 +79,7 @@ class Riffer::Evals::Judge
 
   private
 
+  #--
   #: (String) -> String
   def build_system_message(instructions)
     <<~SYSTEM.strip
@@ -87,6 +91,7 @@ class Riffer::Evals::Judge
     SYSTEM
   end
 
+  #--
   #: (input: String, output: String, ?ground_truth: String?) -> String
   def build_user_message(input:, output:, ground_truth: nil)
     parts = []
@@ -96,6 +101,7 @@ class Riffer::Evals::Judge
     parts.join("\n\n")
   end
 
+  #--
   #: () -> Riffer::Providers::Base
   def provider_instance
     @provider_instance ||= begin
@@ -105,16 +111,19 @@ class Riffer::Evals::Judge
     end
   end
 
+  #--
   #: () -> String
   def provider_name
     @provider_name ||= @model.split("/", 2).first
   end
 
+  #--
   #: () -> String
   def model_name
     @model_name ||= @model.split("/", 2).last
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def parse_tool_response(response)
     tool_call = response.tool_calls.first

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -36,6 +36,7 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
+  #--
   #: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
   def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
     @evaluator = evaluator
@@ -48,6 +49,7 @@ class Riffer::Evals::Result
 
   # Returns a hash representation of the result.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {
@@ -61,6 +63,7 @@ class Riffer::Evals::Result
 
   private
 
+  #--
   #: () -> void
   def validate_score!
     return if score.is_a?(Numeric) && score >= 0.0 && score <= 1.0

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -17,6 +17,7 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
+  #--
   #: (scenario_results: Array[Riffer::Evals::ScenarioResult]) -> void
   def initialize(scenario_results:)
     @scenario_results = scenario_results
@@ -24,6 +25,7 @@ class Riffer::Evals::RunResult
 
   # Returns average scores keyed by evaluator class across all scenarios.
   #
+  #--
   #: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores
     return {} if scenario_results.empty?
@@ -45,6 +47,7 @@ class Riffer::Evals::RunResult
 
   # Returns a hash representation of the run result.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -32,6 +32,7 @@ class Riffer::Evals::ScenarioResult
 
   # Initializes a new scenario result.
   #
+  #--
   #: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
   def initialize(input:, output:, ground_truth:, results:, messages: [])
     @input = input
@@ -43,6 +44,7 @@ class Riffer::Evals::ScenarioResult
 
   # Returns scores keyed by evaluator class.
   #
+  #--
   #: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores
     results.each_with_object({}) do |result, hash|
@@ -52,6 +54,7 @@ class Riffer::Evals::ScenarioResult
 
   # Returns a hash representation of the scenario result.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {

--- a/lib/riffer/file_part.rb
+++ b/lib/riffer/file_part.rb
@@ -43,6 +43,7 @@ class Riffer::FilePart
   # Raises Riffer::ArgumentError if neither data nor url is provided,
   # or if media_type is not supported.
   #
+  #--
   #: (media_type: String, ?data: String?, ?filename: String?, ?url: String?) -> void
   def initialize(media_type:, data: nil, filename: nil, url: nil)
     raise Riffer::ArgumentError, "Either data or url must be provided" if data.nil? && url.nil?
@@ -61,6 +62,7 @@ class Riffer::FilePart
   #
   # Raises Riffer::ArgumentError if media_type cannot be detected.
   #
+  #--
   #: (String, ?media_type: String?) -> Riffer::FilePart
   def self.from_url(url, media_type: nil)
     unless media_type
@@ -77,6 +79,7 @@ class Riffer::FilePart
 
   # Returns the URL if the source was a URL, nil otherwise.
   #
+  #--
   #: () -> String?
   def url
     @url_string
@@ -84,6 +87,7 @@ class Riffer::FilePart
 
   # Returns true if the source was a URL.
   #
+  #--
   #: () -> bool
   def url?
     !@url_string.nil?
@@ -91,6 +95,7 @@ class Riffer::FilePart
 
   # Returns true if the file is an image.
   #
+  #--
   #: () -> bool
   def image?
     media_type.start_with?("image/")
@@ -98,6 +103,7 @@ class Riffer::FilePart
 
   # Returns true if the file is a document (not an image).
   #
+  #--
   #: () -> bool
   def document?
     !image?
@@ -105,6 +111,7 @@ class Riffer::FilePart
 
   # Serializes the FilePart to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {media_type: media_type}

--- a/lib/riffer/guardrail.rb
+++ b/lib/riffer/guardrail.rb
@@ -21,9 +21,10 @@ class Riffer::Guardrail
   #
   # Override this method in subclasses to implement input processing.
   #
-  # +messages+ - the input messages.
-  # +context+ - optional context passed to the agent.
+  # [messages] the input messages.
+  # [context] optional context passed to the agent.
   #
+  #--
   #: (Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
   def process_input(messages, context:)
     pass(messages)
@@ -33,10 +34,11 @@ class Riffer::Guardrail
   #
   # Override this method in subclasses to implement output processing.
   #
-  # +response+ - the LLM response.
-  # +messages+ - the conversation messages.
-  # +context+ - optional context passed to the agent.
+  # [response] the LLM response.
+  # [messages] the conversation messages.
+  # [context] optional context passed to the agent.
   #
+  #--
   #: (Riffer::Messages::Assistant, messages: Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
   def process_output(response, messages:, context:)
     pass(response)
@@ -46,8 +48,9 @@ class Riffer::Guardrail
 
   # Creates a pass result that continues with unchanged data.
   #
-  # +data+ - the original data to pass through.
+  # [data] the original data to pass through.
   #
+  #--
   #: (untyped) -> Riffer::Guardrails::Result
   def pass(data)
     Riffer::Guardrails::Result.pass(data)
@@ -55,8 +58,9 @@ class Riffer::Guardrail
 
   # Creates a transform result that continues with transformed data.
   #
-  # +data+ - the transformed data.
+  # [data] the transformed data.
   #
+  #--
   #: (untyped) -> Riffer::Guardrails::Result
   def transform(data)
     Riffer::Guardrails::Result.transform(data)
@@ -64,9 +68,10 @@ class Riffer::Guardrail
 
   # Creates a block result that halts execution.
   #
-  # +reason+ - the reason for blocking.
-  # +metadata+ - optional additional information.
+  # [reason] the reason for blocking.
+  # [metadata] optional additional information.
   #
+  #--
   #: (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
   def block(reason, metadata: nil)
     Riffer::Guardrails::Result.block(reason, metadata: metadata)

--- a/lib/riffer/guardrails/modification.rb
+++ b/lib/riffer/guardrails/modification.rb
@@ -18,10 +18,11 @@ class Riffer::Guardrails::Modification
 
   # Creates a new modification record.
   #
-  # +guardrail+ - the guardrail class that transformed.
-  # +phase+ - :before or :after.
-  # +message_indices+ - indices of changed messages.
+  # [guardrail] the guardrail class that transformed.
+  # [phase] :before or :after.
+  # [message_indices] indices of changed messages.
   #
+  #--
   #: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
   def initialize(guardrail:, phase:, message_indices:)
     @guardrail = guardrail
@@ -31,6 +32,7 @@ class Riffer::Guardrails::Modification
 
   # Converts the modification to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {

--- a/lib/riffer/guardrails/result.rb
+++ b/lib/riffer/guardrails/result.rb
@@ -9,6 +9,7 @@
 # - block: Halt execution with a reason
 #
 # Use the factory methods to create results:
+#
 #   Result.pass(data)
 #   Result.transform(data)
 #   Result.block(reason, metadata: nil)
@@ -27,8 +28,9 @@ class Riffer::Guardrails::Result
   class << self
     # Creates a pass result that continues with unchanged data.
     #
-    # +data+ - the original data to pass through.
+    # [data] the original data to pass through.
     #
+    #--
     #: (untyped) -> Riffer::Guardrails::Result
     def pass(data)
       new(:pass, data)
@@ -36,8 +38,9 @@ class Riffer::Guardrails::Result
 
     # Creates a transform result that continues with transformed data.
     #
-    # +data+ - the transformed data.
+    # [data] the transformed data.
     #
+    #--
     #: (untyped) -> Riffer::Guardrails::Result
     def transform(data)
       new(:transform, data)
@@ -45,9 +48,10 @@ class Riffer::Guardrails::Result
 
     # Creates a block result that halts execution.
     #
-    # +reason+ - the reason for blocking.
-    # +metadata+ - optional additional information.
+    # [reason] the reason for blocking.
+    # [metadata] optional additional information.
     #
+    #--
     #: (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
     def block(reason, metadata: nil)
       new(:block, reason, metadata: metadata)
@@ -56,12 +60,13 @@ class Riffer::Guardrails::Result
 
   # Creates a new result.
   #
-  # +type+ - the result type (:pass, :transform, or :block).
-  # +data+ - the data or reason.
-  # +metadata+ - optional metadata for block results.
+  # [type] the result type (:pass, :transform, or :block).
+  # [data] the data or reason.
+  # [metadata] optional metadata for block results.
   #
   # Raises Riffer::ArgumentError if the result type is invalid.
   #
+  #--
   #: (Symbol, untyped, ?metadata: Hash[Symbol, untyped]?) -> void
   def initialize(type, data, metadata: nil)
     raise Riffer::ArgumentError, "Invalid result type: #{type}" unless TYPES.include?(type)
@@ -73,6 +78,7 @@ class Riffer::Guardrails::Result
 
   # Returns true if this is a pass result.
   #
+  #--
   #: () -> bool
   def pass?
     type == :pass
@@ -80,6 +86,7 @@ class Riffer::Guardrails::Result
 
   # Returns true if this is a transform result.
   #
+  #--
   #: () -> bool
   def transform?
     type == :transform
@@ -87,6 +94,7 @@ class Riffer::Guardrails::Result
 
   # Returns true if this is a block result.
   #
+  #--
   #: () -> bool
   def block?
     type == :block

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -21,10 +21,11 @@ class Riffer::Guardrails::Runner
 
   # Creates a new runner.
   #
-  # +guardrail_configs+ - configs with :class and :options keys.
-  # +phase+ - :before or :after.
-  # +context+ - optional context to pass to guardrails.
+  # [guardrail_configs] configs with :class and :options keys.
+  # [phase] :before or :after.
+  # [context] optional context to pass to guardrails.
   #
+  #--
   #: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
   def initialize(guardrail_configs, phase:, context: nil)
     @guardrail_configs = guardrail_configs
@@ -37,9 +38,10 @@ class Riffer::Guardrails::Runner
   # For before phase, data should be an array of messages.
   # For after phase, data should be a response and messages must be provided.
   #
-  # +data+ - the data to process (messages for before, response for after).
-  # +messages+ - the conversation messages (required for after phase).
+  # [data] the data to process (messages for before, response for after).
+  # [messages] the conversation messages (required for after phase).
   #
+  #--
   #: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run(data, messages: nil)
     current_data = data
@@ -75,11 +77,13 @@ class Riffer::Guardrails::Runner
 
   private
 
+  #--
   #: (Hash[Symbol, untyped]) -> Riffer::Guardrail
   def instantiate_guardrail(config)
     config[:class].new(**config[:options])
   end
 
+  #--
   #: (untyped, untyped) -> Array[Integer]
   def detect_changed_indices(old_data, new_data)
     if old_data.is_a?(Array) && new_data.is_a?(Array)
@@ -90,6 +94,7 @@ class Riffer::Guardrails::Runner
     end
   end
 
+  #--
   #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail(guardrail, data, messages:)
     case phase

--- a/lib/riffer/guardrails/tripwire.rb
+++ b/lib/riffer/guardrails/tripwire.rb
@@ -29,13 +29,14 @@ class Riffer::Guardrails::Tripwire
 
   # Creates a new tripwire.
   #
-  # +reason+ - the reason for blocking.
-  # +guardrail+ - the guardrail class that blocked.
-  # +phase+ - :before or :after.
-  # +metadata+ - optional additional information.
+  # [reason] the reason for blocking.
+  # [guardrail] the guardrail class that blocked.
+  # [phase] :before or :after.
+  # [metadata] optional additional information.
   #
   # Raises Riffer::ArgumentError if the phase is invalid.
   #
+  #--
   #: (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
   def initialize(reason:, guardrail:, phase:, metadata: nil)
     raise Riffer::ArgumentError, "Invalid phase: #{phase}" unless PHASES.include?(phase)
@@ -48,6 +49,7 @@ class Riffer::Guardrails::Tripwire
 
   # Converts the tripwire to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {

--- a/lib/riffer/helpers/class_name_converter.rb
+++ b/lib/riffer/helpers/class_name_converter.rb
@@ -7,6 +7,7 @@ module Riffer::Helpers::ClassNameConverter
 
   # Converts a class name to snake_case identifier format.
   #
+  #--
   #: (String, ?separator: String) -> String
   def class_name_to_path(class_name, separator: DEFAULT_SEPARATOR)
     class_name

--- a/lib/riffer/helpers/dependencies.rb
+++ b/lib/riffer/helpers/dependencies.rb
@@ -19,6 +19,7 @@ module Riffer::Helpers::Dependencies
   # Raises LoadError if the gem is not installed.
   # Raises VersionError if the gem version does not satisfy requirements.
   #
+  #--
   #: (String, ?req: (bool | String)) -> true
   def depends_on(gem_name, req: true)
     gem(gem_name)

--- a/lib/riffer/helpers/validations.rb
+++ b/lib/riffer/helpers/validations.rb
@@ -7,6 +7,7 @@ module Riffer::Helpers::Validations
   #
   # Raises Riffer::ArgumentError if the value is not a string or is empty.
   #
+  #--
   #: (untyped, ?String) -> true
   def validate_is_string!(value, name = "value")
     raise Riffer::ArgumentError, "#{name} must be a String" unless value.is_a?(String)

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -22,6 +22,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # Parsed structured output hash, or nil when not applicable.
   attr_reader :structured_output #: Hash[Symbol, untyped]?
 
+  #--
   #: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
   def initialize(content, tool_calls: [], token_usage: nil, structured_output: nil)
     super(content)
@@ -30,11 +31,13 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     @structured_output = structured_output
   end
 
+  #--
   #: () -> Symbol
   def role
     :assistant
   end
 
+  #--
   #: () -> bool
   def structured_output?
     !@structured_output.nil?
@@ -42,6 +45,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
 
   # Converts the message to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -8,6 +8,7 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader :content #: String
 
+  #--
   #: (String) -> void
   def initialize(content)
     @content = content
@@ -15,6 +16,7 @@ class Riffer::Messages::Base
 
   # Converts the message to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: role, content: content}
@@ -24,6 +26,7 @@ class Riffer::Messages::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: () -> Symbol
   def role
     raise NotImplementedError, "Subclasses must implement #role"

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -9,6 +9,7 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
+  #--
   #: ((Hash[Symbol, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
   def convert_to_message_object(msg)
     return msg if msg.is_a?(Riffer::Messages::Base)
@@ -24,11 +25,12 @@ module Riffer::Messages::Converter
   #
   # Accepts:
   # - +Riffer::FilePart+ objects (passed through)
-  # - +{url: "https://...", media_type: "..."}+ (URL source)
-  # - +{data: "...", media_type: "..."}+ (raw base64)
+  # - <tt>{url: "https://...", media_type: "..."}</tt> (URL source)
+  # - <tt>{data: "...", media_type: "..."}</tt> (raw base64)
   #
   # Raises Riffer::ArgumentError if the hash format is invalid.
   #
+  #--
   #: ((Hash[Symbol, untyped] | Riffer::FilePart)) -> Riffer::FilePart
   def convert_to_file_part(file)
     return file if file.is_a?(Riffer::FilePart)
@@ -53,6 +55,7 @@ module Riffer::Messages::Converter
 
   private
 
+  #--
   #: (Hash[Symbol, untyped]) -> Riffer::Messages::Base
   def convert_hash_to_message(hash)
     role = hash[:role]

--- a/lib/riffer/messages/system.rb
+++ b/lib/riffer/messages/system.rb
@@ -8,6 +8,7 @@
 #   msg.content  # => "You are a helpful assistant."
 #
 class Riffer::Messages::System < Riffer::Messages::Base
+  #--
   #: () -> Symbol
   def role
     :system

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -25,6 +25,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
   attr_reader :error_type #: Symbol?
 
+  #--
   #: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
   def initialize(content, tool_call_id:, name:, error: nil, error_type: nil)
     super(content)
@@ -36,11 +37,13 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
 
   # Returns true if the tool execution resulted in an error.
   #
+  #--
   #: () -> bool
   def error?
     !@error.nil?
   end
 
+  #--
   #: () -> Symbol
   def role
     :tool
@@ -48,6 +51,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
 
   # Converts the message to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content, tool_call_id: tool_call_id, name: name}

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -16,17 +16,20 @@ class Riffer::Messages::User < Riffer::Messages::Base
 
   # Initializes a user message.
   #
+  #--
   #: (String, ?files: Array[Riffer::FilePart]) -> void
   def initialize(content, files: [])
     super(content)
     @files = files
   end
 
+  #--
   #: () -> Symbol
   def role
     :user
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}

--- a/lib/riffer/param.rb
+++ b/lib/riffer/param.rb
@@ -17,7 +17,7 @@ class Riffer::Param
     Hash => "object"
   }.freeze #: Hash[Module, String]
 
-  # Primitive types allowed for the +of:+ keyword on Array params
+  # Primitive types allowed for the <tt>of:</tt> keyword on Array params
   PRIMITIVE_TYPES = (TYPE_MAPPINGS.keys - [Array, Hash]).freeze #: Array[Class]
 
   attr_reader :name #: Symbol
@@ -29,6 +29,7 @@ class Riffer::Param
   attr_reader :item_type #: Class?
   attr_reader :nested_params #: Riffer::Params?
 
+  #--
   #: (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?item_type: Class?, ?nested_params: Riffer::Params?) -> void
   def initialize(name:, type:, required:, description: nil, enum: nil, default: nil, item_type: nil, nested_params: nil)
     @name = name.to_sym
@@ -43,6 +44,7 @@ class Riffer::Param
 
   # Validates that a value matches the expected type.
   #
+  #--
   #: (untyped) -> bool
   def valid_type?(value)
     return true if value.nil? && !required
@@ -56,6 +58,7 @@ class Riffer::Param
 
   # Returns the JSON Schema type name for this parameter.
   #
+  #--
   #: () -> String
   def type_name
     TYPE_MAPPINGS[type] || type.to_s.downcase
@@ -64,13 +67,14 @@ class Riffer::Param
   # Converts this parameter to JSON Schema format.
   #
   # When +strict+ is true, optional parameters are made nullable
-  # (+["type", "null"]+) so that strict mode providers can distinguish
+  # (<tt>["type", "null"]</tt>) so that strict mode providers can distinguish
   # "absent" from "present" without rejecting the schema.
   #
   # Optional parameters with an +enum+ use +anyOf+ to separate the enum
   # constraint from the null type, since providers like Anthropic reject
-  # +{"type": ["string", "null"], "enum": [...]}+.
+  # <tt>{"type": ["string", "null"], "enum": [...]}</tt>.
   #
+  #--
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema(strict: false)
     nullable = strict && !required

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -14,6 +14,7 @@
 class Riffer::Params
   attr_reader :parameters #: Array[Riffer::Param]
 
+  #--
   #: () -> void
   def initialize
     @parameters = []
@@ -21,6 +22,7 @@ class Riffer::Params
 
   # Defines a required parameter.
   #
+  #--
   #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
   def required(name, type, description: nil, enum: nil, of: nil, &block)
     nested = build_nested(type, of, &block)
@@ -37,6 +39,7 @@ class Riffer::Params
 
   # Defines an optional parameter.
   #
+  #--
   #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
   def optional(name, type, description: nil, enum: nil, default: nil, of: nil, &block)
     nested = build_nested(type, of, &block)
@@ -56,6 +59,7 @@ class Riffer::Params
   #
   # Raises Riffer::ValidationError if validation fails.
   #
+  #--
   #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def validate(arguments)
     validated = {}
@@ -100,6 +104,7 @@ class Riffer::Params
   # optional properties are made nullable instead. This satisfies
   # providers that enforce strict structured output schemas.
   #
+  #--
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema(strict: false)
     properties = {}
@@ -120,6 +125,7 @@ class Riffer::Params
 
   private
 
+  #--
   #: (Class, Class?) ?{ () -> void } -> Riffer::Params?
   def build_nested(type, of, &block)
     if of && block
@@ -147,6 +153,7 @@ class Riffer::Params
     end
   end
 
+  #--
   #: (Riffer::Param, untyped, Array[String]) -> untyped
   def validate_nested(param, value, errors)
     if param.type == Hash && param.nested_params
@@ -161,6 +168,7 @@ class Riffer::Params
     end
   end
 
+  #--
   #: (Riffer::Param, Hash[Symbol, untyped], Array[String]) -> Hash[Symbol, untyped]
   def validate_nested_hash(param, value, errors)
     param.nested_params.validate(value)
@@ -171,6 +179,7 @@ class Riffer::Params
     value
   end
 
+  #--
   #: (Riffer::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_nested_array_of_objects(param, value, errors)
     value.map.with_index do |item, i|
@@ -187,6 +196,7 @@ class Riffer::Params
     end
   end
 
+  #--
   #: (Riffer::Param, Array[untyped], Array[String]) -> void
   def validate_typed_array(param, value, errors)
     type_name = Riffer::Param::TYPE_MAPPINGS[param.item_type]

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -9,6 +9,7 @@
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # Initializes the Amazon Bedrock provider.
   #
+  #--
   #: (?api_token: String?, ?region: String?, **untyped) -> void
   def initialize(api_token: nil, region: nil, **options)
     depends_on "aws-sdk-bedrockruntime"
@@ -30,6 +31,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
 
   private
 
+  #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     partitioned_messages = partition_messages(messages)
@@ -69,11 +71,13 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     params
   end
 
+  #--
   #: (Hash[Symbol, untyped]) -> Aws::BedrockRuntime::Types::ConverseResponse
   def execute_generate(params)
     @client.converse(**params)
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
@@ -87,6 +91,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ConverseResponse) -> String
   def extract_content(response)
     content_blocks = response.output&.message&.content
@@ -101,6 +106,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     text_content
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ConverseResponse) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls(response)
     content_blocks = response.output&.message&.content
@@ -122,6 +128,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     tool_calls
   end
 
+  #--
   #: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream(params, yielder)
     current_state = {
@@ -147,6 +154,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_start_tool_use(event, state:, yielder:)
     state[:tool_call] = {
@@ -156,6 +164,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     }
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_delta_text_delta(event, state:, yielder:)
     delta_text = event.delta.text
@@ -164,6 +173,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::TextDelta.new(delta_text)
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_delta_tool_use(event, state:, yielder:)
     input_delta = event.delta.tool_use.input
@@ -177,12 +187,14 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_stop_text_delta(_event, state:, yielder:)
     yielder << Riffer::StreamEvents::TextDone.new(state[:text])
     state[:text] = nil
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_stop_tool_use(_event, state:, yielder:)
     tool_call = state[:tool_call]
@@ -195,6 +207,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     state[:tool_call] = nil
   end
 
+  #--
   #: (Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_metadata_usage(event, state:, yielder:)
     yielder << Riffer::StreamEvents::TokenUsageDone.new(
@@ -207,6 +220,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages(messages)
     system_prompts = []
@@ -233,6 +247,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     }
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_bedrock_format(message)
     content = []
@@ -251,6 +266,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     {role: "assistant", content: content}
   end
 
+  #--
   #: (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
   def append_tool_result(conversation_messages, message)
     tool_result = {
@@ -268,6 +284,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_bedrock_format(file)
     raise Riffer::ArgumentError, "Amazon Bedrock does not support URL file sources; provide base64 data instead" if file.url? && file.data.nil?
@@ -293,11 +310,13 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     "text/html" => "html"
   }.freeze #: Hash[String, String]
 
+  #--
   #: (String) -> String
   def bedrock_format(media_type)
     BEDROCK_FORMAT_MAP.fetch(media_type)
   end
 
+  #--
   #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_bedrock_format(tool)
     {

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -11,6 +11,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
   # Returns the XML skill adapter for Anthropic/Claude.
   #
+  #--
   #: () -> singleton(Riffer::Skills::Adapter)
   def self.skills_adapter
     Riffer::Skills::XmlAdapter
@@ -18,6 +19,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
   # Initializes the Anthropic provider.
   #
+  #--
   #: (?api_key: String?, **untyped) -> void
   def initialize(api_key: nil, **options)
     depends_on "anthropic"
@@ -29,6 +31,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
   private
 
+  #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     partitioned_messages = partition_messages(messages)
@@ -73,11 +76,13 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     params
   end
 
+  #--
   #: (Hash[Symbol, untyped]) -> Anthropic::Models::Message
   def execute_generate(params)
     @client.messages.create(**params)
   end
 
+  #--
   #: (Anthropic::Models::Message) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
@@ -91,6 +96,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (Anthropic::Models::Message) -> String
   def extract_content(response)
     content_blocks = response.content
@@ -105,6 +111,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     text_content
   end
 
+  #--
   #: (Anthropic::Models::Message) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls(response)
     content_blocks = response.content
@@ -126,6 +133,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     tool_calls
   end
 
+  #--
   #: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream(params, yielder)
     current_state = {
@@ -165,6 +173,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped]) -> void
   def handle_raw_content_block_start(event, state:)
     content_block = event.content_block
@@ -174,6 +183,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped]) -> void
   def handle_raw_content_block_delta(event, state:)
     return unless state[:web_search_index] == event.index
@@ -182,6 +192,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     state[:web_search_json] += delta.partial_json if delta.respond_to?(:partial_json)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_text_event(event, state:, yielder:)
     state[:text] ||= ""
@@ -189,6 +200,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::TextDelta.new(event.text)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_thinking_event(event, state:, yielder:)
     state[:reasoning] ||= ""
@@ -196,6 +208,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::ReasoningDelta.new(event.thinking)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_input_json_event(event, state:, yielder:)
     if state[:tool_call].nil?
@@ -209,6 +222,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_tool_use(event, state:, yielder:)
     content_block = event.content_block
@@ -222,18 +236,21 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     state[:tool_call] = nil
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_thinking(_event, state:, yielder:)
     yielder << Riffer::StreamEvents::ReasoningDone.new(state[:reasoning])
     state[:reasoning] = nil
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_text(_event, state:, yielder:)
     yielder << Riffer::StreamEvents::TextDone.new(state[:text])
     state[:text] = nil
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_server_tool_use(_event, state:, yielder:)
     return unless state[:web_search_json]
@@ -245,6 +262,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::WebSearchStatus.new("searching", query: input[:query])
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_web_search_result(event, state:, yielder:)
     content_block = event.content_block
@@ -257,6 +275,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     state[:web_search_query] = nil
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_message_stop(_event, state:, yielder:)
     final_message = state[:stream].accumulated_message
@@ -273,6 +292,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages(messages)
     system_prompts = []
@@ -310,6 +330,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     }
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_anthropic_format(message)
     content = []
@@ -327,6 +348,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     {role: "assistant", content: content}
   end
 
+  #--
   #: (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_anthropic_format(file)
     type = file.image? ? "image" : "document"
@@ -340,6 +362,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     {type: type, source: source}
   end
 
+  #--
   #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_anthropic_format(tool)
     {

--- a/lib/riffer/providers/azure_open_ai.rb
+++ b/lib/riffer/providers/azure_open_ai.rb
@@ -7,7 +7,7 @@
 #
 # Credentials are resolved in order:
 # 1. Keyword arguments (+api_key+, +base_url+)
-# 2. Config (+Riffer.config.azure_openai.api_key+ / +.endpoint+)
+# 2. Config (<tt>Riffer.config.azure_openai.api_key</tt> / <tt>.endpoint</tt>)
 # 3. Environment variables (+AZURE_OPENAI_API_KEY+ / +AZURE_OPENAI_ENDPOINT+)
 #
 #   Riffer::Providers::AzureOpenAI.new(
@@ -18,9 +18,10 @@
 class Riffer::Providers::AzureOpenAI < Riffer::Providers::OpenAI
   # Initializes the Azure OpenAI provider.
   #
-  # +api_key+ - Azure OpenAI API key. Falls back to config, then +AZURE_OPENAI_API_KEY+.
-  # +base_url+ - Azure OpenAI endpoint URL. Falls back to config, then +AZURE_OPENAI_ENDPOINT+.
+  # [api_key] Azure OpenAI API key. Falls back to config, then +AZURE_OPENAI_API_KEY+.
+  # [base_url] Azure OpenAI endpoint URL. Falls back to config, then +AZURE_OPENAI_ENDPOINT+.
   #
+  #--
   #: (**untyped) -> void
   def initialize(**options)
     depends_on "openai"

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -10,12 +10,12 @@ require "json"
 #
 # ==== Hook methods
 #
-# - +build_request_params+ — convert messages, tools, and options into SDK params
-# - +execute_generate+ — call the SDK and return the raw response
-# - +execute_stream+ — call the streaming SDK, mapping events to the yielder
-# - +extract_token_usage+ — pull token counts from the SDK response
-# - +extract_content+ — extract text content from the SDK response
-# - +extract_tool_calls+ — extract tool calls from the SDK response
+# [build_request_params] convert messages, tools, and options into SDK params
+# [execute_generate] call the SDK and return the raw response
+# [execute_stream] call the streaming SDK, mapping events to the yielder
+# [extract_token_usage] pull token counts from the SDK response
+# [extract_content] extract text content from the SDK response
+# [extract_tool_calls] extract tool calls from the SDK response
 class Riffer::Providers::Base
   include Riffer::Helpers::Dependencies
   include Riffer::Messages::Converter
@@ -24,6 +24,7 @@ class Riffer::Providers::Base
   #
   # Override in subclasses for provider-specific formats.
   #
+  #--
   #: () -> singleton(Riffer::Skills::Adapter)
   def self.skills_adapter
     Riffer::Skills::MarkdownAdapter
@@ -31,6 +32,7 @@ class Riffer::Providers::Base
 
   # Generates text using the provider.
   #
+  #--
   #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant
   def generate_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
@@ -54,6 +56,7 @@ class Riffer::Providers::Base
 
   # Streams text from the provider.
   #
+  #--
   #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
@@ -67,36 +70,43 @@ class Riffer::Providers::Base
 
   private
 
+  #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     raise NotImplementedError, "Subclasses must implement #build_request_params"
   end
 
+  #--
   #: (Hash[Symbol, untyped]) -> untyped
   def execute_generate(params)
     raise NotImplementedError, "Subclasses must implement #execute_generate"
   end
 
+  #--
   #: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream(params, yielder)
     raise NotImplementedError, "Subclasses must implement #execute_stream"
   end
 
+  #--
   #: (untyped) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     raise NotImplementedError, "Subclasses must implement #extract_token_usage"
   end
 
+  #--
   #: (untyped) -> String
   def extract_content(response)
     raise NotImplementedError, "Subclasses must implement #extract_content"
   end
 
+  #--
   #: (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls(response)
     raise NotImplementedError, "Subclasses must implement #extract_tool_calls"
   end
 
+  #--
   #: (String) -> Hash[Symbol, untyped]?
   def parse_structured_output(content)
     JSON.parse(content, symbolize_names: true)
@@ -104,12 +114,14 @@ class Riffer::Providers::Base
     nil
   end
 
+  #--
   #: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
     arguments.is_a?(String) ? JSON.parse(arguments) : arguments
   end
 
+  #--
   #: (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
   def validate_input!(prompt:, system:, messages:)
     if messages.nil?
@@ -120,6 +132,7 @@ class Riffer::Providers::Base
     end
   end
 
+  #--
   #: (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Array[Riffer::Messages::Base]
   def normalize_messages(prompt:, system:, messages:, files: nil)
     if messages && files && !files.empty?
@@ -137,6 +150,7 @@ class Riffer::Providers::Base
     result
   end
 
+  #--
   #: (Array[Riffer::Messages::Base]) -> void
   def validate_normalized_messages!(messages)
     has_user = messages.any? { |msg| msg.is_a?(Riffer::Messages::User) }

--- a/lib/riffer/providers/mock.rb
+++ b/lib/riffer/providers/mock.rb
@@ -10,6 +10,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
   # Initializes the mock provider.
   #
+  #--
   #: (**untyped) -> void
   def initialize(**options)
     @responses = options[:responses] || []
@@ -26,6 +27,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
   #   provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
   #   provider.stub_response("Final response", token_usage: Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 5))
   #
+  #--
   #: (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
   def stub_response(content, tool_calls: [], token_usage: nil)
     formatted_tool_calls = tool_calls.map.with_index do |tc, idx|
@@ -41,6 +43,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
   # Clears all stubbed responses.
   #
+  #--
   #: () -> void
   def clear_stubs
     @stubbed_responses = []
@@ -48,6 +51,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
   private
 
+  #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     web_search = options[:web_search]
@@ -57,26 +61,31 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
     {response: response}
   end
 
+  #--
   #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def execute_generate(params)
     params[:response]
   end
 
+  #--
   #: (untyped) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     response[:token_usage]
   end
 
+  #--
   #: (untyped) -> String
   def extract_content(response)
     response.is_a?(Hash) ? (response[:content] || "") : response.content
   end
 
+  #--
   #: (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls(response)
     response.is_a?(Hash) ? (response[:tool_calls] || []) : response.tool_calls
   end
 
+  #--
   #: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream(params, yielder)
     response = params[:response]
@@ -118,6 +127,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::TokenUsageDone.new(token_usage: token_usage) if token_usage
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def next_response
     if @stubbed_responses.any?

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -9,6 +9,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
 
   # Initializes the OpenAI provider.
   #
+  #--
   #: (**untyped) -> void
   def initialize(**options)
     depends_on "openai"
@@ -19,6 +20,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
 
   private
 
+  #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params(messages, model, options)
     reasoning = options[:reasoning]
@@ -63,11 +65,13 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     params.compact
   end
 
+  #--
   #: (Hash[Symbol, untyped]) -> OpenAI::Models::Responses::Response
   def execute_generate(params)
     @client.responses.create(params)
   end
 
+  #--
   #: (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
   def extract_token_usage(response)
     usage = response.usage
@@ -79,6 +83,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (OpenAI::Models::Responses::Response) -> String
   def extract_content(response)
     text_content = ""
@@ -93,6 +98,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     text_content
   end
 
+  #--
   #: (OpenAI::Models::Responses::Response) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls(response)
     tool_calls = []
@@ -111,6 +117,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     tool_calls
   end
 
+  #--
   #: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream(params, yielder)
     current_state = {
@@ -148,6 +155,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_item_added_function_call(event, state:, yielder:)
     state[:tool_info][event.item.id] = {
@@ -156,26 +164,31 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     }
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_text_delta(event, state:, yielder:)
     yielder << Riffer::StreamEvents::TextDelta.new(event.delta)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_text_done(event, state:, yielder:)
     yielder << Riffer::StreamEvents::TextDone.new(event.text)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_reasoning_summary_text_delta(event, state:, yielder:)
     yielder << Riffer::StreamEvents::ReasoningDelta.new(event.delta)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_reasoning_summary_text_done(event, state:, yielder:)
     yielder << Riffer::StreamEvents::ReasoningDone.new(event.text)
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_function_call_arguments_delta(event, state:, yielder:)
     tracked = state[:tool_info][event.item_id] || {}
@@ -186,6 +199,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_function_call_arguments_done(event, state:, yielder:)
     tracked = state[:tool_info][event.item_id] || {}
@@ -197,6 +211,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_response_completed(event, state:, yielder:)
     usage = event.response&.usage
@@ -210,11 +225,13 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     )
   end
 
+  #--
   #: (untyped, status: String, yielder: Enumerator::Yielder) -> void
   def handle_web_search_status(_event, status:, yielder:)
     yielder << Riffer::StreamEvents::WebSearchStatus.new(status)
   end
 
+  #--
   #: (untyped, yielder: Enumerator::Yielder) -> void
   def handle_output_item_done_web_search(event, yielder:)
     action = event.item.action
@@ -229,6 +246,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
   def convert_messages_to_openai_format(messages)
     messages.flat_map do |message|
@@ -255,6 +273,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
   def convert_assistant_to_openai_format(message)
     if message.tool_calls.empty?
@@ -275,6 +294,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_openai_format(file)
     if file.image?
@@ -288,6 +308,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     end
   end
 
+  #--
   #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_openai_format(tool)
     {

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -14,6 +14,7 @@ class Riffer::Providers::Repository
 
   # Finds a provider class by identifier.
   #
+  #--
   #: ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def self.find(identifier)
     REPO.fetch(identifier.to_sym, nil)&.call

--- a/lib/riffer/runner.rb
+++ b/lib/riffer/runner.rb
@@ -13,11 +13,12 @@
 class Riffer::Runner
   # Maps over items using the provided block.
   #
-  # +items+ - the items to process.
-  # +context+ - context hash forwarded from the agent.
+  # [items] the items to process.
+  # [context] context hash forwarded from the agent.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     raise NotImplementedError, "#{self.class} must implement #map"

--- a/lib/riffer/runner/sequential.rb
+++ b/lib/riffer/runner/sequential.rb
@@ -6,6 +6,7 @@
 # This is the default runner used when no concurrency is needed.
 #
 class Riffer::Runner::Sequential < Riffer::Runner
+  #--
   #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     items.map(&block)

--- a/lib/riffer/runner/threaded.rb
+++ b/lib/riffer/runner/threaded.rb
@@ -16,13 +16,15 @@
 class Riffer::Runner::Threaded < Riffer::Runner
   DEFAULT_MAX_CONCURRENCY = 5 #: Integer
 
-  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  # [max_concurrency] maximum number of threads to run simultaneously.
   #
+  #--
   #: (?max_concurrency: Integer) -> void
   def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
     @max_concurrency = max_concurrency
   end
 
+  #--
   #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     return [] if items.empty?

--- a/lib/riffer/skills/activate_tool.rb
+++ b/lib/riffer/skills/activate_tool.rb
@@ -19,9 +19,10 @@ class Riffer::Skills::ActivateTool < Riffer::Tool
 
   # Activates a skill by name and returns its body.
   #
-  # +context+ - tool context containing +:skills+ (a Riffer::Skills::Context).
-  # +name+ - the skill name to activate.
+  # [context] tool context containing +:skills+ (a Riffer::Skills::Context).
+  # [name] the skill name to activate.
   #
+  #--
   #: (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
   def call(context:, name:)
     skills_context = context&.dig(:skills)

--- a/lib/riffer/skills/adapter.rb
+++ b/lib/riffer/skills/adapter.rb
@@ -15,10 +15,11 @@
 class Riffer::Skills::Adapter
   # Renders a skill catalog section for the system prompt.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     raise NotImplementedError, "#{self.class} must implement #render_catalog"
@@ -28,6 +29,7 @@ class Riffer::Skills::Adapter
   #
   # Override to provide a custom activation tool.
   #
+  #--
   #: () -> singleton(Riffer::Tool)
   def activate_tool
     Riffer::Skills::ActivateTool

--- a/lib/riffer/skills/backend.rb
+++ b/lib/riffer/skills/backend.rb
@@ -18,6 +18,7 @@ class Riffer::Skills::Backend
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def list_skills
     raise NotImplementedError, "#{self.class} must implement #list_skills"
@@ -25,11 +26,12 @@ class Riffer::Skills::Backend
 
   # Returns the full SKILL.md body (without frontmatter) for a skill.
   #
-  # +name+ - the skill name to read.
+  # [name] the skill name to read.
   #
   # Raises NotImplementedError if not implemented by subclass.
   # Raises Riffer::ArgumentError if skill not found.
   #
+  #--
   #: (String) -> String
   def read_skill(name)
     raise NotImplementedError, "#{self.class} must implement #read_skill"

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -13,6 +13,7 @@
 class Riffer::Skills::Config
   # Creates a new Config with all options unset.
   #
+  #--
   #: () -> void
   def initialize
     @backend = nil
@@ -25,6 +26,7 @@ class Riffer::Skills::Config
   # Accepts a Riffer::Skills::Backend instance, or a Proc that receives
   # +context+ and returns a Backend.
   #
+  #--
   #: (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
   def backend(value = nil)
     return @backend if value.nil?
@@ -36,6 +38,7 @@ class Riffer::Skills::Config
   # Must be a subclass of Riffer::Skills::Adapter.
   # Defaults to the provider's preferred adapter.
   #
+  #--
   #: (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
   def adapter(value = nil)
     return @adapter if value.nil?
@@ -50,6 +53,7 @@ class Riffer::Skills::Config
   # Accepts an array of skill name strings or a Proc that receives
   # +context+ and returns an array of names.
   #
+  #--
   #: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
   def activate(value = nil)
     return @activate if value.nil?

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -22,10 +22,11 @@ class Riffer::Skills::Context
 
   # Creates a new skills context for a generation cycle.
   #
-  # +backend+ - the skills backend for reading skill bodies.
-  # +skills+ - skill catalog indexed by name.
-  # +adapter+ - the adapter used to render skill content.
+  # [backend] the skills backend for reading skill bodies.
+  # [skills] skill catalog indexed by name.
+  # [adapter] the adapter used to render skill content.
   #
+  #--
   #: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
   def initialize(backend:, skills:, adapter:)
     @backend = backend
@@ -38,6 +39,7 @@ class Riffer::Skills::Context
   #
   # Raises Riffer::ArgumentError if the skill is not in the catalog.
   #
+  #--
   #: (String) -> String
   def activate(name)
     raise Riffer::ArgumentError, "Unknown skill: '#{name}'" unless skills.key?(name)
@@ -49,6 +51,7 @@ class Riffer::Skills::Context
 
   # Returns whether a skill has been activated.
   #
+  #--
   #: (String) -> bool
   def activated?(name)
     @activated.key?(name)
@@ -58,6 +61,7 @@ class Riffer::Skills::Context
   #
   # Includes the catalog and any pre-activated skill bodies.
   #
+  #--
   #: () -> String
   def system_prompt
     available = available_skills
@@ -69,6 +73,7 @@ class Riffer::Skills::Context
 
   private
 
+  #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def available_skills
     skills.values.reject { |skill| @activated.key?(skill.name) }

--- a/lib/riffer/skills/filesystem_backend.rb
+++ b/lib/riffer/skills/filesystem_backend.rb
@@ -13,8 +13,9 @@
 class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   # Creates a new FilesystemBackend.
   #
-  # +paths+ - one or more directory paths to scan for skills.
+  # [paths] one or more directory paths to scan for skills.
   #
+  #--
   #: (*String) -> void
   def initialize(*paths)
     @paths = paths.flatten.map { |p| File.expand_path(p) }
@@ -27,6 +28,7 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   # SKILL.md. When multiple paths contain a skill with the same name,
   # first-path-wins.
   #
+  #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def list_skills
     @skills_cache = {}
@@ -55,10 +57,11 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
 
   # Returns the full SKILL.md body (without frontmatter) for a skill.
   #
-  # +name+ - the skill name to read.
+  # [name] the skill name to read.
   #
   # Raises Riffer::ArgumentError if skill not found.
   #
+  #--
   #: (String) -> String
   def read_skill(name)
     list_skills unless @skills_cache
@@ -71,6 +74,7 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
 
   private
 
+  #--
   #: (String, String) -> void
   def validate_dirname_matches_name!(dirname, name)
     return if dirname == name

--- a/lib/riffer/skills/frontmatter.rb
+++ b/lib/riffer/skills/frontmatter.rb
@@ -33,6 +33,7 @@ class Riffer::Skills::Frontmatter
   #
   # Raises Riffer::ArgumentError if frontmatter is invalid.
   #
+  #--
   #: (String) -> [Riffer::Skills::Frontmatter, String]
   def self.parse(raw)
     yaml, body = split_frontmatter(raw)
@@ -44,6 +45,7 @@ class Riffer::Skills::Frontmatter
   #
   # Raises Riffer::ArgumentError if frontmatter is invalid.
   #
+  #--
   #: (String) -> Riffer::Skills::Frontmatter
   def self.parse_frontmatter(raw)
     yaml, _ = split_frontmatter(raw)
@@ -51,6 +53,7 @@ class Riffer::Skills::Frontmatter
     new(name: yaml.delete(:name), description: yaml.delete(:description), metadata: yaml)
   end
 
+  #--
   #: (String) -> [Hash[Symbol, untyped], String]
   def self.split_frontmatter(raw) # :nodoc:
     parts = raw.split(/^---\s*$/, 3)
@@ -67,12 +70,13 @@ class Riffer::Skills::Frontmatter
 
   # Creates a new Frontmatter.
   #
-  # +name+ - the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
-  # +description+ - the skill description (1-1024 chars).
-  # +metadata+ - optional metadata hash.
+  # [name] the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
+  # [description] the skill description (1-1024 chars).
+  # [metadata] optional metadata hash.
   #
   # Raises Riffer::ArgumentError if name or description is invalid.
   #
+  #--
   #: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
   def initialize(name:, description:, metadata: {})
     validate_name!(name)
@@ -84,6 +88,7 @@ class Riffer::Skills::Frontmatter
 
   private
 
+  #--
   #: (untyped) -> void
   def validate_name!(name)
     raise Riffer::ArgumentError, "name must be a String" unless name.is_a?(String)
@@ -91,6 +96,7 @@ class Riffer::Skills::Frontmatter
     raise Riffer::ArgumentError, "name must match #{NAME_PATTERN.source}" unless NAME_PATTERN.match?(name)
   end
 
+  #--
   #: (untyped) -> void
   def validate_description!(description)
     raise Riffer::ArgumentError, "description must be a String" unless description.is_a?(String)

--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -10,8 +10,9 @@
 class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
   # Renders a skill catalog as Markdown.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
+  #--
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     lines = []

--- a/lib/riffer/skills/xml_adapter.rb
+++ b/lib/riffer/skills/xml_adapter.rb
@@ -11,8 +11,9 @@ require "cgi"
 class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
   # Renders a skill catalog as XML.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
+  #--
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     lines = []

--- a/lib/riffer/stream_events/base.rb
+++ b/lib/riffer/stream_events/base.rb
@@ -8,6 +8,7 @@ class Riffer::StreamEvents::Base
   # The message role (typically :assistant).
   attr_reader :role #: Symbol
 
+  #--
   #: (?role: Symbol) -> void
   def initialize(role: :assistant)
     @role = role
@@ -17,6 +18,7 @@ class Riffer::StreamEvents::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     raise NotImplementedError, "Subclasses must implement #to_h"

--- a/lib/riffer/stream_events/guardrail_modification.rb
+++ b/lib/riffer/stream_events/guardrail_modification.rb
@@ -10,9 +10,10 @@ class Riffer::StreamEvents::GuardrailModification < Riffer::StreamEvents::Base
 
   # Creates a new guardrail modification stream event.
   #
-  # +modification+ - the modification details.
-  # +role+ - the message role (defaults to :assistant).
+  # [modification] the modification details.
+  # [role] the message role (defaults to :assistant).
   #
+  #--
   #: (Riffer::Guardrails::Modification, ?role: Symbol) -> void
   def initialize(modification, role: :assistant)
     super(role: role)
@@ -21,21 +22,25 @@ class Riffer::StreamEvents::GuardrailModification < Riffer::StreamEvents::Base
 
   # The guardrail class that made the transformation.
   #
+  #--
   #: () -> singleton(Riffer::Guardrail)
   def guardrail = modification.guardrail
 
   # The phase when the transformation occurred.
   #
+  #--
   #: () -> Symbol
   def phase = modification.phase
 
   # The indices of messages that were changed.
   #
+  #--
   #: () -> Array[Integer]
   def message_indices = modification.message_indices
 
   # Converts the event to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, modification: modification.to_h}

--- a/lib/riffer/stream_events/guardrail_tripwire.rb
+++ b/lib/riffer/stream_events/guardrail_tripwire.rb
@@ -10,9 +10,10 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # Creates a new tripwire stream event.
   #
-  # +tripwire+ - the tripwire details.
-  # +role+ - the message role (defaults to :assistant).
+  # [tripwire] the tripwire details.
+  # [role] the message role (defaults to :assistant).
   #
+  #--
   #: (Riffer::Guardrails::Tripwire, ?role: Symbol) -> void
   def initialize(tripwire, role: :assistant)
     super(role: role)
@@ -21,6 +22,7 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # The reason for blocking.
   #
+  #--
   #: () -> String
   def reason
     tripwire.reason
@@ -28,6 +30,7 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # The phase when blocking occurred (:before or :after).
   #
+  #--
   #: () -> Symbol
   def phase
     tripwire.phase
@@ -35,6 +38,7 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # The guardrail class that triggered the block.
   #
+  #--
   #: () -> singleton(Riffer::Guardrail)
   def guardrail
     tripwire.guardrail
@@ -42,6 +46,7 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # Converts the event to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {

--- a/lib/riffer/stream_events/interrupt.rb
+++ b/lib/riffer/stream_events/interrupt.rb
@@ -8,6 +8,7 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader :reason #: (String | Symbol)?
 
+  #--
   #: (?reason: (String | Symbol)?) -> void
   def initialize(reason: nil)
     super(role: :system)
@@ -16,6 +17,7 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
 
   # Converts the event to a hash.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     h = {role: @role, interrupt: true}

--- a/lib/riffer/stream_events/reasoning_delta.rb
+++ b/lib/riffer/stream_events/reasoning_delta.rb
@@ -9,12 +9,14 @@ class Riffer::StreamEvents::ReasoningDelta < Riffer::StreamEvents::Base
   # The incremental reasoning content.
   attr_reader :content #: String
 
+  #--
   #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}

--- a/lib/riffer/stream_events/reasoning_done.rb
+++ b/lib/riffer/stream_events/reasoning_done.rb
@@ -9,12 +9,14 @@ class Riffer::StreamEvents::ReasoningDone < Riffer::StreamEvents::Base
   # The complete reasoning content.
   attr_reader :content #: String
 
+  #--
   #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}

--- a/lib/riffer/stream_events/skill_activation.rb
+++ b/lib/riffer/stream_events/skill_activation.rb
@@ -9,12 +9,14 @@ class Riffer::StreamEvents::SkillActivation < Riffer::StreamEvents::Base
   # The activated skill name.
   attr_reader :name #: String
 
+  #--
   #: (String, ?role: Symbol) -> void
   def initialize(name, role: :system)
     super(role: role)
     @name = name
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, name: @name}

--- a/lib/riffer/stream_events/text_delta.rb
+++ b/lib/riffer/stream_events/text_delta.rb
@@ -8,12 +8,14 @@ class Riffer::StreamEvents::TextDelta < Riffer::StreamEvents::Base
   # The incremental text content.
   attr_reader :content #: String
 
+  #--
   #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}

--- a/lib/riffer/stream_events/text_done.rb
+++ b/lib/riffer/stream_events/text_done.rb
@@ -8,12 +8,14 @@ class Riffer::StreamEvents::TextDone < Riffer::StreamEvents::Base
   # The complete text content.
   attr_reader :content #: String
 
+  #--
   #: (String, ?role: Symbol) -> void
   def initialize(content, role: :assistant)
     super(role: role)
     @content = content
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, content: @content}

--- a/lib/riffer/stream_events/token_usage_done.rb
+++ b/lib/riffer/stream_events/token_usage_done.rb
@@ -13,12 +13,14 @@ class Riffer::StreamEvents::TokenUsageDone < Riffer::StreamEvents::Base
   # The token usage data for this response.
   attr_reader :token_usage #: Riffer::TokenUsage
 
+  #--
   #: (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
   def initialize(token_usage:, role: :assistant)
     super(role: role)
     @token_usage = token_usage
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, token_usage: @token_usage.to_h}

--- a/lib/riffer/stream_events/tool_call_delta.rb
+++ b/lib/riffer/stream_events/tool_call_delta.rb
@@ -14,6 +14,7 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
   # The incremental arguments JSON fragment.
   attr_reader :arguments_delta #: String
 
+  #--
   #: (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
   def initialize(item_id:, arguments_delta:, name: nil, role: :assistant)
     super(role: role)
@@ -22,6 +23,7 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
     @arguments_delta = arguments_delta
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, item_id: @item_id, name: @name, arguments_delta: @arguments_delta}.compact

--- a/lib/riffer/stream_events/tool_call_done.rb
+++ b/lib/riffer/stream_events/tool_call_done.rb
@@ -17,6 +17,7 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
   # The complete arguments JSON string.
   attr_reader :arguments #: String
 
+  #--
   #: (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
   def initialize(item_id:, call_id:, name:, arguments:, role: :assistant)
     super(role: role)
@@ -26,6 +27,7 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
     @arguments = arguments
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, item_id: @item_id, call_id: @call_id, name: @name, arguments: @arguments}

--- a/lib/riffer/stream_events/web_search_done.rb
+++ b/lib/riffer/stream_events/web_search_done.rb
@@ -11,6 +11,7 @@ class Riffer::StreamEvents::WebSearchDone < Riffer::StreamEvents::Base
   # The search result sources with title and url.
   attr_reader :sources #: Array[Hash[Symbol, String?]]
 
+  #--
   #: (String, ?sources: Array[Hash[Symbol, String?]], ?role: Symbol) -> void
   def initialize(query, sources: [], role: :assistant)
     super(role: role)
@@ -18,6 +19,7 @@ class Riffer::StreamEvents::WebSearchDone < Riffer::StreamEvents::Base
     @sources = sources
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {role: @role, query: @query, sources: @sources}

--- a/lib/riffer/stream_events/web_search_status.rb
+++ b/lib/riffer/stream_events/web_search_status.rb
@@ -14,6 +14,7 @@ class Riffer::StreamEvents::WebSearchStatus < Riffer::StreamEvents::Base
   # The search query (present when available during status changes).
   attr_reader :query #: String?
 
+  #--
   #: (String, ?url: String?, ?query: String?, ?role: Symbol) -> void
   def initialize(status, url: nil, query: nil, role: :assistant)
     super(role: role)
@@ -22,6 +23,7 @@ class Riffer::StreamEvents::WebSearchStatus < Riffer::StreamEvents::Base
     @query = query
   end
 
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     h = {role: @role, status: @status}

--- a/lib/riffer/structured_output.rb
+++ b/lib/riffer/structured_output.rb
@@ -15,6 +15,7 @@ require "json"
 class Riffer::StructuredOutput
   attr_reader :params #: Riffer::Params
 
+  #--
   #: (Riffer::Params) -> void
   def initialize(params)
     @params = params
@@ -22,6 +23,7 @@ class Riffer::StructuredOutput
 
   # Returns the JSON Schema for this structured output.
   #
+  #--
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def json_schema(strict: false)
     @params.to_json_schema(strict: strict)
@@ -31,6 +33,7 @@ class Riffer::StructuredOutput
   #
   # Returns a Result with the validated object on success, or an error message on failure.
   #
+  #--
   #: (String) -> Riffer::StructuredOutput::Result
   def parse_and_validate(json_string)
     parsed = JSON.parse(json_string, symbolize_names: true)

--- a/lib/riffer/structured_output/result.rb
+++ b/lib/riffer/structured_output/result.rb
@@ -17,6 +17,7 @@ class Riffer::StructuredOutput::Result
   attr_reader :object #: Hash[Symbol, untyped]?
   attr_reader :error #: String?
 
+  #--
   #: (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
   def initialize(object: nil, error: nil)
     @object = object
@@ -25,11 +26,13 @@ class Riffer::StructuredOutput::Result
 
   # Returns true when parsing and validation succeeded.
   #
+  #--
   #: () -> bool
   def success? = @error.nil?
 
   # Returns true when parsing or validation failed.
   #
+  #--
   #: () -> bool
   def failure? = !success?
 end

--- a/lib/riffer/token_usage.rb
+++ b/lib/riffer/token_usage.rb
@@ -23,6 +23,7 @@ class Riffer::TokenUsage
   # Number of tokens read from cache (Anthropic-specific).
   attr_reader :cache_read_tokens #: Integer?
 
+  #--
   #: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
   def initialize(input_tokens:, output_tokens:, cache_creation_tokens: nil, cache_read_tokens: nil)
     @input_tokens = input_tokens
@@ -33,6 +34,7 @@ class Riffer::TokenUsage
 
   # Returns the total number of tokens (input + output).
   #
+  #--
   #: () -> Integer
   def total_tokens
     input_tokens + output_tokens
@@ -40,6 +42,7 @@ class Riffer::TokenUsage
 
   # Combines two TokenUsage objects for cumulative tracking.
   #
+  #--
   #: (Riffer::TokenUsage) -> Riffer::TokenUsage
   def +(other)
     Riffer::TokenUsage.new(
@@ -54,6 +57,7 @@ class Riffer::TokenUsage
   #
   # Cache tokens are omitted if nil.
   #
+  #--
   #: () -> Hash[Symbol, Integer]
   def to_h
     hash = {input_tokens: input_tokens, output_tokens: output_tokens}
@@ -64,6 +68,7 @@ class Riffer::TokenUsage
 
   private
 
+  #--
   #: (Integer?, Integer?) -> Integer?
   def add_nullable(a, b)
     return nil if a.nil? && b.nil?

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -33,6 +33,7 @@ class Riffer::Tool
 
   # Gets or sets the tool description.
   #
+  #--
   #: (?String?) -> String?
   def self.description(value = nil)
     return @description if value.nil?
@@ -41,6 +42,7 @@ class Riffer::Tool
 
   # Gets or sets the tool identifier/name.
   #
+  #--
   #: (?String?) -> String
   def self.identifier(value = nil)
     return @identifier || class_name_to_path(Module.instance_method(:name).bind_call(self), separator: TOOL_SEPARATOR) if value.nil?
@@ -49,6 +51,7 @@ class Riffer::Tool
 
   # Alias for identifier - used by providers.
   #
+  #--
   #: (?String?) -> String
   def self.name(value = nil)
     return identifier(value) unless value.nil?
@@ -57,6 +60,7 @@ class Riffer::Tool
 
   # Gets or sets the tool timeout in seconds.
   #
+  #--
   #: (?(Integer | Float)?) -> (Integer | Float)
   def self.timeout(value = nil)
     return @timeout || DEFAULT_TIMEOUT if value.nil?
@@ -65,6 +69,7 @@ class Riffer::Tool
 
   # Defines parameters using the Params DSL.
   #
+  #--
   #: () ?{ () -> void } -> Riffer::Params?
   def self.params(&block)
     return @params_builder if block.nil?
@@ -74,6 +79,7 @@ class Riffer::Tool
 
   # Returns the JSON Schema for the tool's parameters.
   #
+  #--
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def self.parameters_schema(strict: false)
     @params_builder&.to_json_schema(strict: strict) || empty_schema
@@ -88,6 +94,7 @@ class Riffer::Tool
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  #--
   #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call(context:, **kwargs)
     raise NotImplementedError, "#{self.class} must implement #call"
@@ -95,6 +102,7 @@ class Riffer::Tool
 
   # Creates a text response. Shorthand for Riffer::Tools::Response.text.
   #
+  #--
   #: (untyped) -> Riffer::Tools::Response
   def text(result)
     Riffer::Tools::Response.text(result)
@@ -102,6 +110,7 @@ class Riffer::Tool
 
   # Creates a JSON response. Shorthand for Riffer::Tools::Response.json.
   #
+  #--
   #: (untyped) -> Riffer::Tools::Response
   def json(result)
     Riffer::Tools::Response.json(result)
@@ -109,6 +118,7 @@ class Riffer::Tool
 
   # Creates an error response. Shorthand for Riffer::Tools::Response.error.
   #
+  #--
   #: (String, ?type: Symbol) -> Riffer::Tools::Response
   def error(message, type: :execution_error)
     Riffer::Tools::Response.error(message, type: type)
@@ -120,6 +130,7 @@ class Riffer::Tool
   # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
   # Raises Riffer::Error if the tool does not return a Response object.
   #
+  #--
   #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -15,23 +15,25 @@ require "json"
 #   results = runtime.execute(tool_calls, tools: tools, context: context)
 #
 class Riffer::ToolRuntime
-  # +runner+ - the concurrency runner to use for batch execution.
+  # [runner] the concurrency runner to use for batch execution.
   #
   # Subclasses must provide a runner; instantiating ToolRuntime directly
   # raises +NotImplementedError+.
   #
+  #--
   #: (runner: Riffer::Runner) -> void
   def initialize(runner:)
     raise NotImplementedError, "#{self.class} is abstract — use a subclass like Riffer::ToolRuntime::Inline" if instance_of?(Riffer::ToolRuntime)
     @runner = runner
   end
 
-  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  # Executes a batch of tool calls, returning <tt>[tool_call, response]</tt> pairs.
   #
-  # +tool_calls+ - the tool calls to execute.
-  # +tools+ - the resolved tool classes.
-  # +context+ - the context hash.
+  # [tool_calls] the tool calls to execute.
+  # [tools] the resolved tool classes.
+  # [context] the context hash.
   #
+  #--
   #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute(tool_calls, tools:, context:)
     @runner.map(tool_calls, context: context) do |tool_call|
@@ -58,6 +60,7 @@ class Riffer::ToolRuntime
   #     end
   #   end
   #
+  #--
   #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
   def around_tool_call(tool_call, context:)
     yield
@@ -68,10 +71,11 @@ class Riffer::ToolRuntime
   # Dispatches a single tool call. Override in subclasses to change
   # how individual tools are invoked (e.g., HTTP, gRPC).
   #
-  # +tool_call+ - the tool call to execute.
-  # +tools+ - the resolved tool classes.
-  # +context+ - the context hash.
+  # [tool_call] the tool call to execute.
+  # [tools] the resolved tool classes.
+  # [context] the context hash.
   #
+  #--
   #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
   def dispatch_tool_call(tool_call, tools:, context:)
     tool_class = tools.find { |tc| tc.name == tool_call.name }
@@ -97,6 +101,7 @@ class Riffer::ToolRuntime
     Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
   end
 
+  #--
   #: (String?) -> Hash[Symbol, untyped]
   def parse_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?

--- a/lib/riffer/tool_runtime/inline.rb
+++ b/lib/riffer/tool_runtime/inline.rb
@@ -6,6 +6,7 @@
 # This is the default tool runtime used when no runtime is configured.
 #
 class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+  #--
   #: () -> void
   def initialize
     super(runner: Riffer::Runner::Sequential.new)

--- a/lib/riffer/tool_runtime/threaded.rb
+++ b/lib/riffer/tool_runtime/threaded.rb
@@ -10,8 +10,9 @@
 class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
   DEFAULT_MAX_CONCURRENCY = 5 #: Integer
 
-  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  # [max_concurrency] maximum number of tool calls to execute simultaneously.
   #
+  #--
   #: (?max_concurrency: Integer) -> void
   def initialize(max_concurrency: DEFAULT_MAX_CONCURRENCY)
     super(runner: Riffer::Runner::Threaded.new(max_concurrency: max_concurrency))

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -28,6 +28,7 @@ class Riffer::Tools::Response
   #
   # Raises Riffer::ArgumentError if format is invalid.
   #
+  #--
   #: (untyped, ?format: Symbol) -> Riffer::Tools::Response
   def self.success(result, format: :text)
     unless VALID_FORMATS.include?(format)
@@ -40,6 +41,7 @@ class Riffer::Tools::Response
 
   # Creates a success response with text format.
   #
+  #--
   #: (untyped) -> Riffer::Tools::Response
   def self.text(result)
     success(result, format: :text)
@@ -47,6 +49,7 @@ class Riffer::Tools::Response
 
   # Creates a success response with JSON format.
   #
+  #--
   #: (untyped) -> Riffer::Tools::Response
   def self.json(result)
     success(result, format: :json)
@@ -54,19 +57,23 @@ class Riffer::Tools::Response
 
   # Creates an error response.
   #
+  #--
   #: (String, ?type: Symbol) -> Riffer::Tools::Response
   def self.error(message, type: :execution_error)
     new(content: message, success: false, error_message: message, error_type: type)
   end
 
+  #--
   #: () -> bool
   def success? = @success
 
+  #--
   #: () -> bool
   def error? = !@success
 
   # Returns a hash representation of the response.
   #
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     {content: @content, error: @error_message, error_type: @error_type}
@@ -74,6 +81,7 @@ class Riffer::Tools::Response
 
   private
 
+  #--
   #: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
   def initialize(content:, success:, error_message: nil, error_type: nil)
     @content = content

--- a/sig/generated/riffer.rbs
+++ b/sig/generated/riffer.rbs
@@ -23,6 +23,7 @@ module Riffer
 
   # Returns the Riffer configuration.
   #
+  # --
   # : () -> Riffer::Config
   def self.config: () -> Riffer::Config
 
@@ -32,9 +33,11 @@ module Riffer
   #     config.openai.api_key = ENV['OPENAI_API_KEY']
   #   end
   #
+  # --
   # : () ?{ (Riffer::Config) -> void } -> void
   def self.configure: () ?{ (Riffer::Config) -> void } -> void
 
+  # --
   # : () -> String
   def self.version: () -> String
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -27,11 +27,13 @@ class Riffer::Agent
 
   # Gets or sets the agent identifier.
   #
+  # --
   # : (?String?) -> String
   def self.identifier: (?String?) -> String
 
   # Gets or sets the model string (e.g., "openai/gpt-4o") or Proc.
   #
+  # --
   # : (?(String | Proc)?) -> (String | Proc)?
   def self.model: (?(String | Proc)?) -> (String | Proc)?
 
@@ -47,16 +49,19 @@ class Riffer::Agent
   #     "You are assisting #{context[:name]}"
   #   }
   #
+  # --
   # : (?(String | Proc)?) -> (String | Proc)?
   def self.instructions: (?(String | Proc)?) -> (String | Proc)?
 
   # Gets or sets provider options passed to the provider client.
   #
+  # --
   # : (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.provider_options: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
 
   # Gets or sets model options passed to generate_text/stream_text.
   #
+  # --
   # : (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
   def self.model_options: (?Hash[Symbol, untyped]?) -> Hash[Symbol, untyped]
 
@@ -64,6 +69,7 @@ class Riffer::Agent
   #
   # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
+  # --
   # : (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
   def self.structured_output: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
 
@@ -72,11 +78,13 @@ class Riffer::Agent
   # Defaults to DEFAULT_MAX_STEPS (16). Set to +Float::INFINITY+ for
   # unlimited steps.
   #
+  # --
   # : (?Numeric?) -> Numeric
   def self.max_steps: (?Numeric?) -> Numeric
 
   # Gets or sets the tools used by this agent.
   #
+  # --
   # : (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
 
@@ -86,8 +94,9 @@ class Riffer::Agent
   # or a Proc.
   #
   # Inherited by subclasses. When unset, walks the ancestor chain and
-  # falls back to the global +Riffer.config.tool_runtime+.
+  # falls back to the global <tt>Riffer.config.tool_runtime</tt>.
   #
+  # --
   # : (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
   def self.tool_runtime: (?(singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?) -> (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)?
 
@@ -101,16 +110,19 @@ class Riffer::Agent
   #     activate ["code-review"]
   #   end
   #
+  # --
   # : () ?{ () -> void } -> Riffer::Skills::Config?
   def self.skills: () ?{ () -> void } -> Riffer::Skills::Config?
 
   # Finds an agent class by identifier.
   #
+  # --
   # : (String) -> singleton(Riffer::Agent)?
   def self.find: (String) -> singleton(Riffer::Agent)?
 
   # Returns all agent subclasses.
   #
+  # --
   # : () -> Array[singleton(Riffer::Agent)]
   def self.all: () -> Array[singleton(Riffer::Agent)]
 
@@ -118,6 +130,7 @@ class Riffer::Agent
   #
   # See #generate for parameters and return value.
   #
+  # --
   # : (*untyped, **untyped) -> Riffer::Agent::Response
   def self.generate: (*untyped, **untyped) -> Riffer::Agent::Response
 
@@ -125,23 +138,26 @@ class Riffer::Agent
   #
   # See #stream for parameters and return value.
   #
+  # --
   # : (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def self.stream: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a guardrail for input, output, or both phases.
   #
-  # +phase+ - :before, :after, or :around.
-  # +with+ - the guardrail class (must be subclass of Riffer::Guardrail).
-  # +options+ - additional options passed to the guardrail.
+  # [phase] :before, :after, or :around.
+  # [with] the guardrail class (must be subclass of Riffer::Guardrail).
+  # [options] additional options passed to the guardrail.
   #
   # Raises Riffer::ArgumentError if phase is invalid or guardrail is not a Guardrail class.
+  # --
   # : (Symbol, with: singleton(Riffer::Guardrail), **untyped) -> void
   def self.guardrail: (Symbol, with: singleton(Riffer::Guardrail), **untyped) -> void
 
   # Returns the registered guardrail configs for a given phase.
   #
-  # +phase+ - :before or :after.
+  # [phase] :before or :after.
   #
+  # --
   # : (Symbol) -> Array[Hash[Symbol, untyped]]
   def self.guardrails_for: (Symbol) -> Array[Hash[Symbol, untyped]]
 
@@ -156,11 +172,13 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
+  # --
   # : () -> void
   def initialize: () -> void
 
   # Generates a response from the agent.
   #
+  # --
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
@@ -168,6 +186,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
+  # --
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
@@ -175,6 +194,7 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if no block is given.
   #
+  # --
   # : () { (Riffer::Messages::Base) -> void } -> self
   def on_message: () { (Riffer::Messages::Base) -> void } -> self
 
@@ -185,6 +205,7 @@ class Riffer::Agent
   #
   # Returns +nil+ when no instructions are configured.
   #
+  # --
   # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def generate_instruction_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
@@ -195,55 +216,70 @@ class Riffer::Agent
   #
   # Returns +nil+ when no skills are configured or the catalog is empty.
   #
+  # --
   # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def generate_skills_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
   # Interrupts the agent loop.
   #
   # Call from an +on_message+ callback to cleanly interrupt the loop.
-  # Equivalent to +throw :riffer_interrupt, reason+.
+  # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
+  # --
   # : (?(String | Symbol)?) -> void
   def interrupt!: (?(String | Symbol)?) -> void
 
   private
 
+  # --
   # : (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
   def run_generate_loop: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
 
+  # --
   # : (Riffer::Messages::Base) -> void
   def add_message: (Riffer::Messages::Base) -> void
 
+  # --
   # : (Riffer::TokenUsage?) -> void
   def track_token_usage: (Riffer::TokenUsage?) -> void
 
+  # --
   # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
   def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
+  # --
   # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def build_instruction_message: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 
+  # --
   # : (?Riffer::Skills::Context?) -> Riffer::Messages::System?
   def build_skills_message: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
 
+  # --
   # : () -> Integer
   def count_assistant_messages: () -> Integer
 
+  # --
   # : (Enumerator::Yielder) -> void
   def run_stream_loop: (Enumerator::Yielder) -> void
 
+  # --
   # : () -> Riffer::Messages::Assistant
   def call_llm: () -> Riffer::Messages::Assistant
 
+  # --
   # : () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream: () -> Enumerator[Riffer::StreamEvents::Base, void]
 
+  # --
   # : () -> Riffer::Providers::Base
   def provider_instance: () -> Riffer::Providers::Base
 
+  # --
   # : (Riffer::Messages::Assistant) -> bool
   def has_tool_calls?: (Riffer::Messages::Assistant) -> bool
 
+  # --
   # : (Riffer::Messages::Assistant) -> void
   def execute_tool_calls: (Riffer::Messages::Assistant) -> void
 
@@ -255,6 +291,7 @@ class Riffer::Agent
   # last assistant message against the tool result messages that follow it,
   # then executes any that are missing.
   #
+  # --
   # : () -> void
   # Executes tool calls from the last assistant message that don't yet
   # have a corresponding tool result. Safe to call unconditionally —
@@ -263,26 +300,33 @@ class Riffer::Agent
 
   def pending_tool_calls: () -> untyped
 
+  # --
   # : () -> void
   def prepare_run: () -> void
 
+  # --
   # : (untyped) -> void
   def parse_model_string!: (untyped) -> void
 
+  # --
   # : () -> void
   def clear_resolved_model: () -> void
 
+  # --
   # : (?Hash[Symbol, untyped]?) -> String?
   def generate_instructions: (?Hash[Symbol, untyped]?) -> String?
 
   attr_reader resolved_model: String?
 
+  # --
   # : () -> String
   def resolve_model: () -> String
 
+  # --
   # : () -> Array[singleton(Riffer::Tool)]
   def resolved_tools: () -> Array[singleton(Riffer::Tool)]
 
+  # --
   # : () -> Riffer::ToolRuntime
   def resolve_tool_runtime: () -> Riffer::ToolRuntime
 
@@ -292,30 +336,39 @@ class Riffer::Agent
   # Does not mutate instance state — callers are responsible for
   # assigning the returned context.
   #
+  # --
   # : (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
   def resolve_skills: (?Hash[Symbol, untyped]?) -> Riffer::Skills::Context?
 
+  # --
   # : () -> singleton(Riffer::Providers::Base)
   def provider_class: () -> singleton(Riffer::Providers::Base)
 
+  # --
   # : () -> Riffer::Messages::Assistant?
   def extract_final_response: () -> Riffer::Messages::Assistant?
 
+  # --
   # : () -> [Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_before_guardrails: () -> [ Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
+  # --
   # : (Riffer::Messages::Assistant) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run_after_guardrails: (Riffer::Messages::Assistant) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
+  # --
   # : (Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
   def validate_structured_output: (Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
 
+  # --
   # : () -> Riffer::StructuredOutput?
   def resolve_structured_output: () -> Riffer::StructuredOutput?
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def merged_model_options: () -> Hash[Symbol, untyped]
 
+  # --
   # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
   def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 end

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -32,30 +32,34 @@ class Riffer::Agent::Response
 
   # Creates a new response.
   #
-  # +content+ - the response content.
-  # +tripwire+ - optional tripwire for blocked responses.
-  # +modifications+ - guardrail modifications applied during processing.
-  # +interrupted+ - whether the agent loop was interrupted by a callback.
-  # +interrupt_reason+ - optional reason passed via +throw :riffer_interrupt, reason+.
-  # +structured_output+ - parsed structured output when structured output is configured.
-  # +messages+ - the full message history from the agent conversation.
+  # [content] the response content.
+  # [tripwire] optional tripwire for blocked responses.
+  # [modifications] guardrail modifications applied during processing.
+  # [interrupted] whether the agent loop was interrupted by a callback.
+  # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
+  # [structured_output] parsed structured output when structured output is configured.
+  # [messages] the full message history from the agent conversation.
   #
+  # --
   # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
   def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #
+  # --
   # : () -> bool
   def blocked?: () -> bool
 
   # Returns true if any guardrail modified data during processing.
   #
+  # --
   # : () -> bool
   def modified?: () -> bool
 
   # Returns true if the agent loop was interrupted by a callback
-  # via +throw :riffer_interrupt+.
+  # via <tt>throw :riffer_interrupt</tt>.
   #
+  # --
   # : () -> bool
   def interrupted?: () -> bool
 end

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -70,7 +70,7 @@ class Riffer::Config
   # Global tool runtime configuration (experimental).
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
-  # or a Proc. Defaults to +Riffer::ToolRuntime::Inline.new+.
+  # or a Proc. Defaults to <tt>Riffer::ToolRuntime::Inline.new</tt>.
   attr_reader tool_runtime: singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc
 
   # Sets the global tool runtime.
@@ -78,9 +78,11 @@ class Riffer::Config
   # Raises +Riffer::ArgumentError+ if the value is not a valid runtime
   # (ToolRuntime subclass, ToolRuntime instance, or Proc).
   #
+  # --
   # : ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc) -> void
 
+  # --
   # : () -> void
   def initialize: () -> void
 end

--- a/sig/generated/riffer/core.rbs
+++ b/sig/generated/riffer/core.rbs
@@ -7,11 +7,13 @@ class Riffer::Core
   # The logger instance for Riffer.
   attr_reader logger: Logger
 
+  # --
   # : () -> void
   def initialize: () -> void
 
   # Yields self for configuration.
   #
+  # --
   # : () ?{ (Riffer::Core) -> void } -> void
   def configure: () ?{ (Riffer::Core) -> void } -> void
 end

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -16,16 +16,19 @@
 class Riffer::Evals::Evaluator
   # Gets or sets the evaluation instructions (criteria and scoring rubric).
   #
+  # --
   # : (?String?) -> String?
   def self.instructions: (?String?) -> String?
 
   # Gets or sets whether higher scores are better.
   #
+  # --
   # : (?bool?) -> bool
   def self.higher_is_better: (?bool?) -> bool
 
   # Gets or sets the judge model for LLM-as-judge evaluations.
   #
+  # --
   # : (?String?) -> String?
   def self.judge_model: (?String?) -> String?
 
@@ -34,13 +37,14 @@ class Riffer::Evals::Evaluator
   # The default implementation calls the judge with the class-level +instructions+.
   # Override this method for custom evaluation logic (e.g. rule-based evaluators).
   #
-  # +input+ - the input to evaluate; String or Array of message hashes/Message objects.
-  # +output+ - the agent's response to evaluate.
-  # +ground_truth+ - optional reference answer for comparison.
-  # +messages+ - the full message history from the agent conversation.
+  # [input] the input to evaluate; String or Array of message hashes/Message objects.
+  # [output] the agent's response to evaluate.
+  # [ground_truth] optional reference answer for comparison.
+  # [messages] the full message history from the agent conversation.
   #
   # Raises NotImplementedError if neither +instructions+ is set nor +evaluate+ is overridden.
   #
+  # --
   # : (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
   def evaluate: (input: String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], output: String, ?ground_truth: String?, ?messages: Array[Riffer::Messages::Base]) -> Riffer::Evals::Result
 
@@ -52,16 +56,19 @@ class Riffer::Evals::Evaluator
   # Array inputs (message hashes or Message objects) are formatted
   # as labeled role/content pairs separated by blank lines.
   #
+  # --
   # : (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
   def format_input: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> String
 
   # Returns a Judge instance configured for this evaluator.
   #
+  # --
   # : () -> Riffer::Evals::Judge
   def judge: () -> Riffer::Evals::Judge
 
   # Helper to build a Result object.
   #
+  # --
   # : (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
   def result: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
 end

--- a/sig/generated/riffer/evals/evaluator_runner.rbs
+++ b/sig/generated/riffer/evals/evaluator_runner.rbs
@@ -19,23 +19,27 @@
 class Riffer::Evals::EvaluatorRunner
   # Runs evaluators against an agent for the given scenarios.
   #
-  # +agent+ - an Agent subclass (not an instance).
-  # +scenarios+ - array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
-  # +evaluators+ - array of Evaluator subclasses to run against each scenario.
-  # +context+ - optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
+  # [agent] an Agent subclass (not an instance).
+  # [scenarios] array of hashes with +:input+, optional +:ground_truth+, and optional +:context+.
+  # [evaluators] array of Evaluator subclasses to run against each scenario.
+  # [context] optional hash passed to +agent.generate+. Per-scenario +:context+ takes precedence.
   #
   # Raises Riffer::ArgumentError if agent is not a Riffer::Agent subclass
   # or any eval is not a Riffer::Evals::Evaluator subclass.
   #
+  # --
   # : (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
   def self.run: (agent: singleton(Riffer::Agent), scenarios: Array[Hash[Symbol, untyped]], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::RunResult
 
+  # --
   # : (singleton(Riffer::Agent)) -> void
   def self.validate_agent!: (singleton(Riffer::Agent)) -> void
 
+  # --
   # : (Array[singleton(Riffer::Evals::Evaluator)]) -> void
   def self.validate_evaluators!: (Array[singleton(Riffer::Evals::Evaluator)]) -> void
 
+  # --
   # : (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
   def self.run_scenario: (agent: singleton(Riffer::Agent), scenario: Hash[Symbol, untyped], evaluators: Array[singleton(Riffer::Evals::Evaluator)], ?context: Hash[Symbol, untyped]?) -> Riffer::Evals::ScenarioResult
 end

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -17,6 +17,7 @@
 class Riffer::Evals::Judge
   # Internal tool for structured evaluation output.
   class EvaluationTool < Riffer::Tool
+    # --
     # : (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
     def call: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
   end
@@ -26,37 +27,45 @@ class Riffer::Evals::Judge
 
   # Initializes a new judge.
   #
+  # --
   # : (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
   def initialize: (model: String, ?provider_options: Hash[Symbol, untyped]) -> void
 
   # Evaluates using the configured LLM.
   #
   # Composes system and user messages from the semantic fields:
-  # +instructions+ - evaluation criteria and scoring rubric.
-  # +input+ - the original input/question.
-  # +output+ - the agent's response to evaluate.
-  # +ground_truth+ - optional reference answer for comparison.
+  # [instructions] evaluation criteria and scoring rubric.
+  # [input] the original input/question.
+  # [output] the agent's response to evaluate.
+  # [ground_truth] optional reference answer for comparison.
   #
+  # --
   # : (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
   def evaluate: (instructions: String, input: String, output: String, ?ground_truth: String?) -> Hash[Symbol, untyped]
 
   private
 
+  # --
   # : (String) -> String
   def build_system_message: (String) -> String
 
+  # --
   # : (input: String, output: String, ?ground_truth: String?) -> String
   def build_user_message: (input: String, output: String, ?ground_truth: String?) -> String
 
+  # --
   # : () -> Riffer::Providers::Base
   def provider_instance: () -> Riffer::Providers::Base
 
+  # --
   # : () -> String
   def provider_name: () -> String
 
+  # --
   # : () -> String
   def model_name: () -> String
 
+  # --
   # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def parse_tool_response: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/evals/result.rbs
+++ b/sig/generated/riffer/evals/result.rbs
@@ -34,16 +34,19 @@ class Riffer::Evals::Result
   #
   # Raises Riffer::ArgumentError if score is not between 0.0 and 1.0.
   #
+  # --
   # : (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
   def initialize: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
 
   # Returns a hash representation of the result.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 
   private
 
+  # --
   # : () -> void
   def validate_score!: () -> void
 end

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -15,16 +15,19 @@ class Riffer::Evals::RunResult
 
   # Initializes a new run result.
   #
+  # --
   # : (scenario_results: Array[Riffer::Evals::ScenarioResult]) -> void
   def initialize: (scenario_results: Array[Riffer::Evals::ScenarioResult]) -> void
 
   # Returns average scores keyed by evaluator class across all scenarios.
   #
+  # --
   # : () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
 
   # Returns a hash representation of the run result.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/evals/scenario_result.rbs
+++ b/sig/generated/riffer/evals/scenario_result.rbs
@@ -30,16 +30,19 @@ class Riffer::Evals::ScenarioResult
 
   # Initializes a new scenario result.
   #
+  # --
   # : (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
   def initialize: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
 
   # Returns scores keyed by evaluator class.
   #
+  # --
   # : () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
 
   # Returns a hash representation of the scenario result.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/file_part.rbs
+++ b/sig/generated/riffer/file_part.rbs
@@ -27,6 +27,7 @@ class Riffer::FilePart
   # Raises Riffer::ArgumentError if neither data nor url is provided,
   # or if media_type is not supported.
   #
+  # --
   # : (media_type: String, ?data: String?, ?filename: String?, ?url: String?) -> void
   def initialize: (media_type: String, ?data: String?, ?filename: String?, ?url: String?) -> void
 
@@ -37,6 +38,7 @@ class Riffer::FilePart
   #
   # Raises Riffer::ArgumentError if media_type cannot be detected.
   #
+  # --
   # : (String, ?media_type: String?) -> Riffer::FilePart
   def self.from_url: (String, ?media_type: String?) -> Riffer::FilePart
 
@@ -45,26 +47,31 @@ class Riffer::FilePart
 
   # Returns the URL if the source was a URL, nil otherwise.
   #
+  # --
   # : () -> String?
   def url: () -> String?
 
   # Returns true if the source was a URL.
   #
+  # --
   # : () -> bool
   def url?: () -> bool
 
   # Returns true if the file is an image.
   #
+  # --
   # : () -> bool
   def image?: () -> bool
 
   # Returns true if the file is a document (not an image).
   #
+  # --
   # : () -> bool
   def document?: () -> bool
 
   # Serializes the FilePart to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/guardrail.rbs
+++ b/sig/generated/riffer/guardrail.rbs
@@ -20,9 +20,10 @@ class Riffer::Guardrail
   #
   # Override this method in subclasses to implement input processing.
   #
-  # +messages+ - the input messages.
-  # +context+ - optional context passed to the agent.
+  # [messages] the input messages.
+  # [context] optional context passed to the agent.
   #
+  # --
   # : (Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
   def process_input: (Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
 
@@ -30,32 +31,36 @@ class Riffer::Guardrail
   #
   # Override this method in subclasses to implement output processing.
   #
-  # +response+ - the LLM response.
-  # +messages+ - the conversation messages.
-  # +context+ - optional context passed to the agent.
+  # [response] the LLM response.
+  # [messages] the conversation messages.
+  # [context] optional context passed to the agent.
   #
+  # --
   # : (Riffer::Messages::Assistant, messages: Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
   def process_output: (Riffer::Messages::Assistant, messages: Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
 
   # Creates a pass result that continues with unchanged data.
   #
-  # +data+ - the original data to pass through.
+  # [data] the original data to pass through.
   #
+  # --
   # : (untyped) -> Riffer::Guardrails::Result
   def pass: (untyped) -> Riffer::Guardrails::Result
 
   # Creates a transform result that continues with transformed data.
   #
-  # +data+ - the transformed data.
+  # [data] the transformed data.
   #
+  # --
   # : (untyped) -> Riffer::Guardrails::Result
   def transform: (untyped) -> Riffer::Guardrails::Result
 
   # Creates a block result that halts execution.
   #
-  # +reason+ - the reason for blocking.
-  # +metadata+ - optional additional information.
+  # [reason] the reason for blocking.
+  # [metadata] optional additional information.
   #
+  # --
   # : (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
   def block: (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
 end

--- a/sig/generated/riffer/guardrails/modification.rbs
+++ b/sig/generated/riffer/guardrails/modification.rbs
@@ -17,15 +17,17 @@ class Riffer::Guardrails::Modification
 
   # Creates a new modification record.
   #
-  # +guardrail+ - the guardrail class that transformed.
-  # +phase+ - :before or :after.
-  # +message_indices+ - indices of changed messages.
+  # [guardrail] the guardrail class that transformed.
+  # [phase] :before or :after.
+  # [message_indices] indices of changed messages.
   #
+  # --
   # : (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
   def initialize: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, message_indices: Array[Integer]) -> void
 
   # Converts the modification to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/guardrails/result.rbs
+++ b/sig/generated/riffer/guardrails/result.rbs
@@ -8,6 +8,7 @@
 # - block: Halt execution with a reason
 #
 # Use the factory methods to create results:
+#
 #   Result.pass(data)
 #   Result.transform(data)
 #   Result.block(reason, metadata: nil)
@@ -25,49 +26,56 @@ class Riffer::Guardrails::Result
 
   # Creates a pass result that continues with unchanged data.
   #
-  # +data+ - the original data to pass through.
+  # [data] the original data to pass through.
   #
+  # --
   # : (untyped) -> Riffer::Guardrails::Result
   def self.pass: (untyped) -> Riffer::Guardrails::Result
 
   # Creates a transform result that continues with transformed data.
   #
-  # +data+ - the transformed data.
+  # [data] the transformed data.
   #
+  # --
   # : (untyped) -> Riffer::Guardrails::Result
   def self.transform: (untyped) -> Riffer::Guardrails::Result
 
   # Creates a block result that halts execution.
   #
-  # +reason+ - the reason for blocking.
-  # +metadata+ - optional additional information.
+  # [reason] the reason for blocking.
+  # [metadata] optional additional information.
   #
+  # --
   # : (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
   def self.block: (String, ?metadata: Hash[Symbol, untyped]?) -> Riffer::Guardrails::Result
 
   # Creates a new result.
   #
-  # +type+ - the result type (:pass, :transform, or :block).
-  # +data+ - the data or reason.
-  # +metadata+ - optional metadata for block results.
+  # [type] the result type (:pass, :transform, or :block).
+  # [data] the data or reason.
+  # [metadata] optional metadata for block results.
   #
   # Raises Riffer::ArgumentError if the result type is invalid.
   #
+  # --
   # : (Symbol, untyped, ?metadata: Hash[Symbol, untyped]?) -> void
   def initialize: (Symbol, untyped, ?metadata: Hash[Symbol, untyped]?) -> void
 
   # Returns true if this is a pass result.
   #
+  # --
   # : () -> bool
   def pass?: () -> bool
 
   # Returns true if this is a transform result.
   #
+  # --
   # : () -> bool
   def transform?: () -> bool
 
   # Returns true if this is a block result.
   #
+  # --
   # : () -> bool
   def block?: () -> bool
 end

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -20,10 +20,11 @@ class Riffer::Guardrails::Runner
 
   # Creates a new runner.
   #
-  # +guardrail_configs+ - configs with :class and :options keys.
-  # +phase+ - :before or :after.
-  # +context+ - optional context to pass to guardrails.
+  # [guardrail_configs] configs with :class and :options keys.
+  # [phase] :before or :after.
+  # [context] optional context to pass to guardrails.
   #
+  # --
   # : (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
   def initialize: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
 
@@ -32,20 +33,24 @@ class Riffer::Guardrails::Runner
   # For before phase, data should be an array of messages.
   # For after phase, data should be a response and messages must be provided.
   #
-  # +data+ - the data to process (messages for before, response for after).
-  # +messages+ - the conversation messages (required for after phase).
+  # [data] the data to process (messages for before, response for after).
+  # [messages] the conversation messages (required for after phase).
   #
+  # --
   # : (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
   def run: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
 
   private
 
+  # --
   # : (Hash[Symbol, untyped]) -> Riffer::Guardrail
   def instantiate_guardrail: (Hash[Symbol, untyped]) -> Riffer::Guardrail
 
+  # --
   # : (untyped, untyped) -> Array[Integer]
   def detect_changed_indices: (untyped, untyped) -> Array[Integer]
 
+  # --
   # : (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
 end

--- a/sig/generated/riffer/guardrails/tripwire.rbs
+++ b/sig/generated/riffer/guardrails/tripwire.rbs
@@ -28,18 +28,20 @@ class Riffer::Guardrails::Tripwire
 
   # Creates a new tripwire.
   #
-  # +reason+ - the reason for blocking.
-  # +guardrail+ - the guardrail class that blocked.
-  # +phase+ - :before or :after.
-  # +metadata+ - optional additional information.
+  # [reason] the reason for blocking.
+  # [guardrail] the guardrail class that blocked.
+  # [phase] :before or :after.
+  # [metadata] optional additional information.
   #
   # Raises Riffer::ArgumentError if the phase is invalid.
   #
+  # --
   # : (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
   def initialize: (reason: String, guardrail: singleton(Riffer::Guardrail), phase: Symbol, ?metadata: Hash[Symbol, untyped]?) -> void
 
   # Converts the tripwire to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/helpers/class_name_converter.rbs
+++ b/sig/generated/riffer/helpers/class_name_converter.rbs
@@ -6,6 +6,7 @@ module Riffer::Helpers::ClassNameConverter
 
   # Converts a class name to snake_case identifier format.
   #
+  # --
   # : (String, ?separator: String) -> String
   def class_name_to_path: (String, ?separator: String) -> String
 end

--- a/sig/generated/riffer/helpers/dependencies.rbs
+++ b/sig/generated/riffer/helpers/dependencies.rbs
@@ -20,6 +20,7 @@ module Riffer::Helpers::Dependencies
   # Raises LoadError if the gem is not installed.
   # Raises VersionError if the gem version does not satisfy requirements.
   #
+  # --
   # : (String, ?req: (bool | String)) -> true
   def depends_on: (String, ?req: bool | String) -> true
 end

--- a/sig/generated/riffer/helpers/validations.rbs
+++ b/sig/generated/riffer/helpers/validations.rbs
@@ -6,6 +6,7 @@ module Riffer::Helpers::Validations
   #
   # Raises Riffer::ArgumentError if the value is not a string or is empty.
   #
+  # --
   # : (untyped, ?String) -> true
   def validate_is_string!: (untyped, ?String) -> true
 end

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -31,17 +31,21 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # Parsed structured output hash, or nil when not applicable.
   attr_reader structured_output: Hash[Symbol, untyped]?
 
+  # --
   # : (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
   def initialize: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
 
+  # --
   # : () -> Symbol
   def role: () -> Symbol
 
+  # --
   # : () -> bool
   def structured_output?: () -> bool
 
   # Converts the message to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/messages/base.rbs
+++ b/sig/generated/riffer/messages/base.rbs
@@ -7,11 +7,13 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader content: String
 
+  # --
   # : (String) -> void
   def initialize: (String) -> void
 
   # Converts the message to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 
@@ -19,6 +21,7 @@ class Riffer::Messages::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : () -> Symbol
   def role: () -> Symbol
 end

--- a/sig/generated/riffer/messages/converter.rbs
+++ b/sig/generated/riffer/messages/converter.rbs
@@ -8,6 +8,7 @@ module Riffer::Messages::Converter
   #
   # Raises Riffer::ArgumentError if the message format is invalid.
   #
+  # --
   # : ((Hash[Symbol, untyped] | Riffer::Messages::Base)) -> Riffer::Messages::Base
   def convert_to_message_object: (Hash[Symbol, untyped] | Riffer::Messages::Base) -> Riffer::Messages::Base
 
@@ -15,16 +16,18 @@ module Riffer::Messages::Converter
   #
   # Accepts:
   # - +Riffer::FilePart+ objects (passed through)
-  # - +{url: "https://...", media_type: "..."}+ (URL source)
-  # - +{data: "...", media_type: "..."}+ (raw base64)
+  # - <tt>{url: "https://...", media_type: "..."}</tt> (URL source)
+  # - <tt>{data: "...", media_type: "..."}</tt> (raw base64)
   #
   # Raises Riffer::ArgumentError if the hash format is invalid.
   #
+  # --
   # : ((Hash[Symbol, untyped] | Riffer::FilePart)) -> Riffer::FilePart
   def convert_to_file_part: (Hash[Symbol, untyped] | Riffer::FilePart) -> Riffer::FilePart
 
   private
 
+  # --
   # : (Hash[Symbol, untyped]) -> Riffer::Messages::Base
   def convert_hash_to_message: (Hash[Symbol, untyped]) -> Riffer::Messages::Base
 end

--- a/sig/generated/riffer/messages/system.rbs
+++ b/sig/generated/riffer/messages/system.rbs
@@ -6,6 +6,7 @@
 #   msg.role     # => :system
 #   msg.content  # => "You are a helpful assistant."
 class Riffer::Messages::System < Riffer::Messages::Base
+  # --
   # : () -> Symbol
   def role: () -> Symbol
 end

--- a/sig/generated/riffer/messages/tool.rbs
+++ b/sig/generated/riffer/messages/tool.rbs
@@ -23,19 +23,23 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
   attr_reader error_type: Symbol?
 
+  # --
   # : (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
   def initialize: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
 
   # Returns true if the tool execution resulted in an error.
   #
+  # --
   # : () -> bool
   def error?: () -> bool
 
+  # --
   # : () -> Symbol
   def role: () -> Symbol
 
   # Converts the message to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/messages/user.rbs
+++ b/sig/generated/riffer/messages/user.rbs
@@ -14,12 +14,15 @@ class Riffer::Messages::User < Riffer::Messages::Base
 
   # Initializes a user message.
   #
+  # --
   # : (String, ?files: Array[Riffer::FilePart]) -> void
   def initialize: (String, ?files: Array[Riffer::FilePart]) -> void
 
+  # --
   # : () -> Symbol
   def role: () -> Symbol
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/param.rbs
+++ b/sig/generated/riffer/param.rbs
@@ -7,7 +7,7 @@ class Riffer::Param
   # Maps Ruby types to JSON Schema type strings
   TYPE_MAPPINGS: Hash[Module, String]
 
-  # Primitive types allowed for the +of:+ keyword on Array params
+  # Primitive types allowed for the <tt>of:</tt> keyword on Array params
   PRIMITIVE_TYPES: Array[Class]
 
   attr_reader name: Symbol
@@ -26,29 +26,33 @@ class Riffer::Param
 
   attr_reader nested_params: Riffer::Params?
 
+  # --
   # : (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?item_type: Class?, ?nested_params: Riffer::Params?) -> void
   def initialize: (name: Symbol, type: Class, required: bool, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?item_type: Class?, ?nested_params: Riffer::Params?) -> void
 
   # Validates that a value matches the expected type.
   #
+  # --
   # : (untyped) -> bool
   def valid_type?: (untyped) -> bool
 
   # Returns the JSON Schema type name for this parameter.
   #
+  # --
   # : () -> String
   def type_name: () -> String
 
   # Converts this parameter to JSON Schema format.
   #
   # When +strict+ is true, optional parameters are made nullable
-  # (+["type", "null"]+) so that strict mode providers can distinguish
+  # (<tt>["type", "null"]</tt>) so that strict mode providers can distinguish
   # "absent" from "present" without rejecting the schema.
   #
   # Optional parameters with an +enum+ use +anyOf+ to separate the enum
   # constraint from the null type, since providers like Anthropic reject
-  # +{"type": ["string", "null"], "enum": [...]}+.
+  # <tt>{"type": ["string", "null"], "enum": [...]}</tt>.
   #
+  # --
   # : (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema: (?strict: bool) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -12,16 +12,19 @@
 class Riffer::Params
   attr_reader parameters: Array[Riffer::Param]
 
+  # --
   # : () -> void
   def initialize: () -> void
 
   # Defines a required parameter.
   #
+  # --
   # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
   def required: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
 
   # Defines an optional parameter.
   #
+  # --
   # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
   def optional: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
 
@@ -29,6 +32,7 @@ class Riffer::Params
   #
   # Raises Riffer::ValidationError if validation fails.
   #
+  # --
   # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def validate: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
@@ -38,23 +42,29 @@ class Riffer::Params
   # optional properties are made nullable instead. This satisfies
   # providers that enforce strict structured output schemas.
   #
+  # --
   # : (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema: (?strict: bool) -> Hash[Symbol, untyped]
 
   private
 
+  # --
   # : (Class, Class?) ?{ () -> void } -> Riffer::Params?
   def build_nested: (Class, Class?) ?{ () -> void } -> Riffer::Params?
 
+  # --
   # : (Riffer::Param, untyped, Array[String]) -> untyped
   def validate_nested: (Riffer::Param, untyped, Array[String]) -> untyped
 
+  # --
   # : (Riffer::Param, Hash[Symbol, untyped], Array[String]) -> Hash[Symbol, untyped]
   def validate_nested_hash: (Riffer::Param, Hash[Symbol, untyped], Array[String]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Riffer::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_nested_array_of_objects: (Riffer::Param, Array[untyped], Array[String]) -> Array[untyped]
 
+  # --
   # : (Riffer::Param, Array[untyped], Array[String]) -> void
   def validate_typed_array: (Riffer::Param, Array[untyped], Array[String]) -> void
 end

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -8,64 +8,83 @@
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # Initializes the Amazon Bedrock provider.
   #
+  # --
   # : (?api_token: String?, ?region: String?, **untyped) -> void
   def initialize: (?api_token: String?, ?region: String?, **untyped) -> void
 
   private
 
+  # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Hash[Symbol, untyped]) -> Aws::BedrockRuntime::Types::ConverseResponse
   def execute_generate: (Hash[Symbol, untyped]) -> Aws::BedrockRuntime::Types::ConverseResponse
 
+  # --
   # : (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
   def extract_token_usage: (Aws::BedrockRuntime::Types::ConverseResponse) -> Riffer::TokenUsage?
 
+  # --
   # : (Aws::BedrockRuntime::Types::ConverseResponse) -> String
   def extract_content: (Aws::BedrockRuntime::Types::ConverseResponse) -> String
 
+  # --
   # : (Aws::BedrockRuntime::Types::ConverseResponse) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls: (Aws::BedrockRuntime::Types::ConverseResponse) -> Array[Riffer::Messages::Assistant::ToolCall]
 
+  # --
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_start_tool_use: (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_delta_text_delta: (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_delta_tool_use: (Aws::BedrockRuntime::Types::ContentBlockDeltaEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_stop_text_delta: (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_stop_tool_use: (Aws::BedrockRuntime::Types::ContentBlockStopEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_metadata_usage: (Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
 
+  # --
   # : (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_bedrock_format: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 
+  # --
   # : (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
   def append_tool_result: (Array[Hash[Symbol, untyped]], Riffer::Messages::Tool) -> void
 
+  # --
   # : (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_bedrock_format: (Riffer::FilePart) -> Hash[Symbol, untyped]
 
   BEDROCK_FORMAT_MAP: Hash[String, String]
 
+  # --
   # : (String) -> String
   def bedrock_format: (String) -> String
 
+  # --
   # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_bedrock_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -10,76 +10,99 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
   # Returns the XML skill adapter for Anthropic/Claude.
   #
+  # --
   # : () -> singleton(Riffer::Skills::Adapter)
   def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
 
   # Initializes the Anthropic provider.
   #
+  # --
   # : (?api_key: String?, **untyped) -> void
   def initialize: (?api_key: String?, **untyped) -> void
 
   private
 
+  # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Hash[Symbol, untyped]) -> Anthropic::Models::Message
   def execute_generate: (Hash[Symbol, untyped]) -> Anthropic::Models::Message
 
+  # --
   # : (Anthropic::Models::Message) -> Riffer::TokenUsage?
   def extract_token_usage: (Anthropic::Models::Message) -> Riffer::TokenUsage?
 
+  # --
   # : (Anthropic::Models::Message) -> String
   def extract_content: (Anthropic::Models::Message) -> String
 
+  # --
   # : (Anthropic::Models::Message) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls: (Anthropic::Models::Message) -> Array[Riffer::Messages::Assistant::ToolCall]
 
+  # --
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped]) -> void
   def handle_raw_content_block_start: (untyped, state: Hash[Symbol, untyped]) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped]) -> void
   def handle_raw_content_block_delta: (untyped, state: Hash[Symbol, untyped]) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_text_event: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_thinking_event: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_input_json_event: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_tool_use: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_thinking: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_text: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_server_tool_use: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_content_block_stop_web_search_result: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_message_stop: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
   def partition_messages: (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
   def convert_assistant_to_anthropic_format: (Riffer::Messages::Assistant) -> Hash[Symbol, untyped]
 
+  # --
   # : (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_anthropic_format: (Riffer::FilePart) -> Hash[Symbol, untyped]
 
+  # --
   # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_anthropic_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/azure_open_ai.rbs
+++ b/sig/generated/riffer/providers/azure_open_ai.rbs
@@ -6,7 +6,7 @@
 #
 # Credentials are resolved in order:
 # 1. Keyword arguments (+api_key+, +base_url+)
-# 2. Config (+Riffer.config.azure_openai.api_key+ / +.endpoint+)
+# 2. Config (<tt>Riffer.config.azure_openai.api_key</tt> / <tt>.endpoint</tt>)
 # 3. Environment variables (+AZURE_OPENAI_API_KEY+ / +AZURE_OPENAI_ENDPOINT+)
 #
 #   Riffer::Providers::AzureOpenAI.new(
@@ -16,9 +16,10 @@
 class Riffer::Providers::AzureOpenAI < Riffer::Providers::OpenAI
   # Initializes the Azure OpenAI provider.
   #
-  # +api_key+ - Azure OpenAI API key. Falls back to config, then +AZURE_OPENAI_API_KEY+.
-  # +base_url+ - Azure OpenAI endpoint URL. Falls back to config, then +AZURE_OPENAI_ENDPOINT+.
+  # [api_key] Azure OpenAI API key. Falls back to config, then +AZURE_OPENAI_API_KEY+.
+  # [base_url] Azure OpenAI endpoint URL. Falls back to config, then +AZURE_OPENAI_ENDPOINT+.
   #
+  # --
   # : (**untyped) -> void
   def initialize: (**untyped) -> void
 end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -7,12 +7,12 @@
 #
 # ==== Hook methods
 #
-# - +build_request_params+ — convert messages, tools, and options into SDK params
-# - +execute_generate+ — call the SDK and return the raw response
-# - +execute_stream+ — call the streaming SDK, mapping events to the yielder
-# - +extract_token_usage+ — pull token counts from the SDK response
-# - +extract_content+ — extract text content from the SDK response
-# - +extract_tool_calls+ — extract tool calls from the SDK response
+# [build_request_params] convert messages, tools, and options into SDK params
+# [execute_generate] call the SDK and return the raw response
+# [execute_stream] call the streaming SDK, mapping events to the yielder
+# [extract_token_usage] pull token counts from the SDK response
+# [extract_content] extract text content from the SDK response
+# [extract_tool_calls] extract tool calls from the SDK response
 class Riffer::Providers::Base
   include Riffer::Helpers::Dependencies
 
@@ -22,51 +22,65 @@ class Riffer::Providers::Base
   #
   # Override in subclasses for provider-specific formats.
   #
+  # --
   # : () -> singleton(Riffer::Skills::Adapter)
   def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
 
   # Generates text using the provider.
   #
+  # --
   # : (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant
   def generate_text: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant
 
   # Streams text from the provider.
   #
+  # --
   # : (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream_text: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   private
 
+  # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Hash[Symbol, untyped]) -> untyped
   def execute_generate: (Hash[Symbol, untyped]) -> untyped
 
+  # --
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # --
   # : (untyped) -> Riffer::TokenUsage?
   def extract_token_usage: (untyped) -> Riffer::TokenUsage?
 
+  # --
   # : (untyped) -> String
   def extract_content: (untyped) -> String
 
+  # --
   # : (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls: (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
 
+  # --
   # : (String) -> Hash[Symbol, untyped]?
   def parse_structured_output: (String) -> Hash[Symbol, untyped]?
 
+  # --
   # : ((String | Hash[String, untyped])?) -> Hash[String, untyped]
   def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
 
+  # --
   # : (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
   def validate_input!: (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
 
+  # --
   # : (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Array[Riffer::Messages::Base]
   def normalize_messages: (prompt: String?, system: String?, messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Array[Riffer::Messages::Base]
 
+  # --
   # : (Array[Riffer::Messages::Base]) -> void
   def validate_normalized_messages!: (Array[Riffer::Messages::Base]) -> void
 end

--- a/sig/generated/riffer/providers/mock.rbs
+++ b/sig/generated/riffer/providers/mock.rbs
@@ -9,6 +9,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
   # Initializes the mock provider.
   #
+  # --
   # : (**untyped) -> void
   def initialize: (**untyped) -> void
 
@@ -20,34 +21,43 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
   #   provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
   #   provider.stub_response("Final response", token_usage: Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 5))
   #
+  # --
   # : (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
   def stub_response: (String, ?tool_calls: Array[Hash[Symbol, untyped]], ?token_usage: Riffer::TokenUsage?) -> void
 
   # Clears all stubbed responses.
   #
+  # --
   # : () -> void
   def clear_stubs: () -> void
 
   private
 
+  # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def execute_generate: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (untyped) -> Riffer::TokenUsage?
   def extract_token_usage: (untyped) -> Riffer::TokenUsage?
 
+  # --
   # : (untyped) -> String
   def extract_content: (untyped) -> String
 
+  # --
   # : (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls: (untyped) -> Array[Riffer::Messages::Assistant::ToolCall]
 
+  # --
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def next_response: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/open_ai.rbs
+++ b/sig/generated/riffer/providers/open_ai.rbs
@@ -8,68 +8,89 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
 
   # Initializes the OpenAI provider.
   #
+  # --
   # : (**untyped) -> void
   def initialize: (**untyped) -> void
 
   private
 
+  # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # --
   # : (Hash[Symbol, untyped]) -> OpenAI::Models::Responses::Response
   def execute_generate: (Hash[Symbol, untyped]) -> OpenAI::Models::Responses::Response
 
+  # --
   # : (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
   def extract_token_usage: (OpenAI::Models::Responses::Response) -> Riffer::TokenUsage?
 
+  # --
   # : (OpenAI::Models::Responses::Response) -> String
   def extract_content: (OpenAI::Models::Responses::Response) -> String
 
+  # --
   # : (OpenAI::Models::Responses::Response) -> Array[Riffer::Messages::Assistant::ToolCall]
   def extract_tool_calls: (OpenAI::Models::Responses::Response) -> Array[Riffer::Messages::Assistant::ToolCall]
 
+  # --
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_item_added_function_call: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_text_delta: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_text_done: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_reasoning_summary_text_delta: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_reasoning_summary_text_done: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_function_call_arguments_delta: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_function_call_arguments_done: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_response_completed: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, status: String, yielder: Enumerator::Yielder) -> void
   def handle_web_search_status: (untyped, status: String, yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (untyped, yielder: Enumerator::Yielder) -> void
   def handle_output_item_done_web_search: (untyped, yielder: Enumerator::Yielder) -> void
 
+  # --
   # : (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
   def convert_messages_to_openai_format: (Array[Riffer::Messages::Base]) -> Array[Hash[Symbol, untyped]]
 
+  # --
   # : (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
   def convert_assistant_to_openai_format: (Riffer::Messages::Assistant) -> (Hash[Symbol, untyped] | Array[Hash[Symbol, untyped]])
 
+  # --
   # : (Riffer::FilePart) -> Hash[Symbol, untyped]
   def convert_file_part_to_openai_format: (Riffer::FilePart) -> Hash[Symbol, untyped]
 
+  # --
   # : (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_openai_format: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/repository.rbs
+++ b/sig/generated/riffer/providers/repository.rbs
@@ -7,6 +7,7 @@ class Riffer::Providers::Repository
 
   # Finds a provider class by identifier.
   #
+  # --
   # : ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def self.find: (String | Symbol) -> singleton(Riffer::Providers::Base)?
 end

--- a/sig/generated/riffer/runner.rbs
+++ b/sig/generated/riffer/runner.rbs
@@ -11,11 +11,12 @@
 class Riffer::Runner
   # Maps over items using the provided block.
   #
-  # +items+ - the items to process.
-  # +context+ - context hash forwarded from the agent.
+  # [items] the items to process.
+  # [context] context hash forwarded from the agent.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/sequential.rbs
+++ b/sig/generated/riffer/runner/sequential.rbs
@@ -4,6 +4,7 @@
 #
 # This is the default runner used when no concurrency is needed.
 class Riffer::Runner::Sequential < Riffer::Runner
+  # --
   # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/threaded.rbs
+++ b/sig/generated/riffer/runner/threaded.rbs
@@ -14,11 +14,13 @@
 class Riffer::Runner::Threaded < Riffer::Runner
   DEFAULT_MAX_CONCURRENCY: Integer
 
-  # +max_concurrency+ - maximum number of threads to run simultaneously.
+  # [max_concurrency] maximum number of threads to run simultaneously.
   #
+  # --
   # : (?max_concurrency: Integer) -> void
   def initialize: (?max_concurrency: Integer) -> void
 
+  # --
   # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
   def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/skills/activate_tool.rbs
+++ b/sig/generated/riffer/skills/activate_tool.rbs
@@ -9,9 +9,10 @@
 class Riffer::Skills::ActivateTool < Riffer::Tool
   # Activates a skill by name and returns its body.
   #
-  # +context+ - tool context containing +:skills+ (a Riffer::Skills::Context).
-  # +name+ - the skill name to activate.
+  # [context] tool context containing +:skills+ (a Riffer::Skills::Context).
+  # [name] the skill name to activate.
   #
+  # --
   # : (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
   def call: (context: Hash[Symbol, untyped]?, name: String) -> Riffer::Tools::Response
 end

--- a/sig/generated/riffer/skills/adapter.rbs
+++ b/sig/generated/riffer/skills/adapter.rbs
@@ -14,10 +14,11 @@
 class Riffer::Skills::Adapter
   # Renders a skill catalog section for the system prompt.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
 
@@ -25,6 +26,7 @@ class Riffer::Skills::Adapter
   #
   # Override to provide a custom activation tool.
   #
+  # --
   # : () -> singleton(Riffer::Tool)
   def activate_tool: () -> singleton(Riffer::Tool)
 end

--- a/sig/generated/riffer/skills/backend.rbs
+++ b/sig/generated/riffer/skills/backend.rbs
@@ -17,16 +17,18 @@ class Riffer::Skills::Backend
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : () -> Array[Riffer::Skills::Frontmatter]
   def list_skills: () -> Array[Riffer::Skills::Frontmatter]
 
   # Returns the full SKILL.md body (without frontmatter) for a skill.
   #
-  # +name+ - the skill name to read.
+  # [name] the skill name to read.
   #
   # Raises NotImplementedError if not implemented by subclass.
   # Raises Riffer::ArgumentError if skill not found.
   #
+  # --
   # : (String) -> String
   def read_skill: (String) -> String
 end

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -12,6 +12,7 @@
 class Riffer::Skills::Config
   # Creates a new Config with all options unset.
   #
+  # --
   # : () -> void
   def initialize: () -> void
 
@@ -20,6 +21,7 @@ class Riffer::Skills::Config
   # Accepts a Riffer::Skills::Backend instance, or a Proc that receives
   # +context+ and returns a Backend.
   #
+  # --
   # : (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
   def backend: (?(Riffer::Skills::Backend | Proc)?) -> (Riffer::Skills::Backend | Proc)?
 
@@ -28,6 +30,7 @@ class Riffer::Skills::Config
   # Must be a subclass of Riffer::Skills::Adapter.
   # Defaults to the provider's preferred adapter.
   #
+  # --
   # : (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
   def adapter: (?singleton(Riffer::Skills::Adapter)?) -> singleton(Riffer::Skills::Adapter)?
 
@@ -39,6 +42,7 @@ class Riffer::Skills::Config
   # Accepts an array of skill name strings or a Proc that receives
   # +context+ and returns an array of names.
   #
+  # --
   # : (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
   def activate: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
 end

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -21,10 +21,11 @@ class Riffer::Skills::Context
 
   # Creates a new skills context for a generation cycle.
   #
-  # +backend+ - the skills backend for reading skill bodies.
-  # +skills+ - skill catalog indexed by name.
-  # +adapter+ - the adapter used to render skill content.
+  # [backend] the skills backend for reading skill bodies.
+  # [skills] skill catalog indexed by name.
+  # [adapter] the adapter used to render skill content.
   #
+  # --
   # : (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
   def initialize: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
 
@@ -32,11 +33,13 @@ class Riffer::Skills::Context
   #
   # Raises Riffer::ArgumentError if the skill is not in the catalog.
   #
+  # --
   # : (String) -> String
   def activate: (String) -> String
 
   # Returns whether a skill has been activated.
   #
+  # --
   # : (String) -> bool
   def activated?: (String) -> bool
 
@@ -44,11 +47,13 @@ class Riffer::Skills::Context
   #
   # Includes the catalog and any pre-activated skill bodies.
   #
+  # --
   # : () -> String
   def system_prompt: () -> String
 
   private
 
+  # --
   # : () -> Array[Riffer::Skills::Frontmatter]
   def available_skills: () -> Array[Riffer::Skills::Frontmatter]
 end

--- a/sig/generated/riffer/skills/filesystem_backend.rbs
+++ b/sig/generated/riffer/skills/filesystem_backend.rbs
@@ -11,8 +11,9 @@
 class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   # Creates a new FilesystemBackend.
   #
-  # +paths+ - one or more directory paths to scan for skills.
+  # [paths] one or more directory paths to scan for skills.
   #
+  # --
   # : (*String) -> void
   def initialize: (*String) -> void
 
@@ -22,20 +23,23 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   # SKILL.md. When multiple paths contain a skill with the same name,
   # first-path-wins.
   #
+  # --
   # : () -> Array[Riffer::Skills::Frontmatter]
   def list_skills: () -> Array[Riffer::Skills::Frontmatter]
 
   # Returns the full SKILL.md body (without frontmatter) for a skill.
   #
-  # +name+ - the skill name to read.
+  # [name] the skill name to read.
   #
   # Raises Riffer::ArgumentError if skill not found.
   #
+  # --
   # : (String) -> String
   def read_skill: (String) -> String
 
   private
 
+  # --
   # : (String, String) -> void
   def validate_dirname_matches_name!: (String, String) -> void
 end

--- a/sig/generated/riffer/skills/frontmatter.rbs
+++ b/sig/generated/riffer/skills/frontmatter.rbs
@@ -31,6 +31,7 @@ class Riffer::Skills::Frontmatter
   #
   # Raises Riffer::ArgumentError if frontmatter is invalid.
   #
+  # --
   # : (String) -> [Riffer::Skills::Frontmatter, String]
   def self.parse: (String) -> [ Riffer::Skills::Frontmatter, String ]
 
@@ -38,28 +39,33 @@ class Riffer::Skills::Frontmatter
   #
   # Raises Riffer::ArgumentError if frontmatter is invalid.
   #
+  # --
   # : (String) -> Riffer::Skills::Frontmatter
   def self.parse_frontmatter: (String) -> Riffer::Skills::Frontmatter
 
+  # --
   # : (String) -> [Hash[Symbol, untyped], String]
   def self.split_frontmatter: (String) -> [ Hash[Symbol, untyped], String ]
 
   # Creates a new Frontmatter.
   #
-  # +name+ - the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
-  # +description+ - the skill description (1-1024 chars).
-  # +metadata+ - optional metadata hash.
+  # [name] the skill name (must match +[a-z0-9]([a-z0-9-]*[a-z0-9])?+, 1-64 chars).
+  # [description] the skill description (1-1024 chars).
+  # [metadata] optional metadata hash.
   #
   # Raises Riffer::ArgumentError if name or description is invalid.
   #
+  # --
   # : (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
   def initialize: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
 
   private
 
+  # --
   # : (untyped) -> void
   def validate_name!: (untyped) -> void
 
+  # --
   # : (untyped) -> void
   def validate_description!: (untyped) -> void
 end

--- a/sig/generated/riffer/skills/markdown_adapter.rbs
+++ b/sig/generated/riffer/skills/markdown_adapter.rbs
@@ -9,8 +9,9 @@
 class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
   # Renders a skill catalog as Markdown.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
+  # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
 end

--- a/sig/generated/riffer/skills/xml_adapter.rbs
+++ b/sig/generated/riffer/skills/xml_adapter.rbs
@@ -8,8 +8,9 @@
 class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
   # Renders a skill catalog as XML.
   #
-  # +skills+ - array of Frontmatter objects to render.
+  # [skills] array of Frontmatter objects to render.
   #
+  # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
 end

--- a/sig/generated/riffer/stream_events/base.rbs
+++ b/sig/generated/riffer/stream_events/base.rbs
@@ -7,6 +7,7 @@ class Riffer::StreamEvents::Base
   # The message role (typically :assistant).
   attr_reader role: Symbol
 
+  # --
   # : (?role: Symbol) -> void
   def initialize: (?role: Symbol) -> void
 
@@ -14,6 +15,7 @@ class Riffer::StreamEvents::Base
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/guardrail_modification.rbs
+++ b/sig/generated/riffer/stream_events/guardrail_modification.rbs
@@ -9,29 +9,34 @@ class Riffer::StreamEvents::GuardrailModification < Riffer::StreamEvents::Base
 
   # Creates a new guardrail modification stream event.
   #
-  # +modification+ - the modification details.
-  # +role+ - the message role (defaults to :assistant).
+  # [modification] the modification details.
+  # [role] the message role (defaults to :assistant).
   #
+  # --
   # : (Riffer::Guardrails::Modification, ?role: Symbol) -> void
   def initialize: (Riffer::Guardrails::Modification, ?role: Symbol) -> void
 
   # The guardrail class that made the transformation.
   #
+  # --
   # : () -> singleton(Riffer::Guardrail)
   def guardrail: () -> singleton(Riffer::Guardrail)
 
   # The phase when the transformation occurred.
   #
+  # --
   # : () -> Symbol
   def phase: () -> Symbol
 
   # The indices of messages that were changed.
   #
+  # --
   # : () -> Array[Integer]
   def message_indices: () -> Array[Integer]
 
   # Converts the event to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/guardrail_tripwire.rbs
+++ b/sig/generated/riffer/stream_events/guardrail_tripwire.rbs
@@ -9,29 +9,34 @@ class Riffer::StreamEvents::GuardrailTripwire < Riffer::StreamEvents::Base
 
   # Creates a new tripwire stream event.
   #
-  # +tripwire+ - the tripwire details.
-  # +role+ - the message role (defaults to :assistant).
+  # [tripwire] the tripwire details.
+  # [role] the message role (defaults to :assistant).
   #
+  # --
   # : (Riffer::Guardrails::Tripwire, ?role: Symbol) -> void
   def initialize: (Riffer::Guardrails::Tripwire, ?role: Symbol) -> void
 
   # The reason for blocking.
   #
+  # --
   # : () -> String
   def reason: () -> String
 
   # The phase when blocking occurred (:before or :after).
   #
+  # --
   # : () -> Symbol
   def phase: () -> Symbol
 
   # The guardrail class that triggered the block.
   #
+  # --
   # : () -> singleton(Riffer::Guardrail)
   def guardrail: () -> singleton(Riffer::Guardrail)
 
   # Converts the event to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/interrupt.rbs
+++ b/sig/generated/riffer/stream_events/interrupt.rbs
@@ -7,11 +7,13 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader reason: (String | Symbol)?
 
+  # --
   # : (?reason: (String | Symbol)?) -> void
   def initialize: (?reason: (String | Symbol)?) -> void
 
   # Converts the event to a hash.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/reasoning_delta.rbs
+++ b/sig/generated/riffer/stream_events/reasoning_delta.rbs
@@ -8,9 +8,11 @@ class Riffer::StreamEvents::ReasoningDelta < Riffer::StreamEvents::Base
   # The incremental reasoning content.
   attr_reader content: String
 
+  # --
   # : (String, ?role: Symbol) -> void
   def initialize: (String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/reasoning_done.rbs
+++ b/sig/generated/riffer/stream_events/reasoning_done.rbs
@@ -8,9 +8,11 @@ class Riffer::StreamEvents::ReasoningDone < Riffer::StreamEvents::Base
   # The complete reasoning content.
   attr_reader content: String
 
+  # --
   # : (String, ?role: Symbol) -> void
   def initialize: (String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/skill_activation.rbs
+++ b/sig/generated/riffer/stream_events/skill_activation.rbs
@@ -8,9 +8,11 @@ class Riffer::StreamEvents::SkillActivation < Riffer::StreamEvents::Base
   # The activated skill name.
   attr_reader name: String
 
+  # --
   # : (String, ?role: Symbol) -> void
   def initialize: (String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/text_delta.rbs
+++ b/sig/generated/riffer/stream_events/text_delta.rbs
@@ -7,9 +7,11 @@ class Riffer::StreamEvents::TextDelta < Riffer::StreamEvents::Base
   # The incremental text content.
   attr_reader content: String
 
+  # --
   # : (String, ?role: Symbol) -> void
   def initialize: (String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/text_done.rbs
+++ b/sig/generated/riffer/stream_events/text_done.rbs
@@ -7,9 +7,11 @@ class Riffer::StreamEvents::TextDone < Riffer::StreamEvents::Base
   # The complete text content.
   attr_reader content: String
 
+  # --
   # : (String, ?role: Symbol) -> void
   def initialize: (String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/token_usage_done.rbs
+++ b/sig/generated/riffer/stream_events/token_usage_done.rbs
@@ -11,9 +11,11 @@ class Riffer::StreamEvents::TokenUsageDone < Riffer::StreamEvents::Base
   # The token usage data for this response.
   attr_reader token_usage: Riffer::TokenUsage
 
+  # --
   # : (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
   def initialize: (token_usage: Riffer::TokenUsage, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/tool_call_delta.rbs
+++ b/sig/generated/riffer/stream_events/tool_call_delta.rbs
@@ -13,9 +13,11 @@ class Riffer::StreamEvents::ToolCallDelta < Riffer::StreamEvents::Base
   # The incremental arguments JSON fragment.
   attr_reader arguments_delta: String
 
+  # --
   # : (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
   def initialize: (item_id: String, arguments_delta: String, ?name: String?, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/tool_call_done.rbs
+++ b/sig/generated/riffer/stream_events/tool_call_done.rbs
@@ -16,9 +16,11 @@ class Riffer::StreamEvents::ToolCallDone < Riffer::StreamEvents::Base
   # The complete arguments JSON string.
   attr_reader arguments: String
 
+  # --
   # : (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
   def initialize: (item_id: String, call_id: String, name: String, arguments: String, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/web_search_done.rbs
+++ b/sig/generated/riffer/stream_events/web_search_done.rbs
@@ -10,9 +10,11 @@ class Riffer::StreamEvents::WebSearchDone < Riffer::StreamEvents::Base
   # The search result sources with title and url.
   attr_reader sources: Array[Hash[Symbol, String?]]
 
+  # --
   # : (String, ?sources: Array[Hash[Symbol, String?]], ?role: Symbol) -> void
   def initialize: (String, ?sources: Array[Hash[Symbol, String?]], ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/stream_events/web_search_status.rbs
+++ b/sig/generated/riffer/stream_events/web_search_status.rbs
@@ -13,9 +13,11 @@ class Riffer::StreamEvents::WebSearchStatus < Riffer::StreamEvents::Base
   # The search query (present when available during status changes).
   attr_reader query: String?
 
+  # --
   # : (String, ?url: String?, ?query: String?, ?role: Symbol) -> void
   def initialize: (String, ?url: String?, ?query: String?, ?role: Symbol) -> void
 
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/structured_output.rbs
+++ b/sig/generated/riffer/structured_output.rbs
@@ -11,11 +11,13 @@
 class Riffer::StructuredOutput
   attr_reader params: Riffer::Params
 
+  # --
   # : (Riffer::Params) -> void
   def initialize: (Riffer::Params) -> void
 
   # Returns the JSON Schema for this structured output.
   #
+  # --
   # : (?strict: bool) -> Hash[Symbol, untyped]
   def json_schema: (?strict: bool) -> Hash[Symbol, untyped]
 
@@ -23,6 +25,7 @@ class Riffer::StructuredOutput
   #
   # Returns a Result with the validated object on success, or an error message on failure.
   #
+  # --
   # : (String) -> Riffer::StructuredOutput::Result
   def parse_and_validate: (String) -> Riffer::StructuredOutput::Result
 end

--- a/sig/generated/riffer/structured_output/result.rbs
+++ b/sig/generated/riffer/structured_output/result.rbs
@@ -16,16 +16,19 @@ class Riffer::StructuredOutput::Result
 
   attr_reader error: String?
 
+  # --
   # : (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
   def initialize: (?object: Hash[Symbol, untyped]?, ?error: String?) -> void
 
   # Returns true when parsing and validation succeeded.
   #
+  # --
   # : () -> bool
   def success?: () -> bool
 
   # Returns true when parsing or validation failed.
   #
+  # --
   # : () -> bool
   def failure?: () -> bool
 end

--- a/sig/generated/riffer/token_usage.rbs
+++ b/sig/generated/riffer/token_usage.rbs
@@ -21,16 +21,19 @@ class Riffer::TokenUsage
   # Number of tokens read from cache (Anthropic-specific).
   attr_reader cache_read_tokens: Integer?
 
+  # --
   # : (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
   def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
 
   # Returns the total number of tokens (input + output).
   #
+  # --
   # : () -> Integer
   def total_tokens: () -> Integer
 
   # Combines two TokenUsage objects for cumulative tracking.
   #
+  # --
   # : (Riffer::TokenUsage) -> Riffer::TokenUsage
   def +: (Riffer::TokenUsage) -> Riffer::TokenUsage
 
@@ -38,11 +41,13 @@ class Riffer::TokenUsage
   #
   # Cache tokens are omitted if nil.
   #
+  # --
   # : () -> Hash[Symbol, Integer]
   def to_h: () -> Hash[Symbol, Integer]
 
   private
 
+  # --
   # : (Integer?, Integer?) -> Integer?
   def add_nullable: (Integer?, Integer?) -> Integer?
 end

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -29,31 +29,37 @@ class Riffer::Tool
 
   # Gets or sets the tool description.
   #
+  # --
   # : (?String?) -> String?
   def self.description: (?String?) -> String?
 
   # Gets or sets the tool identifier/name.
   #
+  # --
   # : (?String?) -> String
   def self.identifier: (?String?) -> String
 
   # Alias for identifier - used by providers.
   #
+  # --
   # : (?String?) -> String
   def self.name: (?String?) -> String
 
   # Gets or sets the tool timeout in seconds.
   #
+  # --
   # : (?(Integer | Float)?) -> (Integer | Float)
   def self.timeout: (?(Integer | Float)?) -> (Integer | Float)
 
   # Defines parameters using the Params DSL.
   #
+  # --
   # : () ?{ () -> void } -> Riffer::Params?
   def self.params: () ?{ () -> void } -> Riffer::Params?
 
   # Returns the JSON Schema for the tool's parameters.
   #
+  # --
   # : (?strict: bool) -> Hash[Symbol, untyped]
   def self.parameters_schema: (?strict: bool) -> Hash[Symbol, untyped]
 
@@ -63,21 +69,25 @@ class Riffer::Tool
   #
   # Raises NotImplementedError if not implemented by subclass.
   #
+  # --
   # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
 
   # Creates a text response. Shorthand for Riffer::Tools::Response.text.
   #
+  # --
   # : (untyped) -> Riffer::Tools::Response
   def text: (untyped) -> Riffer::Tools::Response
 
   # Creates a JSON response. Shorthand for Riffer::Tools::Response.json.
   #
+  # --
   # : (untyped) -> Riffer::Tools::Response
   def json: (untyped) -> Riffer::Tools::Response
 
   # Creates an error response. Shorthand for Riffer::Tools::Response.error.
   #
+  # --
   # : (String, ?type: Symbol) -> Riffer::Tools::Response
   def error: (String, ?type: Symbol) -> Riffer::Tools::Response
 
@@ -87,6 +97,7 @@ class Riffer::Tool
   # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
   # Raises Riffer::Error if the tool does not return a Response object.
   #
+  # --
   # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
   def call_with_validation: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
 end

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -11,20 +11,22 @@
 #   runtime = Riffer::ToolRuntime::Inline.new
 #   results = runtime.execute(tool_calls, tools: tools, context: context)
 class Riffer::ToolRuntime
-  # +runner+ - the concurrency runner to use for batch execution.
+  # [runner] the concurrency runner to use for batch execution.
   #
   # Subclasses must provide a runner; instantiating ToolRuntime directly
   # raises +NotImplementedError+.
   #
+  # --
   # : (runner: Riffer::Runner) -> void
   def initialize: (runner: Riffer::Runner) -> void
 
-  # Executes a batch of tool calls, returning +[tool_call, response]+ pairs.
+  # Executes a batch of tool calls, returning <tt>[tool_call, response]</tt> pairs.
   #
-  # +tool_calls+ - the tool calls to execute.
-  # +tools+ - the resolved tool classes.
-  # +context+ - the context hash.
+  # [tool_calls] the tool calls to execute.
+  # [tools] the resolved tool classes.
+  # [context] the context hash.
   #
+  # --
   # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
 
@@ -44,6 +46,7 @@ class Riffer::ToolRuntime
   #     end
   #   end
   #
+  # --
   # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
   def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
 
@@ -52,13 +55,15 @@ class Riffer::ToolRuntime
   # Dispatches a single tool call. Override in subclasses to change
   # how individual tools are invoked (e.g., HTTP, gRPC).
   #
-  # +tool_call+ - the tool call to execute.
-  # +tools+ - the resolved tool classes.
-  # +context+ - the context hash.
+  # [tool_call] the tool call to execute.
+  # [tools] the resolved tool classes.
+  # [context] the context hash.
   #
+  # --
   # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
   def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
 
+  # --
   # : (String?) -> Hash[Symbol, untyped]
   def parse_arguments: (String?) -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/tool_runtime/inline.rbs
+++ b/sig/generated/riffer/tool_runtime/inline.rbs
@@ -4,6 +4,7 @@
 #
 # This is the default tool runtime used when no runtime is configured.
 class Riffer::ToolRuntime::Inline < Riffer::ToolRuntime
+  # --
   # : () -> void
   def initialize: () -> void
 end

--- a/sig/generated/riffer/tool_runtime/threaded.rbs
+++ b/sig/generated/riffer/tool_runtime/threaded.rbs
@@ -8,8 +8,9 @@
 class Riffer::ToolRuntime::Threaded < Riffer::ToolRuntime
   DEFAULT_MAX_CONCURRENCY: Integer
 
-  # +max_concurrency+ - maximum number of tool calls to execute simultaneously.
+  # [max_concurrency] maximum number of tool calls to execute simultaneously.
   #
+  # --
   # : (?max_concurrency: Integer) -> void
   def initialize: (?max_concurrency: Integer) -> void
 end

--- a/sig/generated/riffer/tools/response.rbs
+++ b/sig/generated/riffer/tools/response.rbs
@@ -26,37 +26,45 @@ class Riffer::Tools::Response
   #
   # Raises Riffer::ArgumentError if format is invalid.
   #
+  # --
   # : (untyped, ?format: Symbol) -> Riffer::Tools::Response
   def self.success: (untyped, ?format: Symbol) -> Riffer::Tools::Response
 
   # Creates a success response with text format.
   #
+  # --
   # : (untyped) -> Riffer::Tools::Response
   def self.text: (untyped) -> Riffer::Tools::Response
 
   # Creates a success response with JSON format.
   #
+  # --
   # : (untyped) -> Riffer::Tools::Response
   def self.json: (untyped) -> Riffer::Tools::Response
 
   # Creates an error response.
   #
+  # --
   # : (String, ?type: Symbol) -> Riffer::Tools::Response
   def self.error: (String, ?type: Symbol) -> Riffer::Tools::Response
 
+  # --
   # : () -> bool
   def success?: () -> bool
 
+  # --
   # : () -> bool
   def error?: () -> bool
 
   # Returns a hash representation of the response.
   #
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 
   private
 
+  # --
   # : (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
   def initialize: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
 end


### PR DESCRIPTION
## Summary

Fix three systemic formatting issues in the RDoc-generated API docs on docs.riffer.ai:

- **Remove `--markup markdown`** from Rakefile so RDoc-native syntax works correctly
- **Add `#--` before all standalone `#:`** RBS annotation lines (346 occurrences across 69 files) — RDoc was parsing `#:` as a label-list marker, corrupting preceding comments into `<pre>` blocks
- **Convert parameter lists** from `+param+ - desc` to `[param] desc` (RDoc labeled list syntax) so they render as `<dl>` definition lists instead of run-on paragraphs
- **Replace multi-word `+...+`** with `<tt>...</tt>` for proper inline code rendering
- **Add missing blank line** before code block in `guardrails/result.rb`
- **Update `.agents/rdoc.md`** with corrected conventions (`[param]`, `<tt>`, `#--`)
- Regenerate RBS type signatures

### Before

<img width="539" height="1300" alt="image" src="https://github.com/user-attachments/assets/0123599c-e4b1-4983-9000-2eccec0d09bb" />

### After
<img width="531" height="1304" alt="image" src="https://github.com/user-attachments/assets/348ae65c-8ff4-40ad-b0e4-5ceae3a814b0" />

## Test plan

- [x] `bundle exec rake` — all tests pass, StandardRB clean, Steep type check passes
- [x] `bundle exec rake rbs:generate` — RBS regenerated
- [x] `bundle exec rake rdoc` — docs generated and verified:
  - Method descriptions render as `<p>` (not `<pre>`)
  - Parameter lists render as `<dl>` definition lists
  - Multi-word `<tt>` inline code renders as `<code>`
  - Code examples render as syntax-highlighted `<pre class="ruby">` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)