### PR TITLE
fix: validate tools before sending them to providers

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -834,9 +834,12 @@ class Riffer::Agent
 
   #: () -> Array[singleton(Riffer::Tool)]
   def resolved_tools
-    @resolved_tools ||= self.class.resolved_tool_classes(context: @context) + resolve_mcp_tool_classes
-    assert_distinct_tool_names!(@resolved_tools)
-    @resolved_tools
+    @resolved_tools ||= begin
+      tools = self.class.resolved_tool_classes(context: @context) + resolve_mcp_tool_classes
+      assert_distinct_tool_names!(tools)
+      tools.each(&:validate_as_tool!)
+      tools
+    end
   end
 
   #--

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3581,7 +3581,7 @@ describe Riffer::Agent do
     after { clear_mcp_registry! }
 
     let(:fake_tool_class) do
-      klass = Class.new(Riffer::Tool)
+      klass = Class.new(Riffer::Tool) { description "Fake MCP tool" }
       klass.instance_variable_set(:@identifier, "srv__mcp_tool")
       klass.define_singleton_method(:mcp_server_tool_name) { "mcp_tool" }
       klass
@@ -3606,7 +3606,10 @@ describe Riffer::Agent do
     end
 
     it "merges MCP tools with uses_tools tools" do
-      static_tool = Class.new(Riffer::Tool)
+      static_tool = Class.new(Riffer::Tool) {
+        identifier "static_tool"
+        description "Static tool"
+      }
       inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
       klass = Class.new(Riffer::Agent) do
@@ -3621,7 +3624,10 @@ describe Riffer::Agent do
     end
 
     it "raises ArgumentError when tools share the same name" do
-      static = Class.new(Riffer::Tool) { identifier "srv__mcp_tool" }
+      static = Class.new(Riffer::Tool) {
+        identifier "srv__mcp_tool"
+        description "Static tool"
+      }
       inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
       klass = Class.new(Riffer::Agent) do
@@ -3677,6 +3683,23 @@ describe Riffer::Agent do
       expect(tools.first.name).must_equal fake_tool_class.name
     ensure
       Riffer.config.mcp.credentials = prev
+    end
+  end
+
+  describe "#resolved_tools validation" do
+    it "raises when a tool is missing a description" do
+      bad_tool = Class.new(Riffer::Tool) { identifier "bad_tool" }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [bad_tool]
+      end
+
+      instance = klass.allocate
+      instance.instance_variable_set(:@context, nil)
+
+      err = expect { instance.send(:resolved_tools) }.must_raise Riffer::ArgumentError
+      expect(err.message).must_match(/must define a description/)
     end
   end
 end


### PR DESCRIPTION
## Summary

- `Riffer::Toolable#validate_as_tool!` existed but was never called outside its own tests, so tools with missing/empty `description` or `identifier` slipped through to provider calls.
- AWS Bedrock's Converse API rejects empty `toolSpec.description` with `Aws::BedrockRuntime::Errors::ValidationException`, surfacing as a cryptic Bedrock error far from the actual misconfiguration. Likely root cause of Sentry [MAESTRO-15](https://jane-app.sentry.io/issues/MAESTRO-15) — an MCP tool definition with a blank description was forwarded verbatim to Bedrock.
- `Riffer::Agent#resolved_tools` now invokes `validate_as_tool!` on every resolved tool class, so we fail with a clear `Riffer::ArgumentError` at the Riffer layer instead of relying on provider-side validation.

## Test plan

- [x] `bundle exec rake test`
- [x] `bundle exec rake standard`
- [x] Added regression test: agent raises `Riffer::ArgumentError` when a registered tool is missing a description.
- [ ] Confirm in Maestro that the underlying tool still needs a real description (the fix only changes *where* this fails — the tool itself is still misconfigured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tool validation to ensure all tools are properly configured with required properties before being used, preventing invalid tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->