### PR TITLE
Adding Workflows capabilities

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,180 @@
+# Workflows
+
+This tech design describes the architecture and decisions to implement a minimum viable workflow feature
+in Riffer.
+The rest of this document is organized as follows: Section [1. Introduction](#1-introduction) describes the problem we are resolving in detail,
+Section [2. Assumptions](#2-Assumptions) list all the assumptions made with explanations of each one. The section [3. Design](#3-design) presents the solution. The section [4. What should we build next?](#4-what-should-we-build-next) Organize the next steps of this work. The section [5. Implementation](#5-implementation) describes the implementation in detail.
+
+# 1. Introduction
+Riffer (https://github.com/janeapp/riffer) is the largest Ruby AI-powered framework developed by Jane App.
+Riffer simplifies the process of creating AI agents in Ruby without coupling your application to an AI model/provider. So, you can create your AI-Agent using Riffer and later decide which model and provider to use.
+
+Riffer has 2 important concepts: Agents and Tools. Agents are an abstraction of an AI-Agent. You can create your AI-Agent using this class and later choose the model. Tools are pieces of code or functionality that your AI-Agent can use.
+
+So, let's see a simple example of it in action. Imagine that we want to create an agent that returns the temperature in a city in Celsius. Using Riffer, we can do this by creating an agent responsible for answering this question.
+We also need 2 tools: one to scrape the temperature of a city from a website and another to convert temperatures from Fahrenheit to Celsius.
+
+Keep in mind that this is just an example; there is a better way to do this instead of using 2 tools. The Riffer documentation, for example, shows how to do this with just one tool. The purpose of the exercise here is to exemplify
+and discuss the problem.
+
+```ruby
+class TemperatureAgent < Riffer::Agent
+  model 'select the model here'
+  instructions 'You are a helpful assistant who helps users get the temperature of a city. Given a {city}, use the tools to get the temperature in Fahrenheit in this specific city, convert it to Celsius and return it to the user.'
+  uses_tools [WeatherTool, TemperatureConversion]
+end
+
+
+class WeatherTool < Riffer::Tool
+  description "Gets the current weather for a city."
+
+  params do
+    required :city, String, description: "The city name."
+  end
+
+  def call(context:, city:, units: nil)
+    weather = WeatherAPI.fetch(city, units: "fahrenheit")
+    text(weather.temperature)
+  end
+end
+
+
+class TemperatureConversion < Riffer::Tool
+  description "Convert the temperature from Fahrenheit to Celsius."
+
+  params do
+    required :temperature, Float, description: "The temperature in Fahrenheit."
+  end
+
+  def call(context:, temperature:)
+    result = (temperature − 32) * 5.0 / 9
+    text(result)
+  end
+end
+```
+
+This example shows that the Agent is acting like an orchestrator of the tools. Also, what if we want to run 2 different agents to compose our answer? This is the problem we are resolving with this new feature, Workflows.
+
+`Workflows` are a simple way to run multiple agents, tools, and other workflows in a serial, step-by-step manner.
+From the example above, the agent will no longer use the tools; it will be the first step in our workflow. The output of this will be the input to the `WeatherTool`, and the output of the `WeatherTool` will be the input to the `TemperatureConversion` tool.
+The `Workflow` will run step by step and return all the outputs in a structured way for the user. We can rewrite the example above using this new feature as follows:
+```ruby
+
+   class MyWorkflow < Riffer::Workflow
+     step :weather, WheatherTool
+     step :temperature_conversion, TemperatureConversion, depends_on: :weather
+   end
+
+   workflow = MyWorkflow.new
+   workflow.run(context:nil, city: 'toronto', units: 'fahrenheit')
+```
+
+# 1.1 In Scope
+
+1. A workflow is composed of multiple steps, each of which could be:
+    * Agent: The Agent class as defined in Riffer
+    * Tool: The Tool class as defined in Riffer
+    * Workflow: Another workflow.
+2. No dependencies: Everything is made with just Riffer and Ruby.
+3. Sequential composition: Workflows do not provide parallelism, branching, looping, suspend/resume, or streaming. Also, it is not thread-safe.
+4. Single process, in-memory execution.
+5. Valid inputs when the step provides validation
+
+# 1.2 Not in scope
+
+1. Parallelism and thread-safe
+2. Data Persistence: Every result is in memory; nothing is persistent on disk.
+3. suspend/resume: We cannot pause execution and resume it later.
+
+
+# 2. Assumptions
+For this proof of concept, we made some assumptions that guide our solution:
+
+1. A step can depend on any previous steps, including multiple dependencies.
+2. When `structure_output` is available in the result of a step, use it instead of raw output.
+4. Steps are finite and fit in memory
+5. The Workflow Results fit in memory
+
+
+# 3. Design
+```
+    +---------------------------+
+    |      Riffer::Workflow     |
+    | (Base Class for Workflows)|
+    +---------------------------+
+           |     ^
+           |     | Inherits from Riffer::Toolable
+           v     |
+    +---------------------------+
+    |   MyWorkflow (Subclass)   |
+    | (e.g., MyWorkflow <  Riffer::Workflow)
+    +---------------------------+
+           |
+           |  Defines steps using DSL:
+           |  `step :name, StepClass, depends_on: [...]`
+           v
+    +---------------------------+       +---------------------------+
+    |  Step Definition Storage  |<-----|  Riffer::Agent / Riffer::Tool / |
+    | (@steps Array of Hashes)   |       |  Riffer::Workflow (Step Classes) |
+    +---------------------------+       +---------------------------+
+           |
+           |  `run(context:, **kwargs)` method initiates execution
+           v
+    +---------------------------------------------------------------------------------------------------------------------------------+
+    |                                                   Workflow Execution Flow                                                       |
+    +---------------------------------------------------------------------------------------------------------------------------------+
+    |                                                                                                                                 |
+    |  1. Initialize: `@context`, `@default_input` (initial `kwargs`)                                                                 |
+    |                                                                                                                                 |
+    |  2. Iterate through `self.class.steps` (defined order, but execution respects dependencies)                                     |
+    |                                                                                                                                 |
+    |     +-----------------------------------------------------------------------------------------------------+                     |
+    |     |  For Each Step (`step_config`)                                                                      |                     |
+    |     |                                                                                                     |                     |
+    |     |  a. `generate_validated_args(step_config)`                                                          |                     |
+    |     |     - Gathers inputs:                                                                               |                     |
+    |     |       - If `depends_on` is empty: Uses `@default_input`                                             |                     |
+    |     |       - If `depends_on` present: Slices `@results` (outputs from completed upstream steps)          |                     |
+    |     |     - Transforms step results (e.g., `structured_output`, `content`, `to_h`)                        |                     |
+    |     |     - Validates arguments via `step_class.params` (if defined)                                      |                     |
+    |     |                                                                                                     |                     |
+    |     |  b. `Timeout.timeout(self.class.timeout)`                                                           |                     |
+    |     |     +---------------------------------------------------------------------------------------------+ |                     |
+    |     |     |  Execute Step:                                                                              | |                     |
+    |     |     |  - Creates `step = step_config[:step_class].new`                                           | |                     |
+    |     |     |  - **Case Statement:**                                                                      | |                     |
+    |     |     |    - **When `Riffer::Agent`:** Calls `step.generate(prompt, files:, context: @context)`     | |                     |
+    |     |     |    - **When `Riffer::Tool`:** Calls `step.call(**validated_args)`                            | |                     |
+    |     |     |    - **When `Riffer::Workflow`:** Calls `step.run(**validated_args)`                         | |                     |
+    |     |     +---------------------------------------------------------------------------------------------+ |                     |
+    |     |                                                                                                     |                     |
+    |     |  c. Stores `result` in `@results` hash (keyed by step name)                                         |                     |
+    |     +-----------------------------------------------------------------------------------------------------+                     |
+    |                                                                                                                                 |
+    |  3. Final Result:                                                                                                               |
+    |     - On Success: `Riffer::Workflow::Response.success(identifier:, steps_response: @results)`                                   |
+    |     - On Error (Timeout, Validation, Argument, Riffer::Error): `Riffer::Workflow::Response.error(...)`                          |
+    |                                                                                                                                 |
+    +---------------------------------------------------------------------------------------------------------------------------------+
+```
+
+The solution will consist of just one main class, `Riffer::Workflow`. When a user needs to write their workflow, they must subclass this class.
+The steps are defined as a very simple DSL that allows the user to specify the dependencies between steps.
+After defining the subclass and its steps, the user just needs to create a new instance of the class and call the `run` method. To execute the workflow.
+After execution, the workflow will return a `Riffer::Workflow::Response` containing the responses for all steps and a `success?` field to check the solution status.
+
+
+# 4. What should we build next?
+1. Input declaration for workflow: Including input declaration allows us to validate the inputs.
+2. Parallel execution: We can run steps in parallel when there is no explicit dependency
+3. Pause/Resume: We do not have a way to pause and resume an exception
+4. Persistency: We do not have a way to save the data to disk during execution. In a large workflow, persistence, along with pause/resume, is a must-have production feature.
+5. Retries: We should be able to retry a step based on the error. For example, if fetching a website results in a timeout or connection error, it could be retried. Also, limited the number of retries.
+
+# 5. Implementation
+This section describes the implementation plan:
+
+1. The first commit is this tech design to provide context and share the assumptions and decisions.
+2. The second commit will include the new class Workflow, allowing users to define the steps, for now just Agent and execute the workflow.
+3. The third commit includes the Tool as a possible step in a workflow
+4. The last commit includes the workflow as a step for a workflow.

--- a/lib/riffer/workflow.rb
+++ b/lib/riffer/workflow.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Riffer::Workflow is the base class for all workflows in the Riffer framework.
+#
+# Subclass this to create your own workflows.
+# Provides a simple DSL for defining steps.
+# See Riffer::Agent.
+# For now, we will support just Riffer::Agent; in the next commit, we will onboard Riffer::Tools
+#
+# In case of success, a Riffer::Workflow::Response is returned in the method run.
+# The exceptions Riffer::ValidationError, Riffer::ArgumentError, Riffer::Error, and Riffer::TimeoutError
+# are captured, and a response with the error is returned. All other exceptions are not being suppressed.
+#
+# In the example below, MyWorkflow defines 4 steps: search1, search2, search3, search4. search1 does not
+# depends in any steps, search2 depends_on search1, search3 does not have any dependency, and
+# search4 depends on search1 and search2. All results from previous steps are available for the current
+# step to consume.
+# If a step has no dependencies, it will receive the initial parameters passed to the method run.
+#
+#   class MyAgent < Riffer::Agent
+#     model 'openai/gpt-4o'
+#     instructions 'You are a helpful assistant.'
+#   end
+#
+#   class MyWorkflow < Riffer::Workflow
+#     step :search1, MyAgent
+#     step :search2, MyAgent, depends_on: :search1
+#     step :search3, MyAgent
+#     step :search4, MyAgent, depends_on: [:search1, :search2]
+#   end
+#
+#   workflow = MyWorkflow.new
+#   workflow.run(context:nil, prompt: "Hello!")
+#
+class Riffer::Workflow
+  extend Riffer::Toolable
+
+  kind :workflow
+  VALID_STEP_RESPONSE = [Riffer::Agent::Response].freeze
+  DEFAULT_TIMEOUT = 60 #: Integer
+
+  # We use a class instance variable to store steps for each specific subclass
+  #
+  #: () -> Array[Hash[Symbol, untyped]]
+  def self.steps
+    @steps ||= []
+  end
+
+  # 'DSL' method to define a step, for now accepting just Agent, we will update it latter
+  #
+  #--
+  #: (Symbol, singleton(Riffer::Agent), ?Hash[Symbol, untyped]) -> Array[Hash[Symbol, untyped]]
+  def self.step(name, agent_class, options = {})
+    steps << {
+      name: name,
+      step_class: agent_class,
+      depends_on: Array(options[:depends_on]) # Ensure it's always an array
+    }
+  end
+
+  # Initializes a new workflow.
+  #
+  #--
+  #: () -> void
+  def initialize
+    @results = {}
+    @default_input = {}
+    @context = {}
+  end
+
+  # Run all the workflow steps
+  #
+  #--
+  #: (context: Hash[Symbol, untyped], **untyped) -> Riffer::Workflow::Response
+  def run(context:, **kwargs)
+    @context = context
+    @default_input = kwargs
+
+    self.class.steps.each do |step_config|
+      @results[step_config[:name]] = run_step_with_validation(step_config: step_config)
+    end
+
+    Riffer::Workflow::Response.success(identifier: self.class.identifier, steps_response: @results)
+  rescue Riffer::ValidationError, Riffer::ArgumentError, Riffer::Error => e
+    Riffer::Workflow::Response.error(
+      identifier: self.class.identifier, steps_response: @results, message: e.message, type: :validation_error
+    )
+  rescue Riffer::TimeoutError => e
+    Riffer::Workflow::Response.error(
+      identifier: self.class.identifier, steps_response: @results, message: e.message, type: :execution_error
+    )
+  end
+
+  private
+
+  # Executes the step with validation and timeout.
+  #
+  # Raises Riffer::ValidationError if validation fails.
+  # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
+  # Raises Riffer::Error if the step(Agent) does not return a Response::Agent object.
+  # Raises Riffer::ArgumentError if the step is not an Agent(we will update latter to accept Tool and Workflow).
+  #
+  #--
+  #: (step_config: Hash[Symbol, untyped]) -> Riffer::Agent::Response
+  def run_step_with_validation(step_config:)
+    validated_args = generate_validated_args(step_config)
+
+    result = Timeout.timeout(self.class.timeout) do
+      agent = step_config[:step_class].new
+
+      case agent
+      when Riffer::Agent
+        files = validated_args.delete(:files)
+        prompt = validated_args.values.join(" ")
+        agent = step_config[:step_class].new
+
+        agent.generate(prompt, files:, context: @context)
+      else
+        raise Riffer::ArgumentError, "Unknown message step: #{step_config[:step_class]}"
+      end
+    end
+
+    unless VALID_STEP_RESPONSE.any? { |cls| result.is_a?(cls) }
+      raise Riffer::Error, "#{self.class} must return a Riffer::Response from #run"
+    end
+
+    result
+  rescue Timeout::Error
+    raise Riffer::TimeoutError, "Step execution timed out after #{self.class.timeout} seconds"
+  end
+
+  # Generate and validate the arguments for a step, if the class provide one
+  #
+  #--
+  #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def generate_validated_args(step_config)
+    params_builder = step_config[:step_class].respond_to?(:params) ? step_config[:step_class].params : nil
+    sliced = @results.slice(*step_config[:depends_on])
+    payload = sliced.empty? ? @default_input : sliced
+
+    payload = payload.map do |_key, result|
+      if result.respond_to?(:structured_output)
+        result.structured_output
+      elsif result.respond_to?(:content)
+        {content: result.content}
+      else
+        {content: result}
+      end
+    end.reduce({}, :merge!)
+
+    params_builder ? params_builder.validate(payload) : payload
+  end
+end

--- a/lib/riffer/workflow.rb
+++ b/lib/riffer/workflow.rb
@@ -5,8 +5,7 @@
 #
 # Subclass this to create your own workflows.
 # Provides a simple DSL for defining steps.
-# See Riffer::Agent.
-# For now, we will support just Riffer::Agent; in the next commit, we will onboard Riffer::Tools
+# See Riffer::Agent, Riffer::Tool.
 #
 # In case of success, a Riffer::Workflow::Response is returned in the method run.
 # The exceptions Riffer::ValidationError, Riffer::ArgumentError, Riffer::Error, and Riffer::TimeoutError
@@ -37,7 +36,7 @@ class Riffer::Workflow
   extend Riffer::Toolable
 
   kind :workflow
-  VALID_STEP_RESPONSE = [Riffer::Agent::Response, Riffer::Tools::Response].freeze
+  VALID_STEP_RESPONSE = [Riffer::Agent::Response, Riffer::Tools::Response, Riffer::Workflow::Response].freeze
   DEFAULT_TIMEOUT = 60 #: Integer
 
   # We use a class instance variable to store steps for each specific subclass
@@ -51,7 +50,7 @@ class Riffer::Workflow
   # we will update it later to also accept Riffer::Workflow
   #
   #--
-  #: (Symbol, singleton(Riffer::Agent|Riffer::Tool), ?Hash[Symbol, untyped]) -> Array[Hash[Symbol, untyped]]
+  #: (Symbol, singleton(Riffer::Agent|Riffer::Tool|Riffer::Workflow), ?Hash[Symbol, untyped]) -> Array[Hash[Symbol, untyped]]
   def self.step(name, step_class, options = {})
     steps << {
       name: name,
@@ -103,7 +102,7 @@ class Riffer::Workflow
   # Raises Riffer::ArgumentError if the step is not an Agent(we will update latter to accept Tool and Workflow).
   #
   #--
-  #: (step_config: Hash[Symbol, untyped]) -> Riffer::Agent::Response|Riffer::Tool::Response
+  #: (step_config: Hash[Symbol, untyped]) -> Riffer::Agent::Response|Riffer::Tool::Response|Riffer::Workflow::Response
   def run_step_with_validation(step_config:)
     validated_args = generate_validated_args(step_config)
 
@@ -119,6 +118,9 @@ class Riffer::Workflow
       when Riffer::Tool
         validated_args[:context] = @context
         step.call(**validated_args)
+      when Riffer::Workflow
+        validated_args[:context] = @context
+        step.run(**validated_args)
       else
         raise Riffer::ArgumentError, "Unknown message step: #{step_config[:step_class]}"
       end

--- a/lib/riffer/workflow.rb
+++ b/lib/riffer/workflow.rb
@@ -37,7 +37,7 @@ class Riffer::Workflow
   extend Riffer::Toolable
 
   kind :workflow
-  VALID_STEP_RESPONSE = [Riffer::Agent::Response].freeze
+  VALID_STEP_RESPONSE = [Riffer::Agent::Response, Riffer::Tools::Response].freeze
   DEFAULT_TIMEOUT = 60 #: Integer
 
   # We use a class instance variable to store steps for each specific subclass
@@ -47,14 +47,15 @@ class Riffer::Workflow
     @steps ||= []
   end
 
-  # 'DSL' method to define a step, for now accepting just Agent, we will update it latter
+  # 'DSL' method to define a step, for now accepting just Riffer::Agent and Riffer::Tool,
+  # we will update it later to also accept Riffer::Workflow
   #
   #--
-  #: (Symbol, singleton(Riffer::Agent), ?Hash[Symbol, untyped]) -> Array[Hash[Symbol, untyped]]
-  def self.step(name, agent_class, options = {})
+  #: (Symbol, singleton(Riffer::Agent|Riffer::Tool), ?Hash[Symbol, untyped]) -> Array[Hash[Symbol, untyped]]
+  def self.step(name, step_class, options = {})
     steps << {
       name: name,
-      step_class: agent_class,
+      step_class: step_class,
       depends_on: Array(options[:depends_on]) # Ensure it's always an array
     }
   end
@@ -82,13 +83,13 @@ class Riffer::Workflow
     end
 
     Riffer::Workflow::Response.success(identifier: self.class.identifier, steps_response: @results)
-  rescue Riffer::ValidationError, Riffer::ArgumentError, Riffer::Error => e
-    Riffer::Workflow::Response.error(
-      identifier: self.class.identifier, steps_response: @results, message: e.message, type: :validation_error
-    )
   rescue Riffer::TimeoutError => e
     Riffer::Workflow::Response.error(
       identifier: self.class.identifier, steps_response: @results, message: e.message, type: :execution_error
+    )
+  rescue Riffer::ValidationError, Riffer::ArgumentError, Riffer::Error => e
+    Riffer::Workflow::Response.error(
+      identifier: self.class.identifier, steps_response: @results, message: e.message, type: :validation_error
     )
   end
 
@@ -102,20 +103,22 @@ class Riffer::Workflow
   # Raises Riffer::ArgumentError if the step is not an Agent(we will update latter to accept Tool and Workflow).
   #
   #--
-  #: (step_config: Hash[Symbol, untyped]) -> Riffer::Agent::Response
+  #: (step_config: Hash[Symbol, untyped]) -> Riffer::Agent::Response|Riffer::Tool::Response
   def run_step_with_validation(step_config:)
     validated_args = generate_validated_args(step_config)
 
     result = Timeout.timeout(self.class.timeout) do
-      agent = step_config[:step_class].new
+      step = step_config[:step_class].new
 
-      case agent
+      case step
       when Riffer::Agent
         files = validated_args.delete(:files)
         prompt = validated_args.values.join(" ")
-        agent = step_config[:step_class].new
 
-        agent.generate(prompt, files:, context: @context)
+        step.generate(prompt, files:, context: @context)
+      when Riffer::Tool
+        validated_args[:context] = @context
+        step.call(**validated_args)
       else
         raise Riffer::ArgumentError, "Unknown message step: #{step_config[:step_class]}"
       end
@@ -139,15 +142,17 @@ class Riffer::Workflow
     sliced = @results.slice(*step_config[:depends_on])
     payload = sliced.empty? ? @default_input : sliced
 
-    payload = payload.map do |_key, result|
+    payload.transform_values do |result|
       if result.respond_to?(:structured_output)
         result.structured_output
       elsif result.respond_to?(:content)
         {content: result.content}
+      elsif result.respond_to?(:to_h)
+        result.to_h
       else
-        {content: result}
+        result # No need to wrap in {key => result} here
       end
-    end.reduce({}, :merge!)
+    end
 
     params_builder ? params_builder.validate(payload) : payload
   end

--- a/lib/riffer/workflow/response.rb
+++ b/lib/riffer/workflow/response.rb
@@ -10,7 +10,7 @@ class Riffer::Workflow::Response
   attr_reader :identifier #: String
 
   # The output of each agent
-  attr_reader :steps_response #: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response]
+  attr_reader :steps_response #: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response|Riffer::Workflow::Response]
 
   # The error message when something fail
   attr_reader :error_message #: String?
@@ -21,7 +21,7 @@ class Riffer::Workflow::Response
   # Creates a success response.
   #
   #--
-  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response]) -> Riffer::Workflow::Response
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response|Riffer::Workflow::Response]) -> Riffer::Workflow::Response
   def self.success(identifier:, steps_response:)
     new(identifier: identifier, success: true, steps_response: steps_response)
   end
