### PR TITLE
feat: accept StructuredOutput on Agent.structured_output and add from_json_schema

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -163,7 +163,7 @@ end
 
 ### structured_output
 
-Configures the agent to return structured JSON responses conforming to a schema. Accepts a `Riffer::Params` instance or a block DSL:
+Configures the agent to return structured JSON responses conforming to a schema. Accepts a `Riffer::Params` instance, a `Riffer::StructuredOutput` instance, or a block DSL:
 
 ```ruby
 class SentimentAgent < Riffer::Agent
@@ -178,6 +178,21 @@ end
 ```
 
 The LLM response is automatically parsed and validated against the schema. Access the result via `response.structured_output`.
+
+#### From a pre-built JSON Schema
+
+When the schema is generated externally (e.g. exported from another tool or loaded from disk), use `Riffer::StructuredOutput.from_json_schema` to skip the Params DSL:
+
+```ruby
+schema = JSON.parse(File.read("sentiment.schema.json"), symbolize_names: true)
+
+class SentimentAgent < Riffer::Agent
+  model 'openai/gpt-5-mini'
+  structured_output Riffer::StructuredOutput.from_json_schema(schema)
+end
+```
+
+The schema is forwarded verbatim to the provider — no client-side validation runs against it, since the provider enforces the schema server-side. JSON parse errors on the response are still surfaced via `response.structured_output` being `nil`.
 
 #### Nested Objects
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -95,19 +95,24 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Riffer::Params instance or a block evaluated against a new Params.
+  # Accepts a Riffer::Params instance, a Riffer::StructuredOutput instance,
+  # or a block evaluated against a new Params. Use
+  # +Riffer::StructuredOutput.from_json_schema+ to pass a pre-built JSON Schema
+  # without going through the Params DSL.
   #
   #--
-  #: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
-  def self.structured_output(params = nil, &block)
+  #: (?(Riffer::Params | Riffer::StructuredOutput)?) ?{ () -> void } -> (Riffer::Params | Riffer::StructuredOutput)?
+  def self.structured_output(value = nil, &block)
     if block
       @structured_output = Riffer::Params.new
       @structured_output.instance_eval(&block)
-    elsif params.nil?
+    elsif value.nil?
       @structured_output
     else
-      raise Riffer::ArgumentError, "structured_output must be a Riffer::Params" unless params.is_a?(Riffer::Params)
-      @structured_output = params
+      unless value.is_a?(Riffer::Params) || value.is_a?(Riffer::StructuredOutput)
+        raise Riffer::ArgumentError, "structured_output must be a Riffer::Params or Riffer::StructuredOutput"
+      end
+      @structured_output = value
     end
   end
 
@@ -965,8 +970,12 @@ class Riffer::Agent
   #--
   #: () -> Riffer::StructuredOutput?
   def resolve_structured_output
-    params = self.class.structured_output
-    params ? Riffer::StructuredOutput.new(params) : nil
+    value = self.class.structured_output
+    case value
+    when nil then nil
+    when Riffer::StructuredOutput then value
+    else Riffer::StructuredOutput.new(value)
+    end
   end
 
   #--

--- a/lib/riffer/structured_output.rb
+++ b/lib/riffer/structured_output.rb
@@ -21,6 +21,29 @@ class Riffer::StructuredOutput
     @params = params
   end
 
+  # Builds a StructuredOutput from a pre-built JSON Schema, bypassing the
+  # Params DSL.
+  #
+  # Useful when the schema is generated externally (e.g. from a Pydantic-style
+  # model, dumped JSON, or another tool). The returned object exposes the same
+  # +json_schema+ and +parse_and_validate+ surface as a Params-backed
+  # StructuredOutput. Client-side validation only checks that the LLM produced
+  # parseable JSON whose top level is an object — schema enforcement is left
+  # to the LLM provider, which receives the raw schema verbatim.
+  #
+  #   schema = JSON.parse(File.read("sentiment.schema.json"), symbolize_names: true)
+  #   so = Riffer::StructuredOutput.from_json_schema(schema)
+  #   class SentimentAgent < Riffer::Agent
+  #     model "openai/gpt-5-mini"
+  #     structured_output so
+  #   end
+  #
+  #--
+  #: (Hash[Symbol, untyped]) -> Riffer::StructuredOutput
+  def self.from_json_schema(schema)
+    new(RawJsonSchema.new(schema))
+  end
+
   # Returns the JSON Schema for this structured output.
   #
   #--
@@ -44,4 +67,31 @@ class Riffer::StructuredOutput
   rescue Riffer::ValidationError => e
     Result.new(error: "Validation error: #{e.message}")
   end
