### PR TITLE
feat!: forward assistant_message to ToolRuntime hooks

### DIFF
--- a/docs/07_TOOL_ADVANCED.md
+++ b/docs/07_TOOL_ADVANCED.md
@@ -215,7 +215,7 @@ Create a custom runtime by subclassing `Riffer::ToolRuntime` and overriding the 
 class HttpToolRuntime < Riffer::ToolRuntime
   private
 
-  def dispatch_tool_call(tool_call, tools:, context:)
+  def dispatch_tool_call(tool_call, tools:, context:, assistant_message: nil)
     # Dispatch tool execution to an external service
     response = HttpClient.post("/tools/execute", {
       name: tool_call.name,
@@ -238,7 +238,7 @@ Each tool call is wrapped by the `around_tool_call` method, which yields by defa
 class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   private
 
-  def around_tool_call(tool_call, context:)
+  def around_tool_call(tool_call, context:, assistant_message: nil)
     start = Time.now
     result = yield
     duration = Time.now - start
@@ -249,3 +249,7 @@ end
 ```
 
 Subclasses inherit the hook and can override it further.
+
+The `assistant_message:` kwarg is the `Riffer::Messages::Assistant` that produced the tool calls (the same object the agent appends to message history). It is `nil` when the runtime is invoked outside an agent loop. Use it when your hook or dispatcher needs context that lives on the assistant turn — for example, the accompanying assistant text, the model's reasoning content, or the full set of sibling tool calls from the same turn. The kwarg is **not** forwarded to `Tool#call`; tools that need it must read it via a custom `dispatch_tool_call` override.
+
+> **Note:** Custom runtimes that override `around_tool_call` or `dispatch_tool_call` must accept the `assistant_message:` kwarg (or `**kwargs`). Older overrides that omit it will raise `ArgumentError: unknown keyword: :assistant_message`.

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -671,7 +671,7 @@ class Riffer::Agent
   #: (Riffer::Messages::Assistant) -> void
   def execute_tool_calls(response)
     runtime = resolve_tool_runtime
-    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @context)
+    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @context, assistant_message: response)
 
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
@@ -698,11 +698,11 @@ class Riffer::Agent
   # have a corresponding tool result. Safe to call unconditionally —
   # returns immediately when there is nothing pending.
   def execute_pending_tool_calls
-    pending = pending_tool_calls
+    assistant, pending = pending_tool_calls
     return if pending.empty?
 
     runtime = resolve_tool_runtime
-    results = runtime.execute(pending, tools: resolved_tools, context: @context)
+    results = runtime.execute(pending, tools: resolved_tools, context: @context, assistant_message: assistant)
 
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
@@ -715,18 +715,24 @@ class Riffer::Agent
     end
   end
 
+  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
+  # When there is no assistant message or no pending calls, the second
+  # element is an empty array.
+  #
+  #--
+  #: () -> [untyped, Array[Riffer::Messages::Assistant::ToolCall]]
   def pending_tool_calls
     last_assistant_idx = @messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
-    return [] unless last_assistant_idx
+    return [nil, []] unless last_assistant_idx
 
     assistant = @messages[last_assistant_idx]
-    return [] if assistant.tool_calls.empty?
+    return [assistant, []] if assistant.tool_calls.empty?
 
     executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
       m.is_a?(Riffer::Messages::Tool)
     }.map(&:tool_call_id)
 
-    assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }
+    [assistant, assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }]
   end
 
   #--

--- a/lib/riffer/tool_runtime.rb
+++ b/lib/riffer/tool_runtime.rb
@@ -32,13 +32,17 @@ class Riffer::ToolRuntime
   # [tool_calls] the tool calls to execute.
   # [tools] the resolved tool classes.
   # [context] the context hash.
+  # [assistant_message] the assistant message that produced these tool
+  #   calls, when known. Forwarded to +around_tool_call+ and
+  #   +dispatch_tool_call+ so subclasses can access it (e.g. for
+  #   instrumentation that needs the accompanying assistant text).
   #
   #--
-  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
-  def execute(tool_calls, tools:, context:)
+  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute(tool_calls, tools:, context:, assistant_message: nil)
     @runner.map(tool_calls, context: context) do |tool_call|
-      result = around_tool_call(tool_call, context: context) do
-        dispatch_tool_call(tool_call, tools: tools, context: context)
+      result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
+        dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
       end
       [tool_call, result]
     end