@@ -29,7 +29,7 @@ class Riffer::Workflow::Response
   # Creates an error response.
   #
   #--
-  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response], message: String, ?type: Symbol) -> Riffer::Workflow::Response
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response|Riffer::Workflow::Response], message: String, ?type: Symbol) -> Riffer::Workflow::Response
   def self.error(identifier:, steps_response:, message:, type: :execution_error)
     new(identifier: identifier, success: false, steps_response: steps_response,
       error_message: message, error_type: type)
@@ -46,7 +46,7 @@ class Riffer::Workflow::Response
   private
 
   #--
-  #: (identifier: String, success: bool, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response], ?error_message: String?, ?error_type: Symbol?) -> void
+  #: (identifier: String, success: bool, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response|Riffer::Workflow::Response], ?error_message: String?, ?error_type: Symbol?) -> void
   def initialize(identifier:, success:, steps_response:, error_message: nil, error_type: nil)
     @identifier = identifier
     @steps_response = steps_response

--- a/lib/riffer/workflow/response.rb
+++ b/lib/riffer/workflow/response.rb
@@ -10,7 +10,7 @@ class Riffer::Workflow::Response
   attr_reader :identifier #: String
 
   # The output of each agent
-  attr_reader :steps_response #: Hash[Symbol, Riffer::Agent::Response]
+  attr_reader :steps_response #: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response]
 
   # The error message when something fail
   attr_reader :error_message #: String?
