### PR TITLE
fix: close streaming HTTP connections when consumer raises

### DIFF
--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -152,28 +152,35 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     )
     current_state[:stream] = stream
 
-    stream.each do |event|
-      case event
-      when Anthropic::Models::RawContentBlockStartEvent
-        handle_raw_content_block_start(event, state: current_state)
-      when Anthropic::Models::RawContentBlockDeltaEvent
-        handle_raw_content_block_delta(event, state: current_state)
-      when Anthropic::Streaming::TextEvent
-        handle_text_event(event, state: current_state, yielder: yielder)
-      when Anthropic::Streaming::ThinkingEvent
-        handle_thinking_event(event, state: current_state, yielder: yielder)
-      when Anthropic::Streaming::InputJsonEvent
-        handle_input_json_event(event, state: current_state, yielder: yielder)
-      when Anthropic::Streaming::ContentBlockStopEvent
-        block_type = event.content_block&.type.to_s
-        handle_content_block_stop_text(event, state: current_state, yielder: yielder) if block_type == "text" && current_state[:text]
-        handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if block_type == "tool_use"
-        handle_content_block_stop_thinking(event, state: current_state, yielder: yielder) if block_type == "thinking" && current_state[:reasoning]
-        handle_content_block_stop_server_tool_use(event, state: current_state, yielder: yielder) if block_type == "server_tool_use"
-        handle_content_block_stop_web_search_result(event, state: current_state, yielder: yielder) if block_type == "web_search_tool_result"
-      when Anthropic::Streaming::MessageStopEvent
-        handle_message_stop(event, state: current_state, yielder: yielder)
+    begin
+      stream.each do |event|
+        case event
+        when Anthropic::Models::RawContentBlockStartEvent
+          handle_raw_content_block_start(event, state: current_state)
+        when Anthropic::Models::RawContentBlockDeltaEvent
+          handle_raw_content_block_delta(event, state: current_state)
+        when Anthropic::Streaming::TextEvent
+          handle_text_event(event, state: current_state, yielder: yielder)
+        when Anthropic::Streaming::ThinkingEvent
+          handle_thinking_event(event, state: current_state, yielder: yielder)
+        when Anthropic::Streaming::InputJsonEvent
+          handle_input_json_event(event, state: current_state, yielder: yielder)
+        when Anthropic::Streaming::ContentBlockStopEvent
+          block_type = event.content_block&.type.to_s
+          handle_content_block_stop_text(event, state: current_state, yielder: yielder) if block_type == "text" && current_state[:text]
+          handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if block_type == "tool_use"
+          handle_content_block_stop_thinking(event, state: current_state, yielder: yielder) if block_type == "thinking" && current_state[:reasoning]
+          handle_content_block_stop_server_tool_use(event, state: current_state, yielder: yielder) if block_type == "server_tool_use"
+          handle_content_block_stop_web_search_result(event, state: current_state, yielder: yielder) if block_type == "web_search_tool_result"
+        when Anthropic::Streaming::MessageStopEvent
+          handle_message_stop(event, state: current_state, yielder: yielder)
+        end
       end
+    ensure
+      # Anthropic SDK does not auto-close the underlying HTTP stream when
+      # iteration is interrupted (raise / fiber cancellation), so the SSE
+      # socket leaks until GC. close is idempotent and a no-op after EOF.
+      stream.close
     end
   end
 

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -150,7 +150,6 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       **params,
       request_options: {extra_headers: {"accept-encoding" => "identity"}}
     )
-    current_state[:stream] = stream
 
     begin
       stream.each do |event|
@@ -173,7 +172,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
           handle_content_block_stop_server_tool_use(event, state: current_state, yielder: yielder) if block_type == "server_tool_use"
           handle_content_block_stop_web_search_result(event, state: current_state, yielder: yielder) if block_type == "web_search_tool_result"
         when Anthropic::Streaming::MessageStopEvent
-          handle_message_stop(event, state: current_state, yielder: yielder)
+          handle_message_stop(event, accumulated_message: stream.accumulated_message, yielder: yielder)
         end
       end
     ensure
@@ -287,20 +286,19 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   end
 
   #--
-  #: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
-  def handle_message_stop(_event, state:, yielder:)
-    final_message = state[:stream].accumulated_message
-    if final_message&.usage
-      usage = final_message.usage
-      yielder << Riffer::StreamEvents::TokenUsageDone.new(
-        token_usage: Riffer::TokenUsage.new(
-          input_tokens: usage.input_tokens,
-          output_tokens: usage.output_tokens,
-          cache_creation_tokens: usage.cache_creation_input_tokens,
-          cache_read_tokens: usage.cache_read_input_tokens
-        )
+  #: (untyped, accumulated_message: Anthropic::Models::Message?, yielder: Enumerator::Yielder) -> void
+  def handle_message_stop(_event, accumulated_message:, yielder:)
+    usage = accumulated_message&.usage
+    return unless usage
+
+    yielder << Riffer::StreamEvents::TokenUsageDone.new(
+      token_usage: Riffer::TokenUsage.new(
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens
       )
-    end
+    )
   end
 
   #--

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -124,33 +124,40 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     }
 
     stream = @client.responses.stream(params)
