### PR TITLE
chore(deps-dev): upgrade steep to 2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,19 +7,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     anthropic (1.35.0)
@@ -48,7 +35,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    bigdecimal (4.1.1)
+    bigdecimal (4.1.2)
     cgi (0.5.1)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
@@ -98,8 +85,6 @@ GEM
       guard (>= 2.0.0)
       guard-compat (~> 1.0)
     hashdiff (1.2.1)
-    i18n (1.14.8)
-      concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     io-event (1.15.1)
     irb (1.17.0)
@@ -108,7 +93,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.3)
+    json (2.19.4)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -122,7 +107,6 @@ GEM
     minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
-    mutex_m (0.3.0)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -132,7 +116,7 @@ GEM
       cgi
       connection_pool
     parallel (1.27.0)
-    parser (3.3.11.0)
+    parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
     pp (0.6.3)
@@ -153,8 +137,9 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.4)
+    rbs (4.0.2)
       logger
+      prism (>= 1.6.0)
       tsort
     rbs-inline (0.13.0)
       prism (>= 0.29)
@@ -200,8 +185,7 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.0.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -209,23 +193,21 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
       uri (>= 0.12.0)
     stringio (3.2.0)
-    strscan (3.1.7)
+    strscan (3.1.8)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     traces (0.18.2)
     tsort (0.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -265,7 +247,7 @@ DEPENDENCIES
   rbs-inline (~> 0.12)
   riffer!
   standard (~> 1.3)
-  steep (~> 1.10.0)
+  steep (~> 2.0)
   vcr (~> 6.0)
   webmock (~> 3.0)
 

--- a/Steepfile
+++ b/Steepfile
@@ -5,10 +5,13 @@ target :lib do
 
   check "lib"
 
-  library "logger"
   library "anthropic"
-  library "openai"
   library "aws-sdk-bedrockruntime"
+  library "aws-sdk-core"
+  library "logger"
+  library "net-http"
+  library "openai"
+  library "uri"
 
   configure_code_diagnostics(D::Ruby.lenient)
 end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -176,7 +176,7 @@ class Riffer::Agent
   #--
   #: (String) -> singleton(Riffer::Agent)?
   def self.find(identifier)
-    subclasses.find { |agent_class| agent_class.identifier == identifier.to_s }
+    all.find { |agent_class| agent_class.identifier == identifier.to_s }
   end
 
   # Returns all agent subclasses.
@@ -184,7 +184,7 @@ class Riffer::Agent
   #--
   #: () -> Array[singleton(Riffer::Agent)]
   def self.all
-    subclasses
+    subclasses #: Array[singleton(Riffer::Agent)]
   end
 
   # Generates a response using a new agent instance.
@@ -783,7 +783,7 @@ class Riffer::Agent
   #--
   #: () -> Riffer::Messages::Assistant?
   def extract_final_response
-    @messages.reverse.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
+    @messages.reverse.find { |msg| msg.is_a?(Riffer::Messages::Assistant) } #: Riffer::Messages::Assistant?
   end
 
   #--

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
 
   # Type checking
   spec.add_development_dependency "rbs-inline", "~> 0.12"
-  spec.add_development_dependency "steep", "~> 1.10.0"
+  spec.add_development_dependency "steep", "~> 2.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
## Summary
- Relax the `steep` development dependency to `~> 2.0` and update `Gemfile.lock` (steep 2.0.0, rbs 4.0.2, prism added; activesupport and its transitive deps — i18n, tzinfo, mutex_m — removed since steep 2.0 drops the activesupport dependency).
- Add `aws-sdk-core`, `net-http`, and `uri` library declarations to `Steepfile` for steep 2.0's stricter type resolution.
- Add two inline `#:` type assertions in `lib/riffer/agent.rb` (`Riffer::Agent.all` and `extract_final_response`) so Steep narrows the return types correctly, and switch `Riffer::Agent.find` to call `all` instead of `subclasses` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced agent discovery to scan all subclasses for better agent location

* **Chores**
  - Updated Steep type checker from v1.10.0 to v2.0
  - Added type-checking support for AWS SDK, Net::HTTP, and URI libraries
  - Improved type annotations for better code safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->