@@ -21,7 +21,7 @@ class Riffer::Workflow::Response
   # Creates a success response.
   #
   #--
-  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response]) -> Riffer::Workflow::Response
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response]) -> Riffer::Workflow::Response
   def self.success(identifier:, steps_response:)
     new(identifier: identifier, success: true, steps_response: steps_response)
   end
@@ -29,7 +29,7 @@ class Riffer::Workflow::Response
   # Creates an error response.
   #
   #--
-  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response], message: String, ?type: Symbol) -> Riffer::Workflow::Response
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response], message: String, ?type: Symbol) -> Riffer::Workflow::Response
   def self.error(identifier:, steps_response:, message:, type: :execution_error)
     new(identifier: identifier, success: false, steps_response: steps_response,
       error_message: message, error_type: type)
@@ -46,7 +46,7 @@ class Riffer::Workflow::Response
   private
 
   #--
-  #: (identifier: String, success: bool, steps_response: Hash[Symbol, Riffer::Agent::Response], ?error_message: String?, ?error_type: Symbol?) -> void
+  #: (identifier: String, success: bool, steps_response: Hash[Symbol, Riffer::Agent::Response|Riffer::Tool::Response], ?error_message: String?, ?error_type: Symbol?) -> void
   def initialize(identifier:, success:, steps_response:, error_message: nil, error_type: nil)
     @identifier = identifier
     @steps_response = steps_response

