### PR TITLE
refactor: remove redundant `id` from ToolCall struct

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -502,7 +502,6 @@ class Riffer::Agent
             current_tool_call[:name] ||= event.name
           when Riffer::StreamEvents::ToolCallDone
             accumulated_tool_calls << Riffer::Messages::Assistant::ToolCall.new(
-              id: event.item_id,
               call_id: event.call_id,
               name: event.name,
               arguments: event.arguments
@@ -590,7 +589,7 @@ class Riffer::Agent
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
-        tool_call_id: tool_call.id,
+        tool_call_id: tool_call.call_id,
         name: tool_call.name,
         error: result.error_message,
         error_type: result.error_type
@@ -621,7 +620,7 @@ class Riffer::Agent
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
         result.content,
-        tool_call_id: tool_call.id,
+        tool_call_id: tool_call.call_id,
         name: tool_call.name,
         error: result.error_message,
         error_type: result.error_type
@@ -640,7 +639,7 @@ class Riffer::Agent
       m.is_a?(Riffer::Messages::Tool)
     }.map(&:tool_call_id)
 
-    assistant.tool_calls.reject { |tc| executed_ids.include?(tc.id) }
+    assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }
   end
 
   #--

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -11,7 +11,7 @@
 #   msg.tool_calls  # => []
 #
 class Riffer::Messages::Assistant < Riffer::Messages::Base
-  ToolCall = Struct.new(:id, :call_id, :name, :arguments, keyword_init: true)
+  ToolCall = Struct.new(:call_id, :name, :arguments, keyword_init: true)
 
   # Array of tool calls requested by the assistant.
   attr_reader :tool_calls #: Array[Riffer::Messages::Assistant::ToolCall]

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -119,7 +119,6 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     content_blocks.each do |block|
       if block.respond_to?(:tool_use) && block.tool_use
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
-          id: block.tool_use.tool_use_id,
           call_id: block.tool_use.tool_use_id,
           name: block.tool_use.name,
           arguments: block.tool_use.input.to_json