+
+  # Adapter used by StructuredOutput.from_json_schema to make a raw JSON
+  # Schema look like a Riffer::Params for the two methods StructuredOutput
+  # calls on it. Validation is intentionally a pass-through: the LLM provider
+  # already enforces the schema server-side, and bringing in a JSON Schema
+  # validator on the client would be a heavier dependency than this entry
+  # point warrants.
+  class RawJsonSchema
+    #--
+    #: (Hash[Symbol, untyped]) -> void
+    def initialize(schema)
+      @schema = schema
+    end
+
+    #--
+    #: (?strict: bool) -> Hash[Symbol, untyped]
+    def to_json_schema(strict: false)
+      @schema
+    end
+
+    #--
+    #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+    def validate(arguments)
+      arguments
+    end
+  end
+  private_constant :RawJsonSchema
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -67,11 +67,14 @@ class Riffer::Agent
 
   # Gets or sets the structured output schema for this agent.
   #
-  # Accepts a Riffer::Params instance or a block evaluated against a new Params.
+  # Accepts a Riffer::Params instance, a Riffer::StructuredOutput instance,
+  # or a block evaluated against a new Params. Use
+  # +Riffer::StructuredOutput.from_json_schema+ to pass a pre-built JSON Schema
+  # without going through the Params DSL.
   #
   # --
-  # : (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
-  def self.structured_output: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
+  # : (?(Riffer::Params | Riffer::StructuredOutput)?) ?{ () -> void } -> (Riffer::Params | Riffer::StructuredOutput)?
+  def self.structured_output: (?(Riffer::Params | Riffer::StructuredOutput)?) ?{ () -> void } -> (Riffer::Params | Riffer::StructuredOutput)?
 
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #

--- a/sig/generated/riffer/structured_output.rbs
+++ b/sig/generated/riffer/structured_output.rbs
@@ -15,6 +15,27 @@ class Riffer::StructuredOutput
   # : (Riffer::Params) -> void
   def initialize: (Riffer::Params) -> void
 
+  # Builds a StructuredOutput from a pre-built JSON Schema, bypassing the
+  # Params DSL.
+  #
+  # Useful when the schema is generated externally (e.g. from a Pydantic-style
+  # model, dumped JSON, or another tool). The returned object exposes the same
+  # +json_schema+ and +parse_and_validate+ surface as a Params-backed
+  # StructuredOutput. Client-side validation only checks that the LLM produced
+  # parseable JSON whose top level is an object — schema enforcement is left
+  # to the LLM provider, which receives the raw schema verbatim.
+  #
+  #   schema = JSON.parse(File.read("sentiment.schema.json"), symbolize_names: true)
+  #   so = Riffer::StructuredOutput.from_json_schema(schema)
+  #   class SentimentAgent < Riffer::Agent
+  #     model "openai/gpt-5-mini"
+  #     structured_output so
+  #   end
+  #
+  # --
+  # : (Hash[Symbol, untyped]) -> Riffer::StructuredOutput
+  def self.from_json_schema: (Hash[Symbol, untyped]) -> Riffer::StructuredOutput
+
   # Returns the JSON Schema for this structured output.
   #
   # --
@@ -28,4 +49,24 @@ class Riffer::StructuredOutput
   # --
   # : (String) -> Riffer::StructuredOutput::Result
   def parse_and_validate: (String) -> Riffer::StructuredOutput::Result
+
+  # Adapter used by StructuredOutput.from_json_schema to make a raw JSON
+  # Schema look like a Riffer::Params for the two methods StructuredOutput
+  # calls on it. Validation is intentionally a pass-through: the LLM provider
+  # already enforces the schema server-side, and bringing in a JSON Schema
+  # validator on the client would be a heavier dependency than this entry
+  # point warrants.
+  class RawJsonSchema
+    # --
+    # : (Hash[Symbol, untyped]) -> void
+    def initialize: (Hash[Symbol, untyped]) -> void
+
+    # --
+    # : (?strict: bool) -> Hash[Symbol, untyped]
+    def to_json_schema: (?strict: bool) -> Hash[Symbol, untyped]
+
+    # --
+    # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+    def validate: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  end
 end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -750,12 +750,21 @@ describe Riffer::Agent do
       expect(klass.structured_output.parameters.size).must_equal 2
     end
 
-    it "raises ArgumentError for non-Params argument" do
+    it "stores StructuredOutput instance" do
+      so = Riffer::StructuredOutput.from_json_schema({type: "object", properties: {}})
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+      end
+      klass.structured_output(so)
+      expect(klass.structured_output).must_equal so
+    end
+
+    it "raises ArgumentError for non-Params, non-StructuredOutput argument" do
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
       end
       error = expect { klass.structured_output({sentiment: String}) }.must_raise(Riffer::ArgumentError)
-      expect(error.message).must_match(/structured_output must be a Riffer::Params/)
+      expect(error.message).must_match(/structured_output must be a Riffer::Params or Riffer::StructuredOutput/)
     end
   end
 