--- a/lib/riffer/workflow/response.rb
+++ b/lib/riffer/workflow/response.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Wraps workflow responses.
+#
+#   response = workflow.run("Hello")
+#   puts response.steps_response
+class Riffer::Workflow::Response
+  # The workflow identifier
+  attr_reader :identifier #: String
+
+  # The output of each agent
+  attr_reader :steps_response #: Hash[Symbol, Riffer::Agent::Response]
+
+  # The error message when something fail
+  attr_reader :error_message #: String?
+
+  # The error type that causes the workflow to fail
+  attr_reader :error_type #: Symbol?
+
+  # Creates a success response.
+  #
+  #--
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response]) -> Riffer::Workflow::Response
+  def self.success(identifier:, steps_response:)
+    new(identifier: identifier, success: true, steps_response: steps_response)
+  end
+
+  # Creates an error response.
+  #
+  #--
+  #: (identifier: String, steps_response: Hash[Symbol, Riffer::Agent::Response], message: String, ?type: Symbol) -> Riffer::Workflow::Response
+  def self.error(identifier:, steps_response:, message:, type: :execution_error)
+    new(identifier: identifier, success: false, steps_response: steps_response,
+      error_message: message, error_type: type)
+  end
+
+  #--
+  #: () -> bool
+  def success? = @success
+
+  #--
+  #: () -> bool
+  def error? = !@success
+
+  private
+
+  #--
+  #: (identifier: String, success: bool, steps_response: Hash[Symbol, Riffer::Agent::Response], ?error_message: String?, ?error_type: Symbol?) -> void
+  def initialize(identifier:, success:, steps_response:, error_message: nil, error_type: nil)
+    @identifier = identifier
+    @steps_response = steps_response
+    @success = success
+    @error_message = error_message
+    @error_type = error_type
+  end
+end

