### PR TITLE
feat: add timestamp to messages

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -65,6 +65,8 @@ Typed message objects that extend `Riffer::Messages::Base`:
 - `Assistant` - AI responses
 - `Tool` - tool execution results
 
+All messages carry a `timestamp` (`Time`, defaults to creation time, ISO 8601 with millisecond precision in `to_h`). Override when rehydrating persisted messages.
+
 `Riffer::FilePart` represents file attachments (images and documents) that can be included with User messages. Supports file paths, URLs, and raw base64 data.
 
 The `Converter` module handles hash-to-object conversion, including file hash-to-`FilePart` conversion.

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -23,9 +23,9 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   attr_reader :structured_output #: Hash[Symbol, untyped]?
 
   #--
-  #: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize(content, tool_calls: [], token_usage: nil, structured_output: nil)
-    super(content)
+  #: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?timestamp: Time) -> void
+  def initialize(content, tool_calls: [], token_usage: nil, structured_output: nil, timestamp: Time.now)
+    super(content, timestamp: timestamp)
     @tool_calls = tool_calls
     @token_usage = token_usage
     @structured_output = structured_output
@@ -48,7 +48,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content}
+    hash = super
     hash[:tool_calls] = tool_calls.map(&:to_h) unless tool_calls.empty?
     hash[:token_usage] = token_usage.to_h if token_usage
     hash[:structured_output] = structured_output if structured_output?

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -8,10 +8,14 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader :content #: String
 
+  # The time the message was created.
+  attr_reader :timestamp #: Time
+
   #--
-  #: (String) -> void
-  def initialize(content)
+  #: (String, ?timestamp: Time) -> void
+  def initialize(content, timestamp: Time.now)
     @content = content
+    @timestamp = timestamp
   end
 
   # Converts the message to a hash.
@@ -19,7 +23,7 @@ class Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    {role: role, content: content}
+    {role: role, content: content, timestamp: timestamp.iso8601(3)}
   end
 
   # Returns the message role.

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -65,22 +65,28 @@ module Riffer::Messages::Converter
       raise Riffer::ArgumentError, "Message hash must include a 'role' key"
     end
 
+    timestamp_kwarg = if hash.key?(:timestamp)
+      {timestamp: hash[:timestamp].is_a?(Time) ? hash[:timestamp] : Time.iso8601(hash[:timestamp])}
+    else
+      {}
+    end
+
     case role.to_sym
     when :user
       files = (hash[:files] || []).map { |f| convert_to_file_part(f) }
-      Riffer::Messages::User.new(content, files: files)
+      Riffer::Messages::User.new(content, files: files, **timestamp_kwarg)
     when :assistant
       tool_calls = (hash[:tool_calls] || []).map { |tc|
         tc.is_a?(Riffer::Messages::Assistant::ToolCall) ? tc : Riffer::Messages::Assistant::ToolCall.new(**tc)
       }
       structured_output = hash[:structured_output]
-      Riffer::Messages::Assistant.new(content, tool_calls: tool_calls, structured_output: structured_output)
+      Riffer::Messages::Assistant.new(content, tool_calls: tool_calls, structured_output: structured_output, **timestamp_kwarg)
     when :system
-      Riffer::Messages::System.new(content)
+      Riffer::Messages::System.new(content, **timestamp_kwarg)
     when :tool
       tool_call_id = hash[:tool_call_id]
       name = hash[:name]
-      Riffer::Messages::Tool.new(content, tool_call_id: tool_call_id, name: name)
+      Riffer::Messages::Tool.new(content, tool_call_id: tool_call_id, name: name, **timestamp_kwarg)
     else
       raise Riffer::ArgumentError, "Unknown message role: #{role}"
     end

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -26,9 +26,9 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   attr_reader :error_type #: Symbol?
 
   #--
-  #: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
-  def initialize(content, tool_call_id:, name:, error: nil, error_type: nil)
-    super(content)
+  #: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?, ?timestamp: Time) -> void
+  def initialize(content, tool_call_id:, name:, error: nil, error_type: nil, timestamp: Time.now)
+    super(content, timestamp: timestamp)
     @tool_call_id = tool_call_id
     @name = name
     @error = error
