### PR TITLE
refactor: add no-op initialize to Skills::Backend

### DIFF
--- a/lib/riffer/skills/backend.rb
+++ b/lib/riffer/skills/backend.rb
@@ -12,6 +12,8 @@
 class Riffer::Skills::Backend
   SKILL_FILENAME = "SKILL.md" #: String
 
+  def initialize = nil
+
   # Returns frontmatter for all available skills.
   #
   # Called once at the start of generate/stream.

--- a/sig/generated/riffer/skills/backend.rbs
+++ b/sig/generated/riffer/skills/backend.rbs
@@ -11,6 +11,8 @@
 class Riffer::Skills::Backend
   SKILL_FILENAME: String
 
+  def initialize: () -> untyped
+
   # Returns frontmatter for all available skills.
   #
   # Called once at the start of generate/stream.


### PR DESCRIPTION
Lets subclasses call `super` and not trigger Rubocop's `Lint/MissingSuper` cop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal initialization behavior made explicit.
  * No user-facing changes or visible feature differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->