### PR TITLE
External agents

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2,9 +2,17 @@
 
 ## Core Components
 
+### AgentInterface (`lib/riffer/agent_interface.rb`)
+
+Module that declares the formal public contract for any Riffer agent implementation. Defines five instance methods: `#generate`, `#stream`, `#messages`, `#token_usage`, and `#on_message`. All raise `NotImplementedError` unless overridden. Include this module in any class that should be treated as a Riffer agent without subclassing `Riffer::Agent` (e.g. vendor-mediated external agents).
+
+### AgentResponse (`lib/riffer/agent_response.rb`)
+
+Base class for all agent responses. Carries attributes that are meaningful across all agent implementations: `content`, `messages`, `token_usage`, `vendor_metadata` (frozen Hash), and `success?` (default `true`). Subclasses add implementation-specific attributes. `vendor_metadata` is frozen on construction to prevent accidental mutation.
+
 ### Agent (`lib/riffer/agent.rb`)
 
-Base class for AI agents. Subclass and use DSL methods `model`, `instructions`, `structured_output`, and `skills` to configure. Orchestrates message flow, LLM calls, tool execution, structured output parsing, and skill activation via a generate/stream loop.
+Base class for AI agents. Includes `Riffer::AgentInterface` and satisfies the full interface contract. Subclass and use DSL methods `model`, `instructions`, `structured_output`, and `skills` to configure. Orchestrates message flow, LLM calls, tool execution, structured output parsing, and skill activation via a generate/stream loop.
 
 ```ruby
 class EchoAgent < Riffer::Agent
@@ -177,6 +185,8 @@ lib/
     version.rb           # VERSION constant
     config.rb            # Configuration class
     core.rb              # Core functionality
+    agent_interface.rb   # AgentInterface module (formal contract)
+    agent_response.rb    # AgentResponse base class
     agent.rb             # Agent class
     messages.rb          # Messages namespace/module
     providers.rb         # Providers namespace/module

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -35,6 +35,25 @@ end
 PersonalAgent.generate('Hello!', context: { name: 'Jane' })
 ```
 
+### ExternalAgent (`lib/riffer/external_agent.rb`)
+
+Base class for vendor-mediated agents that drive an external process or SDK rather than the in-process LLM loop. Includes `Riffer::AgentInterface` and provides shared bookkeeping for subclasses: `@messages`, `@token_usage`, and `on_message` callback dispatch via the `record_message` and `accumulate_token_usage` protected helpers. `#generate` and `#stream` inherit `NotImplementedError` bodies from `AgentInterface`; subclasses must override at least `#generate`. Subclasses also implement the abstract `#extract_telemetry(raw_output) -> [TokenUsage, Array<ToolCall>]` hook to keep vendor-output parsing separate from response construction.
+
+```ruby
+class MyExternalAgent < Riffer::ExternalAgent
+  def generate(prompt, files: nil, context: nil)
+    raw = call_vendor(prompt)
+    usage, tool_calls = extract_telemetry(raw)
+    record_message(Riffer::Messages::User.new(prompt))
+    record_message(Riffer::Messages::Assistant.new(raw[:reply]))
+    accumulate_token_usage(usage)
+    Riffer::ExternalAgent::Response.new(raw[:reply], messages: messages.dup, token_usage: token_usage, tool_calls: tool_calls)
+  end
+end
+```
+
+`Riffer::ExternalAgent::Response` extends `AgentResponse` with a `tool_calls` attribute. `Riffer::ExternalAgent::ToolCall` is the value object for each tool invocation (`name`, `arguments`, `result`, `error`).
+
 ### Providers (`lib/riffer/providers/`)
 
 Adapters for LLM APIs. The base class uses a template-method pattern — `generate_text` and `stream_text` orchestrate the flow, delegating to five hook methods each provider implements:
@@ -188,6 +207,10 @@ lib/
     agent_interface.rb   # AgentInterface module (formal contract)
     agent_response.rb    # AgentResponse base class
     agent.rb             # Agent class
+    external_agent.rb    # ExternalAgent base class for vendor-mediated agents
+    external_agent/
+      response.rb        # ExternalAgent::Response (adds tool_calls)
+      tool_call.rb       # ExternalAgent::ToolCall value object
     messages.rb          # Messages namespace/module
     providers.rb         # Providers namespace/module
     param.rb             # Single parameter definition (shared by tools and structured output)

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -185,6 +185,26 @@ Key types: `Manifest` (`discovery_headers`, optional `credentials_scope` hint), 
 
 **on_pending strategies** (global default `:ignore`): `:ignore` skips the server; `:wait` blocks until ready, re-raises failed discovery immediately, or times out; `:raise` re-raises failed discovery or `NotReadyError` while still pending.
 
+### MCP Server (`lib/riffer/mcp_server/`)
+
+The inverse of `Riffer::Mcp`: instead of consuming third-party MCP servers, `Riffer::McpServer` lets a riffer process **host** an MCP-compliant server that exposes registered `Riffer::Tool` subclasses to external clients. Used by external agents (e.g. the riffer-claude-code plugin) for tool callbacks.
+
+```ruby
+Riffer::McpServer.configure do |s|
+  s.expose MyTool, scope: :default
+  s.authenticator = ->(token) { JwtThing.verify(token) || nil }
+  s.context_builder = ->(token_object) { {tenant_id: token_object.tenant_id} }
+end
+
+run Riffer::McpServer.rack_app   # mount in Puma/Falcon
+```
+
+Key types: `Config` (singleton, holds authenticator + context_builder), `Registry` (per-process `Array<{tool_class:, scope:}>`, separate from the client-side `Riffer::Mcp::Registry`), `AuthMiddleware` (Rack middleware enforcing `Authorization: Bearer ...`), `ToolAdapter` (per-tool `MCP::Tool` subclass that dispatches via `Riffer::Tool#call_with_validation` — bypasses `Riffer::ToolRuntime` because the MCP server *is* the outer loop), `RackApp::ContextBridge` (builds a fresh `MCP::Server` per request with the per-request riffer context baked in, avoiding shared mutable state).
+
+The transport runs in stateless + JSON-response mode (no session negotiation). `Riffer::McpServer` and `Riffer::Mcp` share neither registry nor configuration; they are independent namespaces.
+
+See `docs/15_MCP_SERVER.md` for the public API.
+
 ## Key Patterns
 
 - Model config accepts a `provider/model` string (e.g., `openai/gpt-5-mini`) or a Proc/lambda that returns one
@@ -266,6 +286,13 @@ lib/
       client.rb          # Thin mcp gem wrapper
       authenticated_tool.rb  # Wraps MCP tools when credentials proc is configured
       tool_factory.rb    # Generates Riffer::Tool subclasses from MCP tools
+    mcp_server.rb        # Riffer::McpServer public API + error classes
+    mcp_server/
+      config.rb          # Singleton config (authenticator, context_builder)
+      registry.rb        # Per-process exposed-tool store
+      auth_middleware.rb # Rack middleware for Bearer-token auth
+      tool_adapter.rb    # Builds MCP::Tool subclasses from Riffer::Tool subclasses
+      rack_app.rb        # Composes the Rack app + per-request ContextBridge
 test/
   test_helper.rb         # Minitest configuration with VCR
   riffer_test.rb         # Main module tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    riffer (0.27.0)
+    riffer (0.28.0)
       zeitwerk (~> 2.6, >= 2.6.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
     nenv (0.3.0)
     net-http (0.9.1)
       uri (>= 0.11.1)
+    nio4r (2.7.5)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -144,7 +145,10 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
+    puma (6.6.1)
+      nio4r (~> 2.0)
     racc (1.8.1)
+    rack (3.2.6)
     rainbow (3.1.1)
     rake (13.4.2)
     rb-fsevent (0.11.2)
@@ -255,9 +259,11 @@ DEPENDENCIES
   guard-shell
   io-event (< 1.16)
   irb
-  mcp (~> 0.8)
+  mcp (~> 0.14)
   minitest (~> 6.0)
   openai (~> 0.60.0)
+  puma (~> 6.0)
+  rack (~> 3.0)
   rake (~> 13.0)
   rbs-inline (~> 0.12)
   riffer!

--- a/docs/01_OVERVIEW.md
+++ b/docs/01_OVERVIEW.md
@@ -134,3 +134,5 @@ Response
 - [Evals](11_EVALS.md) - Evaluating agent quality
 - [Guardrails](12_GUARDRAILS.md) - Input/output validation
 - [Skills](13_SKILLS.md) - Packaged agent capabilities
+- [MCP](14_MCP.md) - Consume third-party MCP servers as tool sources
+- [MCP Server](15_MCP_SERVER.md) - Host an MCP server that exposes Riffer tools to external clients

--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -6,6 +6,12 @@ Agents are the central orchestrator in Riffer. They manage the conversation flow
 
 Use an agent when the task is open-ended and the LLM needs to reason, iterate, or call tools to produce a result. If your task follows a fixed sequence of steps with no LLM decision-making, consider a simpler pipeline instead.
 
+## The Agent Contract
+
+`Riffer::AgentInterface` is the formal contract that all agent implementations must satisfy. It declares five instance methods: `#generate`, `#stream`, `#messages`, `#token_usage`, and `#on_message`. `Riffer::Agent` includes this module and provides the full implementation. Third-party or vendor-mediated agent classes should include `Riffer::AgentInterface` and override each method.
+
+All `#generate` and `#stream` implementations return a `Riffer::AgentResponse` (or a subclass). The base response carries `content`, `messages`, `token_usage`, and `vendor_metadata`. `Riffer::Agent::Response` extends this with loop-specific attributes (`tripwire`, `interrupted?`, `structured_output`, etc.).
+
 ## Defining an Agent
 
 Create an agent by subclassing `Riffer::Agent`:

--- a/docs/15_MCP_SERVER.md
+++ b/docs/15_MCP_SERVER.md
@@ -1,0 +1,113 @@
+# MCP Server
+
+Riffer can **host** an MCP-compliant server that exposes registered `Riffer::Tool` subclasses to any [Model Context Protocol](https://modelcontextprotocol.io) client. This is the inverse of [`Riffer::Mcp`](14_MCP.md): instead of consuming third-party MCP servers as tool sources, `Riffer::McpServer` lets your application **be** an MCP server that other agents (e.g. Claude Code, Cursor, custom clients) can call into.
+
+## Overview
+
+1. Configure the server via `Riffer::McpServer.configure`: expose tools, set the bearer-token authenticator, optionally provide a per-request context builder.
+2. Mount the resulting Rack app under any Rack-compatible server (Puma, Falcon).
+3. Authenticated MCP clients call `tools/list` and `tools/call`; requests dispatch through the same `Riffer::Tool#call_with_validation` machinery used by `Riffer::Agent`.
+
+## Configuration
+
+```ruby
+Riffer::McpServer.configure do |s|
+  s.expose MyTool                               # default scope
+  s.expose AdminTool, scope: :admin             # custom scope
+  s.expose ReadOnlyTool, scope: [:default, :admin] # multi-scope
+
+  s.authenticator = lambda do |bearer_token_string|
+    JwtThing.verify(bearer_token_string) || nil # nil → 401
+  end
+
+  s.context_builder = lambda do |token_object|
+    {tenant_id: token_object.tenant_id, user_id: token_object.user_id}
+  end
+
+  s.server_name = "my-app-mcp"      # optional; defaults to "riffer-mcp-server"
+  s.server_version = "1.2.3"        # optional; defaults to "1.0.0"
+end
+```
+
+`expose` accumulates across multiple `configure` calls. Re-exposing the same tool under a different scope keeps both records.
+
+## Authentication
+
+The `authenticator` is a `Proc` that receives the bearer token (the part after `Bearer ` in the `Authorization` header) as a `String` and must return either:
+
+- An opaque **token object** (any object — typically a struct or model carrying tenant id, user id, scope) for valid tokens.
+- `nil` (or raise) for invalid tokens — the middleware converts both to a JSON-RPC `401` response.
+
+The token object is opaque to the server; it is only consumed by the `context_builder` you supply.
+
+If `rack_app` is built without an authenticator configured, `Riffer::McpServer::ConfigurationError` is raised.
+
+## Per-request context
+
+The `context_builder` is a `Proc` that receives the resolved token object and returns a `Hash` to use as the per-request `context:` passed into every tool call. The default returns `{}`.
+
+```ruby
+s.context_builder = ->(token) { {tenant_id: token.tenant_id} }
+```
+
+Inside your tool's `#call(context:, **args)`, that hash is what you receive in `context:`.
+
+## Mounting the Rack app
+
+```ruby
+# config.ru
+require "riffer"
+
+Riffer::McpServer.configure { |s| ... }
+
+run Riffer::McpServer.rack_app
+```
+
+`Riffer::McpServer.rack_app` is memoized; subsequent calls return the same Rack app. Call `Riffer::McpServer.reset!` (test-only) to clear configuration, the registry, and the cached app.
+
+The transport runs in **stateless** + **JSON-response** mode: each POST is independent, no session negotiation required. Clients simply send JSON-RPC `tools/list` / `tools/call` requests with `Content-Type: application/json` and `Accept: application/json`.
+
+## Tool dispatch
+
+Each registered `Riffer::Tool` subclass is wrapped in an `MCP::Tool` adapter. On a `tools/call`, the adapter:
+
+1. Reads the per-request riffer context from the request's `server_context`.
+2. Instantiates the tool and invokes `call_with_validation(context: ..., **args)` — applying the same parameter validation, timeout, and return-type guarantees as agent-loop dispatch.
+3. Translates the result:
+   - Success → `MCP::Tool::Response` with the tool's text content.
+   - `Riffer::ValidationError`, `Riffer::TimeoutError`, or any `StandardError` → `MCP::Tool::Response` with `isError: true` and the message (no backtrace leak).
+
+Dispatch deliberately **does not** route through `Riffer::ToolRuntime` — that runtime is for agent-loop exception conversion, whereas the MCP server *is* the outer loop and we want exceptions to surface at the HTTP boundary.
+
+## Error Classes
+
+| Class                                    | Raised when                                                                  |
+| ---------------------------------------- | ---------------------------------------------------------------------------- |
+| `Riffer::McpServer::Error`               | Base class for all server failures.                                          |
+| `Riffer::McpServer::AuthenticationError` | Internal signal from the auth middleware (HTTP 401 is what the client sees). |
+| `Riffer::McpServer::ConfigurationError`  | `rack_app` requested before `authenticator` was set.                         |
+
+All inherit from `Riffer::McpServer::Error < Riffer::Error`.
+
+## Requirements
+
+`rack`, `puma`, and the `mcp` gem are **optional** development dependencies of riffer. To run the MCP server, add to your own Gemfile:
+
+```ruby
+gem "rack", "~> 3.0"
+gem "puma", "~> 6.0"  # or falcon, etc.
+gem "mcp", "~> 0.14"
+```
+
+If any gem is missing when `Riffer::McpServer.rack_app` is called, a `Riffer::Helpers::Dependencies::LoadError` is raised.
+
+## Limitations
+
+- **Single server per process.** Different consumers (e.g. internal vs external) get different scopes via `expose(..., scope:)`, not different servers.
+- **No token storage or revocation.** The authenticator is a `Proc`; how it validates is the application's problem. Short-lived signed tokens are recommended.
+- **Stateless only.** Sessions, server-to-client requests (`sampling/createMessage`, elicitation), and SSE streaming are not exposed in this release. Add them when a concrete need arises.
+- **Tool results are text only.** Non-text MCP content types (images, embedded resources) are not surfaced.
+
+## Relationship to `Riffer::Mcp`
+
+`Riffer::Mcp` (client) and `Riffer::McpServer` (host) are **independent** namespaces — either can be used without the other. The client side discovers tools from third-party MCP servers; the server side exposes tools to MCP clients. They share neither registry nor configuration.

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -19,6 +19,7 @@ require "json"
 #   agent.generate('Hello!')
 #
 class Riffer::Agent
+  include Riffer::AgentInterface
   include Riffer::Messages::Converter
   extend Riffer::Helpers::ClassNameConverter
   extend Riffer::Helpers::Validations

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -12,10 +12,7 @@
 #   else
 #     puts response.content
 #   end
-class Riffer::Agent::Response
-  # The response content.
-  attr_reader :content #: String
-
+class Riffer::Agent::Response < Riffer::AgentResponse
   # The tripwire if execution was blocked.
   attr_reader :tripwire #: Riffer::Guardrails::Tripwire?
 
@@ -27,9 +24,6 @@ class Riffer::Agent::Response
 
   # The parsed structured output, if structured output was configured.
   attr_reader :structured_output #: Hash[Symbol, untyped]?
-
-  # The full message history from the agent conversation.
-  attr_reader :messages #: Array[Riffer::Messages::Base]
 
   # Creates a new response.
   #
@@ -44,13 +38,12 @@ class Riffer::Agent::Response
   #--
   #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
   def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [])
-    @content = content
+    super(content, messages: messages)
     @tripwire = tripwire
     @modifications = modifications
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output
-    @messages = messages
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/agent_interface.rb
+++ b/lib/riffer/agent_interface.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Declares the public method contract that any Riffer agent implementation must satisfy.
+#
+# Include this module in any class that wants to act as a Riffer agent.
+# All methods raise +NotImplementedError+ unless overridden by the including class.
+#
+# Riffer::Agent already satisfies this contract. Third-party agent implementations
+# (e.g. vendor-mediated agents) should include this module and override each method.
+#
+#   class MyExternalAgent
+#     include Riffer::AgentInterface
+#
+#     def generate(prompt_or_messages, files: nil, context: nil)
+#       # call the vendor API and return a Riffer::AgentResponse
+#     end
+#
+#     # ...
+#   end
+#
+module Riffer::AgentInterface
+  # Generates a response for the given prompt or messages.
+  #
+  # [prompt_or_messages] a String prompt or Array of message objects.
+  # [files] optional file attachments.
+  # [context] optional context hash forwarded to tools, guardrails, and dynamic config.
+  #
+  #--
+  #: ((String | Array[untyped]), ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Riffer::AgentResponse
+  def generate(prompt_or_messages, files: nil, context: nil)
+    raise NotImplementedError, "#{self.class}#generate is not implemented"
+  end
+
+  # Streams a response for the given prompt or messages.
+  #
+  # [prompt_or_messages] a String prompt or Array of message objects.
+  # [files] optional file attachments.
+  # [context] optional context hash forwarded to tools, guardrails, and dynamic config.
+  #
+  #--
+  #: ((String | Array[untyped]), ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[untyped, void]
+  def stream(prompt_or_messages, files: nil, context: nil)
+    raise NotImplementedError, "#{self.class}#stream is not implemented"
+  end
+
+  # Returns the message history for this agent.
+  #
+  #--
+  #: () -> Array[Riffer::Messages::Base]
+  def messages
+    raise NotImplementedError, "#{self.class}#messages is not implemented"
+  end
+
+  # Returns cumulative token usage across all LLM calls.
+  #
+  #--
+  #: () -> Riffer::TokenUsage?
+  def token_usage
+    raise NotImplementedError, "#{self.class}#token_usage is not implemented"
+  end
+
+  # Registers a callback invoked when messages are added during generation.
+  #
+  #--
+  #: () { (Riffer::Messages::Base) -> void } -> self
+  def on_message(&block)
+    raise NotImplementedError, "#{self.class}#on_message is not implemented"
+  end
+end

--- a/lib/riffer/agent_response.rb
+++ b/lib/riffer/agent_response.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for agent generation responses.
+#
+# Carries attributes that are meaningful across all agent implementations:
+# the final content, full message history, token usage, and any
+# vendor-specific metadata. Loop-specific attributes (tripwires, interrupts,
+# structured output) belong on subclasses such as Riffer::Agent::Response.
+#
+#   response = agent.generate("Hello")
+#   puts response.content
+#   puts response.success?
+#
+class Riffer::AgentResponse
+  # The response content.
+  attr_reader :content #: String
+
+  # The full message history from the agent conversation.
+  attr_reader :messages #: Array[Riffer::Messages::Base]
+
+  # Cumulative token usage for this response.
+  attr_reader :token_usage #: Riffer::TokenUsage?
+
+  # Provider-specific metadata, frozen on construction.
+  attr_reader :vendor_metadata #: Hash[Symbol, untyped]
+
+  # Creates a new agent response.
+  #
+  # [content] the response content.
+  # [messages] the full message history from the agent conversation.
+  # [token_usage] optional token usage data.
+  # [vendor_metadata] optional provider-specific metadata hash; frozen on construction.
+  #
+  #--
+  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
+  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {})
+    @content = content
+    @messages = messages
+    @token_usage = token_usage
+    @vendor_metadata = vendor_metadata.freeze
+  end
+
+  # Returns true. Subclasses may override to signal failure.
+  #
+  #--
+  #: () -> bool
+  def success?
+    true
+  end
+end