@@ -54,7 +54,9 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content, tool_call_id: tool_call_id, name: name}
+    hash = super
+    hash[:tool_call_id] = tool_call_id
+    hash[:name] = name
     if error?
       hash[:error] = error
       hash[:error_type] = error_type

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -17,9 +17,9 @@ class Riffer::Messages::User < Riffer::Messages::Base
   # Initializes a user message.
   #
   #--
-  #: (String, ?files: Array[Riffer::FilePart]) -> void
-  def initialize(content, files: [])
-    super(content)
+  #: (String, ?files: Array[Riffer::FilePart], ?timestamp: Time) -> void
+  def initialize(content, files: [], timestamp: Time.now)
+    super(content, timestamp: timestamp)
     @files = files
   end
 
@@ -32,7 +32,7 @@ class Riffer::Messages::User < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content}
+    hash = super
     hash[:files] = files.map(&:to_h) unless files.empty?
     hash
   end

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -32,8 +32,8 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   attr_reader structured_output: Hash[Symbol, untyped]?
 
   # --
-  # : (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  # : (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?timestamp: Time) -> void
+  def initialize: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?timestamp: Time) -> void
 
   # --
   # : () -> Symbol

--- a/sig/generated/riffer/messages/base.rbs
+++ b/sig/generated/riffer/messages/base.rbs
@@ -7,9 +7,12 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader content: String
 
+  # The time the message was created.
+  attr_reader timestamp: Time
+
   # --
-  # : (String) -> void
-  def initialize: (String) -> void
+  # : (String, ?timestamp: Time) -> void
+  def initialize: (String, ?timestamp: Time) -> void
 
   # Converts the message to a hash.
   #

--- a/sig/generated/riffer/messages/tool.rbs
+++ b/sig/generated/riffer/messages/tool.rbs
@@ -24,8 +24,8 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   attr_reader error_type: Symbol?
 
   # --
-  # : (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
-  def initialize: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
+  # : (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?, ?timestamp: Time) -> void
+  def initialize: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?, ?timestamp: Time) -> void
 
   # Returns true if the tool execution resulted in an error.
   #

--- a/sig/generated/riffer/messages/user.rbs
+++ b/sig/generated/riffer/messages/user.rbs
@@ -15,8 +15,8 @@ class Riffer::Messages::User < Riffer::Messages::Base
   # Initializes a user message.
   #
   # --
-  # : (String, ?files: Array[Riffer::FilePart]) -> void
-  def initialize: (String, ?files: Array[Riffer::FilePart]) -> void
+  # : (String, ?files: Array[Riffer::FilePart], ?timestamp: Time) -> void
+  def initialize: (String, ?files: Array[Riffer::FilePart], ?timestamp: Time) -> void
 
   # --
   # : () -> Symbol

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -47,10 +47,32 @@ describe Riffer::Messages::Assistant do
     end
   end
 
+  describe "#timestamp" do
+    it "sets a default timestamp" do
+      before = Time.now
+      message = Riffer::Messages::Assistant.new("I can help")
+      after = Time.now
+      expect(message.timestamp).must_be :>=, before
+      expect(message.timestamp).must_be :<=, after
+    end
+
+    it "accepts a custom timestamp" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::Assistant.new("I can help", timestamp: custom_time)
+      expect(message.timestamp).must_equal custom_time
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::Assistant.new("I can help")
-      expect(message.to_h).must_equal({role: :assistant, content: "I can help"})
+      expect(message.to_h.except(:timestamp)).must_equal({role: :assistant, content: "I can help"})
+    end
+
+    it "includes timestamp as ISO 8601 with milliseconds" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::Assistant.new("I can help", timestamp: custom_time)
+      expect(message.to_h[:timestamp]).must_equal custom_time.iso8601(3)
     end
 
     it "includes tool_calls when provided" do