@@ -258,7 +257,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     message.tool_calls.each do |tc|
       content << {
         tool_use: {
-          tool_use_id: tc.id || tc.call_id,
+          tool_use_id: tc.call_id,
           name: tc.name,
           input: parse_tool_arguments(tc.arguments)
         }

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -122,7 +122,6 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     content_blocks.each do |block|
       if block.type.to_s == "tool_use"
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
-          id: block.id,
           call_id: block.id,
           name: block.name,
           arguments: block.input.to_json
@@ -339,7 +338,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     message.tool_calls.each do |tc|
       content << {
         type: "tool_use",
-        id: tc.id || tc.call_id,
+        id: tc.call_id,
         name: tc.name,
         input: parse_tool_arguments(tc.arguments)
       }

--- a/lib/riffer/providers/mock.rb
+++ b/lib/riffer/providers/mock.rb
@@ -32,7 +32,6 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
   def stub_response(content, tool_calls: [], token_usage: nil)
     formatted_tool_calls = tool_calls.map.with_index do |tc, idx|
       Riffer::Messages::Assistant::ToolCall.new(
-        id: tc[:id] || "mock_id_#{idx}",
         call_id: tc[:call_id] || tc[:id] || "mock_call_#{idx}",
         name: tc[:name],
         arguments: tc[:arguments].is_a?(String) ? tc[:arguments] : tc[:arguments].to_json
@@ -111,12 +110,12 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
     tool_calls.each do |tc|
       yielder << Riffer::StreamEvents::ToolCallDelta.new(
-        item_id: tc.id,
+        item_id: tc.call_id,
         name: tc.name,
         arguments_delta: tc.arguments
       )
       yielder << Riffer::StreamEvents::ToolCallDone.new(
-        item_id: tc.id,
+        item_id: tc.call_id,
         call_id: tc.call_id,
         name: tc.name,
         arguments: tc.arguments

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -106,7 +106,6 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     response.output.each do |item|
       if item.type == :function_call
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
-          id: item.id,
           call_id: item.call_id,
           name: item.name,
           arguments: item.arguments
@@ -284,8 +283,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
       message.tool_calls.each do |tc|
         items << {
           type: "function_call",
-          id: tc.id,
-          call_id: tc.call_id || tc.id,
+          call_id: tc.call_id,
           name: tc.name,
           arguments: tc.arguments.is_a?(String) ? tc.arguments : tc.arguments.to_json
         }

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -10,16 +10,14 @@
 #   msg.tool_calls  # => []
 class Riffer::Messages::Assistant < Riffer::Messages::Base
   class ToolCall < Struct[untyped]
-    attr_accessor id(): untyped
-
     attr_accessor call_id(): untyped
 
     attr_accessor name(): untyped
 
     attr_accessor arguments(): untyped
 
-    def self.new: (?id: untyped, ?call_id: untyped, ?name: untyped, ?arguments: untyped) -> instance
-                | ({ ?id: untyped, ?call_id: untyped, ?name: untyped, ?arguments: untyped }) -> instance
+    def self.new: (?call_id: untyped, ?name: untyped, ?arguments: untyped) -> instance
+                | ({ ?call_id: untyped, ?name: untyped, ?arguments: untyped }) -> instance
   end
 
   # Array of tool calls requested by the assistant.

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/tool_calling/_generate_text/with_tool_message.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_OpenAI/tool_calling/_generate_text/with_tool_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.openai.com/v1/responses
     body:
       encoding: UTF-8
-      string: '{"input":[{"role":"user","content":"What is the weather in Toronto?"},{"type":"function_call","id":"fc_tool_call_123","call_id":"call_tool_123","name":"get_weather","arguments":"{\"city\":\"Toronto\"}"},{"type":"function_call_output","call_id":"call_tool_123","output":"The
+      string: '{"input":[{"role":"user","content":"What is the weather in Toronto?"},{"type":"function_call","call_id":"call_tool_123","name":"get_weather","arguments":"{\"city\":\"Toronto\"}"},{"type":"function_call_output","call_id":"call_tool_123","output":"The
         weather in Toronto is 15 degrees Celsius."}],"model":"gpt-5-mini","tools":[{"type":"function","name":"get_weather","description":"Get
         the current weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string","description":"The
         city name"}},"required":["city"],"additionalProperties":false},"strict":true}]}'

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2403,7 +2403,7 @@ describe Riffer::Agent do
 
         messages = [
           {role: "user", content: "Call tool"},
-          {role: "assistant", content: "", tool_calls: [{id: "tc_1", call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}"}]}
+          {role: "assistant", content: "", tool_calls: [{call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}"}]}
         ]
         result = agent.generate(messages)
         expect(result.interrupted?).must_equal false

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -54,9 +54,9 @@ describe Riffer::Messages::Assistant do
     end
 
     it "includes tool_calls when provided" do
-      tool_call = Riffer::Messages::Assistant::ToolCall.new(id: "1", name: "test")
+      tool_call = Riffer::Messages::Assistant::ToolCall.new(name: "test")
       message = Riffer::Messages::Assistant.new("Using tool", tool_calls: [tool_call])
-      expect(message.to_h[:tool_calls]).must_equal [{id: "1", call_id: nil, name: "test", arguments: nil}]
+      expect(message.to_h[:tool_calls]).must_equal [{call_id: nil, name: "test", arguments: nil}]
     end
 
     it "excludes tool_calls when empty" do

--- a/test/riffer/messages/converter_test.rb
+++ b/test/riffer/messages/converter_test.rb
@@ -91,7 +91,7 @@ describe Riffer::Messages::Converter do
     end
 
     describe "with assistant message with tool_calls" do
-      let(:tool_call) { Riffer::Messages::Assistant::ToolCall.new(id: "1", name: "search") }
+      let(:tool_call) { Riffer::Messages::Assistant::ToolCall.new(name: "search") }
 
       let(:assistant_message) do
         {
@@ -110,11 +110,10 @@ describe Riffer::Messages::Converter do
         result = instance.convert_to_message_object({
           role: "assistant",
           content: "Let me search",
-          tool_calls: [{id: "1", call_id: "c1", name: "search", arguments: "{}"}]
+          tool_calls: [{call_id: "c1", name: "search", arguments: "{}"}]
         })
         tc = result.tool_calls.first
         expect(tc).must_be_instance_of Riffer::Messages::Assistant::ToolCall
-        expect(tc.id).must_equal "1"
         expect(tc.call_id).must_equal "c1"
         expect(tc.name).must_equal "search"
         expect(tc.arguments).must_equal "{}"

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -804,7 +804,7 @@ describe Riffer::Providers::AmazonBedrock do
             model: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
             tools: [weather_tool]
           )
-          expect(result.tool_calls.first.id).wont_be_nil
+          expect(result.tool_calls.first.call_id).wont_be_nil
         end
       end
     end
@@ -816,7 +816,7 @@ describe Riffer::Providers::AmazonBedrock do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_123", call_id: "tooluse_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "tooluse_123", name: "get_weather")
           ]
@@ -835,7 +835,7 @@ describe Riffer::Providers::AmazonBedrock do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_123", call_id: "tooluse_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "tooluse_123", name: "get_weather")
           ]
@@ -856,8 +856,8 @@ describe Riffer::Providers::AmazonBedrock do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto and Vancouver?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'),
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'),
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}')
             ]),
             Riffer::Messages::Tool.new("Toronto: 15°C", tool_call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather"),
             Riffer::Messages::Tool.new("Vancouver: 12°C", tool_call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather")
@@ -877,8 +877,8 @@ describe Riffer::Providers::AmazonBedrock do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto and Vancouver?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'),
-              Riffer::Messages::Assistant::ToolCall.new(id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather", arguments: '{"city":"Toronto"}'),
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather", arguments: '{"city":"Vancouver"}')
             ]),
             Riffer::Messages::Tool.new("Toronto: 15°C", tool_call_id: "tooluse_bdrk_01JK5WNRW22T9YKB4V02NE2S9M", name: "get_weather"),
             Riffer::Messages::Tool.new("Vancouver: 12°C", tool_call_id: "tooluse_bdrk_01JK5WNRWNN4CR0E4R2ZYDNJYZ", name: "get_weather")

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -701,7 +701,7 @@ describe Riffer::Providers::Anthropic do
             model: "claude-haiku-4-5-20251001",
             tools: [weather_tool]
           )
