### PR TITLE
refactor: simplify dependency helper

### DIFF
--- a/lib/riffer/helpers/dependencies.rb
+++ b/lib/riffer/helpers/dependencies.rb
@@ -8,41 +8,14 @@ module Riffer::Helpers::Dependencies
   # Raised when a required gem cannot be loaded.
   class LoadError < ::LoadError; end
 
-  # Raised when a gem version requirement is not satisfied.
-  class VersionError < ScriptError; end
-
-  # Declares a dependency on a gem.
+  # Requires a gem by name, raising a helpful error if it is not installed.
   #
-  # Verifies the gem is installed and satisfies version requirements,
-  # then requires it.
-  #
-  # Raises LoadError if the gem is not installed.
-  # Raises VersionError if the gem version does not satisfy requirements.
+  # Raises LoadError if the gem cannot be required.
   #
   #--
-  #: (String, ?req: (bool | String)) -> true
-  def depends_on(gem_name, req: true)
-    gem(gem_name)
-
-    return true unless defined?(Bundler)
-
-    gem_version = Gem.loaded_specs[gem_name].version
-    gem_dependency = Bundler.load.dependencies.find { |g| g.name == gem_name }
-    gem_requirement = gem_dependency&.requirement
-
-    unless gem_requirement
-      raise VersionError, "The #{gem_name} gem is installed but not specified in your Bundler dependencies (e.g., Gemfile)."
-    end
-
-    unless gem_requirement.satisfied_by?(gem_version)
-      raise VersionError, "The #{gem_name} gem is installed, but version #{gem_requirement} is required. You have #{gem_version}."
-    end
-
-    lib_name = gem_name if req == true
-    lib_name = req if req.is_a?(String)
-
-    require(lib_name) if lib_name
-
+  #: (String) -> true
+  def depends_on(gem_name)
+    require gem_name
     true
   rescue ::LoadError
     raise LoadError, "Could not load #{gem_name}. Please ensure that the #{gem_name} gem is installed."

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -23,7 +23,7 @@ class Riffer::Runner::Fibers < Riffer::Runner
   #: (?max_concurrency: Integer?) -> void
   def initialize(max_concurrency: nil)
     depends_on "async"
-    require "async/semaphore" if max_concurrency
+    depends_on "async/semaphore" if max_concurrency
     @max_concurrency = max_concurrency
   end
 

--- a/sig/generated/riffer/helpers/dependencies.rbs
+++ b/sig/generated/riffer/helpers/dependencies.rbs
@@ -8,19 +8,11 @@ module Riffer::Helpers::Dependencies
   class LoadError < ::LoadError
   end
 
-  # Raised when a gem version requirement is not satisfied.
-  class VersionError < ScriptError
-  end
-
-  # Declares a dependency on a gem.
+  # Requires a gem by name, raising a helpful error if it is not installed.
   #
-  # Verifies the gem is installed and satisfies version requirements,
-  # then requires it.
-  #
-  # Raises LoadError if the gem is not installed.
-  # Raises VersionError if the gem version does not satisfy requirements.
+  # Raises LoadError if the gem cannot be required.
   #
   # --
-  # : (String, ?req: (bool | String)) -> true
-  def depends_on: (String, ?req: bool | String) -> true
+  # : (String) -> true
+  def depends_on: (String) -> true
 end

--- a/test/riffer/helpers/dependencies_test.rb
+++ b/test/riffer/helpers/dependencies_test.rb
@@ -10,6 +10,13 @@ describe Riffer::Helpers::Dependencies do
   let(:instance) { subject_class.new }
 
   describe "#depends_on" do
+    describe "when the gem is installed" do
+      it "returns true" do
+        result = instance.depends_on("rake")
+        expect(result).must_equal true
+      end
+    end
+
     describe "when the gem is not installed" do
       it "raises LoadError" do
         assert_raises(Riffer::Helpers::Dependencies::LoadError) do
@@ -34,55 +41,9 @@ describe Riffer::Helpers::Dependencies do
       end
     end
 
-    describe "when Bundler is not defined" do
-      before do
-        instance.define_singleton_method(:gem) { |_name| true }
-        instance.define_singleton_method(:defined?) { |_const| false }
-      end
-
-      it "returns true when req is true" do
-        result = instance.depends_on("rake", req: true)
-        expect(result).must_equal true
-      end
-
-      it "returns true when req is false" do
-        result = instance.depends_on("rake", req: false)
-        expect(result).must_equal true
-      end
-
-      it "returns true when req is a truthy value other than true or false" do
-        instance.define_singleton_method(:require) { |_lib| true }
-        result = instance.depends_on("rake", req: "custom_lib")
-        expect(result).must_equal true
-      end
-    end
-
     describe "error classes" do
       it "defines LoadError as a subclass of ::LoadError" do
         expect(Riffer::Helpers::Dependencies::LoadError < ::LoadError).must_equal true
-      end
-
-      it "defines VersionError as a subclass of ScriptError" do
-        expect(Riffer::Helpers::Dependencies::VersionError < ScriptError).must_equal true
-      end
-    end
-
-    describe "with a real installed gem from Gemfile" do
-      # Using "rake" which is a dev dependency in the Gemfile
-      before do
-        instance.define_singleton_method(:gem) { |_name| true }
-        instance.define_singleton_method(:defined?) { |const| (const == "Bundler") ? "constant" : nil }
-      end
-
-      it "returns true when gem is in Gemfile and version matches" do
-        result = instance.depends_on("rake", req: false)
-        expect(result).must_equal true
-      end
-
-      it "returns true when req is a custom library name and require succeeds" do
-        instance.define_singleton_method(:require) { |_lib| true }
-        result = instance.depends_on("rake", req: "custom_lib")
-        expect(result).must_equal true
       end
     end
   end


### PR DESCRIPTION
## Summary

- Simplify `Riffer::Helpers::Dependencies#depends_on` to just `require` + friendly error message
- Remove `VersionError` class, `req:` parameter, `gem()` call, and all Bundler version-checking logic
- Use `depends_on` for `async/semaphore` in `Riffer::Runner::Fibers` for consistency
- Update tests and regenerate RBS types

## Test plan

- [x] `bundle exec rake` passes (1165 tests, 0 failures, lint clean, types clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined dependency declaration by removing bundler and version validation checks.
  * Simplified method signature for declaring optional dependencies.

* **Tests**
  * Updated tests to reflect new dependency handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->