### PR TITLE
fix(providers): surface Bedrock stream errors and concat text blocks

### DIFF
--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -139,20 +139,45 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
 
     @client.converse_stream(**params) do |stream|
       stream.on_event do |event|
-        case event.event_type
-        when :content_block_start
+        case event
+        when Aws::BedrockRuntime::Types::ContentBlockStartEvent
           handle_content_block_start_tool_use(event, state: current_state, yielder: yielder) if event.start&.tool_use
-        when :content_block_delta
+        when Aws::BedrockRuntime::Types::ContentBlockDeltaEvent
           handle_content_block_delta_text_delta(event, state: current_state, yielder: yielder) if event.delta&.text
           handle_content_block_delta_tool_use(event, state: current_state, yielder: yielder) if event.delta&.tool_use
-        when :content_block_stop
+        when Aws::BedrockRuntime::Types::ContentBlockStopEvent
           handle_content_block_stop_text_delta(event, state: current_state, yielder: yielder) if current_state[:text]
           handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if current_state[:tool_call]
-        when :metadata
+        when Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent
           handle_metadata_usage(event, state: current_state, yielder: yielder) if event.usage
+        else
+          raise_stream_exception!(event)
         end
       end
     end
+  end
+
+  # Bedrock's ConverseStream delivers API errors (e.g. +throttling_exception+,
+  # +internal_server_exception+) as events on the same channel as content, so
+  # without this check a mid-stream failure would silently end the enumerator
+  # with no tokens or content.
+  #--
+  #: (untyped) -> void
+  def raise_stream_exception!(event)
+    return unless event.respond_to?(:event_type)
+    event_type = event.event_type.to_s
+    return unless event_type.end_with?("_exception") || event_type == "error"
+
+    klass_name = event.class.name&.split("::")&.last
+    error_klass = if klass_name && Aws::BedrockRuntime::Errors.const_defined?(klass_name, false)
+      Aws::BedrockRuntime::Errors.const_get(klass_name, false)
+    else
+      Aws::BedrockRuntime::Errors::ServiceError
+    end
+
+    message = event.respond_to?(:message) ? event.message : event_type
+    context = Seahorse::Client::RequestContext.new(operation_name: :converse_stream)
+    raise error_klass.new(context, message, event)
   end
 
   #--

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -102,7 +102,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     text_content = ""
 
     content_blocks.each do |block|
-      text_content = block.text if block.respond_to?(:text) && block.text
+      text_content += block.text if block.respond_to?(:text) && block.text
     end
 
     text_content

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -150,12 +150,8 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
           handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if current_state[:tool_call]
         when Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent
           handle_metadata_usage(event, state: current_state, yielder: yielder) if event.usage
-        when Aws::BedrockRuntime::Types::InternalServerException,
-          Aws::BedrockRuntime::Types::ModelStreamErrorException,
-          Aws::BedrockRuntime::Types::ThrottlingException,
-          Aws::BedrockRuntime::Types::ValidationException,
-          Aws::BedrockRuntime::Types::ServiceUnavailableException
-          raise_stream_exception!(event)
+        else
+          raise_if_stream_exception!(event)
         end
       end
     end
@@ -165,10 +161,17 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # +Aws::BedrockRuntime::Errors+ service error. ConverseStream delivers API
   # errors on the same channel as content, so without this a mid-stream
   # failure would silently end the enumerator with no tokens or content.
+  #
+  # Detection is by class-name suffix: every Bedrock stream-exception struct
+  # is named +*Exception+ and has a matching +Aws::BedrockRuntime::Errors+
+  # class of the same name (generated via +DynamicErrors+ if not explicit).
+  # Non-exception events (e.g. +MessageStartEvent+) pass through silently.
   #--
   #: (untyped) -> void
-  def raise_stream_exception!(event)
-    klass_name = event.class.name.split("::").last
+  def raise_if_stream_exception!(event)
+    klass_name = event.class.name&.split("::")&.last
+    return unless klass_name&.end_with?("Exception")
+
     error_klass = Aws::BedrockRuntime::Errors.const_get(klass_name)
     context = Seahorse::Client::RequestContext.new(operation_name: :converse_stream)
     raise error_klass.new(context, event.message, event)

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -150,34 +150,28 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
           handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if current_state[:tool_call]
         when Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent
           handle_metadata_usage(event, state: current_state, yielder: yielder) if event.usage
-        else
+        when Aws::BedrockRuntime::Types::InternalServerException,
+          Aws::BedrockRuntime::Types::ModelStreamErrorException,
+          Aws::BedrockRuntime::Types::ThrottlingException,
+          Aws::BedrockRuntime::Types::ValidationException,
+          Aws::BedrockRuntime::Types::ServiceUnavailableException
           raise_stream_exception!(event)
         end
       end
     end
   end
 