--- a/test/riffer/workflow_test.rb
+++ b/test/riffer/workflow_test.rb
@@ -24,11 +24,47 @@ describe Riffer::Workflow do
     end
   end
 
+  let(:weather_tool_class) do
+    Class.new(Riffer::Tool) do
+      description "Gets the current weather"
+
+      params do
+        required :city, String, description: "The city name"
+        optional :units, String, default: "celsius"
+      end
+
+      def call(context:, city:, units: nil)
+        text("Weather in #{city}: 20 #{units || "celsius"}")
+      end
+    end
+  end
+
+  let(:simple_tool_class) do
+    Class.new(Riffer::Tool) do
+      description "A simple tool"
+
+      def call(context:, **kwargs)
+        text("Simple result")
+      end
+    end
+  end
+
+  let(:slow_tool_class) do
+    Class.new(Riffer::Tool) do
+      description "A simple tool"
+
+      def call(context:, **kwargs)
+        sleep 0.02
+        text("Simple result")
+      end
+    end
+  end
+
   let(:workflow) do
     workflow_class.new
   end
 
-  describe "invalid workflows" do
+  describe "workflows with errors" do
     let(:workflow_class) do
       agent_class
       Class.new(Riffer::Workflow) do
@@ -38,7 +74,7 @@ describe Riffer::Workflow do
       end
     end
     describe "validate input when run workflow" do
