### PR TITLE
fix: validate tools at the class-level resolution boundary

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -146,20 +146,30 @@ class Riffer::Agent
   # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
   # from <tt>Riffer.config.skills.default_activate_tool</tt>.
   #
+  # Each returned tool class is validated via +validate_as_tool!+, so
+  # callers serializing this list to a provider can rely on every entry
+  # having the metadata required for tool use (name + description).
+  #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
-  # activation tool.
+  # activation tool, or when a tool class fails +validate_as_tool!+.
   #
   #--
   #: (?context: Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]
   def self.resolved_tool_classes(context: nil)
     base = resolve_uses_tools_config(context)
-    return base unless skills
 
-    skill_activate_tool_class = skills.activate_tool || Riffer.config.skills.default_activate_tool
-    if base.any? { |t| t.name == skill_activate_tool_class.name }
-      raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
+    tools = if skills
+      skill_activate_tool_class = skills.activate_tool || Riffer.config.skills.default_activate_tool
+      if base.any? { |t| t.name == skill_activate_tool_class.name }
+        raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
+      end
+      base + [skill_activate_tool_class]
+    else
+      base
     end
-    base + [skill_activate_tool_class]
+
+    tools.each(&:validate_as_tool!)
+    tools
   end
 
   #--

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -102,8 +102,12 @@ class Riffer::Agent
   # <tt>skills do; activate_tool ...; end</tt> override when set, otherwise
   # from <tt>Riffer.config.skills.default_activate_tool</tt>.
   #
+  # Each returned tool class is validated via +validate_as_tool!+, so
+  # callers serializing this list to a provider can rely on every entry
+  # having the metadata required for tool use (name + description).
+  #
   # Raises Riffer::ArgumentError on tool name conflicts with the skill
-  # activation tool.
+  # activation tool, or when a tool class fails +validate_as_tool!+.
   #
   # --
   # : (?context: Hash[Symbol, untyped]?) -> Array[singleton(Riffer::Tool)]

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3701,5 +3701,70 @@ describe Riffer::Agent do
       err = expect { instance.send(:resolved_tools) }.must_raise Riffer::ArgumentError
       expect(err.message).must_match(/must define a description/)
     end
+
+    it "raises when an MCP tool is missing a description" do
+      bad_mcp_tool = Class.new(Riffer::Tool) { identifier "bad_mcp_tool" }
+
+      manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [:srv], endpoint: "https://x.com", discovery_headers: {})
+      reg = Riffer::Mcp::Registration.allocate
+      reg.instance_variable_set(:@manifest, manifest)
+      reg.instance_variable_set(:@tools, [bad_mcp_tool])
+      reg.instance_variable_set(:@mutex, Mutex.new)
+      store = Riffer::Mcp::Registry.instance_variable_get(:@store)
+      Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store["srv"] = reg }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        use_mcp :srv
+      end
+
+      instance = klass.allocate
+      instance.instance_variable_set(:@context, nil)
+
+      err = expect { instance.send(:resolved_tools) }.must_raise Riffer::ArgumentError
+      expect(err.message).must_match(/must define a description/)
+    ensure
+      clear_mcp_registry!
+    end
+  end
+
+  describe ".resolved_tool_classes validation" do
+    it "raises when a tool is missing a description" do
+      bad_tool = Class.new(Riffer::Tool) { identifier "bad_tool" }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [bad_tool]
+      end
+
+      err = expect { klass.resolved_tool_classes }.must_raise Riffer::ArgumentError
+      expect(err.message).must_match(/must define a description/)
+    end
+
+    it "raises when uses_tools is a Proc returning an invalid tool" do
+      bad_tool = Class.new(Riffer::Tool) { identifier "bad_tool" }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools ->(_ctx) { [bad_tool] }
+      end
+
+      err = expect { klass.resolved_tool_classes(context: {}) }.must_raise Riffer::ArgumentError
+      expect(err.message).must_match(/must define a description/)
+    end
+
+    it "returns valid tool classes unchanged" do
+      good_tool = Class.new(Riffer::Tool) {
+        identifier "good_tool"
+        description "Good tool"
+      }
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [good_tool]
+      end
+
+      expect(klass.resolved_tool_classes).must_equal [good_tool]
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Riffer::Agent.resolved_tool_classes` now calls `validate_as_tool!` on every tool class it returns, so callers that serialize tool definitions through the class method get the same validation guarantee that the instance `#resolved_tools` path has had since #240.
- The instance `#resolved_tools` keeps its own `validate_as_tool!` call. MCP tools are merged in on the instance side via `resolve_mcp_tool_classes` and aren't visible to the class method, so the instance-level pass is what covers them.
- Treats the library boundary as the contract: if Riffer hands a caller a tool list, those tools are valid.

## Why

#240 added validation only inside the instance method `Riffer::Agent#resolved_tools`. Consumers that reach for the class method `Riffer::Agent.resolved_tool_classes` to serialize tool definitions never trigger that validation, so a tool class with a blank description still reaches the provider and produces the original `ValidationException` the previous fix was meant to prevent.

## Tests

- New `.resolved_tool_classes validation` describe block covers:
  - tool with blank description raises `Riffer::ArgumentError`
  - `uses_tools` Proc returning an invalid tool raises
  - valid tool classes pass through unchanged
- New `#resolved_tools validation` test confirms MCP tools with blank descriptions still raise (no regression of the original PR #240 path).
- Existing `#resolved_tools validation` test from #240 still passes.

## Release / version

This repo uses release-please for version bumps and CHANGELOG updates, so I haven't bumped `lib/riffer/version.rb` or edited `CHANGELOG.md` here. The `fix:` commit prefix should trigger a 0.27.2 patch release PR after merge, matching how 0.27.1 shipped after #240. Happy to bump manually if that's preferred for this one.

## Test plan

- [x] `bundle exec rake test` (1389 runs, 0 failures)
- [x] `bundle exec rake standard` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tool validation to consistently validate all configured tools, ensuring invalid tools are properly detected regardless of configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->