-  # Bedrock's ConverseStream delivers API errors (e.g. +throttling_exception+,
-  # +internal_server_exception+) as events on the same channel as content, so
-  # without this check a mid-stream failure would silently end the enumerator
-  # with no tokens or content.
+  # Re-raises a Bedrock stream exception event as the matching
+  # +Aws::BedrockRuntime::Errors+ service error. ConverseStream delivers API
+  # errors on the same channel as content, so without this a mid-stream
+  # failure would silently end the enumerator with no tokens or content.
   #--
   #: (untyped) -> void
   def raise_stream_exception!(event)
-    return unless event.respond_to?(:event_type)
-    event_type = event.event_type.to_s
-    return unless event_type.end_with?("_exception") || event_type == "error"
-
-    klass_name = event.class.name&.split("::")&.last
-    error_klass = if klass_name && Aws::BedrockRuntime::Errors.const_defined?(klass_name, false)
-      Aws::BedrockRuntime::Errors.const_get(klass_name, false)
-    else
-      Aws::BedrockRuntime::Errors::ServiceError
-    end
-
-    message = event.respond_to?(:message) ? event.message : event_type
+    klass_name = event.class.name.split("::").last
+    error_klass = Aws::BedrockRuntime::Errors.const_get(klass_name)
     context = Seahorse::Client::RequestContext.new(operation_name: :converse_stream)
-    raise error_klass.new(context, message, event)
+    raise error_klass.new(context, event.message, event)
   end
 
   #--

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -42,9 +42,14 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # +Aws::BedrockRuntime::Errors+ service error. ConverseStream delivers API
   # errors on the same channel as content, so without this a mid-stream
   # failure would silently end the enumerator with no tokens or content.
+  #
+  # Detection is by class-name suffix: every Bedrock stream-exception struct
+  # is named +*Exception+ and has a matching +Aws::BedrockRuntime::Errors+
+  # class of the same name (generated via +DynamicErrors+ if not explicit).
+  # Non-exception events (e.g. +MessageStartEvent+) pass through silently.
   # --
   # : (untyped) -> void
-  def raise_stream_exception!: (untyped) -> void
+  def raise_if_stream_exception!: (untyped) -> void
 
   # --
   # : (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -38,6 +38,14 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # : (Hash[Symbol, untyped], Enumerator::Yielder) -> void
   def execute_stream: (Hash[Symbol, untyped], Enumerator::Yielder) -> void
 
+  # Re-raises a Bedrock stream exception event as the matching
+  # +Aws::BedrockRuntime::Errors+ service error. ConverseStream delivers API
+  # errors on the same channel as content, so without this a mid-stream
+  # failure would silently end the enumerator with no tokens or content.
+  # --
+  # : (untyped) -> void
+  def raise_stream_exception!: (untyped) -> void
+
   # --
   # : (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void
   def handle_content_block_start_tool_use: (Aws::BedrockRuntime::Types::ContentBlockStartEvent, state: Hash[Symbol, untyped], yielder: Enumerator[Riffer::StreamEvents::Base, void]) -> void

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -528,6 +528,26 @@ describe Riffer::Providers::AmazonBedrock do
         assert_raises(Aws::BedrockRuntime::Errors::ModelStreamErrorException) { enum.to_a }
       end
 
+      it "raises for a future exception type not explicitly known (auto-caught by class-name suffix)" do
+        # Simulates the SDK adding a new stream-exception type we haven't coded
+        # against. The class-name suffix check should still route it through
+        # Aws::BedrockRuntime::Errors (DynamicErrors synthesizes the class)
+        # rather than silently dropping it.
+        provider
+        fake_future_exception_class = Struct.new(:message, :event_type) do
+          def self.name
+            "Aws::BedrockRuntime::Types::HypotheticalFutureException"
+          end
+        end
+        event = fake_future_exception_class.new("surprise", :hypothetical_future_exception)
+        stub_stream_events(provider, [event])
+
+        error = assert_raises(Aws::BedrockRuntime::Errors::ServiceError) do
+          provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+        end
+        expect(error).must_be_kind_of Aws::BedrockRuntime::Errors::HypotheticalFutureException
+      end
+
       it "ignores unknown non-exception events (e.g. message_start) without raising" do
         # Forward-compatible: unknown event types that aren't exceptions should be skipped,
         # not raise. Verified with MessageStartEvent which Bedrock emits but we don't consume.

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -427,6 +427,83 @@ describe Riffer::Providers::AmazonBedrock do
         end
       end
     end