-      it "return response object with error for expected errors" do
+      it "return response object with error for a class that is not expected for step" do
         result = workflow.run(context: nil)
 
         expect(result).must_be_instance_of Riffer::Workflow::Response
@@ -48,9 +84,64 @@ describe Riffer::Workflow do
         expect(result.error_message).must_equal "Invalid model string: "
       end
     end
+
+    describe "workflow with multiple tools steps with dependencies" do
+      let(:workflow_class) do
+        captured_tool = weather_tool_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :weather1, captured_tool
+          step :weather2, captured_tool, depends_on: :weather1
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with fail because the output of the first step does not match the input of the second one" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal false
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 1 # Just the first step ran
+            expect(result.steps_response[:weather1]).must_be_instance_of Riffer::Tools::Response
+          end
+        end
+      end
+    end
+
+    describe "workflow with multiple tools steps with dependencies2" do
+      let(:workflow_class) do
+        captured_tool = slow_tool_class
+        Class.new(Riffer::Workflow) do
+          timeout 0.01
+          identifier "riffer/workflow"
+
+          step :slowtool, captured_tool
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with fail because the timeout on first step" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal false
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.error_message).must_equal "Step execution timed out after 0.01 seconds"
+            expect(result.error_type).must_equal :execution_error
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 0
+          end
+        end
+      end
+    end
   end
 
