### PR TITLE
feat: use human-friendly `/` separator for tool names

### DIFF
--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -120,7 +120,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       if block.respond_to?(:tool_use) && block.tool_use
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
           call_id: block.tool_use.tool_use_id,
-          name: block.tool_use.name,
+          name: decode_tool_name(block.tool_use.name, tools: @current_tools),
           arguments: block.tool_use.input.to_json
         )
       end
@@ -160,7 +160,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   def handle_content_block_start_tool_use(event, state:, yielder:)
     state[:tool_call] = {
       id: event.start.tool_use.tool_use_id,
-      name: event.start.tool_use.name,
+      name: decode_tool_name(event.start.tool_use.name, tools: @current_tools),
       arguments: ""
     }
   end
@@ -258,7 +258,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       content << {
         tool_use: {
           tool_use_id: tc.call_id,
-          name: tc.name,
+          name: encode_tool_name(tc.name),
           input: parse_tool_arguments(tc.arguments)
         }
       }
@@ -327,7 +327,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   def convert_tool_to_bedrock_format(tool)
     {
       tool_spec: {
-        name: tool.name,
+        name: encode_tool_name(tool.name),
         description: tool.description,
         input_schema: {
           json: tool.parameters_schema(strict: true)

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -123,7 +123,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       if block.type.to_s == "tool_use"
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
           call_id: block.id,
-          name: block.name,
+          name: decode_tool_name(block.name, tools: @current_tools),
           arguments: block.input.to_json
         )
       end
@@ -229,7 +229,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::ToolCallDone.new(
       item_id: content_block.id,
       call_id: content_block.id,
-      name: content_block.name,
+      name: decode_tool_name(content_block.name, tools: @current_tools),
       arguments: arguments
     )
     state[:tool_call] = nil
@@ -339,7 +339,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       content << {
         type: "tool_use",
         id: tc.call_id,
-        name: tc.name,
+        name: encode_tool_name(tc.name),
         input: parse_tool_arguments(tc.arguments)
       }
     end
@@ -365,7 +365,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   #: (singleton(Riffer::Tool)) -> Hash[Symbol, untyped]
   def convert_tool_to_anthropic_format(tool)
     {
-      name: tool.name,
+      name: encode_tool_name(tool.name),
       description: tool.description,
       input_schema: tool.parameters_schema(strict: true)
     }

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -20,6 +20,8 @@ class Riffer::Providers::Base
   include Riffer::Helpers::Dependencies
   include Riffer::Messages::Converter
 
+  WIRE_SEPARATOR = "__" #: String
+
   # Returns the preferred skill adapter for this provider.
   #
   # Override in subclasses for provider-specific formats.
@@ -36,6 +38,7 @@ class Riffer::Providers::Base
   #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Riffer::Messages::Assistant
   def generate_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
+    @current_tools = options[:tools] || []
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
     messages = merge_consecutive_messages(messages)
@@ -61,6 +64,7 @@ class Riffer::Providers::Base
   #: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
+    @current_tools = options[:tools] || []
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
     messages = merge_consecutive_messages(messages)
@@ -71,6 +75,19 @@ class Riffer::Providers::Base
   end
 
   private
+
+  #--
+  #: (String) -> String
+  def encode_tool_name(name)
+    name.gsub("/", WIRE_SEPARATOR)
+  end
+
+  #--
+  #: (String, tools: Array[Riffer::Tool]) -> String
+  def decode_tool_name(wire_name, tools:)
+    tool = tools.find { |t| encode_tool_name(t.name) == wire_name }
+    tool ? tool.name : wire_name
+  end
 
   #--
   #: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -107,7 +107,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
       if item.type == :function_call
         tool_calls << Riffer::Messages::Assistant::ToolCall.new(
           call_id: item.call_id,
-          name: item.name,
+          name: decode_tool_name(item.name, tools: @current_tools),
           arguments: item.arguments
         )
       end
@@ -158,7 +158,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
   #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
   def handle_output_item_added_function_call(event, state:, yielder:)
     state[:tool_info][event.item.id] = {
-      name: event.item.name,
+      name: decode_tool_name(event.item.name, tools: @current_tools),
       call_id: event.item.call_id
     }
   end
@@ -284,7 +284,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
         items << {
           type: "function_call",
           call_id: tc.call_id,
-          name: tc.name,
+          name: encode_tool_name(tc.name),
           arguments: tc.arguments.is_a?(String) ? tc.arguments : tc.arguments.to_json
         }
       end
@@ -311,7 +311,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
   def convert_tool_to_openai_format(tool)
     {
       type: "function",
-      name: tool.name,
+      name: encode_tool_name(tool.name),
       description: tool.description,
       parameters: tool.parameters_schema(strict: true),
       strict: true

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -26,9 +26,6 @@ require "timeout"
 class Riffer::Tool
   DEFAULT_TIMEOUT = 10 #: Integer
 
-  # Some providers do not allow "/" in tool names, so we use "__" as separator.
-  TOOL_SEPARATOR = "__" #: String
-
   extend Riffer::Helpers::ClassNameConverter
 
   # Gets or sets the tool description.
@@ -45,7 +42,7 @@ class Riffer::Tool
   #--
   #: (?String?) -> String
   def self.identifier(value = nil)
-    return @identifier || class_name_to_path(Module.instance_method(:name).bind_call(self), separator: TOOL_SEPARATOR) if value.nil?
+    return @identifier || class_name_to_path(Module.instance_method(:name).bind_call(self)) if value.nil?
     @identifier = value.to_s
   end
 

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -18,6 +18,8 @@ class Riffer::Providers::Base
 
   include Riffer::Messages::Converter
 
+  WIRE_SEPARATOR: String
+
   # Returns the preferred skill adapter for this provider.
   #
   # Override in subclasses for provider-specific formats.
@@ -39,6 +41,14 @@ class Riffer::Providers::Base
   def stream_text: (?prompt: String?, ?system: String?, ?messages: Array[Hash[Symbol, untyped] | Riffer::Messages::Base]?, ?model: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   private
+
+  # --
+  # : (String) -> String
+  def encode_tool_name: (String) -> String
+
+  # --
+  # : (String, tools: Array[Riffer::Tool]) -> String
+  def decode_tool_name: (String, tools: Array[Riffer::Tool]) -> String
 
   # --
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -22,9 +22,6 @@
 class Riffer::Tool
   DEFAULT_TIMEOUT: Integer
 
-  # Some providers do not allow "/" in tool names, so we use "__" as separator.
-  TOOL_SEPARATOR: String
-
   extend Riffer::Helpers::ClassNameConverter
 
   # Gets or sets the tool description.


### PR DESCRIPTION
## Summary

- Tool identifiers now use `/` as the namespace separator (e.g., `cities/weather/current_temp_tool`) instead of `__` (`cities__weather__current_temp_tool`), matching the convention already used by agents
- The `__` encoding is applied at the provider serialization boundary and decoded when parsing responses, keeping the wire format compatible with all provider regex constraints (Anthropic, OpenAI, Bedrock)
- Explicitly set identifiers (via `identifier "custom_name"`) are unaffected — the decode uses tool-list matching to avoid corrupting names that legitimately contain `__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool name handling consistency across AI provider integrations to ensure reliable tool identification and execution.

* **Chores**
  * Refactored internal tool name encoding/decoding logic to standardize identifier format translations between different AI providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->