@@ -61,7 +83,7 @@ describe Riffer::Messages::Assistant do
 
     it "excludes tool_calls when empty" do
       message = Riffer::Messages::Assistant.new("No tools")
-      expect(message.to_h).must_equal({role: :assistant, content: "No tools"})
+      expect(message.to_h.except(:timestamp)).must_equal({role: :assistant, content: "No tools"})
     end
 
     it "includes usage when provided" do

--- a/test/riffer/messages/base_test.rb
+++ b/test/riffer/messages/base_test.rb
@@ -9,6 +9,20 @@ describe Riffer::Messages::Base do
     it "sets the content" do
       expect(base_message.content).must_equal "Test content"
     end
+
+    it "sets a default timestamp" do
+      before = Time.now
+      message = Riffer::Messages::Base.new("Test")
+      after = Time.now
+      expect(message.timestamp).must_be :>=, before
+      expect(message.timestamp).must_be :<=, after
+    end
+
+    it "accepts a custom timestamp" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::Base.new("Test", timestamp: custom_time)
+      expect(message.timestamp).must_equal custom_time
+    end
   end
 
   describe "#role" do

--- a/test/riffer/messages/converter_test.rb
+++ b/test/riffer/messages/converter_test.rb
@@ -39,6 +39,35 @@ describe Riffer::Messages::Converter do
       expect(result.content).must_equal "Hello"
     end
 
+    describe "with timestamp" do
+      it "parses ISO 8601 timestamp string" do
+        ts = "2025-01-15T12:00:00.000+00:00"
+        result = instance.convert_to_message_object({role: "user", content: "Hello", timestamp: ts})
+        expect(result.timestamp).must_equal Time.iso8601(ts)
+      end
+
+      it "passes through Time objects" do
+        custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+        result = instance.convert_to_message_object({role: "user", content: "Hello", timestamp: custom_time})
+        expect(result.timestamp).must_equal custom_time
+      end
+
+      it "defaults timestamp when not provided" do
+        before = Time.now
+        result = instance.convert_to_message_object({role: "user", content: "Hello"})
+        after = Time.now
+        expect(result.timestamp).must_be :>=, before
+        expect(result.timestamp).must_be :<=, after
+      end
+
+      it "round-trips timestamp through to_h" do
+        custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+        msg = Riffer::Messages::User.new("Hello", timestamp: custom_time)
+        result = instance.convert_to_message_object(msg.to_h)
+        expect(result.timestamp).must_equal Time.iso8601(custom_time.iso8601(3))
+      end
+    end
+
     it "converts assistant hash to Assistant message" do
       result = instance.convert_to_message_object({role: "assistant", content: "Hi"})
       expect(result).must_be_instance_of Riffer::Messages::Assistant

--- a/test/riffer/messages/system_test.rb
+++ b/test/riffer/messages/system_test.rb
@@ -10,10 +10,32 @@ describe Riffer::Messages::System do
     end
   end
 
+  describe "#timestamp" do
+    it "sets a default timestamp" do
+      before = Time.now
+      message = Riffer::Messages::System.new("You are helpful")
+      after = Time.now
+      expect(message.timestamp).must_be :>=, before
+      expect(message.timestamp).must_be :<=, after
+    end
+
+    it "accepts a custom timestamp" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::System.new("You are helpful", timestamp: custom_time)
+      expect(message.timestamp).must_equal custom_time
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::System.new("You are helpful")
-      expect(message.to_h).must_equal({role: :system, content: "You are helpful"})
+      expect(message.to_h.except(:timestamp)).must_equal({role: :system, content: "You are helpful"})
+    end
+
+    it "includes timestamp as ISO 8601 with milliseconds" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::System.new("You are helpful", timestamp: custom_time)
+      expect(message.to_h[:timestamp]).must_equal custom_time.iso8601(3)
     end
   end
 end

--- a/test/riffer/messages/tool_test.rb
+++ b/test/riffer/messages/tool_test.rb
@@ -10,11 +10,33 @@ describe Riffer::Messages::Tool do
     end
   end
 
