### PR TITLE
feat: model-aware skills adapter selection

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -40,7 +40,7 @@ Adapters for LLM APIs. The base class uses a template-method pattern — `genera
 
 Providers are registered in `Riffer::Providers::Repository::REPO` with identifiers (e.g., `openai`, `amazon_bedrock`).
 
-Each provider declares a preferred skill adapter via `self.skills_adapter` (Markdown for most, XML for Anthropic).
+Each provider declares a preferred skill adapter via `self.skills_adapter(model = nil)`. Default is Markdown; Anthropic returns XML; Amazon Bedrock returns XML when the model identifier matches an Anthropic model (e.g. `anthropic.claude-…` or `us.anthropic.claude-…`); Mock returns XML when the model name contains `claude`. The agent passes the resolved model identifier so proxy providers (Bedrock, Mock) can pick the right adapter without per-agent overrides.
 
 ### Skills (`lib/riffer/skills/`)
 

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -70,7 +70,7 @@ end
 
 ### Custom Adapter
 
-The adapter controls how the skill catalog is rendered in the system prompt and which tool the LLM calls to activate a skill. The adapter is auto-selected by provider (Markdown for most, XML for Anthropic). Override with:
+The adapter controls how the skill catalog is rendered in the system prompt and which tool the LLM calls to activate a skill. The adapter is auto-selected by provider, with model-aware fallback for proxy providers — Markdown for most providers, XML for Anthropic, and XML for Anthropic models routed through Amazon Bedrock (e.g. `us.anthropic.claude-sonnet-4-6`). Override with:
 
 ```ruby
 skills do

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -799,7 +799,7 @@ class Riffer::Agent
     return nil if skills_list.empty?
 
     skills = skills_list.to_h { |s| [s.name, s] }