-          expect(result.tool_calls.first.id).wont_be_nil
+          expect(result.tool_calls.first.call_id).wont_be_nil
         end
       end
     end
@@ -713,7 +713,7 @@ describe Riffer::Providers::Anthropic do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "toolu_123", call_id: "toolu_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "toolu_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "toolu_123", name: "get_weather")
           ]
@@ -732,7 +732,7 @@ describe Riffer::Providers::Anthropic do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "toolu_123", call_id: "toolu_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "toolu_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "toolu_123", name: "get_weather")
           ]

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -86,12 +86,6 @@ describe Riffer::Providers::Mock do
 
   describe "tool calling" do
     describe "#stub_response with tool_calls" do
-      it "formats tool_calls with generated id" do
-        provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
-        result = provider.generate_text(prompt: "Call a tool")
-        expect(result.tool_calls.first.id).must_equal "mock_id_0"
-      end
-
       it "formats tool_calls with generated call_id" do
         provider.stub_response("", tool_calls: [{name: "my_tool", arguments: '{"key":"value"}'}])
         result = provider.generate_text(prompt: "Call a tool")
@@ -114,12 +108,6 @@ describe Riffer::Providers::Mock do
         provider.stub_response("", tool_calls: [{name: "my_tool", arguments: {city: "Toronto"}}])
         result = provider.generate_text(prompt: "Call a tool")
         expect(result.tool_calls.first.arguments).must_equal '{"city":"Toronto"}'
-      end
-
-      it "uses provided id if specified" do
-        provider.stub_response("", tool_calls: [{id: "custom_id", name: "my_tool", arguments: "{}"}])
-        result = provider.generate_text(prompt: "Call a tool")
-        expect(result.tool_calls.first.id).must_equal "custom_id"
       end
 
       it "handles multiple tool calls count" do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -902,7 +902,7 @@ describe Riffer::Providers::OpenAI do
             model: "gpt-5-mini",
             tools: [weather_tool]
           )