@@ -816,6 +825,28 @@ describe Riffer::Agent do
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         structured_output params
+      end
+
+      agent = klass.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response('{"sentiment":"positive"}')
+
+      result = agent.generate("Analyze")
+      expect(result.structured_output).must_equal({sentiment: "positive"})
+    end
+
+    it "works with StructuredOutput.from_json_schema at class level" do
+      schema = {
+        type: "object",
+        properties: {sentiment: {type: "string"}},
+        required: ["sentiment"],
+        additionalProperties: false
+      }
+      so = Riffer::StructuredOutput.from_json_schema(schema)
+
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        structured_output so
       end
 
       agent = klass.new

--- a/test/riffer/structured_output_test.rb
+++ b/test/riffer/structured_output_test.rb
@@ -72,6 +72,51 @@ describe Riffer::StructuredOutput do
       expect(result.failure?).must_equal true
     end
 
+    describe "with .from_json_schema" do
+      let(:raw_schema) do
+        {
+          type: "object",
+          properties: {
+            sentiment: {type: "string"},
+            score: {type: "number"}
+          },
+          required: ["sentiment", "score"],
+          additionalProperties: false
+        }
+      end
+
+      it "returns the schema verbatim from json_schema" do
+        so = Riffer::StructuredOutput.from_json_schema(raw_schema)
+        expect(so.json_schema).must_equal raw_schema
+      end
+
+      it "ignores the strict: keyword (the schema is taken as-is)" do
+        so = Riffer::StructuredOutput.from_json_schema(raw_schema)
+        expect(so.json_schema(strict: true)).must_equal raw_schema
+      end
+
+      it "parses JSON and returns the object verbatim" do
+        so = Riffer::StructuredOutput.from_json_schema(raw_schema)
+        result = so.parse_and_validate('{"sentiment":"positive","score":0.9}')
+        expect(result.success?).must_equal true
+        expect(result.object).must_equal({sentiment: "positive", score: 0.9})
+      end
+
+      it "does not validate against the schema (provider enforces it)" do
+        so = Riffer::StructuredOutput.from_json_schema(raw_schema)
+        result = so.parse_and_validate('{"unexpected":"field"}')
+        expect(result.success?).must_equal true
+        expect(result.object).must_equal({unexpected: "field"})
+      end
+
+      it "still surfaces JSON parse errors" do
+        so = Riffer::StructuredOutput.from_json_schema(raw_schema)
+        result = so.parse_and_validate("not json")
+        expect(result.failure?).must_equal true
+        expect(result.error).must_match(/JSON parse error/)
+      end
+    end
+
     describe "with null optional fields" do
       let(:nested_params) do
         params = Riffer::Params.new


### PR DESCRIPTION
## Summary
- `Agent.structured_output` now accepts a `Riffer::StructuredOutput` in addition to a `Riffer::Params` or block DSL — `resolve_structured_output` no longer double-wraps when one is already passed.
- New `Riffer::StructuredOutput.from_json_schema(schema)` constructor for pre-built JSON Schemas. The schema is forwarded to the provider verbatim; client-side `parse_and_validate` only checks that the response parses as JSON, since the provider enforces the schema server-side.
- Together these remove the need to subclass `Riffer::Params` and reach for `instance_variable_set` to feed Agent a raw JSON Schema.

## Why
The setter previously required a `Riffer::Params`, but the actual runtime contract used by providers and `Agent#validate_structured_output` is `Riffer::StructuredOutput` (`json_schema(strict:)` + `parse_and_validate`). `Params` is the DSL builder, not the runtime type — surfacing `StructuredOutput` as a public input makes that explicit and unblocks consumers whose schemas are generated externally.

## Notes
- Backwards compatible: existing block DSL and `Params`-instance call sites are unchanged. The argument-error message string is updated to reflect the broader accepted set; one test asserting the old message is updated.
- `RawJsonSchema` (the adapter behind `from_json_schema`) is a `private_constant` — not part of the public surface.
- RBS sigs regenerated via `bundle exec rake rbs:generate`.

## Test plan
- [x] `bundle exec rake` — 1396 runs, 0 failures, lint clean, Steep clean
- [x] New tests cover `from_json_schema` (schema returned verbatim, JSON parse path, no client-side schema validation, parse-error surface) and Agent accepting a `StructuredOutput` (setter + end-to-end `#generate`)
- [ ] Manual: smoke-test against a real provider with a pre-built schema (left for the consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded structured_output configuration to accept StructuredOutput instances alongside parameter objects
  * Added support for initializing structured output from pre-built JSON Schemas

* **Documentation**
  * Updated guides with examples and instructions for using pre-built JSON Schemas with structured output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->