+
+    describe "when the stream emits an exception event" do
+      let(:provider) { Riffer::Providers::AmazonBedrock.new(api_token: "test", region: "us-east-1") }
+
+      def stub_stream_events(provider, events)
+        stream_double = Object.new
+        stream_double.define_singleton_method(:on_event) { |&block| events.each { |e| block.call(e) } }
+        client_double = Object.new
+        client_double.define_singleton_method(:converse_stream) { |**_kwargs, &block| block.call(stream_double) }
+        provider.instance_variable_set(:@client, client_double)
+      end
+
+      it "raises a matching Aws::BedrockRuntime::Errors error for a throttling exception" do
+        event = Aws::BedrockRuntime::Types::ThrottlingException.new(
+          message: "rate limit exceeded",
+          event_type: :throttling_exception
+        )
+        stub_stream_events(provider, [event])
+
+        error = assert_raises(Aws::BedrockRuntime::Errors::ThrottlingException) do
+          provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+        end
+        expect(error.message).must_equal "rate limit exceeded"
+      end
+
+      it "raises for an internal_server_exception" do
+        event = Aws::BedrockRuntime::Types::InternalServerException.new(
+          message: "boom",
+          event_type: :internal_server_exception
+        )
+        stub_stream_events(provider, [event])
+
+        assert_raises(Aws::BedrockRuntime::Errors::InternalServerException) do
+          provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+        end
+      end
+
+      it "raises for a model_stream_error_exception mid-stream after content deltas" do
+        delta_event = Aws::BedrockRuntime::Types::ContentBlockDeltaEvent.new(
+          delta: Aws::BedrockRuntime::Types::ContentBlockDelta.new(text: "Hel"),
+          content_block_index: 0,
+          event_type: :content_block_delta
+        )
+        error_event = Aws::BedrockRuntime::Types::ModelStreamErrorException.new(
+          message: "model failed",
+          original_status_code: 500,
+          event_type: :model_stream_error_exception
+        )
+        stub_stream_events(provider, [delta_event, error_event])
+
+        enum = provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        assert_raises(Aws::BedrockRuntime::Errors::ModelStreamErrorException) { enum.to_a }
+      end
+
+      it "ignores unknown non-exception events (e.g. message_start) without raising" do
+        # Forward-compatible: unknown event types that aren't exceptions should be skipped,
+        # not raise. Verified with MessageStartEvent which Bedrock emits but we don't consume.
+        message_start = Aws::BedrockRuntime::Types::MessageStartEvent.new(
+          role: "assistant",
+          event_type: :message_start
+        )
+        metadata = Aws::BedrockRuntime::Types::ConverseStreamMetadataEvent.new(
+          usage: Aws::BedrockRuntime::Types::TokenUsage.new(
+            input_tokens: 5,
+            output_tokens: 3,
+            total_tokens: 8
+          ),
+          event_type: :metadata
+        )
+        stub_stream_events(provider, [message_start, metadata])
+
+        events = provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+        usage_done = events.find { |e| e.is_a?(Riffer::StreamEvents::TokenUsageDone) }
+        expect(usage_done).wont_be_nil
+        expect(usage_done.token_usage.input_tokens).must_equal 5
+      end
+    end
   end
 
   describe "usage" do

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -367,6 +367,54 @@ describe Riffer::Providers::AmazonBedrock do
     end
   end
 
+  describe "#extract_content" do
+    let(:provider) do
+      # Instantiating triggers depends_on "aws-sdk-bedrockruntime", which makes
+      # the Aws::BedrockRuntime::Types constants below available.
+      Riffer::Providers::AmazonBedrock.new(api_token: "test", region: "us-east-1")
+    end
+
+    def build_response(content_blocks)
+      Aws::BedrockRuntime::Types::ConverseResponse.new(
+        output: Aws::BedrockRuntime::Types::ConverseOutput::Message.new(
+          message: Aws::BedrockRuntime::Types::Message.new(
+            role: "assistant",
+            content: content_blocks
+          )
+        )
+      )
+    end
+
+    it "concatenates multiple text blocks in order" do
+      provider # force SDK load before constructing Aws types below
+      # Regression: previously assigned (=) instead of appending (+=), so with
+      # multiple text blocks only the last survived. Bedrock splits output
+      # across several text blocks when reasoning or tool_use blocks are
+      # interleaved, so all text blocks must be preserved.
+      response = build_response([
+        Aws::BedrockRuntime::Types::ContentBlock.new(text: "Hello "),
+        Aws::BedrockRuntime::Types::ContentBlock.new(text: "world")
+      ])
+      expect(provider.send(:extract_content, response)).must_equal "Hello world"
+    end
+
+    it "ignores tool_use blocks when extracting text" do
+      provider # force SDK load before constructing Aws types below
+      response = build_response([
+        Aws::BedrockRuntime::Types::ContentBlock.new(text: "Answer: "),
+        Aws::BedrockRuntime::Types::ContentBlock.new(
+          tool_use: Aws::BedrockRuntime::Types::ToolUseBlock.new(
+            tool_use_id: "id-1",
+            name: "calculator",
+            input: {}
+          )
+        ),
+        Aws::BedrockRuntime::Types::ContentBlock.new(text: "42")
+      ])
+      expect(provider.send(:extract_content, response)).must_equal "Answer: 42"
+    end
+  end
+
   describe "#stream_text" do
     describe "when prompt is provided" do
       it "returns an Enumerator" do

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -487,28 +487,27 @@ describe Riffer::Providers::AmazonBedrock do
         provider.instance_variable_set(:@client, client_double)
       end
 
