### PR TITLE
feat: add optional message id generation

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -112,6 +112,7 @@ On resume, `execute_pending_tool_calls` detects tool calls from the last assista
 Concurrency primitive for batch execution. Subclasses implement `#map(items, context: nil, &block)` to control how items are processed. The `context` keyword carries the agent's context hash, enabling runners that need it for job serialization or routing.
 
 Built-in runners:
+
 - `Sequential` — processes items in the current thread via `Array#map`
 - `Threaded` — processes items concurrently using a thread pool with configurable `max_concurrency`
 
@@ -125,6 +126,7 @@ runner.map(items, context: ctx) { |item| process(item) }
 Composes with a Runner to execute tool calls. Provides `#execute` as the public entry point and `#around_tool_call` as a hook for instrumentation. Passes the agent context through to the runner.
 
 Built-in runtimes:
+
 - `Inline` — uses `Runner::Sequential` (default)
 - `Threaded` — uses `Runner::Threaded`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Ruby gem framework for building AI-powered agents with LLM provider adapters.
 - **Lint + Test**: `bundle exec rake`
 - **Autoloading**: Zeitwerk (file paths must match module/class names)
 - **Model format**: `provider/model` (e.g., `openai/gpt-4`)
+- **Docs**: when adding a public config option or message attribute, update the matching page in `docs/` (e.g., `docs/10_CONFIGURATION.md`, `docs/08_MESSAGES.md`). RDoc ≠ user docs.
 
 ## Topic Guides
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,12 +21,12 @@ Ruby gem framework for building AI-powered agents with LLM provider adapters.
 
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `bundle exec rake` | Run tests + lint (default) |
-| `bundle exec rake test` | Run tests only |
-| `bundle exec rake standard` | Check code style |
-| `bundle exec rake standard:fix` | Auto-fix style issues |
-| `bundle exec rake rbs:generate` | Generate RBS type signatures |
-| `bundle exec rake rbs:watch` | Watch and regenerate RBS files |
-| `bin/console` | Interactive console |
+| Command                         | Description                    |
+| ------------------------------- | ------------------------------ |
+| `bundle exec rake`              | Run tests + lint (default)     |
+| `bundle exec rake test`         | Run tests only                 |
+| `bundle exec rake standard`     | Check code style               |
+| `bundle exec rake standard:fix` | Auto-fix style issues          |
+| `bundle exec rake rbs:generate` | Generate RBS type signatures   |
+| `bundle exec rake rbs:watch`    | Watch and regenerate RBS files |
+| `bin/console`                   | Interactive console            |

--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -252,12 +252,12 @@ Without this step, the same model can receive different input depending on the p
 
 ### Merge rules
 
-| Message type | Content | Auxiliary data | Merged? |
-|--------------|---------|----------------|---------|
-| `System` | Joined with `"\n\n"` | — | Yes |
-| `User` | Joined with `"\n\n"` | `files` arrays concatenated | Yes |
-| `Assistant` | Joined with `"\n\n"` | `tool_calls` arrays concatenated | Yes |
-| `Tool` | — | — | Never (each has a unique `tool_call_id`) |
+| Message type | Content              | Auxiliary data                   | Merged?                                  |
+| ------------ | -------------------- | -------------------------------- | ---------------------------------------- |
+| `System`     | Joined with `"\n\n"` | —                                | Yes                                      |
+| `User`       | Joined with `"\n\n"` | `files` arrays concatenated      | Yes                                      |
+| `Assistant`  | Joined with `"\n\n"` | `tool_calls` arrays concatenated | Yes                                      |
+| `Tool`       | —                    | —                                | Never (each has a unique `tool_call_id`) |
 
 ### Example
 

--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -278,20 +278,50 @@ agent.generate(messages)
 
 Merging happens at serialization time only. The agent's `messages` array still contains the original separate messages for logging, evals, and debugging.
 