--- a/lib/riffer/agent_response.rb
+++ b/lib/riffer/agent_response.rb
@@ -25,20 +25,27 @@ class Riffer::AgentResponse
   # Provider-specific metadata, frozen on construction.
   attr_reader :vendor_metadata #: Hash[Symbol, untyped]
 
+  # The agent identifier this response was produced by, after any
+  # vendor-specific alias resolution. +nil+ when the agent does not
+  # declare an identifier.
+  attr_reader :resolved_identifier #: String?
+
   # Creates a new agent response.
   #
   # [content] the response content.
   # [messages] the full message history from the agent conversation.
   # [token_usage] optional token usage data.
   # [vendor_metadata] optional provider-specific metadata hash; frozen on construction.
+  # [resolved_identifier] optional agent identifier after alias resolution.
   #
   #--
-  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
-  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {})
+  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?resolved_identifier: String?) -> void
+  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {}, resolved_identifier: nil)
     @content = content
     @messages = messages
     @token_usage = token_usage
     @vendor_metadata = vendor_metadata.freeze
+    @resolved_identifier = resolved_identifier
   end
 
   # Returns true. Subclasses may override to signal failure.

--- a/lib/riffer/external_agent.rb
+++ b/lib/riffer/external_agent.rb
@@ -27,6 +27,46 @@
 class Riffer::ExternalAgent
   include Riffer::AgentInterface
 
+  # Class-level DSL for declaring the agent identifier a subclass runs as.
+  #
+  # Mirrors the pattern of Riffer::Agent.identifier: call with a string to
+  # set, call without arguments to read. Inherits from the superclass when
+  # the subclass has not declared its own.
+  #
+  #   class MyAgent < Riffer::ExternalAgent
+  #     agent "my-vendor/1.0"
+  #   end
+  #   MyAgent.agent  # => "my-vendor/1.0"
+  #
+  #--
+  #: (?String?) -> String?
+  def self.agent(identifier_string = nil)
+    @agent_identifier = identifier_string unless identifier_string.nil?
+    return @agent_identifier if defined?(@agent_identifier) && @agent_identifier
+    superclass.respond_to?(:agent) ? superclass.agent : nil
+  end
+
+  # Parses a +"vendor/name"+ identifier string into a frozen Identifier.
+  #
+  # Subclasses override this to add vendor-specific alias resolution
+  # (e.g. mapping +"latest"+ to a concrete version). The default
+  # implementation validates the +"vendor/name"+ shape and treats
+  # +raw+ and +resolved+ as identical.
+  #
+  # Raises Riffer::ArgumentError when the string is missing a slash or
+  # has empty halves.
+  #
+  #--
+  #: (String) -> Riffer::ExternalAgent::Identifier
+  def self.parse_identifier(identifier_string)
+    parts = identifier_string.to_s.split("/", 2)
+    unless parts.size == 2 && parts.none? { |p| p.empty? }
+      raise Riffer::ArgumentError,
+        "agent identifier must be 'vendor/name', got: #{identifier_string.inspect}"
+    end
+    Riffer::ExternalAgent::Identifier.new(vendor: parts[0], raw: parts[1], resolved: parts[1])
+  end
+
   # The accumulated message history for this agent instance.
   attr_reader :messages #: Array[Riffer::Messages::Base]
 

--- a/lib/riffer/external_agent.rb
+++ b/lib/riffer/external_agent.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for vendor-mediated agent implementations.
+#
+# Subclass to wrap an external agent (e.g. a CLI binary or vendor SDK) and
+# expose it through the standard Riffer agent contract. Subclasses override
+# +#generate+, populate +@messages+ via +#record_message+, and accumulate
+# token counts via +#accumulate_token_usage+.
+#
+#   class MyExternalAgent < Riffer::ExternalAgent
+#     def generate(prompt_or_messages, files: nil, context: nil)
+#       # ... call the vendor ...
+#       record_message(Riffer::Messages::User.new(prompt_or_messages))
+#       record_message(Riffer::Messages::Assistant.new(reply))
+#       accumulate_token_usage(usage_from_vendor)
+#       Riffer::ExternalAgent::Response.new(reply, messages: messages.dup, token_usage: token_usage)
+#     end
+#
+#     def extract_telemetry(raw_output)
+#       # ... return [Riffer::TokenUsage, Array<Riffer::ExternalAgent::ToolCall>] ...
+#     end
+#   end
+#
+# +#generate+ and +#stream+ inherit NotImplementedError bodies from
+# Riffer::AgentInterface; subclasses must override at least +#generate+.
+class Riffer::ExternalAgent
+  include Riffer::AgentInterface
+
+  # The accumulated message history for this agent instance.
+  attr_reader :messages #: Array[Riffer::Messages::Base]
+
+  # The cumulative token usage across all generate calls.
+  attr_reader :token_usage #: Riffer::TokenUsage?
+
+  # [context] optional context hash forwarded to subclass-level concerns.
+  #
+  #--
+  #: (?context: Hash[Symbol, untyped]?) -> void
+  def initialize(context: nil)
+    @context = context
+    @messages = []
+    @token_usage = nil
+    @message_callbacks = []
+  end
+
+  # Registers a callback invoked when +#record_message+ appends a message.
+  #
+  # The block receives each Riffer::Messages::Base instance as it is added.
+  # Returns self so registrations can be chained.
+  #
+  #--
+  #: () { (Riffer::Messages::Base) -> void } -> self
+  def on_message(&block)
+    raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
+    @message_callbacks << block
+    self
+  end
+
+  # Subclass hook for normalizing vendor output into Riffer types.
+  #
+  # Implementations should return a tuple of the call's token usage and any
+  # tool calls observed in the vendor output:
+  #
+  #   [Riffer::TokenUsage, Array<Riffer::ExternalAgent::ToolCall>]
+  #
+  # The base class never invokes this method itself; it exists as a
+  # documented seam so subclasses can keep their parsing logic separate
+  # from response construction.
+  #
+  #--
+  #: (untyped) -> [Riffer::TokenUsage, Array[Riffer::ExternalAgent::ToolCall]]
+  def extract_telemetry(raw_output)
+    raise NotImplementedError, "#{self.class}#extract_telemetry is not implemented"
+  end
+
+  protected
+
+  # Appends a message to +#messages+ and fires every registered on_message callback.
+  #
+  #--
+  #: (Riffer::Messages::Base) -> void
+  def record_message(message)
+    @messages << message
+    @message_callbacks.each { |cb| cb.call(message) }
+  end
+
+  # Adds the given usage to the running +#token_usage+ total.
+  #
+  # Sets +@token_usage+ on the first call; subsequent calls combine via
+  # Riffer::TokenUsage#+ to keep cache token semantics correct.
+  #
+  #--
+  #: (Riffer::TokenUsage) -> Riffer::TokenUsage
+  def accumulate_token_usage(usage)
+    @token_usage = @token_usage ? @token_usage + usage : usage
+  end
+end

--- a/lib/riffer/external_agent/identifier.rb
+++ b/lib/riffer/external_agent/identifier.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Frozen value object describing the agent an external implementation runs as.
+#
+# Carries the parsed pieces of an identifier string returned by
+# Riffer::ExternalAgent.parse_identifier:
+#
+# - +vendor+ — the vendor namespace (e.g. "claude-code").
+# - +raw+ — the identifier as supplied by the caller (e.g. "latest" or "2.1.0").
+# - +resolved+ — the same value after any vendor-specific alias resolution.
+#   For vendors that do not alias, +resolved+ equals +raw+.
+#
+# Instances are deep-frozen on construction.
+class Riffer::ExternalAgent::Identifier
+  # The vendor namespace (e.g. "claude-code").
+  attr_reader :vendor #: String
+
+  # The identifier as supplied by the caller, before alias resolution.
+  attr_reader :raw #: String
+
+  # The identifier after any vendor-specific alias resolution.
+  attr_reader :resolved #: String
+
+  # [vendor] the vendor namespace.
+  # [raw] the identifier as supplied.
+  # [resolved] the identifier after any vendor-specific alias resolution.
+  #
+  #--
+  #: (vendor: String, raw: String, resolved: String) -> void
+  def initialize(vendor:, raw:, resolved:)
+    @vendor = vendor.frozen? ? vendor : vendor.dup.freeze
+    @raw = raw.frozen? ? raw : raw.dup.freeze
+    @resolved = resolved.frozen? ? resolved : resolved.dup.freeze
+    freeze
+  end
+end