@@ -52,7 +56,7 @@ class Riffer::ToolRuntime
   #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   #     private
   #
-  #     def around_tool_call(tool_call, context:)
+  #     def around_tool_call(tool_call, context:, assistant_message: nil)
   #       start = Time.now
   #       result = yield
   #       Rails.logger.info("Tool #{tool_call.name} took #{Time.now - start}s")
@@ -61,8 +65,8 @@ class Riffer::ToolRuntime
   #   end
   #
   #--
-  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-  def around_tool_call(tool_call, context:)
+  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call(tool_call, context:, assistant_message: nil)
     yield
   end
 
@@ -74,10 +78,12 @@ class Riffer::ToolRuntime
   # [tool_call] the tool call to execute.
   # [tools] the resolved tool classes.
   # [context] the context hash.
+  # [assistant_message] the assistant message that produced this tool
+  #   call, when known.
   #
   #--
-  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
-  def dispatch_tool_call(tool_call, tools:, context:)
+  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
+  def dispatch_tool_call(tool_call, tools:, context:, assistant_message: nil)
     tool_class = tools.find { |tc| tc.name == tool_call.name }
 
     if tool_class.nil?

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -344,7 +344,13 @@ class Riffer::Agent
   # returns immediately when there is nothing pending.
   def execute_pending_tool_calls: () -> void
 
-  def pending_tool_calls: () -> untyped
+  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
+  # When there is no assistant message or no pending calls, the second
+  # element is an empty array.
+  #
+  # --
+  # : () -> [untyped, Array[Riffer::Messages::Assistant::ToolCall]]
+  def pending_tool_calls: () -> [ untyped, Array[Riffer::Messages::Assistant::ToolCall] ]
 
   # --
   # : () -> void

--- a/sig/generated/riffer/tool_runtime.rbs
+++ b/sig/generated/riffer/tool_runtime.rbs
@@ -25,10 +25,14 @@ class Riffer::ToolRuntime
   # [tool_calls] the tool calls to execute.
   # [tools] the resolved tool classes.
   # [context] the context hash.
+  # [assistant_message] the assistant message that produced these tool
+  #   calls, when known. Forwarded to +around_tool_call+ and
+  #   +dispatch_tool_call+ so subclasses can access it (e.g. for
+  #   instrumentation that needs the accompanying assistant text).
   #
   # --
-  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
-  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
+  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
 
   # Hook that wraps each tool call execution. Override in subclasses
   # to customize. Must +yield+ to continue execution.
@@ -38,7 +42,7 @@ class Riffer::ToolRuntime
   #   class InstrumentedRuntime < Riffer::ToolRuntime::Inline
   #     private
   #
-  #     def around_tool_call(tool_call, context:)
+  #     def around_tool_call(tool_call, context:, assistant_message: nil)
   #       start = Time.now
   #       result = yield
   #       Rails.logger.info("Tool #{tool_call.name} took #{Time.now - start}s")
@@ -47,8 +51,8 @@ class Riffer::ToolRuntime
   #   end
   #
   # --
-  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
 
   private
 
@@ -58,10 +62,12 @@ class Riffer::ToolRuntime
   # [tool_call] the tool call to execute.
   # [tools] the resolved tool classes.
   # [context] the context hash.
+  # [assistant_message] the assistant message that produced this tool
+  #   call, when known.
   #
   # --
-  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
-  def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?) -> Riffer::Tools::Response
+  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
+  def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
 
   # --
   # : (String?) -> Hash[Symbol, untyped]

--- a/test/riffer/tool_runtime_test.rb
+++ b/test/riffer/tool_runtime_test.rb
@@ -184,7 +184,7 @@ describe Riffer::ToolRuntime do
     it "can be overridden in a subclass" do
       log = []
       runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
-        define_method(:around_tool_call) do |tool_call, context:, &block|
+        define_method(:around_tool_call) do |tool_call, **, &block|
           log << "before:#{tool_call.name}"
           result = block.call
           log << "after:#{tool_call.name}"
@@ -201,7 +201,7 @@ describe Riffer::ToolRuntime do
     it "is inherited by subclasses" do
       log = []
       parent = Class.new(Riffer::ToolRuntime::Inline) do
