### PR TITLE
fix: disable gzip on Anthropic stream to avoid SSE buffering

### DIFF
--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -144,7 +144,12 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       web_search_query: nil
     }
 
-    stream = @client.messages.stream(**params)
+    # Workaround for anthropics/anthropic-sdk-ruby#182: force identity
+    # encoding so Net::HTTP/Zlib doesn't buffer SSE chunks until EOF.
+    stream = @client.messages.stream(
+      **params,
+      request_options: {extra_headers: {"accept-encoding" => "identity"}}
+    )
     current_state[:stream] = stream
 
     stream.each do |event|


### PR DESCRIPTION
## Summary
- Force `accept-encoding: identity` on `@client.messages.stream` so Net::HTTP/Zlib doesn't buffer SSE chunks until EOF.
- Workaround for [anthropics/anthropic-sdk-ruby#182](https://github.com/anthropics/anthropic-sdk-ruby/issues/182); can be removed once the upstream SDK fix lands.

## Test plan
- Exercise a streaming Anthropic completion end-to-end and confirm events arrive incrementally rather than in a single burst at stream end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming response buffering issue with Anthropic provider. Streamed responses are now processed incrementally instead of being held until the connection closes, improving responsiveness when using streaming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->