### PR TITLE
feat!: class-level tool resolution; lift activation tool to global config

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,10 +1,12 @@
 {
   "release-type": "ruby",
+  "bump-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "ruby",
       "package-name": "riffer",
-      "version-file": "lib/riffer/version.rb"
+      "version-file": "lib/riffer/version.rb",
+      "bump-minor-pre-major": true
     }
   }
 }

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -54,6 +54,18 @@ end
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
+### Skill Activation Tool
+
+Override the tool the LLM calls to activate a skill. Defaults to `Riffer::Skills::ActivateTool`:
+
+```ruby
+Riffer.configure do |config|
+  config.skill_activate_tool = MyCustomActivateTool
+end
+```
+
+Per-agent override is available inside the `skills` block via `skill_activate_tool MyCustomActivateTool`. See [Skills — Custom Activation Tool](13_SKILLS.md#custom-activation-tool).
+
 ### Message ID Strategy
 
 Opt in to stable identifiers on every message for logging, persistence, or replay:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -70,6 +70,18 @@ end
 
 Per-agent override is available inside the `skills` block via `activate_tool MyCustomActivateTool`. See [Skills — Custom Activation Tool](13_SKILLS.md#custom-activation-tool).
 
+#### Default backend
+
+Set an app-wide default skills backend. Used by any agent that declares a `skills` block without specifying its own `backend`:
+
+```ruby
+Riffer.configure do |config|
+  config.skills.default_backend = Riffer::Skills::FilesystemBackend.new(".skills")
+end
+```
+
+Accepts a `Riffer::Skills::Backend` instance or a `Proc` that receives `context` and returns a backend. Defaults to `nil` — agents that don't set their own backend get no skills, matching pre-existing behavior. Per-agent backends override this default.
+
 ### Message ID Strategy
 
 Opt in to stable identifiers on every message for logging, persistence, or replay:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -64,7 +64,7 @@ Riffer.configure do |config|
 end
 ```
 
-Per-agent override is available inside the `skills` block via `skill_activate_tool MyCustomActivateTool`. See [Skills — Custom Activation Tool](13_SKILLS.md#custom-activation-tool).
+Per-agent override is available inside the `skills` block via `activate_tool MyCustomActivateTool`. See [Skills — Custom Activation Tool](13_SKILLS.md#custom-activation-tool).
 
 ### Message ID Strategy
 

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -54,13 +54,17 @@ end
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
-### Skill Activation Tool
+### Skills
+
+Skills-related global configuration lives under `config.skills`.
+
+#### Default activation tool
 
 Override the tool the LLM calls to activate a skill. Defaults to `Riffer::Skills::ActivateTool`:
 
 ```ruby
 Riffer.configure do |config|
-  config.skill_activate_tool = MyCustomActivateTool
+  config.skills.default_activate_tool = MyCustomActivateTool
 end
 ```
 

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -125,24 +125,39 @@ end
 
 ## Custom Adapters
 
-Subclass `Riffer::Skills::Adapter` to customize how the skill catalog is rendered and which tool the LLM uses to activate skills:
+Subclass `Riffer::Skills::Adapter` to customize how the skill catalog is rendered in the system prompt:
 
 ```ruby
 class CustomAdapter < Riffer::Skills::Adapter
   def render_catalog(skills)
     # Return String (skill catalog for the system prompt)
-    # Use `activate_tool.name` to reference the activation tool
-  end
-
-  def activate_tool
-    # Return a Riffer::Tool subclass
-    # Defaults to Riffer::Skills::ActivateTool
-    Riffer::Skills::ActivateTool
+    # Use `skill_activate_tool.name` to reference the activation tool the LLM should call
   end
 end
 ```
 
+The activation tool is set on the adapter at construction (`Riffer::Skills::Adapter.new(skill_activate_tool: ...)`) and exposed via the `skill_activate_tool` reader. The agent wires this up automatically — custom adapters that override `initialize` must call `super`.
+
 The built-in adapters are `Riffer::Skills::MarkdownAdapter` (default) and `Riffer::Skills::XmlAdapter` (used by Anthropic).
+
+## Custom Activation Tool
+
+The activation tool is global. Set it once via `Riffer.config.skill_activate_tool` to apply across all agents, or override per-agent inside the `skills` block:
+
+```ruby
+# Global default
+Riffer.config.skill_activate_tool = MyCustomActivateTool
+
+# Per-agent override
+class MyAgent < Riffer::Agent
+  skills do
+    backend Riffer::Skills::FilesystemBackend.new(".skills")
+    skill_activate_tool MyCustomActivateTool
+  end
+end
+```
+
+The default is `Riffer::Skills::ActivateTool`. Custom tools must subclass `Riffer::Tool` and accept a `name:` parameter that resolves to a skill body via `context[:skills]`.
 
 ## Accessing Skills in Tools
 

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -161,7 +161,7 @@ Riffer.config.skill_activate_tool = InstrumentedActivateTool
 class MyAgent < Riffer::Agent
   skills do
     backend Riffer::Skills::FilesystemBackend.new(".skills")
-    skill_activate_tool InstrumentedActivateTool
+    activate_tool InstrumentedActivateTool
   end
 end
 ```

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -142,22 +142,31 @@ The built-in adapters are `Riffer::Skills::MarkdownAdapter` (default) and `Riffe
 
 ## Custom Activation Tool
 
-The activation tool is global. Set it once via `Riffer.config.skill_activate_tool` to apply across all agents, or override per-agent inside the `skills` block:
+The activation tool is global. Set it once via `Riffer.config.skill_activate_tool` to apply across all agents, or override per-agent inside the `skills` block.
+
+The recommended approach is to subclass `Riffer::Skills::ActivateTool` so the identifier, description, params, and timeout are inherited — you only override the behavior you need to change:
 
 ```ruby
+# Wrap the default behavior with telemetry
+class InstrumentedActivateTool < Riffer::Skills::ActivateTool
+  def call(context:, name:)
+    Telemetry.measure("skill_activate", skill: name) { super }
+  end
+end
+
 # Global default
-Riffer.config.skill_activate_tool = MyCustomActivateTool
+Riffer.config.skill_activate_tool = InstrumentedActivateTool
 
 # Per-agent override
 class MyAgent < Riffer::Agent
   skills do
     backend Riffer::Skills::FilesystemBackend.new(".skills")
-    skill_activate_tool MyCustomActivateTool
+    skill_activate_tool InstrumentedActivateTool
   end
 end
 ```
 
-The default is `Riffer::Skills::ActivateTool`. Custom tools must subclass `Riffer::Tool` and accept a `name:` parameter that resolves to a skill body via `context[:skills]`.
+If you need a different parameter shape entirely, subclass `Riffer::Tool` directly and provide your own `identifier`, `description`, `params`, and `call`.
 
 ## Accessing Skills in Tools
 

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -142,7 +142,7 @@ The built-in adapters are `Riffer::Skills::MarkdownAdapter` (default) and `Riffe
 
 ## Custom Activation Tool
 
-The activation tool is global. Set it once via `Riffer.config.skill_activate_tool` to apply across all agents, or override per-agent inside the `skills` block.
+The activation tool is global. Set it once via `Riffer.config.skills.default_activate_tool` to apply across all agents, or override per-agent inside the `skills` block.
 
 The recommended approach is to subclass `Riffer::Skills::ActivateTool` so the identifier, description, params, and timeout are inherited — you only override the behavior you need to change:
 
@@ -155,7 +155,7 @@ class InstrumentedActivateTool < Riffer::Skills::ActivateTool
 end
 
 # Global default
-Riffer.config.skill_activate_tool = InstrumentedActivateTool
+Riffer.config.skills.default_activate_tool = InstrumentedActivateTool
 
 # Per-agent override
 class MyAgent < Riffer::Agent

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -144,7 +144,7 @@ class Riffer::Agent
   #
   # The activation tool class is resolved from the agent's
   # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
-  # from <tt>Riffer.config.skill_activate_tool</tt>.
+  # from <tt>Riffer.config.skills.default_activate_tool</tt>.
   #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
   # activation tool.
@@ -155,7 +155,7 @@ class Riffer::Agent
     base = resolve_uses_tools_config(context)
     return base unless skills
 
-    skill_activate_tool_class = skills.activate_tool || Riffer.config.skill_activate_tool
+    skill_activate_tool_class = skills.activate_tool || Riffer.config.skills.default_activate_tool
     if base.any? { |t| t.name == skill_activate_tool_class.name }
       raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
     end
@@ -800,7 +800,7 @@ class Riffer::Agent
 
     skills = skills_list.to_h { |s| [s.name, s] }
     adapter_class = self.class.skills.adapter || provider_class.skills_adapter
-    skill_activate_tool_class = self.class.skills.activate_tool || Riffer.config.skill_activate_tool
+    skill_activate_tool_class = self.class.skills.activate_tool || Riffer.config.skills.default_activate_tool
 
     skills_context = Riffer::Skills::Context.new(
       backend: backend,

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -791,7 +791,7 @@ class Riffer::Agent
   def resolve_skills(context = @context)
     return nil unless self.class.skills
 
-    backend = self.class.skills.backend
+    backend = self.class.skills.backend || Riffer.config.skills.default_backend
     return nil unless backend
 
     backend = backend.is_a?(Proc) ? backend.call(context) : backend

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -143,8 +143,8 @@ class Riffer::Agent
   # When +uses_tools+ is a Proc, +context+ is forwarded to it.
   #
   # The activation tool class is resolved from the agent's
-  # <tt>skills do; skill_activate_tool ...; end</tt> override when set,
-  # otherwise from <tt>Riffer.config.skill_activate_tool</tt>.
+  # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
+  # from <tt>Riffer.config.skill_activate_tool</tt>.
   #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
   # activation tool.
@@ -155,7 +155,7 @@ class Riffer::Agent
     base = resolve_uses_tools_config(context)
     return base unless skills
 
-    skill_activate_tool_class = skills.skill_activate_tool || Riffer.config.skill_activate_tool
+    skill_activate_tool_class = skills.activate_tool || Riffer.config.skill_activate_tool
     if base.any? { |t| t.name == skill_activate_tool_class.name }
       raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
     end
@@ -800,7 +800,7 @@ class Riffer::Agent
 
     skills = skills_list.to_h { |s| [s.name, s] }
     adapter_class = self.class.skills.adapter || provider_class.skills_adapter
-    skill_activate_tool_class = self.class.skills.skill_activate_tool || Riffer.config.skill_activate_tool
+    skill_activate_tool_class = self.class.skills.activate_tool || Riffer.config.skill_activate_tool
 
     skills_context = Riffer::Skills::Context.new(
       backend: backend,

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -132,6 +132,46 @@ class Riffer::Agent
     @tools_config = tools_or_lambda
   end
 
+  # Returns the tool classes the LLM should see for this agent.
+  #
+  # Class-level companion to the instance #resolved_tools. Resolves the
+  # Proc form of +uses_tools+ and appends the skill activation tool when
+  # a +skills+ block is configured. Does not read the skills backend —
+  # the LLM-facing tool schema reflects class-level intent, not the
+  # runtime state of any backend.
+  #
+  # When +uses_tools+ is a Proc, +context+ is forwarded to it.
+  #
+  # The activation tool class is resolved from the agent's
+  # <tt>skills do; skill_activate_tool ...; end</tt> override when set,
+  # otherwise from <tt>Riffer.config.skill_activate_tool</tt>.
+  #
+  # Raises Riffer::ArgumentError on tool name conflicts with the skill
+  # activation tool.
+  #
+  #--
+  #: (?context: Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+  def self.resolved_tool_classes(context: nil)
+    base = resolve_uses_tools_config(context)
+    return base unless skills
+
+    skill_activate_tool_class = skills.skill_activate_tool || Riffer.config.skill_activate_tool
+    if base.any? { |t| t.name == skill_activate_tool_class.name }
+      raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
+    end
+    base + [skill_activate_tool_class]
+  end
+
+  #--
+  #: (Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+  def self.resolve_uses_tools_config(context)
+    config = uses_tools
+    return [] if config.nil?
+    return config unless config.is_a?(Proc)
+    config.arity.zero? ? config.call : config.call(context)
+  end
+  private_class_method :resolve_uses_tools_config
+
   # Gets or sets the tool runtime for this agent.
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,
@@ -717,25 +757,7 @@ class Riffer::Agent
   #--
   #: () -> Array[singleton(Riffer::Tool)]
   def resolved_tools
-    @resolved_tools ||= begin
-      config = self.class.uses_tools
-
-      tools = if config.nil?
-        []
-      elsif config.is_a?(Proc)
-        (config.arity == 0) ? config.call : config.call(@context)
-      else
-        config
-      end
-
-      if @skills_state
-        activate_tool = @skills_state.adapter.activate_tool
-        raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{activate_tool.name}" if tools.any? { |t| t.name == activate_tool.name }
-        tools + [activate_tool]
-      else
-        tools
-      end
-    end
+    @resolved_tools ||= self.class.resolved_tool_classes(context: @context)
   end
 
   #--
@@ -778,8 +800,13 @@ class Riffer::Agent
 
     skills = skills_list.to_h { |s| [s.name, s] }
     adapter_class = self.class.skills.adapter || provider_class.skills_adapter
+    skill_activate_tool_class = self.class.skills.skill_activate_tool || Riffer.config.skill_activate_tool
 
-    skills_context = Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: adapter_class.new)
+    skills_context = Riffer::Skills::Context.new(
+      backend: backend,
+      skills: skills,
+      adapter: adapter_class.new(skill_activate_tool: skill_activate_tool_class)
+    )
     ctx = (context || {}).merge(skills: skills_context)
 
     activate = self.class.skills.activate

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -24,7 +24,8 @@ class Riffer::Config
 
   # Skills-related global configuration.
   #
-  # See <tt>Riffer.config.skills.default_activate_tool</tt>.
+  # See <tt>Riffer.config.skills.default_activate_tool</tt> and
+  # <tt>Riffer.config.skills.default_backend</tt>.
   class Skills
     # Default skill activation tool class.
     #
@@ -33,10 +34,18 @@ class Riffer::Config
     # via <tt>skills do; activate_tool ...; end</tt>.
     attr_reader :default_activate_tool #: singleton(Riffer::Tool)
 
+    # Default skills backend.
+    #
+    # Used by agents that declare a +skills+ block without specifying a
+    # backend. Accepts a Riffer::Skills::Backend instance or a Proc.
+    # Defaults to +nil+ (no global default).
+    attr_reader :default_backend #: (Riffer::Skills::Backend | Proc)?
+
     #--
     #: () -> void
     def initialize
       @default_activate_tool = Riffer::Skills::ActivateTool
+      @default_backend = nil
     end
 
     # Sets the default skill activation tool class.
@@ -48,6 +57,19 @@ class Riffer::Config
     def default_activate_tool=(value)
       raise Riffer::ArgumentError, "default_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
       @default_activate_tool = value
+    end
+
+    # Sets the default skills backend.
+    #
+    # Raises +Riffer::ArgumentError+ if the value is not a
+    # Riffer::Skills::Backend instance, a Proc, or +nil+.
+    #
+    #--
+    #: ((Riffer::Skills::Backend | Proc)?) -> void
+    def default_backend=(value)
+      valid = value.nil? || value.is_a?(Riffer::Skills::Backend) || value.is_a?(Proc)
+      raise Riffer::ArgumentError, "default_backend must be a Riffer::Skills::Backend instance, Proc, or nil" unless valid
+      @default_backend = value
     end
   end
 

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -61,6 +61,24 @@ class Riffer::Config
     @tool_runtime = value
   end
 
+  # Global skill activation tool class.
+  #
+  # The tool class the LLM calls to activate a skill. Defaults to
+  # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
+  # via <tt>skills do; activate_tool ...; end</tt>.
+  attr_reader :skill_activate_tool #: singleton(Riffer::Tool)
+
+  # Sets the global skill activation tool class.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
+  #
+  #--
+  #: (singleton(Riffer::Tool)) -> void
+  def skill_activate_tool=(value)
+    raise Riffer::ArgumentError, "skill_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
+    @skill_activate_tool = value
+  end
+
   # Strategy for auto-generating message ids. One of +:none+ (default, no id),
   # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).
   #
@@ -94,6 +112,7 @@ class Riffer::Config
     @openai = OpenAI.new
     @evals = Evals.new
     @tool_runtime = Riffer::ToolRuntime::Inline.new
+    @skill_activate_tool = Riffer::Skills::ActivateTool
     @message_id_strategy = :none
   end
 end

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -22,6 +22,35 @@ class Riffer::Config
   OpenAI = Struct.new(:api_key, keyword_init: true)
   Evals = Struct.new(:judge_model, keyword_init: true)
 
+  # Skills-related global configuration.
+  #
+  # See <tt>Riffer.config.skills.default_activate_tool</tt>.
+  class Skills
+    # Default skill activation tool class.
+    #
+    # The tool class the LLM calls to activate a skill. Defaults to
+    # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
+    # via <tt>skills do; activate_tool ...; end</tt>.
+    attr_reader :default_activate_tool #: singleton(Riffer::Tool)
+
+    #--
+    #: () -> void
+    def initialize
+      @default_activate_tool = Riffer::Skills::ActivateTool
+    end
+
+    # Sets the default skill activation tool class.
+    #
+    # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
+    #
+    #--
+    #: (singleton(Riffer::Tool)) -> void
+    def default_activate_tool=(value)
+      raise Riffer::ArgumentError, "default_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
+      @default_activate_tool = value
+    end
+  end
+
   VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
@@ -61,23 +90,9 @@ class Riffer::Config
     @tool_runtime = value
   end
 
-  # Global skill activation tool class.
-  #
-  # The tool class the LLM calls to activate a skill. Defaults to
-  # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
-  # via <tt>skills do; activate_tool ...; end</tt>.
-  attr_reader :skill_activate_tool #: singleton(Riffer::Tool)
-
-  # Sets the global skill activation tool class.
-  #
-  # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
-  #
-  #--
-  #: (singleton(Riffer::Tool)) -> void
-  def skill_activate_tool=(value)
-    raise Riffer::ArgumentError, "skill_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
-    @skill_activate_tool = value
-  end
+  # Skills-related global configuration. Returns a Riffer::Config::Skills
+  # object — see <tt>Riffer.config.skills.default_activate_tool</tt>.
+  attr_reader :skills #: Riffer::Config::Skills
 
   # Strategy for auto-generating message ids. One of +:none+ (default, no id),
   # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).
@@ -112,7 +127,7 @@ class Riffer::Config
     @openai = OpenAI.new
     @evals = Evals.new
     @tool_runtime = Riffer::ToolRuntime::Inline.new
-    @skill_activate_tool = Riffer::Skills::ActivateTool
+    @skills = Skills.new
     @message_id_strategy = :none
   end
 end

--- a/lib/riffer/skills/adapter.rb
+++ b/lib/riffer/skills/adapter.rb
@@ -3,16 +3,31 @@
 
 # Base class defining the interface for skill adapters.
 #
-# A skill adapter encapsulates the provider-specific behavior for skills:
-# how the skill catalog is rendered in the system prompt, and which tool
-# the LLM calls to activate a skill.
+# A skill adapter encapsulates the provider-specific catalog rendering for
+# skills — how the available-skills section appears in the system prompt.
 #
-# Subclass and override +render_catalog+ and optionally +activate_tool+
-# to customize behavior.
+# Subclass and override +render_catalog+. The activation tool is set at
+# construction time and is exposed via +#skill_activate_tool+ for use in
+# rendered output.
 #
 # See Riffer::Skills::MarkdownAdapter for the default implementation.
 # See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
 class Riffer::Skills::Adapter
+  # The activation tool class for this adapter.
+  attr_reader :skill_activate_tool #: singleton(Riffer::Tool)
+
+  # Creates a new adapter.
+  #
+  # [skill_activate_tool] the activation tool class — referenced by name
+  #                       in the rendered catalog so the LLM knows which
+  #                       tool to call.
+  #
+  #--
+  #: (skill_activate_tool: singleton(Riffer::Tool)) -> void
+  def initialize(skill_activate_tool:)
+    @skill_activate_tool = skill_activate_tool
+  end
+
   # Renders a skill catalog section for the system prompt.
   #
   # [skills] array of Frontmatter objects to render.
@@ -23,15 +38,5 @@ class Riffer::Skills::Adapter
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     raise NotImplementedError, "#{self.class} must implement #render_catalog"
-  end
-
-  # Returns the tool class used to activate skills.
-  #
-  # Override to provide a custom activation tool.
-  #
-  #--
-  #: () -> singleton(Riffer::Tool)
-  def activate_tool
-    Riffer::Skills::ActivateTool
   end
 end

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -19,7 +19,7 @@ class Riffer::Skills::Config
     @backend = nil
     @adapter = nil
     @activate = nil
-    @skill_activate_tool = nil
+    @activate_tool = nil
   end
 
   # Gets or sets the skills backend.
@@ -68,9 +68,9 @@ class Riffer::Skills::Config
   #
   #--
   #: (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
-  def skill_activate_tool(value = nil)
-    return @skill_activate_tool if value.nil?
-    raise Riffer::ArgumentError, "skill_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
-    @skill_activate_tool = value
+  def activate_tool(value = nil)
+    return @activate_tool if value.nil?
+    raise Riffer::ArgumentError, "activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
+    @activate_tool = value
   end
 end

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -63,7 +63,7 @@ class Riffer::Skills::Config
 
   # Gets or sets a per-agent override for the skill activation tool class.
   #
-  # When unset, falls back to <tt>Riffer.config.skill_activate_tool</tt>.
+  # When unset, falls back to <tt>Riffer.config.skills.default_activate_tool</tt>.
   # The override must be a subclass of Riffer::Tool.
   #
   #--

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -61,9 +61,13 @@ class Riffer::Skills::Config
     @activate = value
   end
 
-  # Gets or sets a per-agent override for the skill activation tool class.
+  # Gets or sets the per-agent override for the skill activation tool class.
   #
-  # When unset, falls back to <tt>Riffer.config.skills.default_activate_tool</tt>.
+  # Returns the configured override when set, or +nil+ when unset. The
+  # global fallback to <tt>Riffer.config.skills.default_activate_tool</tt>
+  # is applied by the agent at resolution time (see
+  # Riffer::Agent.resolved_tool_classes), not by this getter.
+  #
   # The override must be a subclass of Riffer::Tool.
   #
   #--

--- a/lib/riffer/skills/config.rb
+++ b/lib/riffer/skills/config.rb
@@ -19,6 +19,7 @@ class Riffer::Skills::Config
     @backend = nil
     @adapter = nil
     @activate = nil
+    @skill_activate_tool = nil
   end
 
   # Gets or sets the skills backend.
@@ -58,5 +59,18 @@ class Riffer::Skills::Config
   def activate(value = nil)
     return @activate if value.nil?
     @activate = value
+  end
+
+  # Gets or sets a per-agent override for the skill activation tool class.
+  #
+  # When unset, falls back to <tt>Riffer.config.skill_activate_tool</tt>.
+  # The override must be a subclass of Riffer::Tool.
+  #
+  #--
+  #: (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
+  def skill_activate_tool(value = nil)
+    return @skill_activate_tool if value.nil?
+    raise Riffer::ArgumentError, "skill_activate_tool must be a Riffer::Tool subclass" unless value.is_a?(Class) && value < Riffer::Tool
+    @skill_activate_tool = value
   end
 end

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -24,7 +24,8 @@ class Riffer::Skills::Context
   #
   # [backend] the skills backend for reading skill bodies.
   # [skills] skill catalog indexed by name.
-  # [adapter] the adapter used to render skill content.
+  # [adapter] the adapter used to render skill content. The adapter
+  #           carries the activation tool class via its initializer.
   #
   #--
   #: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void

--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -18,7 +18,7 @@ class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
     lines = []
     lines << "## Available Skills"
     lines << ""
-    lines << "When a user's request matches a skill description below, call the `#{activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
     lines << ""
     skills.each do |skill|
       lines << "- **#{skill.name}**: #{skill.description}"

--- a/lib/riffer/skills/xml_adapter.rb
+++ b/lib/riffer/skills/xml_adapter.rb
@@ -17,7 +17,7 @@ class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     lines = []
-    lines << "When a user's request matches a skill description below, call the `#{activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
     lines << ""
     lines << "<available_skills>"
     skills.each do |skill|

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -100,7 +100,7 @@ class Riffer::Agent
   #
   # The activation tool class is resolved from the agent's
   # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
-  # from <tt>Riffer.config.skill_activate_tool</tt>.
+  # from <tt>Riffer.config.skills.default_activate_tool</tt>.
   #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
   # activation tool.

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -88,6 +88,31 @@ class Riffer::Agent
   # : (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
   def self.uses_tools: (?(Array[singleton(Riffer::Tool)] | Proc)?) -> (Array[singleton(Riffer::Tool)] | Proc)?
 
+  # Returns the tool classes the LLM should see for this agent.
+  #
+  # Class-level companion to the instance #resolved_tools. Resolves the
+  # Proc form of +uses_tools+ and appends the skill activation tool when
+  # a +skills+ block is configured. Does not read the skills backend —
+  # the LLM-facing tool schema reflects class-level intent, not the
+  # runtime state of any backend.
+  #
+  # When +uses_tools+ is a Proc, +context+ is forwarded to it.
+  #
+  # The activation tool class is resolved from the agent's
+  # <tt>skills do; skill_activate_tool ...; end</tt> override when set,
+  # otherwise from <tt>Riffer.config.skill_activate_tool</tt>.
+  #
+  # Raises Riffer::ArgumentError on tool name conflicts with the skill
+  # activation tool.
+  #
+  # --
+  # : (?context: Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+  def self.resolved_tool_classes: (?context: Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+
+  # --
+  # : (Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+  def self.resolve_uses_tools_config: (Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
+
   # Gets or sets the tool runtime for this agent.
   #
   # Accepts a Riffer::ToolRuntime subclass, a Riffer::ToolRuntime instance,

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -99,8 +99,8 @@ class Riffer::Agent
   # When +uses_tools+ is a Proc, +context+ is forwarded to it.
   #
   # The activation tool class is resolved from the agent's
-  # <tt>skills do; skill_activate_tool ...; end</tt> override when set,
-  # otherwise from <tt>Riffer.config.skill_activate_tool</tt>.
+  # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
+  # from <tt>Riffer.config.skill_activate_tool</tt>.
   #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
   # activation tool.

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -63,6 +63,30 @@ class Riffer::Config
                 | ({ ?judge_model: untyped }) -> instance
   end
 
+  # Skills-related global configuration.
+  #
+  # See <tt>Riffer.config.skills.default_activate_tool</tt>.
+  class Skills
+    # Default skill activation tool class.
+    #
+    # The tool class the LLM calls to activate a skill. Defaults to
+    # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
+    # via <tt>skills do; activate_tool ...; end</tt>.
+    attr_reader default_activate_tool: singleton(Riffer::Tool)
+
+    # --
+    # : () -> void
+    def initialize: () -> void
+
+    # Sets the default skill activation tool class.
+    #
+    # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
+    #
+    # --
+    # : (singleton(Riffer::Tool)) -> void
+    def default_activate_tool=: (singleton(Riffer::Tool)) -> void
+  end
+
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
@@ -98,20 +122,9 @@ class Riffer::Config
   # : ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc) -> void
 
-  # Global skill activation tool class.
-  #
-  # The tool class the LLM calls to activate a skill. Defaults to
-  # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
-  # via <tt>skills do; activate_tool ...; end</tt>.
-  attr_reader skill_activate_tool: singleton(Riffer::Tool)
-
-  # Sets the global skill activation tool class.
-  #
-  # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
-  #
-  # --
-  # : (singleton(Riffer::Tool)) -> void
-  def skill_activate_tool=: (singleton(Riffer::Tool)) -> void
+  # Skills-related global configuration. Returns a Riffer::Config::Skills
+  # object — see <tt>Riffer.config.skills.default_activate_tool</tt>.
+  attr_reader skills: Riffer::Config::Skills
 
   # Strategy for auto-generating message ids. One of +:none+ (default, no id),
   # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -98,6 +98,21 @@ class Riffer::Config
   # : ((singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc)) -> void
   def tool_runtime=: (singleton(Riffer::ToolRuntime) | Riffer::ToolRuntime | Proc) -> void
 
+  # Global skill activation tool class.
+  #
+  # The tool class the LLM calls to activate a skill. Defaults to
+  # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
+  # via <tt>skills do; activate_tool ...; end</tt>.
+  attr_reader skill_activate_tool: singleton(Riffer::Tool)
+
+  # Sets the global skill activation tool class.
+  #
+  # Raises +Riffer::ArgumentError+ if the value is not a Riffer::Tool subclass.
+  #
+  # --
+  # : (singleton(Riffer::Tool)) -> void
+  def skill_activate_tool=: (singleton(Riffer::Tool)) -> void
+
   # Strategy for auto-generating message ids. One of +:none+ (default, no id),
   # +:uuid+ (UUIDv4), or +:uuidv7+ (time-ordered UUIDv7).
   #

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -65,7 +65,8 @@ class Riffer::Config
 
   # Skills-related global configuration.
   #
-  # See <tt>Riffer.config.skills.default_activate_tool</tt>.
+  # See <tt>Riffer.config.skills.default_activate_tool</tt> and
+  # <tt>Riffer.config.skills.default_backend</tt>.
   class Skills
     # Default skill activation tool class.
     #
@@ -73,6 +74,13 @@ class Riffer::Config
     # <tt>Riffer::Skills::ActivateTool</tt>. Per-agent override is available
     # via <tt>skills do; activate_tool ...; end</tt>.
     attr_reader default_activate_tool: singleton(Riffer::Tool)
+
+    # Default skills backend.
+    #
+    # Used by agents that declare a +skills+ block without specifying a
+    # backend. Accepts a Riffer::Skills::Backend instance or a Proc.
+    # Defaults to +nil+ (no global default).
+    attr_reader default_backend: (Riffer::Skills::Backend | Proc)?
 
     # --
     # : () -> void
@@ -85,6 +93,15 @@ class Riffer::Config
     # --
     # : (singleton(Riffer::Tool)) -> void
     def default_activate_tool=: (singleton(Riffer::Tool)) -> void
+
+    # Sets the default skills backend.
+    #
+    # Raises +Riffer::ArgumentError+ if the value is not a
+    # Riffer::Skills::Backend instance, a Proc, or +nil+.
+    #
+    # --
+    # : ((Riffer::Skills::Backend | Proc)?) -> void
+    def default_backend=: ((Riffer::Skills::Backend | Proc)?) -> void
   end
 
   VALID_MESSAGE_ID_STRATEGIES: untyped

--- a/sig/generated/riffer/skills/adapter.rbs
+++ b/sig/generated/riffer/skills/adapter.rbs
@@ -2,16 +2,29 @@
 
 # Base class defining the interface for skill adapters.
 #
-# A skill adapter encapsulates the provider-specific behavior for skills:
-# how the skill catalog is rendered in the system prompt, and which tool
-# the LLM calls to activate a skill.
+# A skill adapter encapsulates the provider-specific catalog rendering for
+# skills — how the available-skills section appears in the system prompt.
 #
-# Subclass and override +render_catalog+ and optionally +activate_tool+
-# to customize behavior.
+# Subclass and override +render_catalog+. The activation tool is set at
+# construction time and is exposed via +#skill_activate_tool+ for use in
+# rendered output.
 #
 # See Riffer::Skills::MarkdownAdapter for the default implementation.
 # See Riffer::Skills::XmlAdapter for the Anthropic/Claude variant.
 class Riffer::Skills::Adapter
+  # The activation tool class for this adapter.
+  attr_reader skill_activate_tool: singleton(Riffer::Tool)
+
+  # Creates a new adapter.
+  #
+  # [skill_activate_tool] the activation tool class — referenced by name
+  #                       in the rendered catalog so the LLM knows which
+  #                       tool to call.
+  #
+  # --
+  # : (skill_activate_tool: singleton(Riffer::Tool)) -> void
+  def initialize: (skill_activate_tool: singleton(Riffer::Tool)) -> void
+
   # Renders a skill catalog section for the system prompt.
   #
   # [skills] array of Frontmatter objects to render.
@@ -21,12 +34,4 @@ class Riffer::Skills::Adapter
   # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
-
-  # Returns the tool class used to activate skills.
-  #
-  # Override to provide a custom activation tool.
-  #
-  # --
-  # : () -> singleton(Riffer::Tool)
-  def activate_tool: () -> singleton(Riffer::Tool)
 end

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -48,7 +48,7 @@ class Riffer::Skills::Config
 
   # Gets or sets a per-agent override for the skill activation tool class.
   #
-  # When unset, falls back to <tt>Riffer.config.skill_activate_tool</tt>.
+  # When unset, falls back to <tt>Riffer.config.skills.default_activate_tool</tt>.
   # The override must be a subclass of Riffer::Tool.
   #
   # --

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -45,4 +45,13 @@ class Riffer::Skills::Config
   # --
   # : (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
   def activate: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
+
+  # Gets or sets a per-agent override for the skill activation tool class.
+  #
+  # When unset, falls back to <tt>Riffer.config.skill_activate_tool</tt>.
+  # The override must be a subclass of Riffer::Tool.
+  #
+  # --
+  # : (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
+  def skill_activate_tool: (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
 end

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -53,5 +53,5 @@ class Riffer::Skills::Config
   #
   # --
   # : (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
-  def skill_activate_tool: (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
+  def activate_tool: (?singleton(Riffer::Tool)?) -> singleton(Riffer::Tool)?
 end

--- a/sig/generated/riffer/skills/config.rbs
+++ b/sig/generated/riffer/skills/config.rbs
@@ -46,9 +46,13 @@ class Riffer::Skills::Config
   # : (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
   def activate: (?(Array[String] | Proc)?) -> (Array[String] | Proc)?
 
-  # Gets or sets a per-agent override for the skill activation tool class.
+  # Gets or sets the per-agent override for the skill activation tool class.
   #
-  # When unset, falls back to <tt>Riffer.config.skills.default_activate_tool</tt>.
+  # Returns the configured override when set, or +nil+ when unset. The
+  # global fallback to <tt>Riffer.config.skills.default_activate_tool</tt>
+  # is applied by the agent at resolution time (see
+  # Riffer::Agent.resolved_tool_classes), not by this getter.
+  #
   # The override must be a subclass of Riffer::Tool.
   #
   # --

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -23,7 +23,8 @@ class Riffer::Skills::Context
   #
   # [backend] the skills backend for reading skill bodies.
   # [skills] skill catalog indexed by name.
-  # [adapter] the adapter used to render skill content.
+  # [adapter] the adapter used to render skill content. The adapter
+  #           carries the activation tool class via its initializer.
   #
   # --
   # : (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void

--- a/test/riffer/skills/activate_tool_test.rb
+++ b/test/riffer/skills/activate_tool_test.rb
@@ -6,7 +6,7 @@ describe Riffer::Skills::ActivateTool do
   let(:fixtures_path) { File.expand_path("../../../fixtures/skills", __FILE__) }
   let(:backend) { Riffer::Skills::FilesystemBackend.new(fixtures_path) }
   let(:skills) { backend.list_skills.to_h { |s| [s.name, s] } }
-  let(:skills_context) { Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: Riffer::Skills::MarkdownAdapter.new) }
+  let(:skills_context) { Riffer::Skills::Context.new(backend: backend, skills: skills, adapter: Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool)) }
   let(:context) { {skills: skills_context} }
 
   describe "#call" do

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -187,6 +187,55 @@ describe "Agent skills integration" do
         assert_nil system_message
       end
     end
+
+    it "falls back to Riffer.config.skills.default_backend when agent has no per-agent backend" do
+      original_default = Riffer.config.skills.default_backend
+      Riffer.config.skills.default_backend = Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          # no per-agent backend; should pick up the global default
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      skills_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
+      refute_nil skills_message
+      assert_includes skills_message.content, "code-review"
+    ensure
+      Riffer.config.skills.default_backend = original_default
+    end
+
+    it "per-agent backend takes precedence over default_backend" do
+      original_default = Riffer.config.skills.default_backend
+      decoy_backend = Class.new(Riffer::Skills::Backend) do
+        def list_skills
+          raise "default_backend should not be consulted when agent has its own"
+        end
+
+        def read_skill(name)
+        end
+      end.new
+      Riffer.config.skills.default_backend = decoy_backend
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      skills_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
+      refute_nil skills_message
+    ensure
+      Riffer.config.skills.default_backend = original_default
+    end
   end
 
   describe ".resolved_tool_classes" do

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -228,7 +228,7 @@ describe "Agent skills integration" do
       assert_includes tool_names, "skill_activate"
     end
 
-    it "uses the per-agent skill_activate_tool override" do
+    it "uses the per-agent activate_tool override" do
       custom = Class.new(Riffer::Tool) do
         identifier "my_activate"
         description "Custom"
@@ -241,7 +241,7 @@ describe "Agent skills integration" do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
-          skill_activate_tool custom
+          activate_tool custom
         end
       end
 

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -189,6 +189,89 @@ describe "Agent skills integration" do
     end
   end
 
+  describe ".resolved_tool_classes" do
+    it "returns uses_tools when no skills configured" do
+      tool_class = Class.new(Riffer::Tool) do
+        identifier "my_tool"
+        description "A tool"
+        def call(context:)
+          text("ok")
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tool_class]
+      end
+
+      assert_equal ["my_tool"], agent_class.resolved_tool_classes.map(&:name)
+    end
+
+    it "appends skill_activate when skills block is configured, without reading the backend" do
+      backend_class = Class.new(Riffer::Skills::Backend) do
+        def list_skills
+          raise "list_skills should not be called from class-level resolution"
+        end
+
+        def read_skill(name)
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend backend_class.new
+        end
+      end
+
+      tool_names = agent_class.resolved_tool_classes.map(&:name)
+      assert_includes tool_names, "skill_activate"
+    end
+
+    it "uses the per-agent skill_activate_tool override" do
+      custom = Class.new(Riffer::Tool) do
+        identifier "my_activate"
+        description "Custom"
+        def call(context:)
+          text("ok")
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          skill_activate_tool custom
+        end
+      end
+
+      tool_names = agent_class.resolved_tool_classes.map(&:name)
+      assert_includes tool_names, "my_activate"
+      refute_includes tool_names, "skill_activate"
+    end
+
+    it "raises on tool name conflict at class level" do
+      conflict_tool = Class.new(Riffer::Tool) do
+        identifier "skill_activate"
+        description "Conflicts"
+        def call(context:)
+          text("ok")
+        end
+      end
+
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [conflict_tool]
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      error = assert_raises(Riffer::ArgumentError) { agent_class.resolved_tool_classes }
+      assert_match(/Tool name conflict/, error.message)
+    end
+  end
+
   describe "activated skills" do
     it "appends activated skill bodies to skills system message" do
       agent_class = Class.new(Riffer::Agent) do

--- a/test/riffer/skills/markdown_adapter_test.rb
+++ b/test/riffer/skills/markdown_adapter_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 describe Riffer::Skills::MarkdownAdapter do
-  let(:adapter) { Riffer::Skills::MarkdownAdapter.new }
+  let(:adapter) { Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool) }
   let(:skills) do
     [
       Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code for quality."),
@@ -18,6 +18,19 @@ describe Riffer::Skills::MarkdownAdapter do
       assert_includes output, "skill_activate"
       assert_includes output, "- **code-review**: Reviews code for quality."
       assert_includes output, "- **data-analysis**: Analyzes datasets."
+    end
+
+    it "uses the configured skill_activate_tool name in the prompt" do
+      custom = Class.new(Riffer::Tool) do
+        identifier "custom_activate"
+        description "Custom"
+        def call(context:)
+          text("ok")
+        end
+      end
+      custom_adapter = Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: custom)
+      output = custom_adapter.render_catalog(skills)
+      assert_includes output, "`custom_activate`"
     end
   end
 end

--- a/test/riffer/skills/xml_adapter_test.rb
+++ b/test/riffer/skills/xml_adapter_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 describe Riffer::Skills::XmlAdapter do
-  let(:adapter) { Riffer::Skills::XmlAdapter.new }
+  let(:adapter) { Riffer::Skills::XmlAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool) }
   let(:skills) do
     [
       Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code for quality."),
@@ -26,6 +26,19 @@ describe Riffer::Skills::XmlAdapter do
       skill = Riffer::Skills::Frontmatter.new(name: "compare", description: "Compares A & B using <templates>")
       output = adapter.render_catalog([skill])
       assert_includes output, "<description>Compares A &amp; B using &lt;templates&gt;</description>"
+    end
+
+    it "uses the configured skill_activate_tool name in the prompt" do
+      custom = Class.new(Riffer::Tool) do
+        identifier "custom_activate"
+        description "Custom"
+        def call(context:)
+          text("ok")
+        end
+      end
+      custom_adapter = Riffer::Skills::XmlAdapter.new(skill_activate_tool: custom)
+      output = custom_adapter.render_catalog(skills)
+      assert_includes output, "`custom_activate`"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Adds `Riffer::Agent.resolved_tool_classes(context:)` — class-level companion to instance `#resolved_tools` that resolves the LLM-facing tool list without hitting the skills backend or running `prepare_run`. Lets callers compute the tool schema for an agent without instantiating it.
- Lifts the activation tool out of the adapter into global config (`Riffer.config.skill_activate_tool`) with a per-agent override inside the `skills` DSL (`skill_activate_tool MyTool`). Adapters now own only catalog rendering — the part that's actually provider-specific.
- Adapter takes `skill_activate_tool:` at construction; `render_catalog(skills)` is back to a single positional argument.
- Conflict check between agent tools and the activation tool moves out of `#resolved_tools` into the new class method, so it fires before the run loop instead of mid-call.

## Motivation

**Class-level tool resolution.** Out-of-process tool runtimes (e.g. Jane's Sidekiq runtime) need the LLM-facing tool list without instantiating the agent or paying for backend I/O. Today that requires duplicating the resolution logic in calling code (`compute_resolved_tool_classes`). This PR collapses that duplication: the call site becomes one line.

**Cleanly separating "which adapter" from "which activation tool".** The adapter selection is auto per-provider via `provider_class.skills_adapter` (Markdown for most, XML for Anthropic), with the existing per-agent override in the `skills` block. That behavior is preserved unchanged. The activation tool, by contrast, was speculatively coupled to the adapter — neither built-in adapter customizes it. Lifting the tool to global config matches how `tool_runtime` works (global default + per-agent override) and removes the need to re-derive the provider class just to find a default activation tool. Two orthogonal concerns that are now properly separated: adapter handles provider-specific catalog rendering; activation tool is a global concern that any agent can override per-instance.

## Breaking changes

- `Riffer::Skills::Adapter#activate_tool` removed. Configure via `Riffer.config.skill_activate_tool` or per-agent `skills do; skill_activate_tool MyTool; end`.
- `Riffer::Skills::Adapter#render_catalog(skills)` no longer takes an `activate_tool:` kwarg. The activation tool is set at construction: `Adapter.new(skill_activate_tool: ...)`. Custom adapters that override `#initialize` must call `super`.
- `Riffer::Skills::Context.new` no longer accepts a per-cycle activate tool — it lives on the adapter.

Both built-in adapters (`MarkdownAdapter`, `XmlAdapter`) inherit the new initializer; the agent passes the tool through automatically. Only downstream code that overrode `Adapter#activate_tool` or `#render_catalog`, or that constructed `Skills::Context` directly, needs updating.

The `bump-minor-pre-major` flag is added to release-please config in this PR so the breaking change bumps `0.24.x → 0.25.0` rather than `1.0.0`.

## Empty-skills-backend behavior (accepted trade-off)

`resolved_tool_classes` and instance `#resolved_tools` both delegate to the same logic — the tool list reflects class-level intent. When a `skills` block is configured but the backend yields no skills for this cycle (no `.skills/` directory, per-tenant skills with none for the current user, conditional Proc backend returning empty, etc.), the LLM still sees `skill_activate` in the schema even though there's no catalog in the system prompt.

Consequences:

- ~80 tokens/request for the tool definition.
- If the LLM calls it speculatively, the runtime guard in `Riffer::Skills::ActivateTool` returns `"Skills not configured"` — graceful error, recoverable in the loop.
- ~1 wasted round-trip per hallucinated call.

We accept this in favor of consistency between the class and instance views — earlier versions of this PR trimmed the activation tool at runtime when the backend was empty, but the divergence between "what `Agent.resolved_tool_classes` reports" and "what the run loop actually sends to the LLM" is worse than the modest token overhead. Downstream code that wants to filter the activation tool when its backend is empty can do so explicitly: `tool_classes.reject { |c| c == Riffer.config.skill_activate_tool }` — one line at the call site.

If this becomes a real source of pain, the right escape valve is probably an opt-in `read_backend: true` flag on the class method that does run the backend — not silent runtime divergence.

## Test plan

- [x] `bundle exec rake` passes (1282 runs, 1990 assertions, 0 failures, 0 errors)
- [x] `bundle exec rake standard` passes
- [x] `bundle exec steep check` passes
- [x] RBS regenerated (`bundle exec rake rbs:generate`)
- [x] New tests cover `.resolved_tool_classes`: behavior with/without a skills block, no-backend-I/O guarantee, per-agent activation tool override, class-level conflict raising
- [ ] Manual: integrate against Jane's `compute_resolved_tool_classes` and confirm the duplication collapses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide defaults for skill activation tool and skills backend, with per-agent overrides.
  * Class-level tool resolution updated to include skill activation tooling and detect name conflicts.

* **Documentation**
  * Expanded guidance for configuring default activation tool and backend, plus adapter usage examples.

* **Tests**
  * Expanded integration and adapter tests covering configurable activation tooling, backend fallbacks, and class-level resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->