--- a/lib/riffer/external_agent/response.rb
+++ b/lib/riffer/external_agent/response.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Response from a Riffer::ExternalAgent#generate call.
+#
+# Adds +tool_calls+ to the standard Riffer::AgentResponse surface so callers
+# can introspect the tools the agent invoked during generation.
+#
+#   response = agent.generate("search the docs")
+#   response.content         # the assistant's reply text
+#   response.tool_calls      # Array<Riffer::ExternalAgent::ToolCall>
+#
+class Riffer::ExternalAgent::Response < Riffer::AgentResponse
+  # Tool calls the agent made during this generation.
+  attr_reader :tool_calls #: Array[Riffer::ExternalAgent::ToolCall]
+
+  # [content] the response content.
+  # [messages] the full message history from the agent conversation.
+  # [token_usage] optional token usage data.
+  # [vendor_metadata] optional provider-specific metadata; frozen on construction.
+  # [tool_calls] tool calls the agent made during this generation.
+  #
+  #--
+  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
+  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {}, tool_calls: [])
+    super(content, messages: messages, token_usage: token_usage, vendor_metadata: vendor_metadata)
+    @tool_calls = tool_calls
+  end
+end

--- a/lib/riffer/external_agent/response.rb
+++ b/lib/riffer/external_agent/response.rb
@@ -19,11 +19,12 @@ class Riffer::ExternalAgent::Response < Riffer::AgentResponse
   # [token_usage] optional token usage data.
   # [vendor_metadata] optional provider-specific metadata; frozen on construction.
   # [tool_calls] tool calls the agent made during this generation.
+  # [resolved_identifier] optional agent identifier after alias resolution.
   #
   #--
-  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
-  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {}, tool_calls: [])
-    super(content, messages: messages, token_usage: token_usage, vendor_metadata: vendor_metadata)
+  #: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall], ?resolved_identifier: String?) -> void
+  def initialize(content, messages: [], token_usage: nil, vendor_metadata: {}, tool_calls: [], resolved_identifier: nil)
+    super(content, messages: messages, token_usage: token_usage, vendor_metadata: vendor_metadata, resolved_identifier: resolved_identifier)
     @tool_calls = tool_calls
   end
 end

--- a/lib/riffer/external_agent/tool_call.rb
+++ b/lib/riffer/external_agent/tool_call.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# A single tool invocation made by an external agent during +#generate+.
+#
+# Captures the tool's name, the arguments passed to it, the result it
+# returned, and any error it raised. Populated by an external agent's
+# stream/output parser and exposed via Riffer::ExternalAgent::Response#tool_calls.
+#
+#   call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {q: "ruby"}, result: "match")
+#   call.error?  # => false
+#
+class Riffer::ExternalAgent::ToolCall
+  # The tool's registered name.
+  attr_reader :name #: String
+
+  # The arguments the agent passed to the tool.
+  attr_reader :arguments #: Hash[Symbol, untyped]
+
+  # The value the tool returned, or nil if it errored or has not completed.
+  attr_reader :result #: untyped
+
+  # The error message the tool produced, or nil if it succeeded.
+  attr_reader :error #: String?
+
+  # [name] the tool's registered name.
+  # [arguments] the arguments the agent passed to the tool.
+  # [result] the value the tool returned.
+  # [error] the error message the tool produced.
+  #
+  #--
+  #: (name: String, arguments: Hash[Symbol, untyped], ?result: untyped, ?error: String?) -> void
+  def initialize(name:, arguments:, result: nil, error: nil)
+    @name = name
+    @arguments = arguments
+    @result = result
+    @error = error
+  end
+
+  # Returns true if the tool produced an error.
+  #
+  #--
+  #: () -> bool
+  def error?
+    !@error.nil?
+  end
+end

--- a/lib/riffer/mcp_server.rb
+++ b/lib/riffer/mcp_server.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Riffer::McpServer hosts an MCP-compliant server backed by registered
+# +Riffer::Tool+ subclasses. Applications build the Rack app via
+# +Riffer::McpServer.rack_app+ and mount it under any Rack-compatible
+# server (Puma, Falcon).
+#
+# See +docs/15_MCP_SERVER.md+ for the full guide.
+#
+#   Riffer::McpServer.configure do |s|
+#     s.expose MyTool
+#     s.authenticator = ->(token) { JwtThing.verify(token) || nil }
+#     s.context_builder = ->(token_object) { {tenant_id: token_object.tenant_id} }
+#   end
+#
+#   run Riffer::McpServer.rack_app
+#
+module Riffer::McpServer
+  # Base error for all MCP server failures.
+  class Error < Riffer::Error; end
+
+  # Raised when a request fails authentication and we want to signal that to
+  # internal callers (the rack middleware itself returns a 401 response).
+  class AuthenticationError < Error; end
+
+  # Raised when +rack_app+ is requested before the server is fully configured
+  # (e.g., no authenticator set).
+  class ConfigurationError < Error; end
+
+  class << self
+    # Yields a +Config+ for block-based setup.
+    #
+    #   Riffer::McpServer.configure do |s|
+    #     s.expose MyTool, scope: :default
+    #     s.authenticator = ->(token) { JwtThing.verify(token) || nil }
+    #     s.context_builder = ->(token_object) { {tenant_id: token_object.tenant_id} }
+    #   end
+    #
+    #--
+    #: () { (Riffer::McpServer::Config) -> void } -> Riffer::McpServer::Config
+    def configure
+      yield config
+      config
+    end
+
+    # Returns the process-singleton configuration.
+    #
+    #--
+    #: () -> Riffer::McpServer::Config
+    def config
+      @config ||= Config.new(registry: registry)
+    end
+
+    # Returns the process-singleton registry.
+    #
+    #--
+    #: () -> Riffer::McpServer::Registry
+    def registry
+      @registry ||= Registry.new
+    end
+
+    # Returns the composed Rack app, lazily building it the first time and
+    # memoizing the result. Raises +ConfigurationError+ if no authenticator
+    # has been configured yet.
+    #
+    #--
+    #: () -> untyped
+    def rack_app
+      raise ConfigurationError, "Riffer::McpServer requires an authenticator to be configured before #rack_app can be built" if config.authenticator.nil?
+      @rack_app ||= RackApp.build(config: config, registry: registry)
+    end
+
+    # Test-only: clears all configuration, the registry, and the cached
+    # +rack_app+. Mirrors +clear_mcp_registry!+ for the client-side namespace.
+    #
+    #--
+    #: () -> void
+    def reset!
+      @config = nil
+      @registry = nil
+      @rack_app = nil
+    end
+  end
+end

--- a/lib/riffer/mcp_server/auth_middleware.rb
+++ b/lib/riffer/mcp_server/auth_middleware.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "json"
+
+# Rack middleware that validates the +Authorization: Bearer ...+ header
+# against the configured authenticator Proc and stashes the resolved token
+# object in the rack env at +"riffer.mcp_server.token"+.
+#
+# Returns a JSON-RPC 2.0 error envelope with HTTP 401 on rejection. Raises
+# +Riffer::McpServer::ConfigurationError+ when invoked without an
+# authenticator configured — that is a programmer error, not a request
+# error.
+class Riffer::McpServer::AuthMiddleware
+  TOKEN_ENV_KEY = "riffer.mcp_server.token" #: String
+  BEARER_PREFIX = "Bearer " #: String
+  PARSE_ERROR_CODE = -32_000 #: Integer
+
+  #: (untyped, config: Riffer::McpServer::Config) -> void
+  def initialize(app, config:)
+    @app = app
+    @config = config
+  end
+
+  #: (Hash[String, untyped]) -> [Integer, Hash[String, String], Array[String]]
+  def call(env)
+    authenticator = @config.authenticator
+    raise Riffer::McpServer::ConfigurationError, "Riffer::McpServer requires an authenticator to be configured" if authenticator.nil?
+
+    header = env["HTTP_AUTHORIZATION"]
+    return unauthorized("Missing Authorization header") unless header.is_a?(String) && header.start_with?(BEARER_PREFIX)
+
+    token = header.delete_prefix(BEARER_PREFIX).strip
+    return unauthorized("Missing bearer token") if token.empty?
+
+    token_object = begin
+      authenticator.call(token)
+    rescue
+      nil
+    end
+
+    return unauthorized("Invalid bearer token") if token_object.nil?
+
+    env[TOKEN_ENV_KEY] = token_object
+    @app.call(env)
+  end
+
+  private
+
+  #: (String) -> [Integer, Hash[String, String], Array[String]]
+  def unauthorized(message)
+    body = {jsonrpc: "2.0", error: {code: PARSE_ERROR_CODE, message: message}, id: nil}
+    [401, {"Content-Type" => "application/json"}, [JSON.generate(body)]]
+  end
+end

--- a/lib/riffer/mcp_server/config.rb
+++ b/lib/riffer/mcp_server/config.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Holds the configuration for a +Riffer::McpServer+ instance.
+#
+# +authenticator+ is a Proc that receives the bearer token String and returns
+# either an opaque token object (any object) or +nil+ to deny the request.
+# +context_builder+ is a Proc that receives the token object and returns a
+# Hash to use as the per-request riffer context. The default builder returns
+# an empty Hash.
+class Riffer::McpServer::Config
+  DEFAULT_SERVER_NAME = "riffer-mcp-server" #: String
+  DEFAULT_SERVER_VERSION = "1.0.0" #: String
+  DEFAULT_CONTEXT_BUILDER = ->(_) { {} } #: ^(untyped) -> Hash[Symbol, untyped]
+
+  attr_accessor :authenticator #: ^(String) -> untyped | nil
+  attr_accessor :context_builder #: ^(untyped) -> Hash[Symbol, untyped]
+  attr_accessor :server_name #: String
+  attr_accessor :server_version #: String
+  attr_reader :registry #: Riffer::McpServer::Registry
+
+  #: (registry: Riffer::McpServer::Registry) -> void
+  def initialize(registry:)
+    @registry = registry
+    @authenticator = nil
+    @context_builder = DEFAULT_CONTEXT_BUILDER
+    @server_name = DEFAULT_SERVER_NAME
+    @server_version = DEFAULT_SERVER_VERSION
+  end
+
+  # Convenience for +configure+ blocks: registers the tool with the
+  # underlying registry under the given scope.
+  #
+  #--
+  #: (Class, ?scope: (Symbol | Array[Symbol])) -> Hash[Symbol, untyped]
+  def expose(tool_class, scope: :default)
+    @registry.register(tool_class, scope: scope)
+  end
+end

--- a/lib/riffer/mcp_server/rack_app.rb
+++ b/lib/riffer/mcp_server/rack_app.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Composes the +Riffer::McpServer+ Rack pipeline:
+#
+#   AuthMiddleware  →  ContextBridge  →  MCP::StreamableHTTPTransport
+#
+# The transport is configured for stateless + JSON-response delivery so
+# clients can issue +tools/list+ / +tools/call+ requests without negotiating
+# a session. Per-request riffer context flows in through the
+# +ContextBridge+, which builds a fresh +MCP::Server+ each call (cheap;
+# avoids racing on a shared mutable +server_context+).
+class Riffer::McpServer::RackApp
+  extend Riffer::Helpers::Dependencies
+
+  # Builds and returns the composed Rack app.
+  #
+  #--
+  #: (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> untyped
+  def self.build(config:, registry:)
+    depends_on "rack"
+    depends_on "mcp"
+
+    inner = ContextBridge.new(config: config, registry: registry)
+    Riffer::McpServer::AuthMiddleware.new(inner, config: config)
+  end
+
+  # Inner middleware that translates an authenticated request into a
+  # per-request +MCP::Server+ keyed by the riffer context built from the
+  # token object.
+  class ContextBridge
+    #: (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> void
+    def initialize(config:, registry:)
+      @config = config
+      @registry = registry
+    end
+
+    #: (Hash[String, untyped]) -> [Integer, Hash[String, String], untyped]
+    def call(env)
+      token_object = env[Riffer::McpServer::AuthMiddleware::TOKEN_ENV_KEY]
+      riffer_context = @config.context_builder.call(token_object)
+      adapters = build_adapters
+      server = MCP::Server.new(
+        name: @config.server_name,
+        version: @config.server_version,
+        tools: adapters,
+        server_context: {riffer_context: riffer_context}
+      )
+      transport = MCP::Server::Transports::StreamableHTTPTransport.new(
+        server,
+        stateless: true,
+        enable_json_response: true
+      )
+      transport.call(env)
+    end
+
+    private
+
+    #: () -> Array[untyped]
+    def build_adapters
+      @registry.all.map { |record| Riffer::McpServer::ToolAdapter.build_for(record[:tool_class]) }
+    end
+  end
+end

--- a/lib/riffer/mcp_server/registry.rb
+++ b/lib/riffer/mcp_server/registry.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Thread-safe per-instance store of exposed +Riffer::Tool+ subclasses.
+#
+# Each registration is a +{tool_class:, scope:}+ record. The same tool can be
+# registered multiple times (under different scopes); +#lookup+ returns the
+# most recent record. All public methods are mutex-guarded.
+class Riffer::McpServer::Registry
+  #: () -> void
+  def initialize
+    @mutex = Mutex.new
+    @records = [] #: Array[Hash[Symbol, untyped]]
+  end
+
+  # Registers a tool class under the given scope. The same tool may be
+  # registered repeatedly under different scopes.
+  #
+  #--
+  #: (Class, ?scope: (Symbol | Array[Symbol])) -> Hash[Symbol, untyped]
+  def register(tool_class, scope: :default)
+    record = {tool_class: tool_class, scope: scope}
+    @mutex.synchronize { @records << record }
+    record
+  end
+
+  # Returns the most-recently-registered record whose tool name matches.
+  # Returns +nil+ when no record matches.
+  #
+  #--
+  #: (String) -> Hash[Symbol, untyped]?
+  def lookup(name)
+    @mutex.synchronize do
+      result = nil
+      @records.each { |r| result = r if r[:tool_class].name == name }
+      result
+    end
+  end
+
+  # Returns all records whose scope matches +scope+ (Symbol equality, or
+  # Array#include? when the record's scope is an Array).
+  #
+  #--
+  #: (Symbol) -> Array[Hash[Symbol, untyped]]
+  def all_for_scope(scope)
+    @mutex.synchronize do
+      @records.select do |r|
+        rec_scope = r[:scope]
+        rec_scope.is_a?(Array) ? rec_scope.include?(scope) : rec_scope == scope
+      end
+    end
+  end
+
+  # Returns a frozen snapshot of all records. Mutating the snapshot does not
+  # affect the registry.
+  #
+  #--
+  #: () -> Array[Hash[Symbol, untyped]]
+  def all
+    @mutex.synchronize { @records.dup.freeze }
+  end
+
+  # Removes every registration.
+  #
+  #--
+  #: () -> void
+  def clear!
+    @mutex.synchronize { @records.clear }
+  end
+end