-      it "raises a matching Aws::BedrockRuntime::Errors error for a throttling exception" do
-        event = Aws::BedrockRuntime::Types::ThrottlingException.new(
-          message: "rate limit exceeded",
-          event_type: :throttling_exception
-        )
-        stub_stream_events(provider, [event])
+      # Covers the Types → Errors conversion for every stream-exception event
+      # type that Bedrock's ConverseStream can emit. Each Types::X struct must
+      # map to the same-named Aws::BedrockRuntime::Errors::X service error.
+      {
+        InternalServerException: :internal_server_exception,
+        ModelStreamErrorException: :model_stream_error_exception,
+        ThrottlingException: :throttling_exception,
+        ValidationException: :validation_exception,
+        ServiceUnavailableException: :service_unavailable_exception
+      }.each do |class_name, event_type|
+        it "raises Aws::BedrockRuntime::Errors::#{class_name} for a #{event_type} event" do
+          provider # force SDK load so the Aws constants resolve below
+          type_klass = Aws::BedrockRuntime::Types.const_get(class_name)
+          error_klass = Aws::BedrockRuntime::Errors.const_get(class_name)
+          event = type_klass.new(message: "boom", event_type: event_type)
+          stub_stream_events(provider, [event])
 
-        error = assert_raises(Aws::BedrockRuntime::Errors::ThrottlingException) do
-          provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
-        end
-        expect(error.message).must_equal "rate limit exceeded"
-      end
-
-      it "raises for an internal_server_exception" do
-        event = Aws::BedrockRuntime::Types::InternalServerException.new(
-          message: "boom",
-          event_type: :internal_server_exception
-        )
-        stub_stream_events(provider, [event])
-
-        assert_raises(Aws::BedrockRuntime::Errors::InternalServerException) do
-          provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+          error = assert_raises(error_klass) do
+            provider.stream_text(prompt: "Hi", model: "us.anthropic.claude-haiku-4-5-20251001-v1:0").to_a
+          end
+          expect(error.message).must_equal "boom"
         end
       end
 


### PR DESCRIPTION
## Summary

Two independent Bedrock provider fixes. The first addresses an empty-response / 0-token symptom; the second is a smaller bug spotted along the way and can be dropped in review if undesired.

### 1. Raise on Bedrock stream exception events (`0739063`)

`AmazonBedrock#execute_stream` matched only the four content/metadata event types in its `case event.event_type` statement. Bedrock's ConverseStream delivers API errors (`throttling_exception`, `internal_server_exception`, `model_stream_error_exception`, `validation_exception`, `service_unavailable_exception`) as **events on the same channel as content**, so any mid-stream failure fell through the `case`, the enumerator completed cleanly, no `TokenUsageDone` was emitted, and the caller saw an empty successful response.

The fix switches to class-based matching with a default arm that detects stream-exception events (by `event_type` shape) and re-raises them as the corresponding `Aws::BedrockRuntime::Errors::*` class — consistent with the non-streaming path, where the AWS SDK already raises natively. Unknown non-exception events (e.g. `MessageStartEvent`) are still skipped for forward compatibility.

**Note on other providers:** Anthropic, OpenAI/Azure, and Gemini use SSE and their SDKs synthesize exceptions from error events. Only Bedrock's eventstream protocol requires explicit handling. No changes needed elsewhere.

### 2. Concatenate all Bedrock text content blocks (`fbd8f1f`)

`extract_content` used `text_content = block.text` (assignment) instead of `+=` (append) while iterating over the response's content blocks. With multiple text blocks in a single response — which Bedrock emits when text is interleaved with reasoning or tool_use blocks — only the last block's text survived.

**Happy to drop this commit in review if you'd prefer a smaller PR.** It's self-contained with its own tests and doesn't depend on the streaming fix.

## Test plan

- [x] `bundle exec rake` (1294 runs, Steep clean, Standard clean)
- [x] New unit tests stub `converse_stream` / build fake responses — no VCR cassettes needed
- [x] Forward-compat test confirms unknown non-exception events don't raise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content extraction to accumulate multiple response text blocks instead of overwriting earlier content.
  * Stream-side errors are now surfaced as immediate exceptions instead of silently ending the stream.

* **Improvements**
  * More robust streaming event routing to handle concrete runtime event types and unknown future events safely.

* **Tests**
  * Added unit coverage for streaming behavior, error translation, and content extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->