+## IDs
+
+Every message carries an optional `id` attribute. By default ids are disabled (`message.id` returns `nil` and `:id` is omitted from `to_h`). Enable them globally by setting `Riffer.config.message_id_strategy`:
+
+```ruby
+Riffer.configure { |c| c.message_id_strategy = :uuidv7 }
+
+msg = Riffer::Messages::User.new("Hello")
+msg.id     # => "0195a2e1-..." (auto-generated UUIDv7)
+msg.to_h   # => {role: :user, content: "Hello", id: "0195a2e1-..."}
+```
+
+Supported strategies: `:none` (default), `:uuid`, `:uuidv7`. See [Configuration — Message ID Strategy](10_CONFIGURATION.md#message-id-strategy) for the full reference.
+
+Ids pass through to subclass constructors via an `id:` kwarg and are preserved when set explicitly:
+
+```ruby
+msg = Riffer::Messages::Assistant.new("Done.", id: "reply-42")
+msg.id  # => "reply-42"
+```
+
+When seeding an agent with existing conversation history and the strategy is enabled, every seeded message must include an id — Riffer raises `Riffer::ArgumentError` on missing ids rather than fabricating them.
+
 ## Base Class
 
 All messages inherit from `Riffer::Messages::Base`:
 
 ```ruby
 class Riffer::Messages::Base
-  attr_reader :content
+  attr_reader :content, :id
+
+  def initialize(content, id: nil)
+    @content = content
+    @id = id || generate_id  # uses Riffer.config.message_id_strategy
+  end
 
   def role
     raise NotImplementedError
   end
 
   def to_h
-    {role: role, content: content}
+    hash = {role: role, content: content}
+    hash[:id] = id unless id.nil?
+    hash
   end
 end
 ```

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -54,6 +54,39 @@ end
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
+### Message ID Strategy
+
+Opt in to stable identifiers on every message for logging, persistence, or replay:
+
+```ruby
+Riffer.configure do |config|
+  config.message_id_strategy = :uuidv7
+end
+```
+
+| Value             | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `:none` (default) | No id is generated; `message.id` returns `nil` and `:id` is omitted from `to_h`. |
+| `:uuid`           | UUIDv4 via `SecureRandom.uuid`.                                             |
+| `:uuidv7`         | Time-ordered UUIDv7 via `SecureRandom.uuid_v7` (Ruby 3.3+).                  |
+
+When the strategy is not `:none`, every `Riffer::Messages::Base` instance — user prompts, system instructions, assistant responses, and tool results — gets an auto-generated `id` at construction time. IDs are included in `message.to_h` when present and omitted when `nil`. Provider API payloads are unaffected; the `id` stays on the Ruby side.
+
+Seeded messages passed to `agent.generate([...])` must carry their own `:id` when the strategy is enabled — Riffer never fabricates identifiers for pre-existing history:
+
+```ruby
+Riffer.configure { |c| c.message_id_strategy = :uuidv7 }
+
+agent.generate([
+  {role: :user, content: "Hi", id: "msg-001"},
+  {role: :assistant, content: "Hello!", id: "msg-002"}
+])
+```
+
+Missing ids raise `Riffer::ArgumentError` with the offending index.
+
+See [Messages — IDs](08_MESSAGES.md#ids) for more details.
+
 ## Agent-Level Configuration
 
 Override global configuration at the agent level:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -64,11 +64,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value             | Description                                                                 |
-| ----------------- | --------------------------------------------------------------------------- |
+| Value             | Description                                                                      |
+| ----------------- | -------------------------------------------------------------------------------- |
 | `:none` (default) | No id is generated; `message.id` returns `nil` and `:id` is omitted from `to_h`. |
-| `:uuid`           | UUIDv4 via `SecureRandom.uuid`.                                             |
-| `:uuidv7`         | Time-ordered UUIDv7 via `SecureRandom.uuid_v7` (Ruby 3.3+).                  |
+| `:uuid`           | UUIDv4 via `SecureRandom.uuid`.                                                  |
+| `:uuidv7`         | Time-ordered UUIDv7 via `SecureRandom.uuid_v7` (Ruby 3.3+).                      |
 
 When the strategy is not `:none`, every `Riffer::Messages::Base` instance — user prompts, system instructions, assistant responses, and tool results — gets an auto-generated `id` at construction time. IDs are included in `message.to_h` when present and omitted when `nil`. Provider API payloads are unaffected; the `id` stays on the Ruby side.
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -456,7 +456,11 @@ class Riffer::Agent
     return if strategy == :none
 
     items.each_with_index do |item, idx|
-      raw_id = item.is_a?(Hash) ? item[:id] : item.id
+      raw_id = case item
+      when Hash then item[:id]
+      when Riffer::Messages::Base then item.id
+      else next # type errors surface later via convert_to_message_object
+      end
       next unless raw_id.nil?
       raise Riffer::ArgumentError,
         "seeded message at index #{idx} is missing :id (required when Riffer.config.message_id_strategy = #{strategy.inspect})"

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -433,6 +433,7 @@ class Riffer::Agent
     if prompt_or_messages.is_a?(Array)
       raise Riffer::ArgumentError, "cannot pass an array of messages on an agent with existing messages; use a string to continue the conversation or a new agent instance to start fresh" if @messages.any?
       raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
+      validate_seed_ids!(prompt_or_messages)
       @messages = prompt_or_messages.map { |item| convert_to_message_object(item) }
     elsif @messages.any?
       file_parts = (files || []).map { |f| convert_to_file_part(f) }
@@ -445,6 +446,20 @@ class Riffer::Agent
       @messages << skills if skills
       file_parts = (files || []).map { |f| convert_to_file_part(f) }
       @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
+    end
+  end
+
+  #--
+  #: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
+  def validate_seed_ids!(items)
+    strategy = Riffer.config.message_id_strategy
+    return if strategy == :none
+
+    items.each_with_index do |item, idx|
+      raw_id = item.is_a?(Hash) ? item[:id] : item.id
+      next unless raw_id.nil?
+      raise Riffer::ArgumentError,
+        "seeded message at index #{idx} is missing :id (required when Riffer.config.message_id_strategy = #{strategy.inspect})"
     end
   end
 

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -22,6 +22,8 @@ class Riffer::Config
   OpenAI = Struct.new(:api_key, keyword_init: true)
   Evals = Struct.new(:judge_model, keyword_init: true)
 
+  VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
+
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader :amazon_bedrock #: Riffer::Config::AmazonBedrock
 
@@ -59,6 +61,29 @@ class Riffer::Config
     @tool_runtime = value
   end
 
+  # Strategy for auto-generating message ids. One of +:none+ (default, no id),
+  # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).
+  #
+  # When set to anything other than +:none+, each +Riffer::Messages::Base+
+  # instance gets an +id+ populated at construction time, and seeded messages
+  # passed to +Riffer::Agent#generate+ must carry their own +:id+.
+  attr_reader :message_id_strategy #: Symbol
+
+  # Sets the message id strategy.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not one of
+  # +:none+, +:uuid+, or +:uuidv7+.
+  #
+  #--
+  #: (Symbol) -> void
+  def message_id_strategy=(value)
+    unless VALID_MESSAGE_ID_STRATEGIES.include?(value)
+      raise Riffer::ArgumentError,
+        "message_id_strategy must be one of #{VALID_MESSAGE_ID_STRATEGIES.inspect}, got #{value.inspect}"
+    end
+    @message_id_strategy = value
+  end
+
   #--
   #: () -> void
   def initialize
@@ -69,5 +94,6 @@ class Riffer::Config
     @openai = OpenAI.new
     @evals = Evals.new
     @tool_runtime = Riffer::ToolRuntime::Inline.new
+    @message_id_strategy = :none
   end
 end

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -23,9 +23,9 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   attr_reader :structured_output #: Hash[Symbol, untyped]?
 
   #--
-  #: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize(content, tool_calls: [], token_usage: nil, structured_output: nil)
-    super(content)
+  #: (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  def initialize(content, id: nil, tool_calls: [], token_usage: nil, structured_output: nil)
+    super(content, id: id)
     @tool_calls = tool_calls
     @token_usage = token_usage
     @structured_output = structured_output
@@ -55,6 +55,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}
+    hash[:id] = id unless id.nil?
     hash[:tool_calls] = tool_calls.map(&:to_h) unless tool_calls.empty?
     hash[:token_usage] = token_usage.to_h if token_usage
     hash[:structured_output] = structured_output if structured_output?

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
+require "securerandom"
+
 # Base class for all message types in the Riffer framework.
 #
 # Subclasses must implement the +role+ method.
@@ -8,10 +10,14 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader :content #: String
 
+  # The message id, or nil when +Riffer.config.message_id_strategy+ is +:none+.
+  attr_reader :id #: String?
+
   #--
-  #: (String) -> void
-  def initialize(content)
+  #: (String, ?id: String?) -> void
+  def initialize(content, id: nil)
     @content = content
+    @id = id || generate_id
   end
 
   # Converts the message to a hash.
@@ -19,7 +25,9 @@ class Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    {role: role, content: content}
+    hash = {role: role, content: content}
+    hash[:id] = id unless id.nil?
+    hash
   end
 
   # Returns the message role.
@@ -30,5 +38,15 @@ class Riffer::Messages::Base
   #: () -> Symbol
   def role
     raise NotImplementedError, "Subclasses must implement #role"
+  end
+
+  private
+
+  #: () -> String?
+  def generate_id
+    case Riffer.config.message_id_strategy
+    when :uuid then SecureRandom.uuid
+    when :uuidv7 then SecureRandom.uuid_v7
+    end
   end
 end

--- a/lib/riffer/messages/converter.rb
+++ b/lib/riffer/messages/converter.rb
@@ -65,22 +65,24 @@ module Riffer::Messages::Converter
       raise Riffer::ArgumentError, "Message hash must include a 'role' key"
     end
 
+    id = hash[:id]
+
     case role.to_sym
     when :user
       files = (hash[:files] || []).map { |f| convert_to_file_part(f) }
-      Riffer::Messages::User.new(content, files: files)
+      Riffer::Messages::User.new(content, id: id, files: files)
     when :assistant
       tool_calls = (hash[:tool_calls] || []).map { |tc|
         tc.is_a?(Riffer::Messages::Assistant::ToolCall) ? tc : Riffer::Messages::Assistant::ToolCall.new(**tc)
       }
       structured_output = hash[:structured_output]
-      Riffer::Messages::Assistant.new(content, tool_calls: tool_calls, structured_output: structured_output)
+      Riffer::Messages::Assistant.new(content, id: id, tool_calls: tool_calls, structured_output: structured_output)
     when :system
-      Riffer::Messages::System.new(content)
+      Riffer::Messages::System.new(content, id: id)
     when :tool
       tool_call_id = hash[:tool_call_id]
       name = hash[:name]
-      Riffer::Messages::Tool.new(content, tool_call_id: tool_call_id, name: name)
+      Riffer::Messages::Tool.new(content, id: id, tool_call_id: tool_call_id, name: name)
     else
       raise Riffer::ArgumentError, "Unknown message role: #{role}"
     end

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -26,9 +26,9 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   attr_reader :error_type #: Symbol?
 
   #--
-  #: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
-  def initialize(content, tool_call_id:, name:, error: nil, error_type: nil)
-    super(content)
+  #: (String, tool_call_id: String, name: String, ?id: String?, ?error: String?, ?error_type: Symbol?) -> void
+  def initialize(content, tool_call_id:, name:, id: nil, error: nil, error_type: nil)
+    super(content, id: id)
     @tool_call_id = tool_call_id
     @name = name
     @error = error
@@ -55,6 +55,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content, tool_call_id: tool_call_id, name: name}
+    hash[:id] = id unless id.nil?
     if error?
       hash[:error] = error
       hash[:error_type] = error_type

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -17,9 +17,9 @@ class Riffer::Messages::User < Riffer::Messages::Base
   # Initializes a user message.
   #
   #--