--- a/lib/riffer/mcp_server/tool_adapter.rb
+++ b/lib/riffer/mcp_server/tool_adapter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Builds MCP-gem-compatible tool classes from +Riffer::Tool+ subclasses.
+#
+# Each call to +.build_for+ returns an anonymous +MCP::Tool+ subclass that:
+#   1. Mirrors the source tool's name, description, and strict input schema.
+#   2. On +self.call+, instantiates the source tool and dispatches via
+#      +Riffer::Tool#call_with_validation+ — so the same validation, timeout,
+#      and return-type guarantees apply at the HTTP boundary as elsewhere.
+#   3. Translates +Riffer::ValidationError+, +Riffer::TimeoutError+, and any
+#      other +StandardError+ into an error +MCP::Tool::Response+ carrying the
+#      message but never the backtrace.
+#
+# Dispatch deliberately bypasses +Riffer::ToolRuntime+: that runtime exists to
+# convert exceptions back into +Response.error+ objects for an outer agent
+# loop, but here the MCP server *is* the outer loop and we want exceptions to
+# surface at the HTTP boundary.
+class Riffer::McpServer::ToolAdapter
+  extend Riffer::Helpers::Dependencies
+
+  # Builds an MCP::Tool subclass that proxies into the given +Riffer::Tool+ class.
+  #
+  # Raises +Riffer::ArgumentError+ if the source tool is missing a description
+  # or identifier (MCP requires both).
+  #
+  #--
+  #: (Class) -> untyped
+  def self.build_for(tool_class)
+    depends_on "mcp"
+    tool_class.validate_as_tool!
+
+    name = tool_class.name
+    description = tool_class.description
+    schema = sanitize_schema_for_mcp(tool_class.parameters_schema(strict: true))
+
+    Class.new(MCP::Tool) do
+      tool_name name
+      description description
+      input_schema schema
+
+      define_singleton_method(:call) do |server_context: nil, **args|
+        riffer_context = extract_riffer_context(server_context)
+        response = tool_class.new.call_with_validation(context: riffer_context, **args)
+        success_response(response)
+      rescue Riffer::ValidationError => e
+        error_response(e.message)
+      rescue Riffer::TimeoutError => e
+        error_response(e.message)
+      rescue => e
+        error_response("#{e.class}: #{e.message}")
+      end
+
+      define_singleton_method(:extract_riffer_context) do |server_context|
+        return {} if server_context.nil?
+        server_context[:riffer_context] || {}
+      end
+
+      define_singleton_method(:success_response) do |riffer_response|
+        MCP::Tool::Response.new([{type: "text", text: riffer_response.content.to_s}])
+      end
+
+      define_singleton_method(:error_response) do |message|
+        MCP::Tool::Response.new([{type: "text", text: message}], error: true)
+      end
+    end
+  end
+
+  # MCP's draft-04 schema validator rejects an empty +required+ array; strip
+  # it out when the source tool defined no parameters at all.
+  #
+  #--
+  #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def self.sanitize_schema_for_mcp(schema)
+    return schema unless schema.is_a?(Hash) && schema[:required].is_a?(Array) && schema[:required].empty?
+    schema.except(:required)
+  end
+end

--- a/lib/riffer/version.rb
+++ b/lib/riffer/version.rb
@@ -2,5 +2,5 @@
 # rbs_inline: enabled
 
 module Riffer
-  VERSION = "0.27.0" #: String
+  VERSION = "0.28.0" #: String
 end

--- a/riffer.gemspec
+++ b/riffer.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "anthropic", "~> 1.36.0"
   spec.add_development_dependency "aws-sdk-bedrockruntime", "~> 1.42"
   spec.add_development_dependency "faraday", ">= 1.0"
-  spec.add_development_dependency "mcp", "~> 0.8"
+  spec.add_development_dependency "mcp", "~> 0.14"
   spec.add_development_dependency "openai", "~> 0.60.0"
   spec.add_development_dependency "async", "~> 2.25", "< 2.40"
   spec.add_development_dependency "io-event", "< 1.16"
@@ -52,6 +52,8 @@ Gem::Specification.new do |spec|
   # Testing
   spec.add_development_dependency "minitest", "~> 6.0"
   spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rack", "~> 3.0"
+  spec.add_development_dependency "puma", "~> 6.0"
   spec.add_development_dependency "vcr", "~> 6.0"
   spec.add_development_dependency "webmock", "~> 3.0"
 

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -15,6 +15,8 @@
 #   agent = MyAgent.new
 #   agent.generate('Hello!')
 class Riffer::Agent
+  include Riffer::AgentInterface
+
   include Riffer::Messages::Converter
 
   extend Riffer::Helpers::ClassNameConverter

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -11,10 +11,7 @@
 #   else
 #     puts response.content
 #   end
-class Riffer::Agent::Response
-  # The response content.
-  attr_reader content: String
-
+class Riffer::Agent::Response < Riffer::AgentResponse
   # The tripwire if execution was blocked.
   attr_reader tripwire: Riffer::Guardrails::Tripwire?
 
@@ -26,9 +23,6 @@ class Riffer::Agent::Response
 
   # The parsed structured output, if structured output was configured.
   attr_reader structured_output: Hash[Symbol, untyped]?
-
-  # The full message history from the agent conversation.
-  attr_reader messages: Array[Riffer::Messages::Base]
 
   # Creates a new response.
   #

--- a/sig/generated/riffer/agent_interface.rbs
+++ b/sig/generated/riffer/agent_interface.rbs
@@ -1,0 +1,58 @@
+# Generated from lib/riffer/agent_interface.rb with RBS::Inline
+
+# Declares the public method contract that any Riffer agent implementation must satisfy.
+#
+# Include this module in any class that wants to act as a Riffer agent.
+# All methods raise +NotImplementedError+ unless overridden by the including class.
+#
+# Riffer::Agent already satisfies this contract. Third-party agent implementations
+# (e.g. vendor-mediated agents) should include this module and override each method.
+#
+#   class MyExternalAgent
+#     include Riffer::AgentInterface
+#
+#     def generate(prompt_or_messages, files: nil, context: nil)
+#       # call the vendor API and return a Riffer::AgentResponse
+#     end
+#
+#     # ...
+#   end
+module Riffer::AgentInterface
+  # Generates a response for the given prompt or messages.
+  #
+  # [prompt_or_messages] a String prompt or Array of message objects.
+  # [files] optional file attachments.
+  # [context] optional context hash forwarded to tools, guardrails, and dynamic config.
+  #
+  # --
+  # : ((String | Array[untyped]), ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Riffer::AgentResponse
+  def generate: (String | Array[untyped], ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Riffer::AgentResponse
+
+  # Streams a response for the given prompt or messages.
+  #
+  # [prompt_or_messages] a String prompt or Array of message objects.
+  # [files] optional file attachments.
+  # [context] optional context hash forwarded to tools, guardrails, and dynamic config.
+  #
+  # --
+  # : ((String | Array[untyped]), ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[untyped, void]
+  def stream: (String | Array[untyped], ?files: Array[untyped]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[untyped, void]
+
+  # Returns the message history for this agent.
+  #
+  # --
+  # : () -> Array[Riffer::Messages::Base]
+  def messages: () -> Array[Riffer::Messages::Base]
+
+  # Returns cumulative token usage across all LLM calls.
+  #
+  # --
+  # : () -> Riffer::TokenUsage?
+  def token_usage: () -> Riffer::TokenUsage?
+
+  # Registers a callback invoked when messages are added during generation.
+  #
+  # --
+  # : () { (Riffer::Messages::Base) -> void } -> self
+  def on_message: () { (Riffer::Messages::Base) -> void } -> self
+end

--- a/sig/generated/riffer/agent_response.rbs
+++ b/sig/generated/riffer/agent_response.rbs
@@ -23,16 +23,22 @@ class Riffer::AgentResponse
   # Provider-specific metadata, frozen on construction.
   attr_reader vendor_metadata: Hash[Symbol, untyped]
 
+  # The agent identifier this response was produced by, after any
+  # vendor-specific alias resolution. +nil+ when the agent does not
+  # declare an identifier.
+  attr_reader resolved_identifier: String?
+
   # Creates a new agent response.
   #
   # [content] the response content.
   # [messages] the full message history from the agent conversation.
   # [token_usage] optional token usage data.
   # [vendor_metadata] optional provider-specific metadata hash; frozen on construction.
+  # [resolved_identifier] optional agent identifier after alias resolution.
   #
   # --
-  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
-  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
+  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?resolved_identifier: String?) -> void
+  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?resolved_identifier: String?) -> void
 
   # Returns true. Subclasses may override to signal failure.
   #

--- a/sig/generated/riffer/agent_response.rbs
+++ b/sig/generated/riffer/agent_response.rbs
@@ -1,0 +1,42 @@
+# Generated from lib/riffer/agent_response.rb with RBS::Inline
+
+# Base class for agent generation responses.
+#
+# Carries attributes that are meaningful across all agent implementations:
+# the final content, full message history, token usage, and any
+# vendor-specific metadata. Loop-specific attributes (tripwires, interrupts,
+# structured output) belong on subclasses such as Riffer::Agent::Response.
+#
+#   response = agent.generate("Hello")
+#   puts response.content
+#   puts response.success?
+class Riffer::AgentResponse
+  # The response content.
+  attr_reader content: String
+
+  # The full message history from the agent conversation.
+  attr_reader messages: Array[Riffer::Messages::Base]
+
+  # Cumulative token usage for this response.
+  attr_reader token_usage: Riffer::TokenUsage?
+
+  # Provider-specific metadata, frozen on construction.
+  attr_reader vendor_metadata: Hash[Symbol, untyped]
+
+  # Creates a new agent response.
+  #
+  # [content] the response content.
+  # [messages] the full message history from the agent conversation.
+  # [token_usage] optional token usage data.
+  # [vendor_metadata] optional provider-specific metadata hash; frozen on construction.
+  #
+  # --
+  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
+  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped]) -> void
+
+  # Returns true. Subclasses may override to signal failure.
+  #
+  # --
+  # : () -> bool
+  def success?: () -> bool
+end

--- a/sig/generated/riffer/external_agent.rbs
+++ b/sig/generated/riffer/external_agent.rbs
@@ -26,6 +26,35 @@
 class Riffer::ExternalAgent
   include Riffer::AgentInterface
 
+  # Class-level DSL for declaring the agent identifier a subclass runs as.
+  #
+  # Mirrors the pattern of Riffer::Agent.identifier: call with a string to
+  # set, call without arguments to read. Inherits from the superclass when
+  # the subclass has not declared its own.
+  #
+  #   class MyAgent < Riffer::ExternalAgent
+  #     agent "my-vendor/1.0"
+  #   end
+  #   MyAgent.agent  # => "my-vendor/1.0"
+  #
+  # --
+  # : (?String?) -> String?
+  def self.agent: (?String?) -> String?
+
+  # Parses a +"vendor/name"+ identifier string into a frozen Identifier.
+  #
+  # Subclasses override this to add vendor-specific alias resolution
+  # (e.g. mapping +"latest"+ to a concrete version). The default
+  # implementation validates the +"vendor/name"+ shape and treats
+  # +raw+ and +resolved+ as identical.
+  #
+  # Raises Riffer::ArgumentError when the string is missing a slash or
+  # has empty halves.
+  #
+  # --
+  # : (String) -> Riffer::ExternalAgent::Identifier
+  def self.parse_identifier: (String) -> Riffer::ExternalAgent::Identifier
+
   # The accumulated message history for this agent instance.
   attr_reader messages: Array[Riffer::Messages::Base]
 

--- a/sig/generated/riffer/external_agent.rbs
+++ b/sig/generated/riffer/external_agent.rbs
@@ -1,0 +1,79 @@
+# Generated from lib/riffer/external_agent.rb with RBS::Inline
+
+# Base class for vendor-mediated agent implementations.
+#
+# Subclass to wrap an external agent (e.g. a CLI binary or vendor SDK) and
+# expose it through the standard Riffer agent contract. Subclasses override
+# +#generate+, populate +@messages+ via +#record_message+, and accumulate
+# token counts via +#accumulate_token_usage+.
+#
+#   class MyExternalAgent < Riffer::ExternalAgent
+#     def generate(prompt_or_messages, files: nil, context: nil)
+#       # ... call the vendor ...
+#       record_message(Riffer::Messages::User.new(prompt_or_messages))
+#       record_message(Riffer::Messages::Assistant.new(reply))
+#       accumulate_token_usage(usage_from_vendor)
+#       Riffer::ExternalAgent::Response.new(reply, messages: messages.dup, token_usage: token_usage)
+#     end
+#
+#     def extract_telemetry(raw_output)
+#       # ... return [Riffer::TokenUsage, Array<Riffer::ExternalAgent::ToolCall>] ...
+#     end
+#   end
+#
+# +#generate+ and +#stream+ inherit NotImplementedError bodies from
+# Riffer::AgentInterface; subclasses must override at least +#generate+.
+class Riffer::ExternalAgent
+  include Riffer::AgentInterface
+
+  # The accumulated message history for this agent instance.
+  attr_reader messages: Array[Riffer::Messages::Base]
+
+  # The cumulative token usage across all generate calls.
+  attr_reader token_usage: Riffer::TokenUsage?
+
+  # [context] optional context hash forwarded to subclass-level concerns.
+  #
+  # --
+  # : (?context: Hash[Symbol, untyped]?) -> void
+  def initialize: (?context: Hash[Symbol, untyped]?) -> void
+
+  # Registers a callback invoked when +#record_message+ appends a message.
+  #
+  # The block receives each Riffer::Messages::Base instance as it is added.
+  # Returns self so registrations can be chained.
+  #
+  # --
+  # : () { (Riffer::Messages::Base) -> void } -> self
+  def on_message: () { (Riffer::Messages::Base) -> void } -> self
+
+  # Subclass hook for normalizing vendor output into Riffer types.
+  #
+  # Implementations should return a tuple of the call's token usage and any
+  # tool calls observed in the vendor output:
+  #
+  #   [Riffer::TokenUsage, Array<Riffer::ExternalAgent::ToolCall>]
+  #
+  # The base class never invokes this method itself; it exists as a
+  # documented seam so subclasses can keep their parsing logic separate
+  # from response construction.
+  #
+  # --
+  # : (untyped) -> [Riffer::TokenUsage, Array[Riffer::ExternalAgent::ToolCall]]
+  def extract_telemetry: (untyped) -> [ Riffer::TokenUsage, Array[Riffer::ExternalAgent::ToolCall] ]
+
+  # Appends a message to +#messages+ and fires every registered on_message callback.
+  #
+  # --
+  # : (Riffer::Messages::Base) -> void
+  def record_message: (Riffer::Messages::Base) -> void
+
+  # Adds the given usage to the running +#token_usage+ total.
+  #
+  # Sets +@token_usage+ on the first call; subsequent calls combine via
+  # Riffer::TokenUsage#+ to keep cache token semantics correct.
+  #
+  # --
+  # : (Riffer::TokenUsage) -> Riffer::TokenUsage
+  def accumulate_token_usage: (Riffer::TokenUsage) -> Riffer::TokenUsage
+end