+  describe "#timestamp" do
+    it "sets a default timestamp" do
+      before = Time.now
+      message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool")
+      after = Time.now
+      expect(message.timestamp).must_be :>=, before
+      expect(message.timestamp).must_be :<=, after
+    end
+
+    it "accepts a custom timestamp" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool", timestamp: custom_time)
+      expect(message.timestamp).must_equal custom_time
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role, content, tool_call_id, and name" do
       message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool")
       expected = {role: :tool, content: "Result", tool_call_id: "123", name: "my_tool"}
-      expect(message.to_h).must_equal expected
+      expect(message.to_h.except(:timestamp)).must_equal expected
+    end
+
+    it "includes timestamp as ISO 8601 with milliseconds" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::Tool.new("Result", tool_call_id: "123", name: "my_tool", timestamp: custom_time)
+      expect(message.to_h[:timestamp]).must_equal custom_time.iso8601(3)
     end
 
     it "includes error and error_type when present" do
@@ -33,7 +55,7 @@ describe Riffer::Messages::Tool do
         error: "Unknown tool 'foo'",
         error_type: :unknown_tool
       }
-      expect(message.to_h).must_equal expected
+      expect(message.to_h.except(:timestamp)).must_equal expected
     end
 
     it "excludes error fields when not present" do

--- a/test/riffer/messages/user_test.rb
+++ b/test/riffer/messages/user_test.rb
@@ -29,10 +29,32 @@ describe Riffer::Messages::User do
     end
   end
 
+  describe "#timestamp" do
+    it "sets a default timestamp" do
+      before = Time.now
+      message = Riffer::Messages::User.new("Hello")
+      after = Time.now
+      expect(message.timestamp).must_be :>=, before
+      expect(message.timestamp).must_be :<=, after
+    end
+
+    it "accepts a custom timestamp" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::User.new("Hello", timestamp: custom_time)
+      expect(message.timestamp).must_equal custom_time
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::User.new("Hello")
-      expect(message.to_h).must_equal({role: :user, content: "Hello"})
+      expect(message.to_h.except(:timestamp)).must_equal({role: :user, content: "Hello"})
+    end
+
+    it "includes timestamp as ISO 8601 with milliseconds" do
+      custom_time = Time.new(2025, 1, 15, 12, 0, 0)
+      message = Riffer::Messages::User.new("Hello", timestamp: custom_time)
+      expect(message.to_h[:timestamp]).must_equal custom_time.iso8601(3)
     end
 
     it "omits files key when files is empty" do

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -38,12 +38,14 @@ describe Riffer::Providers::Mock do
 
     it "stores normalized messages in calls" do
       provider.generate_text(prompt: "Hello")
-      expect(provider.calls.last[:messages]).must_equal [{role: :user, content: "Hello"}]
+      messages = provider.calls.last[:messages].map { |m| m.except(:timestamp) }
+      expect(messages).must_equal [{role: :user, content: "Hello"}]
     end
 
     it "stores system and user messages in calls when both provided" do
       provider.generate_text(prompt: "Hello", system: "You are helpful")
-      expect(provider.calls.last[:messages]).must_equal [
+      messages = provider.calls.last[:messages].map { |m| m.except(:timestamp) }
+      expect(messages).must_equal [
         {role: :system, content: "You are helpful"},
         {role: :user, content: "Hello"}
       ]


### PR DESCRIPTION
## Summary

- Adds a `timestamp` attribute to `Messages::Base` (defaults to `Time.now`, overridable)
- Serialized as ISO 8601 with millisecond precision in `to_h`
- `Converter` round-trips timestamps from hashes (parses ISO 8601 strings and passes through `Time` objects)
- All subclasses (System, User, Assistant, Tool) forward `timestamp:` to base

## Test plan

- [x] All 1183 existing tests pass (0 failures, 0 errors)
- [x] New tests for default timestamp, custom timestamp, `to_h` serialization, and converter round-trip on each message type
- [x] StandardRB lint clean (no new offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)