-        define_method(:around_tool_call) do |tool_call, context:, &block|
+        define_method(:around_tool_call) do |tool_call, **, &block|
           log << "parent"
           block.call
         end
@@ -217,14 +217,14 @@ describe Riffer::ToolRuntime do
     it "allows subclass to override" do
       log = []
       parent = Class.new(Riffer::ToolRuntime::Inline) do
-        define_method(:around_tool_call) do |_, context:, &block|
+        define_method(:around_tool_call) do |_, **, &block|
           log << "parent"
           block.call
         end
       end
 
       child = Class.new(parent) do
-        define_method(:around_tool_call) do |_, context:, &block|
+        define_method(:around_tool_call) do |_, **, &block|
           log << "child"
           block.call
         end
@@ -234,6 +234,55 @@ describe Riffer::ToolRuntime do
       child.new.execute([tool_call], tools: tools, context: context)
 
       expect(log).must_equal ["child"]
+    end
+
+    it "forwards assistant_message to the hook" do
+      seen = []
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
+        define_method(:around_tool_call) do |_tool_call, context:, assistant_message: nil, &block|
+          seen << assistant_message
+          block.call
+        end
+      end
+
+      assistant = Riffer::Messages::Assistant.new("here you go", tool_calls: [])
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context, assistant_message: assistant)
+
+      expect(seen).must_equal [assistant]
+    end
+
+    it "defaults assistant_message to nil when not supplied" do
+      seen = []
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
+        define_method(:around_tool_call) do |_tool_call, context:, assistant_message: nil, &block|
+          seen << assistant_message
+          block.call
+        end
+      end
+
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context)
+
+      expect(seen).must_equal [nil]
+    end
+  end
+
+  describe "#dispatch_tool_call" do
+    it "forwards assistant_message to overrides" do
+      seen = []
+      runtime_class = Class.new(Riffer::ToolRuntime::Inline) do
+        define_method(:dispatch_tool_call) do |_tool_call, tools:, context:, assistant_message: nil|
+          seen << assistant_message
+          Riffer::Tools::Response.text("ok")
+        end
+      end
+
+      assistant = Riffer::Messages::Assistant.new("calling tool", tool_calls: [])
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      runtime_class.new.execute([tool_call], tools: tools, context: context, assistant_message: assistant)
+
+      expect(seen).must_equal [assistant]
     end
   end
 end


### PR DESCRIPTION
## Summary

- Adds an `assistant_message:` kwarg to `Riffer::ToolRuntime#execute`, `#around_tool_call`, and `#dispatch_tool_call`. The agent threads the originating `Riffer::Messages::Assistant` through both runtime call sites (`execute_tool_calls` and `execute_pending_tool_calls`).
- Custom runtimes can now reach the assistant turn — accompanying text, sibling tool calls, etc. — when wrapping or dispatching individual tool calls. The kwarg is **not** forwarded to `Tool#call`; tools that need it must opt in via a `dispatch_tool_call` override.
- `pending_tool_calls` now returns `[assistant, calls]` so `execute_pending_tool_calls` can forward the message without a second scan over `@messages`.

## Breaking change

Custom subclasses of `Riffer::ToolRuntime` that override `around_tool_call` or `dispatch_tool_call` **must** accept the new `assistant_message:` kwarg (or `**kwargs`). Existing overrides without it will raise `ArgumentError: unknown keyword: :assistant_message` at runtime — Ruby does not silently absorb unknown keyword arguments. Direct callers of `runtime.execute(...)` are unaffected; the kwarg defaults to `nil`.

Migration:

```ruby
# Before
def around_tool_call(tool_call, context:)
  ...
end

# After
def around_tool_call(tool_call, context:, assistant_message: nil)
  ...
end
```

## Test plan

- [x] `bundle exec rake` passes (1392 runs, 0 failures, steep clean, standard clean)
- [x] New tests cover: assistant_message threading into `around_tool_call`, threading into `dispatch_tool_call`, and the default-`nil` case for direct `execute` callers
- [x] Existing override tests updated to accept `**kwargs`, demonstrating the migration path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated custom runtime documentation to reflect new `assistant_message:` parameter in tool execution hook signatures.

* **Chores**
  * Internal changes to forward assistant message through tool execution pipeline. Custom runtime implementations must update hook signatures to accept `assistant_message:` (or `**kwargs`) to prevent errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->