### PR TITLE
feat: normalize consecutive same-role messages before provider serialization

### DIFF
--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -244,6 +244,40 @@ Agents can emit messages as they're added during generation via the `on_message`
 
 See [Agent Lifecycle - on_message](04_AGENT_LIFECYCLE.md#on_message) for details.
 
+## Consecutive Message Merging
+
+Before messages reach a provider adapter, Riffer merges consecutive messages that share the same role into a single message. This guarantees every provider receives an identical message list, regardless of how it handles consecutive same-role messages internally.
+
+Without this step, the same model can receive different input depending on the provider. Anthropic's API silently merges consecutive user messages server-side, while Bedrock and Gemini reject them outright. Normalizing at the Riffer level removes that divergence.
+
+### Merge rules
+
+| Message type | Content | Auxiliary data | Merged? |
+|--------------|---------|----------------|---------|
+| `System` | Joined with `"\n\n"` | — | Yes |
+| `User` | Joined with `"\n\n"` | `files` arrays concatenated | Yes |
+| `Assistant` | Joined with `"\n\n"` | `tool_calls` arrays concatenated | Yes |
+| `Tool` | — | — | Never (each has a unique `tool_call_id`) |
+
+### Example
+
+When a context message is injected before the user's turn, two consecutive user messages are merged into one:
+
+```ruby
+messages = [
+  Riffer::Messages::System.new("You are a code reviewer."),
+  Riffer::Messages::User.new("The repository uses RSpec for testing."),
+  Riffer::Messages::User.new("Review this pull request.")
+]
+
+agent.generate(messages)
+# The provider receives two messages:
+#   1. System  — "You are a code reviewer."
+#   2. User    — "The repository uses RSpec for testing.\n\nReview this pull request."
+```
+
+Merging happens at serialization time only. The agent's `messages` array still contains the original separate messages for logging, evals, and debugging.
+
 ## Base Class
 
 All messages inherit from `Riffer::Messages::Base`:

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -43,6 +43,12 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     !@structured_output.nil?
   end
 
+  #--
+  #: (Riffer::Messages::Assistant) -> Riffer::Messages::Assistant
+  def +(other)
+    self.class.new("#{content}\n\n#{other.content}", tool_calls: tool_calls + other.tool_calls)
+  end
+
   # Converts the message to a hash.
   #
   #--

--- a/lib/riffer/messages/system.rb
+++ b/lib/riffer/messages/system.rb
@@ -13,4 +13,10 @@ class Riffer::Messages::System < Riffer::Messages::Base
   def role
     :system
   end
+
+  #--
+  #: (Riffer::Messages::System) -> Riffer::Messages::System
+  def +(other)
+    self.class.new("#{content}\n\n#{other.content}")
+  end
 end

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -30,6 +30,12 @@ class Riffer::Messages::User < Riffer::Messages::Base
   end
 
   #--
+  #: (Riffer::Messages::User) -> Riffer::Messages::User
+  def +(other)
+    self.class.new("#{content}\n\n#{other.content}", files: files + other.files)
+  end
+
+  #--
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -126,25 +126,10 @@ class Riffer::Providers::Base
   #--
   #: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
   def merge_consecutive_messages(messages)
-    messages.chunk { |msg| msg.class }.flat_map do |klass, group|
-      next group if klass == Riffer::Messages::Tool || group.size == 1
+    messages.chunk { |msg| msg.role }.flat_map do |role, group|
+      next group if role == :tool || group.size == 1
 
-      case klass.name
-      when "Riffer::Messages::System"
-        Riffer::Messages::System.new(group.map(&:content).join("\n\n"))
-      when "Riffer::Messages::User"
-        Riffer::Messages::User.new(
-          group.map(&:content).join("\n\n"),
-          files: group.flat_map(&:files)
-        )
-      when "Riffer::Messages::Assistant"
-        Riffer::Messages::Assistant.new(
-          group.map(&:content).join("\n\n"),
-          tool_calls: group.flat_map(&:tool_calls)
-        )
-      else
-        group
-      end
+      group.inject { |merged, msg| merged + msg }
     end
   end
 

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -38,6 +38,7 @@ class Riffer::Providers::Base
     validate_input!(prompt: prompt, system: system, messages: messages)
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
+    messages = merge_consecutive_messages(messages)
     params = build_request_params(messages, model, options)
     response = execute_generate(params)
 
@@ -62,6 +63,7 @@ class Riffer::Providers::Base
     validate_input!(prompt: prompt, system: system, messages: messages)
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
+    messages = merge_consecutive_messages(messages)
     params = build_request_params(messages, model, options)
     Enumerator.new do |yielder|
       execute_stream(params, yielder)
@@ -119,6 +121,31 @@ class Riffer::Providers::Base
   def parse_tool_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
     arguments.is_a?(String) ? JSON.parse(arguments) : arguments
+  end
+
+  #--
+  #: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
+  def merge_consecutive_messages(messages)
+    messages.chunk { |msg| msg.class }.flat_map do |klass, group|
+      next group if klass == Riffer::Messages::Tool || group.size == 1
+
+      case klass.name
+      when "Riffer::Messages::System"
+        Riffer::Messages::System.new(group.map(&:content).join("\n\n"))
+      when "Riffer::Messages::User"
+        Riffer::Messages::User.new(
+          group.map(&:content).join("\n\n"),
+          files: group.flat_map(&:files)
+        )
+      when "Riffer::Messages::Assistant"
+        Riffer::Messages::Assistant.new(
+          group.map(&:content).join("\n\n"),
+          tool_calls: group.flat_map(&:tool_calls)
+        )
+      else
+        group
+      end
+    end
   end
 
   #--

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -41,6 +41,10 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # : () -> bool
   def structured_output?: () -> bool
 
+  # --
+  # : (Riffer::Messages::Assistant) -> Riffer::Messages::Assistant
+  def +: (Riffer::Messages::Assistant) -> Riffer::Messages::Assistant
+
   # Converts the message to a hash.
   #
   # --

--- a/sig/generated/riffer/messages/system.rbs
+++ b/sig/generated/riffer/messages/system.rbs
@@ -9,4 +9,8 @@ class Riffer::Messages::System < Riffer::Messages::Base
   # --
   # : () -> Symbol
   def role: () -> Symbol
+
+  # --
+  # : (Riffer::Messages::System) -> Riffer::Messages::System
+  def +: (Riffer::Messages::System) -> Riffer::Messages::System
 end

--- a/sig/generated/riffer/messages/user.rbs
+++ b/sig/generated/riffer/messages/user.rbs
@@ -23,6 +23,10 @@ class Riffer::Messages::User < Riffer::Messages::Base
   def role: () -> Symbol
 
   # --
+  # : (Riffer::Messages::User) -> Riffer::Messages::User
+  def +: (Riffer::Messages::User) -> Riffer::Messages::User
+
+  # --
   # : () -> Hash[Symbol, untyped]
   def to_h: () -> Hash[Symbol, untyped]
 end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -73,6 +73,10 @@ class Riffer::Providers::Base
   def parse_tool_arguments: ((String | Hash[String, untyped])?) -> Hash[String, untyped]
 
   # --
+  # : (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
+  def merge_consecutive_messages: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
+
+  # --
   # : (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
   def validate_input!: (prompt: String?, system: String?, messages: Array[Hash[Symbol | String, untyped] | Riffer::Messages::Base]?) -> void
 

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -47,6 +47,48 @@ describe Riffer::Messages::Assistant do
     end
   end
 
+  describe "#+" do
+    it "concatenates content" do
+      a = Riffer::Messages::Assistant.new("Part one")
+      b = Riffer::Messages::Assistant.new("Part two")
+
+      result = a + b
+
+      expect(result.content).must_equal "Part one\n\nPart two"
+    end
+
+    it "returns an Assistant message" do
+      a = Riffer::Messages::Assistant.new("Part one")
+      b = Riffer::Messages::Assistant.new("Part two")
+
+      result = a + b
+
+      expect(result).must_be_instance_of Riffer::Messages::Assistant
+    end
+
+    it "combines tool calls from both messages" do
+      tc_a = Riffer::Messages::Assistant::ToolCall.new(call_id: "1", name: "foo", arguments: "{}")
+      tc_b = Riffer::Messages::Assistant::ToolCall.new(call_id: "2", name: "bar", arguments: "{}")
+      a = Riffer::Messages::Assistant.new("First", tool_calls: [tc_a])
+      b = Riffer::Messages::Assistant.new("Second", tool_calls: [tc_b])
+
+      result = a + b
+
+      expect(result.tool_calls).must_equal [tc_a, tc_b]
+    end
+
+    it "discards token_usage and structured_output" do
+      usage = Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 5)
+      a = Riffer::Messages::Assistant.new("First", token_usage: usage, structured_output: {key: "val"})
+      b = Riffer::Messages::Assistant.new("Second")
+
+      result = a + b
+
+      expect(result.token_usage).must_be_nil
+      expect(result.structured_output).must_be_nil
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::Assistant.new("I can help")