-  #: (String, ?files: Array[Riffer::FilePart]) -> void
-  def initialize(content, files: [])
-    super(content)
+  #: (String, ?id: String?, ?files: Array[Riffer::FilePart]) -> void
+  def initialize(content, id: nil, files: [])
+    super(content, id: id)
     @files = files
   end
 
@@ -39,6 +39,7 @@ class Riffer::Messages::User < Riffer::Messages::Base
   #: () -> Hash[Symbol, untyped]
   def to_h
     hash = {role: role, content: content}
+    hash[:id] = id unless id.nil?
     hash[:files] = files.map(&:to_h) unless files.empty?
     hash
   end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -248,6 +248,10 @@ class Riffer::Agent
   def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
   # --
+  # : (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
+  def validate_seed_ids!: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
+
+  # --
   # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
   def build_instruction_message: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
 

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -63,6 +63,8 @@ class Riffer::Config
                 | ({ ?judge_model: untyped }) -> instance
   end
 
+  VALID_MESSAGE_ID_STRATEGIES: untyped
+
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader amazon_bedrock: Riffer::Config::AmazonBedrock
 
@@ -95,6 +97,23 @@ class Riffer::Config
   # --
   # : ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc) -> void
+
+  # Strategy for auto-generating message ids. One of +:none+ (default, no id),
+  # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).
+  #
+  # When set to anything other than +:none+, each +Riffer::Messages::Base+
+  # instance gets an +id+ populated at construction time, and seeded messages
+  # passed to +Riffer::Agent#generate+ must carry their own +:id+.
+  attr_reader message_id_strategy: Symbol
+
+  # Sets the message id strategy.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not one of
+  # +:none+, +:uuid+, or +:uuidv7+.
+  #
+  # --
+  # : (Symbol) -> void
+  def message_id_strategy=: (Symbol) -> void
 
   # --
   # : () -> void

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -30,8 +30,8 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   attr_reader structured_output: Hash[Symbol, untyped]?
 
   # --