-    stream.each do |event|
-      case event.type
-      when :"response.output_item.added"
-        handle_output_item_added_function_call(event, state: current_state, yielder: yielder) if event.item&.type == :function_call
-      when :"response.output_text.delta"
-        handle_output_text_delta(event, state: current_state, yielder: yielder)
-      when :"response.output_text.done"
-        handle_output_text_done(event, state: current_state, yielder: yielder)
-      when :"response.reasoning_summary_text.delta"
-        handle_reasoning_summary_text_delta(event, state: current_state, yielder: yielder)
-      when :"response.reasoning_summary_text.done"
-        handle_reasoning_summary_text_done(event, state: current_state, yielder: yielder)
-      when :"response.function_call_arguments.delta"
-        handle_function_call_arguments_delta(event, state: current_state, yielder: yielder)
-      when :"response.function_call_arguments.done"
-        handle_function_call_arguments_done(event, state: current_state, yielder: yielder)
-      when :"response.web_search_call.in_progress"
-        handle_web_search_status(event, status: "in_progress", yielder: yielder)
-      when :"response.web_search_call.searching"
-        handle_web_search_status(event, status: "searching", yielder: yielder)
-      when :"response.web_search_call.completed"
-        handle_web_search_status(event, status: "completed", yielder: yielder)
-      when :"response.output_item.done"
-        handle_output_item_done_web_search(event, yielder: yielder) if event.item&.type == :web_search_call
-      when :"response.completed"
-        handle_response_completed(event, state: current_state, yielder: yielder)
+    begin
+      stream.each do |event|
+        case event.type
+        when :"response.output_item.added"
+          handle_output_item_added_function_call(event, state: current_state, yielder: yielder) if event.item&.type == :function_call
+        when :"response.output_text.delta"
+          handle_output_text_delta(event, state: current_state, yielder: yielder)
+        when :"response.output_text.done"
+          handle_output_text_done(event, state: current_state, yielder: yielder)
+        when :"response.reasoning_summary_text.delta"
+          handle_reasoning_summary_text_delta(event, state: current_state, yielder: yielder)
+        when :"response.reasoning_summary_text.done"
+          handle_reasoning_summary_text_done(event, state: current_state, yielder: yielder)
+        when :"response.function_call_arguments.delta"
+          handle_function_call_arguments_delta(event, state: current_state, yielder: yielder)
+        when :"response.function_call_arguments.done"
+          handle_function_call_arguments_done(event, state: current_state, yielder: yielder)
+        when :"response.web_search_call.in_progress"
+          handle_web_search_status(event, status: "in_progress", yielder: yielder)
+        when :"response.web_search_call.searching"
+          handle_web_search_status(event, status: "searching", yielder: yielder)
+        when :"response.web_search_call.completed"
+          handle_web_search_status(event, status: "completed", yielder: yielder)
+        when :"response.output_item.done"
+          handle_output_item_done_web_search(event, yielder: yielder) if event.item&.type == :web_search_call
+        when :"response.completed"
+          handle_response_completed(event, state: current_state, yielder: yielder)
+        end
       end
+    ensure
+      # OpenAI SDK does not auto-close the underlying HTTP stream when
+      # iteration is interrupted (raise / fiber cancellation), so the SSE
+      # socket leaks until GC. close is idempotent and a no-op after EOF.
+      stream.close
     end
   end
 

--- a/sig/generated/riffer/providers/anthropic.rbs
+++ b/sig/generated/riffer/providers/anthropic.rbs
@@ -87,8 +87,8 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
   def handle_content_block_stop_web_search_result: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
 
   # --
-  # : (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
-  def handle_message_stop: (untyped, state: Hash[Symbol, untyped], yielder: Enumerator::Yielder) -> void
+  # : (untyped, accumulated_message: Anthropic::Models::Message?, yielder: Enumerator::Yielder) -> void
+  def handle_message_stop: (untyped, accumulated_message: Anthropic::Models::Message?, yielder: Enumerator::Yielder) -> void
 
   # --
   # : (Array[Riffer::Messages::Base]) -> Hash[Symbol, untyped]

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -910,4 +910,40 @@ describe Riffer::Providers::Anthropic do
       end
     end
   end