--- a/sig/generated/riffer/external_agent/identifier.rbs
+++ b/sig/generated/riffer/external_agent/identifier.rbs
@@ -1,0 +1,31 @@
+# Generated from lib/riffer/external_agent/identifier.rb with RBS::Inline
+
+# Frozen value object describing the agent an external implementation runs as.
+#
+# Carries the parsed pieces of an identifier string returned by
+# Riffer::ExternalAgent.parse_identifier:
+#
+# - +vendor+ — the vendor namespace (e.g. "claude-code").
+# - +raw+ — the identifier as supplied by the caller (e.g. "latest" or "2.1.0").
+# - +resolved+ — the same value after any vendor-specific alias resolution.
+#   For vendors that do not alias, +resolved+ equals +raw+.
+#
+# Instances are deep-frozen on construction.
+class Riffer::ExternalAgent::Identifier
+  # The vendor namespace (e.g. "claude-code").
+  attr_reader vendor: String
+
+  # The identifier as supplied by the caller, before alias resolution.
+  attr_reader raw: String
+
+  # The identifier after any vendor-specific alias resolution.
+  attr_reader resolved: String
+
+  # [vendor] the vendor namespace.
+  # [raw] the identifier as supplied.
+  # [resolved] the identifier after any vendor-specific alias resolution.
+  #
+  # --
+  # : (vendor: String, raw: String, resolved: String) -> void
+  def initialize: (vendor: String, raw: String, resolved: String) -> void
+end

--- a/sig/generated/riffer/external_agent/response.rbs
+++ b/sig/generated/riffer/external_agent/response.rbs
@@ -1,0 +1,24 @@
+# Generated from lib/riffer/external_agent/response.rb with RBS::Inline
+
+# Response from a Riffer::ExternalAgent#generate call.
+#
+# Adds +tool_calls+ to the standard Riffer::AgentResponse surface so callers
+# can introspect the tools the agent invoked during generation.
+#
+#   response = agent.generate("search the docs")
+#   response.content         # the assistant's reply text
+#   response.tool_calls      # Array<Riffer::ExternalAgent::ToolCall>
+class Riffer::ExternalAgent::Response < Riffer::AgentResponse
+  # Tool calls the agent made during this generation.
+  attr_reader tool_calls: Array[Riffer::ExternalAgent::ToolCall]
+
+  # [content] the response content.
+  # [messages] the full message history from the agent conversation.
+  # [token_usage] optional token usage data.
+  # [vendor_metadata] optional provider-specific metadata; frozen on construction.
+  # [tool_calls] tool calls the agent made during this generation.
+  #
+  # --
+  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
+  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
+end

--- a/sig/generated/riffer/external_agent/response.rbs
+++ b/sig/generated/riffer/external_agent/response.rbs
@@ -17,8 +17,9 @@ class Riffer::ExternalAgent::Response < Riffer::AgentResponse
   # [token_usage] optional token usage data.
   # [vendor_metadata] optional provider-specific metadata; frozen on construction.
   # [tool_calls] tool calls the agent made during this generation.
+  # [resolved_identifier] optional agent identifier after alias resolution.
   #
   # --
-  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
-  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall]) -> void
+  # : (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall], ?resolved_identifier: String?) -> void
+  def initialize: (String, ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::TokenUsage?, ?vendor_metadata: Hash[Symbol, untyped], ?tool_calls: Array[Riffer::ExternalAgent::ToolCall], ?resolved_identifier: String?) -> void
 end

--- a/sig/generated/riffer/external_agent/tool_call.rbs
+++ b/sig/generated/riffer/external_agent/tool_call.rbs
@@ -1,0 +1,38 @@
+# Generated from lib/riffer/external_agent/tool_call.rb with RBS::Inline
+
+# A single tool invocation made by an external agent during +#generate+.
+#
+# Captures the tool's name, the arguments passed to it, the result it
+# returned, and any error it raised. Populated by an external agent's
+# stream/output parser and exposed via Riffer::ExternalAgent::Response#tool_calls.
+#
+#   call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {q: "ruby"}, result: "match")
+#   call.error?  # => false
+class Riffer::ExternalAgent::ToolCall
+  # The tool's registered name.
+  attr_reader name: String
+
+  # The arguments the agent passed to the tool.
+  attr_reader arguments: Hash[Symbol, untyped]
+
+  # The value the tool returned, or nil if it errored or has not completed.
+  attr_reader result: untyped
+
+  # The error message the tool produced, or nil if it succeeded.
+  attr_reader error: String?
+
+  # [name] the tool's registered name.
+  # [arguments] the arguments the agent passed to the tool.
+  # [result] the value the tool returned.
+  # [error] the error message the tool produced.
+  #
+  # --
+  # : (name: String, arguments: Hash[Symbol, untyped], ?result: untyped, ?error: String?) -> void
+  def initialize: (name: String, arguments: Hash[Symbol, untyped], ?result: untyped, ?error: String?) -> void
+
+  # Returns true if the tool produced an error.
+  #
+  # --
+  # : () -> bool
+  def error?: () -> bool
+end

--- a/sig/generated/riffer/mcp_server.rbs
+++ b/sig/generated/riffer/mcp_server.rbs
@@ -1,0 +1,70 @@
+# Generated from lib/riffer/mcp_server.rb with RBS::Inline
+
+# Riffer::McpServer hosts an MCP-compliant server backed by registered
+# +Riffer::Tool+ subclasses. Applications build the Rack app via
+# +Riffer::McpServer.rack_app+ and mount it under any Rack-compatible
+# server (Puma, Falcon).
+#
+# See +docs/15_MCP_SERVER.md+ for the full guide.
+#
+#   Riffer::McpServer.configure do |s|
+#     s.expose MyTool
+#     s.authenticator = ->(token) { JwtThing.verify(token) || nil }
+#     s.context_builder = ->(token_object) { {tenant_id: token_object.tenant_id} }
+#   end
+#
+#   run Riffer::McpServer.rack_app
+module Riffer::McpServer
+  # Base error for all MCP server failures.
+  class Error < Riffer::Error
+  end
+
+  # Raised when a request fails authentication and we want to signal that to
+  # internal callers (the rack middleware itself returns a 401 response).
+  class AuthenticationError < Error
+  end
+
+  # Raised when +rack_app+ is requested before the server is fully configured
+  # (e.g., no authenticator set).
+  class ConfigurationError < Error
+  end
+
+  # Yields a +Config+ for block-based setup.
+  #
+  #   Riffer::McpServer.configure do |s|
+  #     s.expose MyTool, scope: :default
+  #     s.authenticator = ->(token) { JwtThing.verify(token) || nil }
+  #     s.context_builder = ->(token_object) { {tenant_id: token_object.tenant_id} }
+  #   end
+  #
+  # --
+  # : () { (Riffer::McpServer::Config) -> void } -> Riffer::McpServer::Config
+  def self.configure: () { (Riffer::McpServer::Config) -> void } -> Riffer::McpServer::Config
+
+  # Returns the process-singleton configuration.
+  #
+  # --
+  # : () -> Riffer::McpServer::Config
+  def self.config: () -> Riffer::McpServer::Config
+
+  # Returns the process-singleton registry.
+  #
+  # --
+  # : () -> Riffer::McpServer::Registry
+  def self.registry: () -> Riffer::McpServer::Registry
+
+  # Returns the composed Rack app, lazily building it the first time and
+  # memoizing the result. Raises +ConfigurationError+ if no authenticator
+  # has been configured yet.
+  #
+  # --
+  # : () -> untyped
+  def self.rack_app: () -> untyped
+
+  # Test-only: clears all configuration, the registry, and the cached
+  # +rack_app+. Mirrors +clear_mcp_registry!+ for the client-side namespace.
+  #
+  # --
+  # : () -> void
+  def self.reset!: () -> void
+end

--- a/sig/generated/riffer/mcp_server/auth_middleware.rbs
+++ b/sig/generated/riffer/mcp_server/auth_middleware.rbs
@@ -1,0 +1,28 @@
+# Generated from lib/riffer/mcp_server/auth_middleware.rb with RBS::Inline
+
+# Rack middleware that validates the +Authorization: Bearer ...+ header
+# against the configured authenticator Proc and stashes the resolved token
+# object in the rack env at +"riffer.mcp_server.token"+.
+#
+# Returns a JSON-RPC 2.0 error envelope with HTTP 401 on rejection. Raises
+# +Riffer::McpServer::ConfigurationError+ when invoked without an
+# authenticator configured — that is a programmer error, not a request
+# error.
+class Riffer::McpServer::AuthMiddleware
+  TOKEN_ENV_KEY: String
+
+  BEARER_PREFIX: String
+
+  PARSE_ERROR_CODE: Integer
+
+  # : (untyped, config: Riffer::McpServer::Config) -> void
+  def initialize: (untyped, config: Riffer::McpServer::Config) -> void
+
+  # : (Hash[String, untyped]) -> [Integer, Hash[String, String], Array[String]]
+  def call: (Hash[String, untyped]) -> [ Integer, Hash[String, String], Array[String] ]
+
+  private
+
+  # : (String) -> [Integer, Hash[String, String], Array[String]]
+  def unauthorized: (String) -> [ Integer, Hash[String, String], Array[String] ]
+end

--- a/sig/generated/riffer/mcp_server/config.rbs
+++ b/sig/generated/riffer/mcp_server/config.rbs
@@ -1,0 +1,36 @@
+# Generated from lib/riffer/mcp_server/config.rb with RBS::Inline
+
+# Holds the configuration for a +Riffer::McpServer+ instance.
+#
+# +authenticator+ is a Proc that receives the bearer token String and returns
+# either an opaque token object (any object) or +nil+ to deny the request.
+# +context_builder+ is a Proc that receives the token object and returns a
+# Hash to use as the per-request riffer context. The default builder returns
+# an empty Hash.
+class Riffer::McpServer::Config
+  DEFAULT_SERVER_NAME: String
+
+  DEFAULT_SERVER_VERSION: String
+
+  DEFAULT_CONTEXT_BUILDER: ^(untyped) -> Hash[Symbol, untyped]
+
+  attr_accessor authenticator: ^(String) -> untyped | nil
+
+  attr_accessor context_builder: ^(untyped) -> Hash[Symbol, untyped]
+
+  attr_accessor server_name: String
+
+  attr_accessor server_version: String
+
+  attr_reader registry: Riffer::McpServer::Registry
+
+  # : (registry: Riffer::McpServer::Registry) -> void
+  def initialize: (registry: Riffer::McpServer::Registry) -> void
+
+  # Convenience for +configure+ blocks: registers the tool with the
+  # underlying registry under the given scope.
+  #
+  # --
+  # : (Class, ?scope: (Symbol | Array[Symbol])) -> Hash[Symbol, untyped]
+  def expose: (Class, ?scope: Symbol | Array[Symbol]) -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/mcp_server/rack_app.rbs
+++ b/sig/generated/riffer/mcp_server/rack_app.rbs
@@ -1,0 +1,36 @@
+# Generated from lib/riffer/mcp_server/rack_app.rb with RBS::Inline
+
+# Composes the +Riffer::McpServer+ Rack pipeline:
+#
+#   AuthMiddleware  →  ContextBridge  →  MCP::StreamableHTTPTransport
+#
+# The transport is configured for stateless + JSON-response delivery so
+# clients can issue +tools/list+ / +tools/call+ requests without negotiating
+# a session. Per-request riffer context flows in through the
+# +ContextBridge+, which builds a fresh +MCP::Server+ each call (cheap;
+# avoids racing on a shared mutable +server_context+).
+class Riffer::McpServer::RackApp
+  extend Riffer::Helpers::Dependencies
+
+  # Builds and returns the composed Rack app.
+  #
+  # --
+  # : (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> untyped
+  def self.build: (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> untyped
+
+  # Inner middleware that translates an authenticated request into a
+  # per-request +MCP::Server+ keyed by the riffer context built from the
+  # token object.
+  class ContextBridge
+    # : (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> void
+    def initialize: (config: Riffer::McpServer::Config, registry: Riffer::McpServer::Registry) -> void
+
+    # : (Hash[String, untyped]) -> [Integer, Hash[String, String], untyped]
+    def call: (Hash[String, untyped]) -> [ Integer, Hash[String, String], untyped ]
+
+    private
+
+    # : () -> Array[untyped]
+    def build_adapters: () -> Array[untyped]
+  end
+end

--- a/sig/generated/riffer/mcp_server/registry.rbs
+++ b/sig/generated/riffer/mcp_server/registry.rbs
@@ -1,0 +1,45 @@
+# Generated from lib/riffer/mcp_server/registry.rb with RBS::Inline
+
+# Thread-safe per-instance store of exposed +Riffer::Tool+ subclasses.
+#
+# Each registration is a +{tool_class:, scope:}+ record. The same tool can be
+# registered multiple times (under different scopes); +#lookup+ returns the
+# most recent record. All public methods are mutex-guarded.
+class Riffer::McpServer::Registry
+  # : () -> void
+  def initialize: () -> void
+
+  # Registers a tool class under the given scope. The same tool may be
+  # registered repeatedly under different scopes.
+  #
+  # --
+  # : (Class, ?scope: (Symbol | Array[Symbol])) -> Hash[Symbol, untyped]
+  def register: (Class, ?scope: Symbol | Array[Symbol]) -> Hash[Symbol, untyped]
+
+  # Returns the most-recently-registered record whose tool name matches.
+  # Returns +nil+ when no record matches.
+  #
+  # --
+  # : (String) -> Hash[Symbol, untyped]?
+  def lookup: (String) -> Hash[Symbol, untyped]?
+
+  # Returns all records whose scope matches +scope+ (Symbol equality, or
+  # Array#include? when the record's scope is an Array).
+  #
+  # --
+  # : (Symbol) -> Array[Hash[Symbol, untyped]]
+  def all_for_scope: (Symbol) -> Array[Hash[Symbol, untyped]]
+
+  # Returns a frozen snapshot of all records. Mutating the snapshot does not
+  # affect the registry.
+  #
+  # --
+  # : () -> Array[Hash[Symbol, untyped]]
+  def all: () -> Array[Hash[Symbol, untyped]]
+
+  # Removes every registration.
+  #
+  # --
+  # : () -> void
+  def clear!: () -> void
+end

--- a/sig/generated/riffer/mcp_server/tool_adapter.rbs
+++ b/sig/generated/riffer/mcp_server/tool_adapter.rbs
@@ -1,0 +1,36 @@
+# Generated from lib/riffer/mcp_server/tool_adapter.rb with RBS::Inline
+
+# Builds MCP-gem-compatible tool classes from +Riffer::Tool+ subclasses.
+#
+# Each call to +.build_for+ returns an anonymous +MCP::Tool+ subclass that:
+#   1. Mirrors the source tool's name, description, and strict input schema.
+#   2. On +self.call+, instantiates the source tool and dispatches via
+#      +Riffer::Tool#call_with_validation+ — so the same validation, timeout,
+#      and return-type guarantees apply at the HTTP boundary as elsewhere.
+#   3. Translates +Riffer::ValidationError+, +Riffer::TimeoutError+, and any
+#      other +StandardError+ into an error +MCP::Tool::Response+ carrying the
+#      message but never the backtrace.
+#
+# Dispatch deliberately bypasses +Riffer::ToolRuntime+: that runtime exists to
+# convert exceptions back into +Response.error+ objects for an outer agent
+# loop, but here the MCP server *is* the outer loop and we want exceptions to
+# surface at the HTTP boundary.
+class Riffer::McpServer::ToolAdapter
+  extend Riffer::Helpers::Dependencies
+
+  # Builds an MCP::Tool subclass that proxies into the given +Riffer::Tool+ class.
+  #
+  # Raises +Riffer::ArgumentError+ if the source tool is missing a description
+  # or identifier (MCP requires both).
+  #
+  # --
+  # : (Class) -> untyped
+  def self.build_for: (Class) -> untyped
+
+  # MCP's draft-04 schema validator rejects an empty +required+ array; strip
+  # it out when the source tool defined no parameters at all.
+  #
+  # --
+  # : (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def self.sanitize_schema_for_mcp: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+end

--- a/test/fixtures/tools/ping_tool.rb
+++ b/test/fixtures/tools/ping_tool.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Minimal +Riffer::Tool+ used in +Riffer::McpServer+ tests to exercise the
+# server's dispatch path. Echoes the +message+ argument back as text.
+module Test
+  class PingTool < Riffer::Tool
+    identifier "ping_tool"
+    description "Echoes the supplied message back to the caller."
+
+    params do
+      required :message, String, description: "The message to echo"
+    end
+
+    def call(context:, message:)
+      text(message)
+    end
+  end
+end

--- a/test/riffer/agent_interface_test.rb
+++ b/test/riffer/agent_interface_test.rb
@@ -32,7 +32,7 @@ describe Riffer::AgentInterface do
 
   describe "#on_message" do
     it "raises NotImplementedError" do
-      expect { stub.on_message { } }.must_raise NotImplementedError
+      expect { stub.on_message {} }.must_raise NotImplementedError
     end
   end
 end

--- a/test/riffer/agent_interface_test.rb
+++ b/test/riffer/agent_interface_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::AgentInterface do
+  let(:stub_class) { Class.new { include Riffer::AgentInterface } }
+  let(:stub) { stub_class.new }
+
+  describe "#generate" do
+    it "raises NotImplementedError" do
+      expect { stub.generate("prompt") }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#stream" do
+    it "raises NotImplementedError" do
+      expect { stub.stream("prompt") }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#messages" do
+    it "raises NotImplementedError" do
+      expect { stub.messages }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#token_usage" do
+    it "raises NotImplementedError" do
+      expect { stub.token_usage }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#on_message" do
+    it "raises NotImplementedError" do
+      expect { stub.on_message { } }.must_raise NotImplementedError
+    end
+  end
+end

--- a/test/riffer/agent_response_test.rb
+++ b/test/riffer/agent_response_test.rb
@@ -42,6 +42,16 @@ describe Riffer::AgentResponse do
       expect(response.vendor_metadata).must_equal({model: "gpt-4o"})
       expect(response.vendor_metadata.frozen?).must_equal true
     end
+
+    it "defaults resolved_identifier to nil" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.resolved_identifier).must_be_nil
+    end
+
+    it "stores resolved_identifier when given" do
+      response = Riffer::AgentResponse.new("Hello", resolved_identifier: "vendor/1.2.3")
+      expect(response.resolved_identifier).must_equal "vendor/1.2.3"
+    end
   end
 
   describe "#success?" do