-  describe "valid workflows" do
+  describe "workflows with no errors" do
     describe "workflow with no steps" do
       let(:workflow_class) do
         agent_class
@@ -113,6 +204,97 @@ describe Riffer::Workflow do
             expect(result.steps_response).must_be_instance_of Hash
             expect(result.steps_response.keys.length).must_equal 2
             expect(result.steps_response[:search1]).must_be_instance_of Riffer::Agent::Response
+            expect(result.steps_response[:search2]).must_be_instance_of Riffer::Agent::Response
+          end
+        end
+      end
+    end
+
+    describe "workflow with multiple tools steps with no dependency" do
+      let(:workflow_class) do
+        captured_tool = weather_tool_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :weather1, captured_tool
+          step :weather2, captured_tool
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with success" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 2
+            expect(result.steps_response[:weather1]).must_be_instance_of Riffer::Tools::Response
+            expect(result.steps_response[:weather2]).must_be_instance_of Riffer::Tools::Response
+          end
+        end
+      end
+    end
+
+    describe "workflow with multiple tools steps with dependencies" do
+      let(:workflow_class) do
+        captured_tool = weather_tool_class
+        captured_simple_tool_class = simple_tool_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :weather1, captured_tool
+          step :simpletool, captured_simple_tool_class, depends_on: :weather1
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with success" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 2
+            expect(result.steps_response[:weather1]).must_be_instance_of Riffer::Tools::Response
+            expect(result.steps_response[:simpletool]).must_be_instance_of Riffer::Tools::Response
+          end
+        end
+      end
+    end
+
+    describe "workflow with multiple agents and tools steps with dependencies" do
+      let(:workflow_class) do
+        captured_tool = weather_tool_class
+        captured_simple_tool_class = simple_tool_class
+        captured_agent = agent_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :weather1, captured_tool
+          step :search1, captured_agent, depends_on: :weather1
+          step :simpletool, captured_simple_tool_class, depends_on: [:weather1, :search1]
+          step :search2, captured_agent, depends_on: :simpletool
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with success" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 4
+            expect(result.steps_response[:weather1]).must_be_instance_of Riffer::Tools::Response
+            expect(result.steps_response[:search1]).must_be_instance_of Riffer::Agent::Response
+            expect(result.steps_response[:simpletool]).must_be_instance_of Riffer::Tools::Response
             expect(result.steps_response[:search2]).must_be_instance_of Riffer::Agent::Response
           end
         end

--- a/test/riffer/workflow_test.rb
+++ b/test/riffer/workflow_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Workflow do
+  let(:agent_class) do
+    Class.new(Riffer::Agent) do
+      identifier "test-agent"
+      model "mock/riffer-1"
+      instructions "You are a helpful assistant."
+    end
+  end
+
+  let(:agent) do
+    agent_class.new
+  end
+
+  let(:workflow_class) do
+    captured_agent = agent_class
+    Class.new(Riffer::Workflow) do
+      identifier "riffer/workflow"
+
+      step :search1, captured_agent
+    end
+  end
+
+  let(:workflow) do
+    workflow_class.new
+  end
+
+  describe "invalid workflows" do
+    let(:workflow_class) do
+      agent_class
+      Class.new(Riffer::Workflow) do
+        identifier "riffer/workflow"
+
+        step :search1, Riffer::Agent
+      end
+    end
+    describe "validate input when run workflow" do
+      it "return response object with error for expected errors" do
+        result = workflow.run(context: nil)
+
+        expect(result).must_be_instance_of Riffer::Workflow::Response
+        expect(result.error?).must_equal true
+        expect(result.success?).must_equal false
+        expect(result.error_type).must_equal :validation_error
+        expect(result.error_message).must_equal "Invalid model string: "
+      end
+    end
+  end
+
+  describe "valid workflows" do
+    describe "workflow with no steps" do
+      let(:workflow_class) do
+        agent_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object" do
+            result = workflow.run(context: nil, prompt: "What is the weather?")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 0
+          end
+        end
+      end
+    end
+
+    describe "workflow with just one agent step" do
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object" do
+            result = workflow.run(context: nil, prompt: "What is the weather?")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 1
+            expect(result.steps_response[:search1]).must_be_instance_of Riffer::Agent::Response
+          end
+        end
+      end
+    end
+
+    describe "workflow with multiple agent steps" do
+      let(:workflow_class) do
+        captured_agent = agent_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :search1, captured_agent
+          step :search2, captured_agent
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object" do
+            result = workflow.run(context: nil, prompt: "What is the weather?")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 2
+            expect(result.steps_response[:search1]).must_be_instance_of Riffer::Agent::Response
+            expect(result.steps_response[:search2]).must_be_instance_of Riffer::Agent::Response
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/riffer/workflow_test.rb
+++ b/test/riffer/workflow_test.rb
@@ -300,5 +300,50 @@ describe Riffer::Workflow do
         end
       end
     end