+
+  describe "#stream_text resource cleanup" do
+    let(:provider) { Riffer::Providers::Anthropic.new(api_key: "test") }
+
+    def install_stream_double(provider, stream_double)
+      messages_double = Object.new
+      messages_double.define_singleton_method(:stream) { |**_kwargs| stream_double }
+      client_double = Object.new
+      client_double.define_singleton_method(:messages) { messages_double }
+      provider.instance_variable_set(:@client, client_double)
+    end
+
+    it "calls stream.close when iteration raises mid-stream" do
+      close_count = 0
+      stream_double = Object.new
+      stream_double.define_singleton_method(:each) { |&_block| raise "kaboom" }
+      stream_double.define_singleton_method(:close) { close_count += 1 }
+      install_stream_double(provider, stream_double)
+
+      assert_raises(RuntimeError) do
+        provider.stream_text(prompt: "Hi", model: "claude-haiku-4-5-20251001").to_a
+      end
+      expect(close_count).must_equal 1
+    end
+
+    it "calls stream.close exactly once on happy path" do
+      close_count = 0
+      stream_double = Object.new
+      stream_double.define_singleton_method(:each) { |&_block| }
+      stream_double.define_singleton_method(:close) { close_count += 1 }
+      install_stream_double(provider, stream_double)
+
+      provider.stream_text(prompt: "Hi", model: "claude-haiku-4-5-20251001").to_a
+      expect(close_count).must_equal 1
+    end
+  end
 end

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -1014,4 +1014,40 @@ describe Riffer::Providers::OpenAI do
       end
     end
   end
+
+  describe "#stream_text resource cleanup" do
+    let(:provider) { Riffer::Providers::OpenAI.new(api_key: "test") }
+
+    def install_stream_double(provider, stream_double)
+      responses_double = Object.new
+      responses_double.define_singleton_method(:stream) { |_params| stream_double }
+      client_double = Object.new
+      client_double.define_singleton_method(:responses) { responses_double }
+      provider.instance_variable_set(:@client, client_double)
+    end
+
+    it "calls stream.close when iteration raises mid-stream" do
+      close_count = 0
+      stream_double = Object.new
+      stream_double.define_singleton_method(:each) { |&_block| raise "kaboom" }
+      stream_double.define_singleton_method(:close) { close_count += 1 }
+      install_stream_double(provider, stream_double)
+
+      assert_raises(RuntimeError) do
+        provider.stream_text(prompt: "Hi", model: "gpt-5-mini").to_a
+      end
+      expect(close_count).must_equal 1
+    end
+
+    it "calls stream.close exactly once on happy path" do
+      close_count = 0
+      stream_double = Object.new
+      stream_double.define_singleton_method(:each) { |&_block| }
+      stream_double.define_singleton_method(:close) { close_count += 1 }
+      install_stream_double(provider, stream_double)
+
+      provider.stream_text(prompt: "Hi", model: "gpt-5-mini").to_a
+      expect(close_count).must_equal 1
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Anthropic and OpenAI streaming providers leak the underlying HTTP socket when the consumer fiber is cancelled or raises mid-stream. The SDKs both expose an idempotent `BaseStream#close` that fires the Net::HTTP cleanup path, but it is never invoked unless iteration completes naturally — so on `Async::Stop` or any handler raise, the producer fiber stays suspended and the socket sits in `CLOSE_WAIT` until GC. This was observed downstream in Maestro bench, with `CLOSE_WAITs` piling up against `api.anthropic.com`.

Wraps `stream.each` in `begin / ensure stream.close` for both providers. The SDK's `close` is documented (and verified) to be idempotent and a no-op after EOF.

### Provider matrix

| Provider | Status | Reason |
|---|---|---|
| **anthropic** | Fixed | SDK has `BaseStream#close` (idempotent, EOF-safe), no auto-close on raise. |
| **open_ai** | Fixed | Same `BaseStream` shape as Anthropic. |
| **azure_open_ai** | Fixed transitively | Inherits `execute_stream` from `OpenAI`. |
| **amazon_bedrock** | Already safe | Block-form `converse_stream(...) { |stream| ... }` is wrapped in Seahorse's `session_for` ensure (`session.finish` runs on raise). |
| **gemini** | Already safe | `Net::HTTP.start(...) { |http| ... }` runs `http.finish` in an ensure when the block exits. |
| **mock** | Skipped | No external resource. |

## Test plan

- [x] `bundle exec rake` (1308 runs, 0 failures, lint clean, steep clean)
- [x] New unit tests assert `stream.close` runs once when iteration raises mid-stream (Anthropic + OpenAI)
- [x] New unit tests assert `stream.close` runs exactly once on the happy path (no double-close after EOF)
- [x] No behavior change on happy path — same events delivered in same order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming connections to AI providers are now deterministically closed after use, both on normal completion and when errors or cancellations occur, preventing resource leaks.

* **Behavior**
  * Token usage is now reported only when available and emitted reliably at stream end, improving accuracy of usage reporting.

* **Tests**
  * Added tests to verify stream resources are closed exactly once across success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->