-          expect(result.tool_calls.first.id).wont_be_nil
+          expect(result.tool_calls.first.call_id).wont_be_nil
         end
       end
 
@@ -926,7 +926,7 @@ describe Riffer::Providers::OpenAI do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "fc_tool_call_123", call_id: "call_tool_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "call_tool_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "call_tool_123", name: "get_weather")
           ]
@@ -945,7 +945,7 @@ describe Riffer::Providers::OpenAI do
           messages = [
             Riffer::Messages::User.new("What is the weather in Toronto?"),
             Riffer::Messages::Assistant.new("", tool_calls: [
-              Riffer::Messages::Assistant::ToolCall.new(id: "fc_tool_call_123", call_id: "call_tool_123", name: "get_weather", arguments: '{"city":"Toronto"}')
+              Riffer::Messages::Assistant::ToolCall.new(call_id: "call_tool_123", name: "get_weather", arguments: '{"city":"Toronto"}')
             ]),
             Riffer::Messages::Tool.new("The weather in Toronto is 15 degrees Celsius.", tool_call_id: "call_tool_123", name: "get_weather")
           ]

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -34,10 +34,9 @@ describe Riffer::ToolRuntime do
   let(:tools) { [weather_tool_class] }
   let(:context) { nil }
 
-  def make_tool_call(name:, arguments:, id: "call_1")
+  def make_tool_call(name:, arguments:, call_id: "call_1")
     Riffer::Messages::Assistant::ToolCall.new(
-      id: id,
-      call_id: "call_id_#{id}",
+      call_id: call_id,
       name: name,
       arguments: arguments
     )
@@ -159,8 +158,8 @@ describe Riffer::ToolRuntime do
 
     it "returns [tool_call, response] pairs in order" do
       runtime = Riffer::ToolRuntime::Inline.new
-      tc1 = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', id: "1")
-      tc2 = make_tool_call(name: "weather_tool", arguments: '{"city":"London"}', id: "2")
+      tc1 = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', call_id: "1")
+      tc2 = make_tool_call(name: "weather_tool", arguments: '{"city":"London"}', call_id: "2")
 
       results = runtime.execute([tc1, tc2], tools: tools, context: context)
 
@@ -261,7 +260,7 @@ describe Riffer::ToolRuntime::Inline do
 
     runtime = Riffer::ToolRuntime::Inline.new
     tool_call = Riffer::Messages::Assistant::ToolCall.new(
-      id: "1", call_id: "cid_1", name: "weather_tool", arguments: '{"city":"Toronto"}'
+      call_id: "cid_1", name: "weather_tool", arguments: '{"city":"Toronto"}'
     )
 
     results = runtime.execute([tool_call], tools: [weather_tool], context: nil)
@@ -289,7 +288,7 @@ describe Riffer::ToolRuntime::Fibers do
     runtime = Riffer::ToolRuntime::Fibers.new
     tool_calls = 3.times.map do |i|
       Riffer::Messages::Assistant::ToolCall.new(
-        id: i.to_s, call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
+        call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
       )
     end
 
@@ -319,7 +318,7 @@ describe Riffer::ToolRuntime::Threaded do
     runtime = Riffer::ToolRuntime::Threaded.new(max_concurrency: 3)
     tool_calls = 3.times.map do |i|
       Riffer::Messages::Assistant::ToolCall.new(
-        id: i.to_s, call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
+        call_id: "cid_#{i}", name: "tracking_tool", arguments: "{}"
       )
     end
 


### PR DESCRIPTION
## Summary
- Remove the `id` field from `Messages::Assistant::ToolCall`, keeping only `call_id` for tool result matching across all providers
- The `id` was originally added because OpenAI distinguishes item IDs (`fc_*`) from call IDs (`call_*`), but in practice only `call_id` is needed — Anthropic and Bedrock already duplicated the same value into both fields
- Update all providers (OpenAI, Anthropic, Amazon Bedrock, Mock), the agent tool execution loop, format converters, RBS signatures, tests, and VCR cassettes

🤖 Generated with [Claude Code](https://claude.com/claude-code)