--- a/test/riffer/agent_response_test.rb
+++ b/test/riffer/agent_response_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::AgentResponse do
+  describe "#initialize" do
+    it "stores the content" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.content).must_equal "Hello"
+    end
+
+    it "defaults messages to an empty array" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.messages).must_equal []
+    end
+
+    it "stores messages" do
+      messages = [Riffer::Messages::User.new("Hi"), Riffer::Messages::Assistant.new("Hello")]
+      response = Riffer::AgentResponse.new("Hello", messages: messages)
+      expect(response.messages).must_equal messages
+    end
+
+    it "defaults token_usage to nil" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.token_usage).must_be_nil
+    end
+
+    it "stores token_usage" do
+      usage = Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 20)
+      response = Riffer::AgentResponse.new("Hello", token_usage: usage)
+      expect(response.token_usage).must_equal usage
+    end
+
+    it "defaults vendor_metadata to an empty frozen hash" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.vendor_metadata).must_equal({})
+      expect(response.vendor_metadata.frozen?).must_equal true
+    end
+
+    it "stores vendor_metadata and freezes it on construction" do
+      response = Riffer::AgentResponse.new("Hello", vendor_metadata: {model: "gpt-4o"})
+      expect(response.vendor_metadata).must_equal({model: "gpt-4o"})
+      expect(response.vendor_metadata.frozen?).must_equal true
+    end
+  end
+
+  describe "#success?" do
+    it "returns true by default" do
+      response = Riffer::AgentResponse.new("Hello")
+      expect(response.success?).must_equal true
+    end
+  end
+end

--- a/test/riffer/external_agent/identifier_test.rb
+++ b/test/riffer/external_agent/identifier_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::ExternalAgent::Identifier do
+  describe "#initialize" do
+    it "stores vendor, raw, and resolved" do
+      id = Riffer::ExternalAgent::Identifier.new(vendor: "claude-code", raw: "2.1.0", resolved: "2.1.0")
+      expect(id.vendor).must_equal "claude-code"
+      expect(id.raw).must_equal "2.1.0"
+      expect(id.resolved).must_equal "2.1.0"
+    end
+
+    it "allows resolved to differ from raw" do
+      id = Riffer::ExternalAgent::Identifier.new(vendor: "claude-code", raw: "latest", resolved: "2.1.131")
+      expect(id.raw).must_equal "latest"
+      expect(id.resolved).must_equal "2.1.131"
+    end
+
+    it "is frozen" do
+      id = Riffer::ExternalAgent::Identifier.new(vendor: "v", raw: "r", resolved: "r")
+      expect(id.frozen?).must_equal true
+    end
+
+    it "freezes the string attributes" do
+      id = Riffer::ExternalAgent::Identifier.new(vendor: "v", raw: "r", resolved: "r")
+      expect(id.vendor.frozen?).must_equal true
+      expect(id.raw.frozen?).must_equal true
+      expect(id.resolved.frozen?).must_equal true
+    end
+  end
+end

--- a/test/riffer/external_agent/response_test.rb
+++ b/test/riffer/external_agent/response_test.rb
@@ -37,6 +37,16 @@ describe Riffer::ExternalAgent::Response do
       expect(response.vendor_metadata).must_equal({model: "claude"})
       expect(response.vendor_metadata.frozen?).must_equal true
     end
+
+    it "defaults resolved_identifier to nil" do
+      response = Riffer::ExternalAgent::Response.new("Hello")
+      expect(response.resolved_identifier).must_be_nil
+    end
+
+    it "passes resolved_identifier through to the parent" do
+      response = Riffer::ExternalAgent::Response.new("Hello", resolved_identifier: "claude-code/2.1.131")
+      expect(response.resolved_identifier).must_equal "claude-code/2.1.131"
+    end
   end
 
   describe "inheritance" do

--- a/test/riffer/external_agent/response_test.rb
+++ b/test/riffer/external_agent/response_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::ExternalAgent::Response do
+  describe "#initialize" do
+    it "stores the content via the parent" do
+      response = Riffer::ExternalAgent::Response.new("Hello")
+      expect(response.content).must_equal "Hello"
+    end
+
+    it "defaults tool_calls to an empty array" do
+      response = Riffer::ExternalAgent::Response.new("Hello")
+      expect(response.tool_calls).must_equal []
+    end
+
+    it "stores tool_calls" do
+      calls = [Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {q: "ruby"})]
+      response = Riffer::ExternalAgent::Response.new("Hello", tool_calls: calls)
+      expect(response.tool_calls).must_equal calls
+    end
+
+    it "passes messages through to the parent" do
+      messages = [Riffer::Messages::User.new("Hi"), Riffer::Messages::Assistant.new("Hello")]
+      response = Riffer::ExternalAgent::Response.new("Hello", messages: messages)
+      expect(response.messages).must_equal messages
+    end
+
+    it "passes token_usage through to the parent" do
+      usage = Riffer::TokenUsage.new(input_tokens: 10, output_tokens: 20)
+      response = Riffer::ExternalAgent::Response.new("Hello", token_usage: usage)
+      expect(response.token_usage).must_equal usage
+    end
+
+    it "passes vendor_metadata through to the parent and freezes it" do
+      response = Riffer::ExternalAgent::Response.new("Hello", vendor_metadata: {model: "claude"})
+      expect(response.vendor_metadata).must_equal({model: "claude"})
+      expect(response.vendor_metadata.frozen?).must_equal true
+    end
+  end
+
+  describe "inheritance" do
+    it "is a Riffer::AgentResponse" do
+      response = Riffer::ExternalAgent::Response.new("Hello")
+      expect(response).must_be_kind_of Riffer::AgentResponse
+    end
+
+    it "reports success? true by default" do
+      response = Riffer::ExternalAgent::Response.new("Hello")
+      expect(response.success?).must_equal true
+    end
+  end
+end

--- a/test/riffer/external_agent/tool_call_test.rb
+++ b/test/riffer/external_agent/tool_call_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::ExternalAgent::ToolCall do
+  describe "#initialize" do
+    it "stores the name" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {q: "ruby"})
+      expect(call.name).must_equal "search"
+    end
+
+    it "stores the arguments" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {q: "ruby"})
+      expect(call.arguments).must_equal({q: "ruby"})
+    end
+
+    it "defaults result to nil" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {})
+      expect(call.result).must_be_nil
+    end
+
+    it "stores the result" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {}, result: "match")
+      expect(call.result).must_equal "match"
+    end
+
+    it "defaults error to nil" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {})
+      expect(call.error).must_be_nil
+    end
+
+    it "stores the error" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {}, error: "boom")
+      expect(call.error).must_equal "boom"
+    end
+  end
+
+  describe "#error?" do
+    it "returns false when no error is set" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {})
+      expect(call.error?).must_equal false
+    end
+
+    it "returns true when an error is set" do
+      call = Riffer::ExternalAgent::ToolCall.new(name: "search", arguments: {}, error: "boom")
+      expect(call.error?).must_equal true
+    end
+  end
+end

--- a/test/riffer/external_agent_test.rb
+++ b/test/riffer/external_agent_test.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Minimal fixture subclass used to exercise the base behavior provided by
+# Riffer::ExternalAgent (record_message, accumulate_token_usage, on_message
+# dispatch). Echoes the prompt back as the response content with a hardcoded
+# token count.
+class EchoExternalAgent < Riffer::ExternalAgent
+  HARDCODED_USAGE = Riffer::TokenUsage.new(input_tokens: 1, output_tokens: 1)
+
+  def generate(prompt_or_messages, files: nil, context: nil)
+    record_message(Riffer::Messages::User.new(prompt_or_messages))
+    record_message(Riffer::Messages::Assistant.new(prompt_or_messages))
+    accumulate_token_usage(HARDCODED_USAGE)
+    Riffer::ExternalAgent::Response.new(
+      prompt_or_messages,
+      messages: messages.dup,
+      token_usage: token_usage
+    )
+  end
+end
+
+describe Riffer::ExternalAgent do
+  describe "#initialize" do
+    it "starts with empty messages" do
+      expect(Riffer::ExternalAgent.new.messages).must_equal []
+    end
+
+    it "starts with nil token_usage" do
+      expect(Riffer::ExternalAgent.new.token_usage).must_be_nil
+    end
+  end
+
+  describe "AgentInterface contract" do
+    it "raises NotImplementedError on #generate when not overridden" do
+      expect { Riffer::ExternalAgent.new.generate("hi") }.must_raise NotImplementedError
+    end
+
+    it "raises NotImplementedError on #stream when not overridden" do
+      expect { Riffer::ExternalAgent.new.stream("hi") }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#extract_telemetry" do
+    it "raises NotImplementedError by default" do
+      expect { Riffer::ExternalAgent.new.extract_telemetry({}) }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#on_message" do
+    it "raises Riffer::ArgumentError without a block" do
+      expect { Riffer::ExternalAgent.new.on_message }.must_raise Riffer::ArgumentError
+    end
+
+    it "returns self for chaining" do
+      agent = Riffer::ExternalAgent.new
+      expect(agent.on_message { |_| }).must_equal agent
+    end
+
+    it "fires the callback for each recorded message" do
+      agent = EchoExternalAgent.new
+      received = []
+      agent.on_message { |m| received << m }
+      agent.generate("ping")
+      expect(received.size).must_equal 2
+      expect(received.first).must_be_kind_of Riffer::Messages::User
+      expect(received.last).must_be_kind_of Riffer::Messages::Assistant
+    end
+  end
+
+  describe "subclass behavior" do
+    it "accumulates messages across record_message calls" do
+      agent = EchoExternalAgent.new
+      agent.generate("first")
+      agent.generate("second")
+      expect(agent.messages.size).must_equal 4
+    end
+
+    it "sums token_usage across accumulate_token_usage calls" do
+      agent = EchoExternalAgent.new
+      agent.generate("first")
+      agent.generate("second")
+      expect(agent.token_usage.input_tokens).must_equal 2
+      expect(agent.token_usage.output_tokens).must_equal 2
+    end
+
+    it "returns a Riffer::ExternalAgent::Response from generate" do
+      response = EchoExternalAgent.new.generate("hello")
+      expect(response).must_be_kind_of Riffer::ExternalAgent::Response
+      expect(response.content).must_equal "hello"
+    end
+  end
+end

--- a/test/riffer/external_agent_test.rb
+++ b/test/riffer/external_agent_test.rb
@@ -91,4 +91,51 @@ describe Riffer::ExternalAgent do
       expect(response.content).must_equal "hello"
     end
   end
