### PR TITLE
chore: drop Ruby 3.2 support (EOL 2026-03-31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Ruby gem framework for building AI-powered agents with LLM provider adapters.
 
 ## Quick Reference
 
-- **Ruby**: 3.2.0+
+- **Ruby**: 3.3.0+
 - **Lint + Test**: `bundle exec rake`
 - **Autoloading**: Zeitwerk (file paths must match module/class names)
 - **Model format**: `provider/model` (e.g., `openai/gpt-4`)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The all-in-one Ruby framework for building AI-powered applications and agents.
 
 ## Requirements
 
-- Ruby 3.2 or later
+- Ruby 3.3 or later
 
 ## Installation
 

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Riffer is a comprehensive Ruby framework designed to simplify the development of AI-powered applications and agents. It provides a complete toolkit for integrating artificial intelligence capabilities into your Ruby projects."
   spec.homepage = "https://riffer.ai"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
## Summary

- Bump minimum Ruby version from 3.2 to 3.3 (`required_ruby_version` in gemspec)
- Remove Ruby 3.2 from the CI test matrix
- Update documentation (README, CLAUDE.md, AGENTS.md) to reflect the new minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)