+
+    describe "workflow with multiple agents, tools, and workflows steps with dependencies" do
+      let(:simple_workflow_class) do
+        captured_agent = agent_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :search1, captured_agent
+        end
+      end
+      let(:workflow_class) do
+        captured_tool = weather_tool_class
+        captured_simple_tool_class = simple_tool_class
+        captured_agent = agent_class
+        captured_simple_workflow_class = simple_workflow_class
+        Class.new(Riffer::Workflow) do
+          identifier "riffer/workflow"
+
+          step :weather1, captured_tool
+          step :search1, captured_agent, depends_on: :weather1
+          step :simpletool, captured_simple_tool_class, depends_on: [:weather1, :search1]
+          step :search2, captured_agent, depends_on: :simpletool
+          step :simple_workflow, captured_simple_workflow_class, depends_on: :search2
+        end
+      end
+
+      describe "#run" do
+        describe "with mock provider" do
+          it "returns a Response object with success" do
+            result = workflow.run(context: nil, city: "Toronto", units: "fahrenheit")
+
+            expect(result).must_be_instance_of Riffer::Workflow::Response
+            expect(result.success?).must_equal true
+            expect(result.identifier).must_equal "riffer/workflow"
+            expect(result.steps_response).must_be_instance_of Hash
+            expect(result.steps_response.keys.length).must_equal 5
+            expect(result.steps_response[:weather1]).must_be_instance_of Riffer::Tools::Response
+            expect(result.steps_response[:search1]).must_be_instance_of Riffer::Agent::Response
+            expect(result.steps_response[:simpletool]).must_be_instance_of Riffer::Tools::Response
+            expect(result.steps_response[:search2]).must_be_instance_of Riffer::Agent::Response
+            expect(result.steps_response[:simple_workflow]).must_be_instance_of Riffer::Workflow::Response
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This diff adds the new **workflow** feature to Riffer. A workflow is composed of steps, and each step could be an Agent, Tool, or another workflow. In addition, each step could depend on multiple other steps.


The best way to review this PR is to take a look at each commit(This is just an exercise; in a production environment, we should break this PR into separate PRs, each commit here could be one separate PR):

1. [Includes the tech design with all the assumptions and decisions made. It also includes a documentation of how to use the workflow] (https://github.com/janeapp/riffer/pull/218/changes/f8a6f6a1a192e0ca82be49b16599f03169b8ada6)
2. [Includes the Workflow class and the ability to use Agent as a step](https://github.com/janeapp/riffer/pull/218/changes/285af2c51e52e1316d3dbd0aa6bb464cd20348c6)
3. [Adding support for the Tool as a step](https://github.com/janeapp/riffer/pull/218/changes/8fd20a809b7879724b198fb3dc5d94a9e31694ac)
4. [Adding support for workflow as a step.](https://github.com/janeapp/riffer/pull/218/changes/4685733cc5d67433b7f62c445fc8b9640eabcdcc)

# How to use the Workflow
The tech design includes detailed instructions on how to use this new feature. Here is an example:
```ruby
class MyAgent < Riffer::Agent
     model 'openai/gpt-4o'
     instructions 'You are a helpful assistant.'
end

class WeatherTool < Riffer::Tool
  description "Gets the current weather for a city"

  params do
    required :city, String, description: "The city name"
    optional :units, String, default: "celsius", enum: ["celsius", "fahrenheit"]
  end

  def call(context:, city:, units: nil)
    weather = WeatherAPI.fetch(city, units: units || "celsius")
    text("The weather in #{city} is #{weather.temperature} #{units}.")
  end
end

class SimpleWorkflow < Riffer::Workflow
end

class MyWorkflow < Riffer::Workflow
     step :weather, WeatherTool
     step :search1, MyAgent
     step :search2, MyAgent, depends_on: :search1
     step :search3, MyAgent
     step :search4, MyAgent, depends_on: [:search1, :search2]
     step :simpleworkflow, SimpleWorkflow
   end

   workflow = MyWorkflow.new
   workflow.run(context:nil, city: "Toronto", units: "celsius")
```  


# Some choices

I chose to exclude some things from this exercise to keep it simple. For example, the step could be encapsulated as a class/interface that the user needs to subclass to create each step. So, it will simplify the Workflow that knows this interface and just needs to handle that, instead of 3. I decided to keep this exercise simple.

I also didn't add tests for the class `Riffer::Workflow::Response` because of time constraints. In a real scenario, we should include tests for this class as well.

I added all of these details to the tech design.