+
+  describe ".agent DSL" do
+    it "stores and retrieves an identifier string" do
+      klass = Class.new(Riffer::ExternalAgent) { agent "test-vendor/1.0" }
+      expect(klass.agent).must_equal "test-vendor/1.0"
+    end
+
+    it "returns nil when not set" do
+      klass = Class.new(Riffer::ExternalAgent)
+      expect(klass.agent).must_be_nil
+    end
+
+    it "inherits from parent class" do
+      parent = Class.new(Riffer::ExternalAgent) { agent "v/1" }
+      child = Class.new(parent)
+      expect(child.agent).must_equal "v/1"
+    end
+
+    it "allows subclass to override" do
+      parent = Class.new(Riffer::ExternalAgent) { agent "v/1" }
+      child = Class.new(parent) { agent "v/2" }
+      expect(child.agent).must_equal "v/2"
+      expect(parent.agent).must_equal "v/1"
+    end
+  end
+
+  describe ".parse_identifier" do
+    it "returns an Identifier for a well-formed vendor/name string" do
+      id = Riffer::ExternalAgent.parse_identifier("acme/2.0")
+      expect(id).must_be_instance_of Riffer::ExternalAgent::Identifier
+      expect(id.vendor).must_equal "acme"
+      expect(id.raw).must_equal "2.0"
+      expect(id.resolved).must_equal "2.0"
+    end
+
+    it "raises Riffer::ArgumentError when there is no slash" do
+      expect { Riffer::ExternalAgent.parse_identifier("nodash") }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises Riffer::ArgumentError when vendor part is empty" do
+      expect { Riffer::ExternalAgent.parse_identifier("/name") }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises Riffer::ArgumentError when name part is empty" do
+      expect { Riffer::ExternalAgent.parse_identifier("vendor/") }.must_raise Riffer::ArgumentError
+    end
+  end
 end

--- a/test/riffer/mcp_server/auth_middleware_test.rb
+++ b/test/riffer/mcp_server/auth_middleware_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::McpServer::AuthMiddleware do
+  let(:token_env_key) { "riffer.mcp_server.token" }
+
+  let(:registry) { Riffer::McpServer::Registry.new }
+  let(:config) { Riffer::McpServer::Config.new(registry: registry) }
+  let(:passthrough) { ->(env) { [200, {}, ["ok #{env[token_env_key].inspect}"]] } }
+  let(:middleware) { Riffer::McpServer::AuthMiddleware.new(passthrough, config: config) }
+
+  def build_env(authorization: nil)
+    env = {
+      "REQUEST_METHOD" => "POST",
+      "PATH_INFO" => "/",
+      "HTTP_HOST" => "example.com",
+      "rack.input" => StringIO.new("")
+    }
+    env["HTTP_AUTHORIZATION"] = authorization if authorization
+    env
+  end
+
+  describe "rejection paths" do
+    before { config.authenticator = ->(_t) { Object.new } }
+
+    it "returns 401 when the Authorization header is missing" do
+      status, _, body = middleware.call(build_env)
+      assert_equal 401, status
+      body_str = body.respond_to?(:join) ? body.join : body.first
+      assert_match(/missing authorization/i, body_str)
+    end
+
+    it "returns 401 when the scheme is not Bearer" do
+      status, _, _ = middleware.call(build_env(authorization: "Basic abc"))
+      assert_equal 401, status
+    end
+
+    it "returns 401 when the Bearer token is empty" do
+      status, _, _ = middleware.call(build_env(authorization: "Bearer "))
+      assert_equal 401, status
+    end
+
+    it "returns 401 when the authenticator returns nil" do
+      config.authenticator = ->(_t) {}
+      status, _, _ = middleware.call(build_env(authorization: "Bearer xyz"))
+      assert_equal 401, status
+    end
+
+    it "returns 401 when the authenticator raises" do
+      config.authenticator = ->(_t) { raise "boom" }
+      status, _, _ = middleware.call(build_env(authorization: "Bearer xyz"))
+      assert_equal 401, status
+    end
+
+    it "returns a JSON-RPC-shaped error body" do
+      _, headers, body = middleware.call(build_env)
+      assert_equal "application/json", headers["Content-Type"]
+      parsed = JSON.parse(body.first)
+      assert_equal "2.0", parsed["jsonrpc"]
+      assert parsed["error"].is_a?(Hash)
+      refute_nil parsed["error"]["code"]
+      refute_nil parsed["error"]["message"]
+    end
+  end
+
+  describe "success path" do
+    it "calls the inner app and stashes the token object in env" do
+      token_object = Struct.new(:role).new(:admin)
+      config.authenticator = ->(t) { (t == "good") ? token_object : nil }
+
+      status, _, body = middleware.call(build_env(authorization: "Bearer good"))
+      assert_equal 200, status
+      assert_match(/role=:admin/, body.first)
+    end
+
+    it "raises ConfigurationError if no authenticator is configured" do
+      config.authenticator = nil
+      assert_raises(Riffer::McpServer::ConfigurationError) do
+        middleware.call(build_env(authorization: "Bearer x"))
+      end
+    end
+  end
+end