--- a/test/riffer/messages/system_test.rb
+++ b/test/riffer/messages/system_test.rb
@@ -10,6 +10,26 @@ describe Riffer::Messages::System do
     end
   end
 
+  describe "#+" do
+    it "concatenates content" do
+      a = Riffer::Messages::System.new("Rule one")
+      b = Riffer::Messages::System.new("Rule two")
+
+      result = a + b
+
+      expect(result.content).must_equal "Rule one\n\nRule two"
+    end
+
+    it "returns a System message" do
+      a = Riffer::Messages::System.new("Rule one")
+      b = Riffer::Messages::System.new("Rule two")
+
+      result = a + b
+
+      expect(result).must_be_instance_of Riffer::Messages::System
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::System.new("You are helpful")

--- a/test/riffer/messages/user_test.rb
+++ b/test/riffer/messages/user_test.rb
@@ -29,6 +29,46 @@ describe Riffer::Messages::User do
     end
   end
 
+  describe "#+" do
+    it "concatenates content" do
+      a = Riffer::Messages::User.new("First")
+      b = Riffer::Messages::User.new("Second")
+
+      result = a + b
+
+      expect(result.content).must_equal "First\n\nSecond"
+    end
+
+    it "returns a User message" do
+      a = Riffer::Messages::User.new("First")
+      b = Riffer::Messages::User.new("Second")
+
+      result = a + b
+
+      expect(result).must_be_instance_of Riffer::Messages::User
+    end
+
+    it "combines files from both messages" do
+      file_a = Riffer::FilePart.new(data: "abc", media_type: "image/png")
+      file_b = Riffer::FilePart.new(data: "def", media_type: "image/jpeg")
+      a = Riffer::Messages::User.new("With image", files: [file_a])
+      b = Riffer::Messages::User.new("Another", files: [file_b])
+
+      result = a + b
+
+      expect(result.files).must_equal [file_a, file_b]
+    end
+
+    it "preserves empty files" do
+      a = Riffer::Messages::User.new("No files")
+      b = Riffer::Messages::User.new("Also no files")
+
+      result = a + b
+
+      expect(result.files).must_equal []
+    end
+  end
+
   describe "#to_h" do
     it "returns hash with role and content" do
       message = Riffer::Messages::User.new("Hello")

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -70,4 +70,129 @@ describe Riffer::Providers::Base do
       end
     end
   end