-    adapter_class = self.class.skills.adapter || provider_class.skills_adapter
+    adapter_class = self.class.skills.adapter || provider_class.skills_adapter(@model_name)
     skill_activate_tool_class = self.class.skills.activate_tool || Riffer.config.skills.default_activate_tool
 
     skills_context = Riffer::Skills::Context.new(

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -9,6 +9,24 @@ require "base64"
 #
 # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/BedrockRuntime/Client.html
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
+  # Matches Anthropic models on Bedrock: bare ids like
+  # +anthropic.claude-3-5-sonnet-20241022-v2:0+ and cross-region prefixed
+  # ids like +us.anthropic.claude-sonnet-4-6+.
+  ANTHROPIC_MODEL_PATTERN = /(?:^|\.)anthropic\./ #: Regexp
+
+  # Returns the preferred skill adapter for the given Bedrock model.
+  #
+  # Bedrock hosts models from multiple vendors. Anthropic models prefer
+  # XML-rendered catalogs; everything else falls back to the default
+  # Markdown adapter.
+  #
+  #--
+  #: (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter(model = nil)
+    return Riffer::Skills::XmlAdapter if model && ANTHROPIC_MODEL_PATTERN.match?(model)
+    Riffer::Skills::MarkdownAdapter
+  end
+
   # Initializes the Amazon Bedrock provider.
   #
   #--

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -12,8 +12,8 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   # Returns the XML skill adapter for Anthropic/Claude.
   #
   #--
-  #: () -> singleton(Riffer::Skills::Adapter)
-  def self.skills_adapter
+  #: (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter(model = nil)
     Riffer::Skills::XmlAdapter
   end
 

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -24,11 +24,15 @@ class Riffer::Providers::Base
 
   # Returns the preferred skill adapter for this provider.
   #
-  # Override in subclasses for provider-specific formats.
+  # Override in subclasses for provider-specific formats. Subclasses may
+  # introspect +model+ (the resolved model identifier, e.g. the part after
+  # +provider/+) to pick an adapter that matches the underlying model
+  # family — useful for proxy providers like Amazon Bedrock that host
+  # models from multiple vendors.
   #
   #--
-  #: () -> singleton(Riffer::Skills::Adapter)
-  def self.skills_adapter
+  #: (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter(model = nil)
     Riffer::Skills::MarkdownAdapter
   end
 

--- a/lib/riffer/providers/mock.rb
+++ b/lib/riffer/providers/mock.rb
@@ -5,6 +5,21 @@
 #
 # No external gems required.
 class Riffer::Providers::Mock < Riffer::Providers::Base
+  # Returns the preferred skill adapter for the given mock model.
+  #
+  # Mock is used to stand in for any real provider in tests, so the model
+  # string itself is the only signal we have. When the model name contains
+  # +claude+ (e.g. +mock/claude-sonnet-4-6+), pick the XML adapter to
+  # mirror what a real Claude-backed provider would do; otherwise fall
+  # back to Markdown.
+  #
+  #--
+  #: (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter(model = nil)
+    return Riffer::Skills::XmlAdapter if model&.include?("claude")
+    Riffer::Skills::MarkdownAdapter
+  end
+
   # Array of recorded method calls for assertions.
   attr_reader :calls #: Array[Hash[Symbol, untyped]]
 

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -6,6 +6,21 @@
 #
 # See https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/BedrockRuntime/Client.html
 class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
+  # Matches Anthropic models on Bedrock: bare ids like
+  # +anthropic.claude-3-5-sonnet-20241022-v2:0+ and cross-region prefixed
+  # ids like +us.anthropic.claude-sonnet-4-6+.
+  ANTHROPIC_MODEL_PATTERN: Regexp
+
+  # Returns the preferred skill adapter for the given Bedrock model.
+  #
+  # Bedrock hosts models from multiple vendors. Anthropic models prefer
+  # XML-rendered catalogs; everything else falls back to the default
+  # Markdown adapter.
+  #
+  # --
+  # : (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: (?String?) -> singleton(Riffer::Skills::Adapter)
+
   # Initializes the Amazon Bedrock provider.
   #
   # --

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -11,8 +11,8 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   # Returns the XML skill adapter for Anthropic/Claude.
   #
   # --
-  # : () -> singleton(Riffer::Skills::Adapter)
-  def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
+  # : (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: (?String?) -> singleton(Riffer::Skills::Adapter)
 
   # Initializes the Anthropic provider.
   #

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -22,11 +22,15 @@ class Riffer::Providers::Base
 
   # Returns the preferred skill adapter for this provider.
   #
-  # Override in subclasses for provider-specific formats.
+  # Override in subclasses for provider-specific formats. Subclasses may
+  # introspect +model+ (the resolved model identifier, e.g. the part after
+  # +provider/+) to pick an adapter that matches the underlying model
+  # family — useful for proxy providers like Amazon Bedrock that host
+  # models from multiple vendors.
   #
   # --
-  # : () -> singleton(Riffer::Skills::Adapter)
-  def self.skills_adapter: () -> singleton(Riffer::Skills::Adapter)
+  # : (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: (?String?) -> singleton(Riffer::Skills::Adapter)
 
   # Generates text using the provider.
   #

--- a/sig/generated/riffer/providers/mock.rbs
+++ b/sig/generated/riffer/providers/mock.rbs
@@ -4,6 +4,18 @@
 #
 # No external gems required.
 class Riffer::Providers::Mock < Riffer::Providers::Base
+  # Returns the preferred skill adapter for the given mock model.
+  #
+  # Mock is used to stand in for any real provider in tests, so the model
+  # string itself is the only signal we have. When the model name contains
+  # +claude+ (e.g. +mock/claude-sonnet-4-6+), pick the XML adapter to
+  # mirror what a real Claude-backed provider would do; otherwise fall
+  # back to Markdown.
+  #
+  # --
+  # : (?String?) -> singleton(Riffer::Skills::Adapter)
+  def self.skills_adapter: (?String?) -> singleton(Riffer::Skills::Adapter)
+
   # Array of recorded method calls for assertions.
   attr_reader calls: Array[Hash[Symbol, untyped]]
 

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -5,6 +5,44 @@ require "test_helper"
 describe Riffer::Providers::AmazonBedrock do
   let(:api_token) { ENV.fetch("AWS_BEDROCK_API_TOKEN", "test_api_token") }
 
+  describe ".skills_adapter" do
+    it "returns XmlAdapter for a bare anthropic.* model id" do
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("anthropic.claude-3-5-sonnet-20241022-v2:0")
+      expect(adapter).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns XmlAdapter for a cross-region us.anthropic.* model id" do
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("us.anthropic.claude-sonnet-4-6")
+      expect(adapter).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns XmlAdapter for a cross-region eu.anthropic.* model id" do
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+      expect(adapter).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns MarkdownAdapter for a non-Anthropic model id" do
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("us.amazon.nova-lite-v1:0")
+      expect(adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "returns MarkdownAdapter for a Meta model id" do
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("meta.llama3-70b-instruct-v1:0")
+      expect(adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "returns MarkdownAdapter when model is nil" do
+      expect(Riffer::Providers::AmazonBedrock.skills_adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "does not match a stray 'anthropic' substring without a dot boundary" do
+      # Guards against regex drift: a model id like "panthropic-..." must not
+      # be treated as Anthropic just because it contains the substring.
+      adapter = Riffer::Providers::AmazonBedrock.skills_adapter("panthropic-foo")
+      expect(adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+  end
+
   describe "#initialize" do
     it "creates Bedrock client with an api_token" do
       provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 describe Riffer::Providers::Anthropic do
   let(:api_key) { ENV.fetch("ANTHROPIC_API_KEY", "test_api_key") }
 
+  describe ".skills_adapter" do
+    it "returns XmlAdapter without a model" do
+      expect(Riffer::Providers::Anthropic.skills_adapter).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns XmlAdapter regardless of the model" do
+      expect(Riffer::Providers::Anthropic.skills_adapter("claude-sonnet-4-6")).must_equal Riffer::Skills::XmlAdapter
+    end
+  end
+
   describe "#initialize" do
     it "creates Anthropic client with an api_key" do
       provider = Riffer::Providers::Anthropic.new(api_key: api_key)

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -5,6 +5,16 @@ require "test_helper"
 describe Riffer::Providers::Base do
   let(:provider) { Riffer::Providers::Base.new }
 
+  describe ".skills_adapter" do
+    it "returns MarkdownAdapter by default" do
+      expect(Riffer::Providers::Base.skills_adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "ignores the model argument" do
+      expect(Riffer::Providers::Base.skills_adapter("anything/at-all")).must_equal Riffer::Skills::MarkdownAdapter
+    end
+  end
+
   describe "#generate_text" do
     it "raises NotImplementedError when hook methods not implemented" do
       error = expect { provider.generate_text(prompt: "Hello") }.must_raise(NotImplementedError)

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -5,6 +5,28 @@ require "test_helper"
 describe Riffer::Providers::Mock do
   let(:provider) { Riffer::Providers::Mock.new }
 
+  describe ".skills_adapter" do
+    it "returns XmlAdapter for a claude-* model name" do
+      expect(Riffer::Providers::Mock.skills_adapter("claude-sonnet-4-6")).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns XmlAdapter for a model name that contains claude" do
+      expect(Riffer::Providers::Mock.skills_adapter("us.anthropic.claude-haiku-4-5")).must_equal Riffer::Skills::XmlAdapter
+    end
+
+    it "returns MarkdownAdapter for a non-claude model name" do
+      expect(Riffer::Providers::Mock.skills_adapter("riffer-1")).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "returns MarkdownAdapter for a gpt-* model name" do
+      expect(Riffer::Providers::Mock.skills_adapter("gpt-4o-mini")).must_equal Riffer::Skills::MarkdownAdapter
+    end
+
+    it "returns MarkdownAdapter when model is nil" do
+      expect(Riffer::Providers::Mock.skills_adapter).must_equal Riffer::Skills::MarkdownAdapter
+    end
+  end
+
   describe "#initialize" do
     it "initializes calls to empty array" do
       expect(provider.calls).must_equal []

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -60,6 +60,77 @@ describe "Agent skills integration" do
       assert_includes skills_message.content, "<available_skills>"
     end
 
+    it "uses XML renderer for mock provider when the model name contains claude" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/claude-sonnet-4-6"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_message = system_messages.find { |m| m.content.include?("<available_skills>") }
+      refute_nil skills_message
+      assert_includes skills_message.content, "<available_skills>"
+    end
+
+    it "explicit adapter wins over model-aware default" do
+      # Mock with a "claude" model name would default to XML; explicit
+      # MarkdownAdapter must still take precedence.
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/claude-sonnet-4-6"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+          adapter Riffer::Skills::MarkdownAdapter
+        end
+      end
+
+      agent = agent_class.new
+      agent.generate("Hello")
+
+      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      skills_message = system_messages.find { |m| m.content.include?("Available Skills") }
+      refute_nil skills_message
+      assert_includes skills_message.content, "## Available Skills"
+    end
+
+    it "selects XmlAdapter for amazon_bedrock with an Anthropic model id" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "amazon_bedrock/us.anthropic.claude-sonnet-4-6"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      # prepare_run resolves the model and skills without instantiating
+      # the AWS client, so we can assert the adapter without VCR.
+      agent = agent_class.new
+      agent.send(:prepare_run)
+
+      skills_state = agent.instance_variable_get(:@skills_state)
+      refute_nil skills_state
+      assert_kind_of Riffer::Skills::XmlAdapter, skills_state.adapter
+    end
+
+    it "selects MarkdownAdapter for amazon_bedrock with a non-Anthropic model id" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "amazon_bedrock/us.amazon.nova-lite-v1:0"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.send(:prepare_run)
+
+      skills_state = agent.instance_variable_get(:@skills_state)
+      refute_nil skills_state
+      assert_kind_of Riffer::Skills::MarkdownAdapter, skills_state.adapter
+    end
+
     it "includes skill_activate tool in resolved tools" do
       agent_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"


### PR DESCRIPTION
## Summary

- Provider `skills_adapter` methods now accept an optional `model` arg so proxy providers can pick the right catalog format based on the underlying model family — non-breaking, since no-arg overrides keep working.
- `Riffer::Providers::AmazonBedrock.skills_adapter` returns `XmlAdapter` when the model id matches `/(?:^|\.)anthropic\./` (covers `anthropic.claude-…` and cross-region `us.anthropic.claude-…`); otherwise `MarkdownAdapter`.
- `Riffer::Providers::Mock.skills_adapter` returns `XmlAdapter` when the model name contains `claude`; otherwise `MarkdownAdapter`. Mock stands in for any real provider in tests, so the model name is the only available signal.
- `Riffer::Agent#resolve_skills` now passes the resolved model to `provider_class.skills_adapter`, so downstream consumers running Claude through Bedrock or Mock can drop their explicit `adapter Riffer::Skills::XmlAdapter` overrides.

## Why

Jane runs Claude through Bedrock in production (`amazon_bedrock/us.anthropic.claude-sonnet-4-6`) and through Mock in tests, but both providers inherit `MarkdownAdapter` from the base class. Claude prefers XML for skill catalogs, so every Jane agent has had to override `adapter` explicitly. This change makes the provider default correct for any Anthropic model regardless of who hosts it.

## Test plan

- [x] `bundle exec rake` (1304 runs, 0 failures, lint + Steep clean)
- [x] Unit tests for `.skills_adapter` on Base, Anthropic, AmazonBedrock, Mock — including a regex-drift guard (`panthropic-foo` must not match)
- [x] Agent-level integration tests for `mock/claude-…`, `amazon_bedrock/us.anthropic.claude-…`, `amazon_bedrock/us.amazon.nova-…`, and explicit `adapter` override still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved skill adapter selection to automatically detect model types and choose the appropriate format (XML for Anthropic models, Markdown for others).
  * Enhanced proxy provider support to intelligently route to the correct adapter based on the model identifier.

* **Documentation**
  * Updated architecture and skills documentation to explain model-aware adapter selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->