--- a/test/riffer/mcp_server/config_test.rb
+++ b/test/riffer/mcp_server/config_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::McpServer::Config do
+  let(:registry) { Riffer::McpServer::Registry.new }
+  let(:config) { Riffer::McpServer::Config.new(registry: registry) }
+
+  let(:tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "demo"
+      description "Demo"
+    end
+  end
+
+  describe "defaults" do
+    it "has no authenticator" do
+      assert_nil config.authenticator
+    end
+
+    it "has a context_builder that returns an empty hash" do
+      assert_equal({}, config.context_builder.call(Object.new))
+    end
+
+    it "has a default server_name" do
+      refute_nil config.server_name
+      refute_empty config.server_name
+    end
+
+    it "has a default server_version" do
+      refute_nil config.server_version
+    end
+  end
+
+  describe "#expose" do
+    it "delegates to the registry" do
+      config.expose(tool_class)
+      assert_equal tool_class, registry.lookup("demo")[:tool_class]
+    end
+
+    it "passes the scope through to the registry" do
+      config.expose(tool_class, scope: :admin)
+      assert_equal :admin, registry.lookup("demo")[:scope]
+    end
+  end
+
+  describe "writers" do
+    it "stores an authenticator" do
+      proc_value = ->(t) { t }
+      config.authenticator = proc_value
+      assert_equal proc_value, config.authenticator
+    end
+
+    it "stores a context_builder" do
+      proc_value = ->(t) { {role: t} }
+      config.context_builder = proc_value
+      assert_equal proc_value, config.context_builder
+    end
+
+    it "stores a custom server_name" do
+      config.server_name = "custom"
+      assert_equal "custom", config.server_name
+    end
+
+    it "stores a custom server_version" do
+      config.server_version = "9.9.9"
+      assert_equal "9.9.9", config.server_version
+    end
+  end
+end

--- a/test/riffer/mcp_server/errors_test.rb
+++ b/test/riffer/mcp_server/errors_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "Riffer::McpServer error hierarchy" do
+  it "Riffer::McpServer::Error inherits from Riffer::Error" do
+    assert_operator Riffer::McpServer::Error, :<, Riffer::Error
+  end
+
+  it "Riffer::McpServer::AuthenticationError inherits from Riffer::McpServer::Error" do
+    assert_operator Riffer::McpServer::AuthenticationError, :<, Riffer::McpServer::Error
+  end
+
+  it "Riffer::McpServer::ConfigurationError inherits from Riffer::McpServer::Error" do
+    assert_operator Riffer::McpServer::ConfigurationError, :<, Riffer::McpServer::Error
+  end
+
+  it "all errors are StandardError descendants" do
+    [Riffer::McpServer::Error, Riffer::McpServer::AuthenticationError, Riffer::McpServer::ConfigurationError].each do |klass|
+      assert_operator klass, :<, StandardError
+    end
+  end
+end

--- a/test/riffer/mcp_server/rack_app_test.rb
+++ b/test/riffer/mcp_server/rack_app_test.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rack"
+require "mcp"
+require_relative "../../fixtures/tools/ping_tool"
+
+describe Riffer::McpServer::RackApp do
+  let(:registry) { Riffer::McpServer::Registry.new }
+  let(:config) { Riffer::McpServer::Config.new(registry: registry) }
+  let(:app) { Riffer::McpServer::RackApp.build(config: config, registry: registry) }
+
+  before do
+    config.authenticator = ->(t) { (t == "good") ? :token_object : nil }
+  end
+
+  def post_jsonrpc(payload, authorization: "Bearer good")
+    body = JSON.generate(payload)
+    headers = {
+      "CONTENT_TYPE" => "application/json",
+      "HTTP_ACCEPT" => "application/json"
+    }
+    headers["HTTP_AUTHORIZATION"] = authorization if authorization
+    Rack::MockRequest.new(app).post("/", input: body, **headers)
+  end
+
+  def jsonrpc_envelope(method, params = {}, id: 1)
+    {jsonrpc: "2.0", id: id, method: method, params: params}
+  end
+
+  def parse(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  describe "authentication" do
+    it "returns 401 when the Authorization header is missing" do
+      response = post_jsonrpc(jsonrpc_envelope("tools/list"), authorization: nil)
+      assert_equal 401, response.status
+    end
+
+    it "returns 401 when the bearer token is invalid" do
+      response = post_jsonrpc(jsonrpc_envelope("tools/list"), authorization: "Bearer bad")
+      assert_equal 401, response.status
+    end
+  end
+
+  describe "tools/list" do
+    before { config.expose(Test::PingTool) }
+
+    it "returns the registered tools with their schemas" do
+      response = post_jsonrpc(jsonrpc_envelope("tools/list"))
+      assert_equal 200, response.status
+
+      tools = parse(response).dig(:result, :tools)
+      assert_equal 1, tools.size
+      assert_equal "ping_tool", tools.first[:name]
+      assert_equal Test::PingTool.description, tools.first[:description]
+      assert_includes tools.first.dig(:inputSchema, :properties).keys, :message
+    end
+  end
+
+  describe "tools/call" do
+    before { config.expose(Test::PingTool) }
+
+    it "dispatches the call and returns the tool's text content" do
+      response = post_jsonrpc(jsonrpc_envelope("tools/call", {name: "ping_tool", arguments: {message: "hello"}}))
+      assert_equal 200, response.status
+
+      content = parse(response).dig(:result, :content)
+      refute_nil content
+      assert_equal "hello", content.first[:text]
+      refute parse(response).dig(:result, :isError)
+    end
+
+    it "surfaces a missing-argument validation failure as a JSON-RPC -32602 error" do
+      response = post_jsonrpc(jsonrpc_envelope("tools/call", {name: "ping_tool", arguments: {}}))
+      assert_equal 200, response.status
+
+      parsed = parse(response)
+      assert_nil parsed[:result]
+      assert_equal(-32_602, parsed.dig(:error, :code))
+      assert_match(/message/i, parsed.dig(:error, :data).to_s)
+    end
+  end
+
+  describe "context_builder threading" do
+    let(:reveal_tool_class) do
+      Class.new(Riffer::Tool) do
+        identifier "reveal_ctx"
+        description "Reveals the per-request context"
+        def call(context:)
+          text(context.inspect)
+        end
+      end
+    end
+
+    it "passes the context_builder's output through to the tool" do
+      config.context_builder = ->(token) { {token_role: token} }
+      config.expose(reveal_tool_class)
+
+      response = post_jsonrpc(jsonrpc_envelope("tools/call", {name: "reveal_ctx", arguments: {}}))
+      assert_equal 200, response.status
+
+      text = parse(response).dig(:result, :content, 0, :text)
+      assert_match(/token_role/, text)
+      assert_match(/token_object/, text)
+    end
+  end
+end

--- a/test/riffer/mcp_server/registry_test.rb
+++ b/test/riffer/mcp_server/registry_test.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::McpServer::Registry do
+  let(:registry) { Riffer::McpServer::Registry.new }
+
+  let(:tool_a) do
+    Class.new(Riffer::Tool) do
+      identifier "tool_a"
+      description "Tool A"
+    end
+  end
+
+  let(:tool_b) do
+    Class.new(Riffer::Tool) do
+      identifier "tool_b"
+      description "Tool B"
+    end
+  end
+
+  describe "#register and #lookup" do
+    it "stores a registration and finds it by tool name" do
+      registry.register(tool_a)
+      record = registry.lookup("tool_a")
+      assert_equal tool_a, record[:tool_class]
+      assert_equal :default, record[:scope]
+    end
+
+    it "returns nil for an unknown tool name" do
+      assert_nil registry.lookup("missing")
+    end
+
+    it "defaults the scope to :default when not given" do
+      registry.register(tool_a)
+      assert_equal :default, registry.lookup("tool_a")[:scope]
+    end
+
+    it "accepts a custom Symbol scope" do
+      registry.register(tool_a, scope: :admin)
+      assert_equal :admin, registry.lookup("tool_a")[:scope]
+    end
+
+    it "accepts an Array<Symbol> scope" do
+      registry.register(tool_a, scope: [:admin, :default])
+      assert_equal [:admin, :default], registry.lookup("tool_a")[:scope]
+    end
+
+    it "keeps both records when re-registering, with lookup returning the most recent" do
+      registry.register(tool_a, scope: :first)
+      registry.register(tool_a, scope: :second)
+      assert_equal :second, registry.lookup("tool_a")[:scope]
+      assert_equal 2, registry.all.size
+    end
+  end
+
+  describe "#all_for_scope" do
+    it "returns records whose scope is the given Symbol" do
+      registry.register(tool_a, scope: :admin)
+      registry.register(tool_b, scope: :default)
+      results = registry.all_for_scope(:admin)
+      assert_equal 1, results.size
+      assert_equal tool_a, results.first[:tool_class]
+    end
+
+    it "returns records whose Array<Symbol> scope includes the given Symbol" do
+      registry.register(tool_a, scope: [:admin, :default])
+      results = registry.all_for_scope(:default)
+      assert_equal 1, results.size
+      assert_equal tool_a, results.first[:tool_class]
+    end
+
+    it "returns empty when no record matches the scope" do
+      registry.register(tool_a, scope: :admin)
+      assert_empty registry.all_for_scope(:nope)
+    end
+
+    it "returns empty when the queried Symbol is not in any Array<Symbol> scope" do
+      registry.register(tool_a, scope: [:admin, :default])
+      assert_empty registry.all_for_scope(:nope)
+    end
+  end
+
+  describe "#all" do
+    it "returns a frozen snapshot of all records" do
+      registry.register(tool_a)
+      snapshot = registry.all
+      assert snapshot.frozen?
+      assert_equal 1, snapshot.size
+    end
+
+    it "returns an independent snapshot — mutating it doesn't affect the registry" do
+      registry.register(tool_a)
+      snapshot = registry.all
+      assert_raises(FrozenError) { snapshot << {tool_class: tool_b, scope: :default} }
+      assert_equal 1, registry.all.size
+    end
+  end
+
+  describe "#clear!" do
+    it "removes all registrations" do
+      registry.register(tool_a)
+      registry.register(tool_b)
+      registry.clear!
+      assert_empty registry.all
+    end
+  end
+
+  describe "thread safety" do
+    it "supports concurrent registration without losing records" do
+      tool_classes = 50.times.map do |i|
+        Class.new(Riffer::Tool) do
+          identifier "tool_#{i}"
+          description "Tool #{i}"
+        end
+      end
+
+      threads = tool_classes.map do |klass|
+        Thread.new { registry.register(klass) }
+      end
+      threads.each(&:join)
+
+      assert_equal 50, registry.all.size
+    end
+  end
+end

--- a/test/riffer/mcp_server/tool_adapter_test.rb
+++ b/test/riffer/mcp_server/tool_adapter_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "mcp"
+require_relative "../../fixtures/tools/ping_tool"
+
+describe Riffer::McpServer::ToolAdapter do
+  let(:adapter_class) { Riffer::McpServer::ToolAdapter.build_for(Test::PingTool) }
+
+  def server_context_double(context_hash)
+    Struct.new(:context) do
+      def [](key)
+        context[key]
+      end
+    end.new(context_hash)
+  end
+
+  describe ".build_for" do
+    it "returns a subclass of MCP::Tool" do
+      assert_operator adapter_class, :<, MCP::Tool
+    end
+
+    it "carries the tool's name forward as MCP tool_name" do
+      assert_equal "ping_tool", adapter_class.tool_name
+    end
+
+    it "carries the tool's description forward" do
+      assert_equal Test::PingTool.description, adapter_class.description_value
+    end
+
+    it "produces an MCP-compatible input_schema with the tool's strict schema" do
+      schema = adapter_class.input_schema_value.to_h
+      assert_includes schema[:properties].keys, :message
+      assert_includes schema[:required], "message"
+    end
+  end
+
+  describe ".call" do
+    it "dispatches the success path and returns an MCP::Tool::Response" do
+      response = adapter_class.call(server_context: server_context_double({}), message: "hello")
+      assert_kind_of MCP::Tool::Response, response
+      refute_predicate response, :error?
+      assert_equal "hello", response.content.first[:text]
+      assert_equal "text", response.content.first[:type]
+    end
+
+    it "passes the riffer context through to the underlying tool" do
+      reveal_tool_class = Class.new(Riffer::Tool) do
+        identifier "reveal_context"
+        description "Reveals the per-request context"
+        def call(context:)
+          text(context.inspect)
+        end
+      end
+
+      reveal_adapter = Riffer::McpServer::ToolAdapter.build_for(reveal_tool_class)
+      ctx = {tenant_id: "abc"}
+      response = reveal_adapter.call(server_context: server_context_double({riffer_context: ctx}))
+      assert_match(/tenant_id/, response.content.first[:text])
+    end
+
+    it "uses an empty hash when server_context is nil" do
+      empty_tool_class = Class.new(Riffer::Tool) do
+        identifier "empty_ctx"
+        description "Returns context inspect"
+        def call(context:)
+          text(context.inspect)
+        end
+      end
+
+      response = Riffer::McpServer::ToolAdapter.build_for(empty_tool_class).call(server_context: nil)
+      assert_equal "{}", response.content.first[:text]
+    end
+
+    it "converts Riffer::ValidationError into an error MCP::Tool::Response with the message" do
+      response = adapter_class.call(server_context: server_context_double({}))
+      assert_predicate response, :error?
+      assert_match(/message is required/, response.content.first[:text])
+    end
+
+    it "converts Riffer::TimeoutError into an error response that mentions the timeout" do
+      slow_tool_class = Class.new(Riffer::Tool) do
+        identifier "slow_tool"
+        description "Sleeps forever"
+        timeout 0.05
+        def call(context:)
+          sleep 1
+          text("never")
+        end
+      end
+
+      response = Riffer::McpServer::ToolAdapter.build_for(slow_tool_class).call(server_context: server_context_double({}))
+      assert_predicate response, :error?
+      assert_match(/timed out/i, response.content.first[:text])
+    end
+
+    it "converts a generic StandardError into an error response without leaking the backtrace" do
+      explosion = Class.new(Riffer::Tool) do
+        identifier "kaboom"
+        description "Raises"
+        def call(context:)
+          raise "kaboom-detail"
+        end
+      end
+
+      response = Riffer::McpServer::ToolAdapter.build_for(explosion).call(server_context: server_context_double({}))
+      assert_predicate response, :error?
+      text = response.content.first[:text]
+      assert_match(/kaboom-detail/, text)
+      refute_match(/tool_adapter\.rb/, text, "backtrace should not leak into the response body")
+    end
+
+    it "raises ArgumentError when the source tool has no description (MCP requires it)" do
+      bare = Class.new(Riffer::Tool) do
+        identifier "bare"
+      end
+      assert_raises(Riffer::ArgumentError) do
+        Riffer::McpServer::ToolAdapter.build_for(bare)
+      end
+    end
+
+    it "treats a server_context with no :riffer_context key as an empty context" do
+      reveal = Class.new(Riffer::Tool) do
+        identifier "no_riffer_ctx"
+        description "Inspects context"
+        def call(context:)
+          text(context.inspect)
+        end
+      end
+      response = Riffer::McpServer::ToolAdapter.build_for(reveal).call(server_context: server_context_double({other: :stuff}))
+      assert_equal "{}", response.content.first[:text]
+    end
+  end
+
+  describe ".sanitize_schema_for_mcp" do
+    it "returns the schema unchanged when :required is non-empty" do
+      schema = {type: "object", required: ["x"]}
+      assert_equal schema, Riffer::McpServer::ToolAdapter.sanitize_schema_for_mcp(schema)
+    end
+
+    it "drops :required when it is an empty array" do
+      schema = {type: "object", properties: {}, required: [], additionalProperties: false}
+      cleaned = Riffer::McpServer::ToolAdapter.sanitize_schema_for_mcp(schema)
+      refute_includes cleaned.keys, :required
+    end
+
+    it "returns the input unchanged when it is not a Hash" do
+      assert_equal "not-a-hash", Riffer::McpServer::ToolAdapter.sanitize_schema_for_mcp("not-a-hash")
+    end
+
+    it "returns the schema unchanged when :required is not an Array" do
+      schema = {type: "object", required: nil}
+      assert_equal schema, Riffer::McpServer::ToolAdapter.sanitize_schema_for_mcp(schema)
+    end
+  end
+end

--- a/test/riffer/mcp_server_test.rb
+++ b/test/riffer/mcp_server_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../fixtures/tools/ping_tool"
+
+describe Riffer::McpServer do
+  before { Riffer::McpServer.reset! }
+  after { Riffer::McpServer.reset! }
+
+  describe ".configure" do
+    it "yields a Config object that exposes tools through the registry" do
+      Riffer::McpServer.configure do |s|
+        s.expose Test::PingTool
+        s.authenticator = ->(_t) { Object.new }
+      end
+
+      assert_equal Test::PingTool, Riffer::McpServer.registry.lookup("ping_tool")[:tool_class]
+      refute_nil Riffer::McpServer.config.authenticator
+    end
+
+    it "accumulates configuration across multiple configure calls" do
+      Riffer::McpServer.configure { |s| s.expose Test::PingTool, scope: :alpha }
+      Riffer::McpServer.configure { |s| s.expose Test::PingTool, scope: :beta }
+      assert_equal 2, Riffer::McpServer.registry.all.size
+    end
+  end
+
+  describe ".rack_app" do
+    it "raises ConfigurationError when no authenticator is configured" do
+      assert_raises(Riffer::McpServer::ConfigurationError) do
+        Riffer::McpServer.rack_app
+      end
+    end
+
+    it "is memoized — repeated calls return the same instance" do
+      Riffer::McpServer.configure { |s| s.authenticator = ->(_t) { Object.new } }
+      first = Riffer::McpServer.rack_app
+      second = Riffer::McpServer.rack_app
+      assert_same first, second
+    end
+  end
+
+  describe ".reset!" do
+    it "clears the registry" do
+      Riffer::McpServer.configure do |s|
+        s.expose Test::PingTool
+        s.authenticator = ->(_t) { Object.new }
+      end
+      Riffer::McpServer.reset!
+      assert_empty Riffer::McpServer.registry.all
+    end
+
+    it "drops the configured authenticator" do
+      Riffer::McpServer.configure { |s| s.authenticator = ->(_t) { Object.new } }
+      Riffer::McpServer.reset!
+      assert_nil Riffer::McpServer.config.authenticator
+    end
+
+    it "drops the cached rack_app so subsequent .rack_app builds afresh" do
+      Riffer::McpServer.configure { |s| s.authenticator = ->(_t) { Object.new } }
+      first = Riffer::McpServer.rack_app
+      Riffer::McpServer.reset!
+      Riffer::McpServer.configure { |s| s.authenticator = ->(_t) { Object.new } }
+      refute_same first, Riffer::McpServer.rack_app
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ VCR.configure do |config|
   config.cassette_library_dir = "test/fixtures/vcr_cassettes"
   config.hook_into :webmock
   config.default_cassette_options = {
-    record: :new_episodes,
+    record: :none,
     match_requests_on: [:method, :uri, :body]
   }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,3 +46,8 @@ SKILLS_FIXTURES_PATH = File.expand_path("fixtures/skills", __dir__)
 def clear_mcp_registry!
   Riffer::Mcp::Registry.registrations.each_key { |name| Riffer::Mcp::Registry.unregister(name) }
 end
+
+# Clears the Riffer::McpServer process-singleton state between tests.
+def clear_mcp_server!
+  Riffer::McpServer.reset!
+end


### PR DESCRIPTION
# PR Description: External Agent Support & MCP Server

## Summary

This PR introduces first-class support for external/vendor-mediated agents in Riffer, and adds the ability for a Riffer application to serve its own MCP server — exposing `Riffer::Tool` subclasses as callable MCP tools to any MCP client.

---

### Phase 1 — Lift the agent contract (`AgentInterface` + `AgentResponse`)

**What:** Extracts the implicit agent contract into two new types:

- `Riffer::AgentInterface` — a module that declares the five-method public contract (`#generate`, `#stream`, `#messages`, `#token_usage`, `#on_message`). All methods raise `NotImplementedError` unless overridden.
- `Riffer::AgentResponse` — a base response class carrying the attributes that generalize across all agent implementations: `content`, `messages`, `token_usage`, `vendor_metadata` (frozen on construction), and `success?`.
- `Riffer::Agent` includes `AgentInterface`. `Riffer::Agent::Response` inherits from `AgentResponse` (loop-specific attributes — `tripwire`, `interrupted?`, `structured_output` — remain on the subclass).

**Why:** Without a formal contract, any non-`Riffer::Agent` implementation (e.g. a vendor CLI wrapper) had no shared type to program against. This gives future external agent classes a well-defined interface to satisfy without needing to subclass `Riffer::Agent`.

---

### Phase 2 — `Riffer::ExternalAgent` base class

**What:** Adds `Riffer::ExternalAgent`, a base class for vendor-mediated agents that drive an external process or SDK rather than the in-process LLM loop. It includes `AgentInterface` and provides shared bookkeeping that every external agent needs: `@messages`, `@token_usage`, and `on_message` callback dispatch via the protected `#record_message` / `#accumulate_token_usage` helpers. Also adds:

- `Riffer::ExternalAgent::Response` — extends `AgentResponse` with a `tool_calls` attribute.
- `Riffer::ExternalAgent::ToolCall` — frozen value object capturing a single tool invocation (`name`, `arguments`, `result`, `error`).
- A class-level `.agent` DSL for declaring the vendor identifier string a subclass runs as.
- `.parse_identifier` for validating and splitting `"vendor/name"` strings.

**Why:** A concrete plugin gem (e.g. `riffer-claude-code`) needs to expose a `Riffer::Agent`-compatible object without reimplementing message tracking, callback dispatch, or token accumulation from scratch. `ExternalAgent` provides exactly that floor with the seam (`#extract_telemetry`) left open for each vendor's output format.

---

### `test: switch VCR to :none mode to prevent cassette drift`

**What:** Changes VCR's default record mode from `:new_episodes` to `:none`.

**Why:** `:new_episodes` was silently appending unmatched HTTP interactions to existing cassettes — in practice this captured local AWS SDK SSO token refresh failures (expired credentials) and polluted unrelated PRs with cassette diffs. `:none` enforces that tests only replay existing cassettes, making cassette state deterministic in CI.

---

### Phase 3 — `ExternalAgent::Identifier` + `resolved_identifier` on `AgentResponse`

**What:**

- `Riffer::ExternalAgent::Identifier` — a deep-frozen value object carrying three fields: `vendor`, `raw` (the identifier as supplied), and `resolved` (after any vendor-specific alias resolution, e.g. `"latest"` → `"2.1.0"`). `ExternalAgent.parse_identifier` returns one of these.
- `resolved_identifier: String?` added to `AgentResponse` — lets an external agent stamp the concrete identifier it ran as onto the response, so callers can observe alias resolution without inspecting raw vendor output.

**Why:** External agents commonly expose aliases (`"latest"`, `"stable"`) that resolve to concrete versions at call time. Callers need to know *which* version actually ran (for logging, audit, and routing). Separating `raw` from `resolved` on the identifier object makes that distinction explicit, and surfacing `resolved_identifier` on the base response keeps it available to any consumer without requiring them to downcast to `ExternalAgent::Response`.

---

### Phase 4 — `Riffer::McpServer`

**What:** Adds a Rack-mountable MCP server that exposes registered `Riffer::Tool` subclasses as callable MCP tools:

- `Riffer::McpServer` — singleton module with `configure`, `rack_app`, and `reset!`. Raises `ConfigurationError` if `rack_app` is called before an authenticator is set.
- `McpServer::Config` — holds `expose`d tool classes, the `authenticator` proc (token → token-object or nil), `context_builder` proc (token-object → Riffer context hash), `server_name`, and `server_version`.
- `McpServer::Registry` — thread-safe store of exposed tool registrations.
- `McpServer::AuthMiddleware` — validates `Authorization: Bearer` headers; returns JSON-RPC 2.0 error envelopes with HTTP 401 on failure; stashes the token object in the Rack env.
- `McpServer::RackApp` — composes `AuthMiddleware → ContextBridge → MCP::StreamableHTTPTransport`. `ContextBridge` builds a fresh `MCP::Server` per request (stateless, JSON-response mode) with the Riffer context injected as `server_context`.
- `McpServer::ToolAdapter` — generates anonymous `MCP::Tool` subclasses from `Riffer::Tool` classes, mirroring the name, description, and strict JSON schema. Routes `ValidationError` / `TimeoutError` to MCP error responses; never leaks backtraces.
- `rack` and `mcp` added as optional development dependencies (loaded lazily via `depends_on`).
- New user-facing guide: `docs/15_MCP_SERVER.md`.

**Why:** Makes Riffer a two-way MCP citizen. Previously Riffer could *consume* MCP tools (via `Riffer::Mcp`); now it can also *serve* them. This is the infrastructure needed for the `riffer-claude-code` plugin to expose Riffer tools to Claude Code's MCP client without any extra glue code.

---

## Test plan

- [ ] `bundle exec rake test` — all tests pass (pre-existing Bedrock errors are AWS SSO credential failures unrelated to this branch)
- [ ] `bundle exec rake standard` — no style violations
- [ ] Manually mount `Riffer::McpServer.rack_app` with a Puma `config.ru` and verify `tools/list` and `tools/call` responses against a real `Riffer::Tool`