+
+  describe "#merge_consecutive_messages" do
+    it "passes through alternating messages unchanged" do
+      messages = [
+        Riffer::Messages::User.new("Hello"),
+        Riffer::Messages::Assistant.new("Hi"),
+        Riffer::Messages::User.new("How are you?")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 3
+    end
+
+    it "passes through a single message unchanged" do
+      messages = [Riffer::Messages::User.new("Hello")]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 1
+      expect(result.first.content).must_equal "Hello"
+    end
+
+    it "merges consecutive user messages" do
+      messages = [
+        Riffer::Messages::User.new("First"),
+        Riffer::Messages::User.new("Second")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 1
+      expect(result.first).must_be_instance_of Riffer::Messages::User
+      expect(result.first.content).must_equal "First\n\nSecond"
+    end
+
+    it "combines files when merging consecutive user messages" do
+      file_a = Riffer::FilePart.new(data: "abc", media_type: "image/png")
+      file_b = Riffer::FilePart.new(data: "def", media_type: "image/jpeg")
+      messages = [
+        Riffer::Messages::User.new("With image", files: [file_a]),
+        Riffer::Messages::User.new("Another image", files: [file_b])
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 1
+      expect(result.first.files).must_equal [file_a, file_b]
+    end
+
+    it "merges consecutive system messages" do
+      messages = [
+        Riffer::Messages::System.new("Rule one"),
+        Riffer::Messages::System.new("Rule two")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 1
+      expect(result.first).must_be_instance_of Riffer::Messages::System
+      expect(result.first.content).must_equal "Rule one\n\nRule two"
+    end
+
+    it "merges consecutive assistant messages and combines tool calls" do
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "1", name: "foo", arguments: "{}")
+      messages = [
+        Riffer::Messages::Assistant.new("Part one", tool_calls: [tc]),
+        Riffer::Messages::Assistant.new("Part two")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 1
+      expect(result.first).must_be_instance_of Riffer::Messages::Assistant
+      expect(result.first.content).must_equal "Part one\n\nPart two"
+      expect(result.first.tool_calls).must_equal [tc]
+    end
+
+    it "does not merge consecutive tool messages" do
+      messages = [
+        Riffer::Messages::Tool.new("Result A", tool_call_id: "1", name: "foo"),
+        Riffer::Messages::Tool.new("Result B", tool_call_id: "2", name: "bar")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 2
+    end
+
+    it "only merges consecutive runs in a mixed sequence" do
+      messages = [
+        Riffer::Messages::System.new("System"),
+        Riffer::Messages::User.new("Context"),
+        Riffer::Messages::User.new("Question"),
+        Riffer::Messages::Assistant.new("Answer"),
+        Riffer::Messages::Tool.new("Result", tool_call_id: "1", name: "t"),
+        Riffer::Messages::Tool.new("Result 2", tool_call_id: "2", name: "t2")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 5
+      expect(result[0]).must_be_instance_of Riffer::Messages::System
+      expect(result[1]).must_be_instance_of Riffer::Messages::User
+      expect(result[1].content).must_equal "Context\n\nQuestion"
+      expect(result[2]).must_be_instance_of Riffer::Messages::Assistant
+      expect(result[3]).must_be_instance_of Riffer::Messages::Tool
+      expect(result[4]).must_be_instance_of Riffer::Messages::Tool
+    end
+
+    it "merges context message with user message" do
+      messages = [
+        Riffer::Messages::System.new("You are helpful"),
+        Riffer::Messages::User.new("Here is some context about the project"),
+        Riffer::Messages::User.new("What does this code do?")
+      ]
+
+      result = provider.send(:merge_consecutive_messages, messages)
+
+      expect(result.size).must_equal 2
+      expect(result[0]).must_be_instance_of Riffer::Messages::System
+      expect(result[1]).must_be_instance_of Riffer::Messages::User
+      expect(result[1].content).must_equal "Here is some context about the project\n\nWhat does this code do?"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `merge_consecutive_messages` to `Riffer::Providers::Base` that merges consecutive same-role messages by concatenating content blocks and combining auxiliary data (files, tool_calls) into a single message
- Runs after validation but before `build_request_params` in both `generate_text` and `stream_text`, ensuring all four providers receive identical normalized message lists
- Tool messages are never merged since each has a unique `tool_call_id`
- Prevents behavioral divergence when the same model is accessed through different providers (e.g. Anthropic direct vs Bedrock) — context tools inject consecutive user messages that some providers reject or auto-merge differently

## Test plan

- 8 new tests covering: alternating passthrough, single message passthrough, consecutive user merge, file combining, system merge, assistant merge with tool_calls, tool non-merge, mixed sequences, and the context message + user message scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consecutive messages from the same role are merged before sending to providers: System/User/Assistant contents are concatenated with a blank line; User file lists and Assistant tool calls are combined; Tool messages are never merged. In-memory message list remains unchanged for logging/debugging.

* **Documentation**
  * Added a “Consecutive Message Merging” doc with rules and a concrete example.

* **Tests**
  * Added tests covering merge semantics and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->