-  # : (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
-  def initialize: (String, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  # : (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
+  def initialize: (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?) -> void
 
   # --
   # : () -> Symbol

--- a/sig/generated/riffer/messages/base.rbs
+++ b/sig/generated/riffer/messages/base.rbs
@@ -7,9 +7,12 @@ class Riffer::Messages::Base
   # The message content.
   attr_reader content: String
 
+  # The message id, or nil when +Riffer.config.message_id_strategy+ is +:none+.
+  attr_reader id: String?
+
   # --
-  # : (String) -> void
-  def initialize: (String) -> void
+  # : (String, ?id: String?) -> void
+  def initialize: (String, ?id: String?) -> void
 
   # Converts the message to a hash.
   #
@@ -24,4 +27,9 @@ class Riffer::Messages::Base
   # --
   # : () -> Symbol
   def role: () -> Symbol
+
+  private
+
+  # : () -> String?
+  def generate_id: () -> String?
 end

--- a/sig/generated/riffer/messages/tool.rbs
+++ b/sig/generated/riffer/messages/tool.rbs
@@ -24,8 +24,8 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   attr_reader error_type: Symbol?
 
   # --
-  # : (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
-  def initialize: (String, tool_call_id: String, name: String, ?error: String?, ?error_type: Symbol?) -> void
+  # : (String, tool_call_id: String, name: String, ?id: String?, ?error: String?, ?error_type: Symbol?) -> void
+  def initialize: (String, tool_call_id: String, name: String, ?id: String?, ?error: String?, ?error_type: Symbol?) -> void
 
   # Returns true if the tool execution resulted in an error.
   #

--- a/sig/generated/riffer/messages/user.rbs
+++ b/sig/generated/riffer/messages/user.rbs
@@ -15,8 +15,8 @@ class Riffer::Messages::User < Riffer::Messages::Base
   # Initializes a user message.
   #
   # --
-  # : (String, ?files: Array[Riffer::FilePart]) -> void
-  def initialize: (String, ?files: Array[Riffer::FilePart]) -> void
+  # : (String, ?id: String?, ?files: Array[Riffer::FilePart]) -> void
+  def initialize: (String, ?id: String?, ?files: Array[Riffer::FilePart]) -> void
 
   # --
   # : () -> Symbol

--- a/test/fixtures/skills/code-review/SKILL.md
+++ b/test/fixtures/skills/code-review/SKILL.md
@@ -3,9 +3,11 @@ name: code-review
 description: Reviews code for quality, style, and potential issues.
 author: test
 ---
+
 You are a code review assistant.
 
 Review the code for:
+
 - Style issues
 - Potential bugs
 - Performance problems

--- a/test/fixtures/skills/data-analysis/SKILL.md
+++ b/test/fixtures/skills/data-analysis/SKILL.md
@@ -2,6 +2,7 @@
 name: data-analysis
 description: Analyzes datasets and generates summary reports.
 ---
+
 You are a data analysis assistant.
 
 Analyze the provided data and generate insights.

--- a/test/fixtures/skills_extra/summarize/SKILL.md
+++ b/test/fixtures/skills_extra/summarize/SKILL.md
@@ -2,6 +2,7 @@
 name: summarize
 description: Summarizes long text into concise bullet points.
 ---
+
 You are a summarization assistant.
 
 Summarize the provided text into concise bullet points.

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -377,6 +377,14 @@ describe Riffer::Agent do
         expect(error.message).must_match(/index 1 is missing :id/)
       end
 
+      it "raises ArgumentError (not NoMethodError) for invalid seed types" do
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        expect {
+          agent.generate([42])
+        }.must_raise(Riffer::ArgumentError)
+      end
+
       it "assigns auto-generated ids to agent-created messages when strategy is set" do
         Riffer.config.message_id_strategy = :uuidv7
         agent = agent_class.new

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -326,6 +326,67 @@ describe Riffer::Agent do
       end
     end
 
+    describe "seed id validation" do
+      before { @original_strategy = Riffer.config.message_id_strategy }
+      after { Riffer.config.message_id_strategy = @original_strategy }
+
+      it "does not require id when strategy is :none" do
+        Riffer.config.message_id_strategy = :none
+        agent = agent_class.new
+        agent.generate([{role: "user", content: "Hi"}])
+        expect(agent.messages.any? { |m| m.is_a?(Riffer::Messages::User) }).must_equal true
+      end
+
+      it "raises when a seeded hash lacks :id and strategy is set" do
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        error = expect {
+          agent.generate([{role: "user", content: "Hi"}])
+        }.must_raise(Riffer::ArgumentError)
+        expect(error.message).must_match(/index 0 is missing :id/)
+      end
+
+      it "preserves the seeded id when provided" do
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        agent.generate([{role: "user", content: "Hi", id: "seed-123"}])
+        user = agent.messages.find { |m| m.is_a?(Riffer::Messages::User) }
+        expect(user.id).must_equal "seed-123"
+      end
+
+      it "raises when a seeded message object has nil id and strategy is set" do
+        Riffer.config.message_id_strategy = :none
+        msg = Riffer::Messages::User.new("Hi") # built while strategy is :none → id is nil
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        error = expect {
+          agent.generate([msg])
+        }.must_raise(Riffer::ArgumentError)
+        expect(error.message).must_match(/index 0 is missing :id/)
+      end
+
+      it "reports the index of the offending seed message" do
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        error = expect {
+          agent.generate([
+            {role: "user", content: "first", id: "ok-1"},
+            {role: "assistant", content: "no-id-here"}
+          ])
+        }.must_raise(Riffer::ArgumentError)
+        expect(error.message).must_match(/index 1 is missing :id/)
+      end
+
+      it "assigns auto-generated ids to agent-created messages when strategy is set" do
+        Riffer.config.message_id_strategy = :uuidv7
+        agent = agent_class.new
+        agent.generate("Hello")
+        agent.messages.each do |msg|
+          expect(msg.id).wont_be_nil
+        end
+      end
+    end
+
     describe "with an array of hashes" do
       it "accepts an array of hashes and converts them to messages" do
         agent = agent_class.new

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -58,4 +58,44 @@ describe Riffer::Config do
       expect(config.evals.judge_model).must_equal "anthropic/claude-sonnet-4-20250514"
     end
   end
+
+  describe "message_id_strategy" do
+    it "defaults to :none" do
+      config = Riffer::Config.new
+      expect(config.message_id_strategy).must_equal :none
+    end
+
+    it "accepts :none" do
+      config = Riffer::Config.new
+      config.message_id_strategy = :none
+      expect(config.message_id_strategy).must_equal :none
+    end
+
+    it "accepts :uuid" do
+      config = Riffer::Config.new
+      config.message_id_strategy = :uuid
+      expect(config.message_id_strategy).must_equal :uuid
+    end
+
+    it "accepts :uuidv7" do
+      config = Riffer::Config.new
+      config.message_id_strategy = :uuidv7
+      expect(config.message_id_strategy).must_equal :uuidv7
+    end
+
+    it "raises for unknown symbols" do
+      config = Riffer::Config.new
+      expect { config.message_id_strategy = :ulid }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises for string values" do
+      config = Riffer::Config.new
+      expect { config.message_id_strategy = "uuid" }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises for nil" do
+      config = Riffer::Config.new
+      expect { config.message_id_strategy = nil }.must_raise Riffer::ArgumentError
+    end
+  end
 end

--- a/test/riffer/messages/base_test.rb
+++ b/test/riffer/messages/base_test.rb
@@ -23,4 +23,50 @@ describe Riffer::Messages::Base do
       expect { base_message.to_h }.must_raise(NotImplementedError)
     end
   end
+
+  describe "#id" do
+    before { @original_strategy = Riffer.config.message_id_strategy }
+    after { Riffer.config.message_id_strategy = @original_strategy }
+
+    it "defaults to nil when strategy is :none" do
+      Riffer.config.message_id_strategy = :none
+      expect(Riffer::Messages::User.new("Hi").id).must_be_nil
+    end
+
+    it "auto-populates a UUID when strategy is :uuid" do
+      Riffer.config.message_id_strategy = :uuid
+      id = Riffer::Messages::User.new("Hi").id
+      expect(id).must_match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
+    end
+
+    it "auto-populates a UUIDv7 when strategy is :uuidv7" do
+      Riffer.config.message_id_strategy = :uuidv7
+      id = Riffer::Messages::User.new("Hi").id
+      expect(id).must_match(/\A[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
+    end
+
+    it "generates different ids for different messages" do
+      Riffer.config.message_id_strategy = :uuidv7
+      a = Riffer::Messages::User.new("Hi").id
+      b = Riffer::Messages::User.new("Hi").id
+      expect(a).wont_equal b
+    end
+
+    it "preserves an explicit id over auto-generation" do
+      Riffer.config.message_id_strategy = :uuidv7
+      msg = Riffer::Messages::User.new("Hi", id: "explicit-id")
+      expect(msg.id).must_equal "explicit-id"
+    end
+
+    it "includes :id in to_h when present" do
+      msg = Riffer::Messages::User.new("Hi", id: "abc-123")
+      expect(msg.to_h[:id]).must_equal "abc-123"
+    end
+
+    it "omits :id from to_h when nil" do
+      Riffer.config.message_id_strategy = :none
+      msg = Riffer::Messages::User.new("Hi")
+      expect(msg.to_h.key?(:id)).must_equal false
+    end
+  end
 end

--- a/test/riffer/messages/converter_test.rb
+++ b/test/riffer/messages/converter_test.rb
@@ -76,6 +76,28 @@ describe Riffer::Messages::Converter do
       expect(result).must_equal msg
     end
 
+    describe "with :id in hash" do
+      it "propagates id to User messages" do
+        result = instance.convert_to_message_object({role: "user", content: "Hi", id: "u-1"})
+        expect(result.id).must_equal "u-1"
+      end
+
+      it "propagates id to Assistant messages" do
+        result = instance.convert_to_message_object({role: "assistant", content: "Hi", id: "a-1"})
+        expect(result.id).must_equal "a-1"
+      end
+
+      it "propagates id to System messages" do
+        result = instance.convert_to_message_object({role: "system", content: "Be nice", id: "s-1"})
+        expect(result.id).must_equal "s-1"
+      end
+
+      it "propagates id to Tool messages" do
+        result = instance.convert_to_message_object({role: "tool", content: "ok", tool_call_id: "c-1", name: "x", id: "t-1"})
+        expect(result.id).must_equal "t-1"
+      end
+    end
+
     describe "with assistant message with structured_output" do
       it "preserves structured_output from hash with symbol keys" do
         result = instance.convert_to_message_object({role: "assistant", content: '{"sentiment":"positive"}', structured_output: {sentiment: "positive"}})

--- a/test/riffer/messages/user_test.rb
+++ b/test/riffer/messages/user_test.rb
@@ -29,6 +29,13 @@ describe Riffer::Messages::User do
     end
   end
 
+  describe "#id" do
+    it "is preserved when passed explicitly" do
+      message = Riffer::Messages::User.new("Hi", id: "user-1")
+      expect(message.id).must_equal "user-1"
+    end
+  end
+
   describe "#+" do
     it "concatenates content" do
       a = Riffer::Messages::User.new("First")
@@ -37,6 +44,21 @@ describe Riffer::Messages::User do
       result = a + b
 
       expect(result.content).must_equal "First\n\nSecond"
+    end
+
+    it "generates a fresh id rather than inheriting from operands" do
+      original = Riffer.config.message_id_strategy
+      Riffer.config.message_id_strategy = :uuidv7
+      a = Riffer::Messages::User.new("First", id: "a-id")
+      b = Riffer::Messages::User.new("Second", id: "b-id")
+
+      result = a + b
+
+      expect(result.id).wont_equal "a-id"
+      expect(result.id).wont_equal "b-id"
+      expect(result.id).wont_be_nil
+    ensure
+      Riffer.config.message_id_strategy = original
     end
 
     it "returns a User message" do


### PR DESCRIPTION
## Summary

Adds a global `Riffer.config.message_id_strategy` setting with three supported values:

- `:none` (default) — no ids, existing behavior preserved
- `:uuid` — UUIDv4 via `SecureRandom.uuid`
- `:uuidv7` — time-ordered UUIDv7 via `SecureRandom.uuid_v7` (Ruby 3.3+ built-in)

When the strategy is not `:none`, each `Riffer::Messages::Base` instance gets an `id` auto-populated at construction time. The `id` is exposed via `#id`, included in `#to_h` when present (and omitted when nil), and preserved when passed explicitly.

Seeded messages passed to `Riffer::Agent#generate` must carry their own `:id` when the strategy is enabled — Riffer never fabricates identifiers for pre-existing history. Missing seed ids raise `Riffer::ArgumentError` with the offending index.

## Changes

- `lib/riffer/config.rb` — new `message_id_strategy` attribute + validated setter
- `lib/riffer/messages/base.rb` — `id` attr, `id:` kwarg, auto-generation, conditional serialization
- `lib/riffer/messages/{user,assistant,tool}.rb` — forward `id:` via `super`, include in `to_h`
- `lib/riffer/messages/converter.rb` — propagate `hash[:id]` into every role branch
- `lib/riffer/agent.rb` — `validate_seed_ids!` called from `initialize_messages`
- Tests for config, base/subclass behavior, converter propagation, and agent seed validation
- Regenerated RBS signatures

Provider serialization is unaffected: providers manually build API-request hashes from message attributes and do not spread `message.to_h`, so the new `id` field does not leak to external APIs.

## Test plan

- [x] `bundle exec rake test` — 1265 tests, 1958 assertions, 0 failures
- [x] `bundle exec rake standard` — clean
- [x] `bundle exec steep check` — no type errors
- [x] `bundle exec rake rbs:generate` — signatures regenerated
- [ ] Verify consumer (downstream app) can opt in with `Riffer.configure { |c| c.message_id_strategy = :uuidv7 }` and round-trip seeded history with ids
- [ ] Confirm mock provider cassettes (if any) still match after the `:id` key addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable message ID strategy with optional auto-generation (:none [default], :uuid, :uuidv7).
  * Messages now support optional per-message IDs and enforce seeded-message ID requirements when strategy is enabled.

* **Documentation**
  * Added configuration and per-message ID docs and clarified docs guidance for public-facing options.
  * Minor formatting improvements to several docs.

* **Tests**
  * Added tests covering ID generation, preservation, seeding validation, and converter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->