### PR TITLE
feat: add history mutation API to Riffer::Agent

### DIFF
--- a/docs/04_AGENT_LIFECYCLE.md
+++ b/docs/04_AGENT_LIFECYCLE.md
@@ -235,31 +235,28 @@ agent.on_message do |msg|
 end
 ```
 
-#### Synthesizing pending tool results on interrupt
+#### Healing pending tool results on interrupt (experimental)
 
 When an interrupt fires while the assistant has a `tool_use` block that hasn't been answered yet, the LLM will reject the next request unless every `tool_use` has a matching `tool_result`. By default, the next `generate` call re-executes those pending tools (see "Resuming an Interrupted Loop" above).
 
-When the interrupt represents a course-change rather than a pause — e.g. a voice barge-in where the user has moved on — re-execution is the wrong behavior. Pass a `synthesize:` block to fill any orphan `tool_use` with a synthesized result, leaving history valid for the next turn:
+When the interrupt represents a course-change rather than a pause — e.g. a voice barge-in where the user has moved on — re-execution is the wrong behavior. Opt into history healing to have riffer fill any orphan `tool_use` with a placeholder `Riffer::Messages::Tool` carrying `error_type: :interrupted`, leaving history valid for the next turn:
 
 ```ruby
+Riffer.configure { |c| c.experimental_history_healing = true }
+
 agent.on_message do |msg|
-  if msg.is_a?(Riffer::Messages::Assistant) && barge_in?
-    agent.interrupt!(:user_interrupt, synthesize: ->(tool_call) {
-      Riffer::Tools::Response.error(
-        "Tool call interrupted; the user changed direction.",
-        type: :interrupted
-      )
-    })
-  end
+  agent.interrupt!(:user_interrupt) if msg.is_a?(Riffer::Messages::Assistant) && barge_in?
 end
 
 response = agent.generate("Tell me a story")
-response.synthesized_tool_call_ids  # => ["call_abc123", ...]
+response.healed_tool_call_ids  # => ["call_abc123", ...]
 ```
 
-The block is called once per orphan and must return a `Riffer::Tools::Response`. Riffer wraps each response into a `Riffer::Messages::Tool` and inserts it immediately after its parent assistant message. The list of synthesized `call_id`s is exposed on `response.synthesized_tool_call_ids` (and on `Riffer::StreamEvents::Interrupt#synthesized_tool_call_ids` when streaming).
+The placeholder content is fixed: `"Tool call interrupted before completion."` with `error_type: :interrupted`. Each placeholder is inserted immediately after its parent assistant message. The list of filled `call_id`s is exposed on `response.healed_tool_call_ids` (and on `Riffer::StreamEvents::Interrupt#healed_tool_call_ids` when streaming).
 
-When the agent itself interrupts (currently: `max_steps` exceeded), riffer fills the orphan tool_use with a built-in error response — `synthesized_tool_call_ids` carries those `call_id`s as well.
+Healing covers all interrupts uniformly — caller-issued `interrupt!` and the built-in `INTERRUPT_MAX_STEPS` ceiling alike. When the flag is off (the default), orphans remain in history and `execute_pending_tool_calls` re-runs them on the next `generate` call.
+
+If you need finer control over placeholder content (per-call shape, structured metadata, etc.), use the `replace_tool_result` mutator below to upgrade a placeholder after the interrupt returns.
 
 ### Mutating history
 
@@ -267,14 +264,9 @@ The agent exposes a small set of in-place mutators that enforce the `tool_use` �
 
 - **`agent.replace_assistant_content(id:, content:)`** — In-place truncation/edit. Preserves `tool_calls`, `token_usage`, and `id`. Empty `content` delegates to `remove_message`.
 - **`agent.remove_message(id:)`** — Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` (use `replace_tool_result`).
-- **`agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)`** — Replace a tool result in place, preserving `name` and `id`.
-- **`agent.synthesize_missing_tool_results(&block)`** — Fill any orphan `tool_use` in history. The block is called once per orphan with the originating `Riffer::Messages::Assistant::ToolCall` and must return a `Riffer::Tools::Response`. Returns the `call_id`s that were synthesized.
+- **`agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)`** — Replace a tool result in place, preserving `name` and `id`. Use this to upgrade an interrupt-time placeholder once the real result is available.
 
-```ruby
-agent.synthesize_missing_tool_results do |tool_call|
-  Riffer::Tools::Response.error("interrupted", type: :interrupted)
-end
-```
+Bulk filling of orphan `tool_use` blocks is handled by `Riffer.config.experimental_history_healing` (see "Healing pending tool results on interrupt" above) — there is no public synthesizer hook.
 
 Read accessors that pair with the mutators:
 
@@ -287,7 +279,7 @@ agent.orphaned_tool_call_ids      # => Array[String]   (zero-cost validation)
 
 Mutating history while a `stream` enumerator is being consumed is undefined; mutators are intended for use between turns.
 
-Mutators do **not** fire `on_message` — that callback is reserved for messages produced by inference (LLM responses, tool execution results). Consumers learn that synthesis happened via `Response#synthesized_tool_call_ids` (and `StreamEvents::Interrupt#synthesized_tool_call_ids`).
+Mutators do **not** fire `on_message` — that callback is reserved for messages produced by inference (LLM responses, tool execution results). Healing placeholders bypass `on_message` for the same reason; consumers learn that healing happened via `Response#healed_tool_call_ids` (and `StreamEvents::Interrupt#healed_tool_call_ids`).
 
 ### token_usage
 
@@ -310,18 +302,18 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 `Riffer::Agent::Response` is returned by `generate`:
 
-| Attribute                   | Type                        | Description                                                                            |
-| --------------------------- | --------------------------- | -------------------------------------------------------------------------------------- |
-| `content`                   | `String`                    | The response text                                                                      |
-| `structured_output`         | `Hash` / `nil`              | Parsed and validated structured output (see below)                                     |
-| `blocked?`                  | `Boolean`                   | `true` if a guardrail tripwire fired                                                   |
-| `tripwire`                  | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request                                        |
-| `modified?`                 | `Boolean`                   | `true` if a guardrail modified the content                                             |
-| `modifications`             | `Array`                     | List of guardrail modifications applied                                                |
-| `interrupted?`              | `Boolean`                   | `true` if the loop was interrupted                                                     |
-| `interrupt_reason`          | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`                                         |
-| `messages`                  | `Array`                     | Full message history from the conversation                                             |
-| `synthesized_tool_call_ids` | `Array[String]`             | `tool_call` ids filled with synthesized results during interrupt synthesis (else `[]`) |
+| Attribute              | Type                        | Description                                                                          |
+| ---------------------- | --------------------------- | ------------------------------------------------------------------------------------ |
+| `content`              | `String`                    | The response text                                                                    |
+| `structured_output`    | `Hash` / `nil`              | Parsed and validated structured output (see below)                                   |
+| `blocked?`             | `Boolean`                   | `true` if a guardrail tripwire fired                                                 |
+| `tripwire`             | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request                                      |
+| `modified?`            | `Boolean`                   | `true` if a guardrail modified the content                                           |
+| `modifications`        | `Array`                     | List of guardrail modifications applied                                              |
+| `interrupted?`         | `Boolean`                   | `true` if the loop was interrupted                                                   |
+| `interrupt_reason`     | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`                                       |
+| `messages`             | `Array`                     | Full message history from the conversation                                           |
+| `healed_tool_call_ids` | `Array[String]`             | `tool_call` ids filled with placeholder results during interrupt healing (else `[]`) |
 
 ### response.structured_output
 

--- a/docs/04_AGENT_LIFECYCLE.md
+++ b/docs/04_AGENT_LIFECYCLE.md
@@ -235,6 +235,54 @@ agent.on_message do |msg|
 end
 ```
 
+#### Synthesizing pending tool results on interrupt
+
+When an interrupt fires while the assistant has a `tool_use` block that hasn't been answered yet, the LLM will reject the next request unless every `tool_use` has a matching `tool_result`. By default, the next `generate` call re-executes those pending tools (see "Resuming an Interrupted Loop" above).
+
+When the interrupt represents a course-change rather than a pause — e.g. a voice barge-in where the user has moved on — re-execution is the wrong behavior. Pass a `synthesize:` block to fill any orphan `tool_use` with a synthesized result, leaving history valid for the next turn:
+
+```ruby
+agent.on_message do |msg|
+  if msg.is_a?(Riffer::Messages::Assistant) && barge_in?
+    agent.interrupt!(:user_interrupt, synthesize: ->(tool_call) {
+      Riffer::Tools::Response.error(
+        "Tool call interrupted; the user changed direction.",
+        type: :interrupted
+      )
+    })
+  end
+end
+
+response = agent.generate("Tell me a story")
+response.synthesized_tool_call_ids  # => ["call_abc123", ...]
+```
+
+The block is called once per orphan and must return a `Riffer::Tools::Response`. Riffer wraps each response into a `Riffer::Messages::Tool` and inserts it immediately after its parent assistant message. The list of synthesized `call_id`s is exposed on `response.synthesized_tool_call_ids` (and on `Riffer::StreamEvents::Interrupt#synthesized_tool_call_ids` when streaming).
+
+When the agent itself interrupts (currently: `max_steps` exceeded), riffer fills the orphan tool_use with a built-in error response — `synthesized_tool_call_ids` carries those `call_id`s as well.
+
+### Mutating history
+
+The agent exposes a small set of in-place mutators that enforce the `tool_use` ↔ `tool_result` invariant on every operation. Use these to align the agent's history with external state (persisted transcript, partial output that wasn't actually delivered, etc.) without rebuilding the agent.
+
+| Method                                                                    | Purpose                                                                                                                                            |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------ |
+| `agent.replace_assistant_content(id:, content:)`                          | In-place truncation/edit. Preserves `tool_calls`, `token_usage`, and `id`. Empty `content` delegates to `remove_message`.                          |
+| `agent.remove_message(id:)`                                               | Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` (use `replace_tool_result`). |
+| `agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)` | Replace a tool result in place, preserving `name` and `id`.                                                                                        |
+| `agent.synthesize_missing_tool_results {                                  | tc                                                                                                                                                 | Riffer::Tools::Response.error(...) }` | Fill any orphan `tool_use` in history. Returns the `call_id`s that were synthesized. |
+
+Read accessors that pair with the mutators:
+
+```ruby
+agent.message_by_id(id)           # => Riffer::Messages::Base or nil
+agent.tool_message_for(call_id)   # => Riffer::Messages::Tool or nil
+agent.last_assistant              # => Riffer::Messages::Assistant or nil
+agent.orphaned_tool_call_ids      # => Array[String]   (zero-cost validation)
+```
+
+Mutating history while a `stream` enumerator is being consumed is undefined; mutators are intended for use between turns.
+
 ### token_usage
 
 Access cumulative token usage across all LLM calls:

--- a/docs/04_AGENT_LIFECYCLE.md
+++ b/docs/04_AGENT_LIFECYCLE.md
@@ -265,12 +265,16 @@ When the agent itself interrupts (currently: `max_steps` exceeded), riffer fills
 
 The agent exposes a small set of in-place mutators that enforce the `tool_use` ↔ `tool_result` invariant on every operation. Use these to align the agent's history with external state (persisted transcript, partial output that wasn't actually delivered, etc.) without rebuilding the agent.
 
-| Method                                                                    | Purpose                                                                                                                                            |
-| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------ |
-| `agent.replace_assistant_content(id:, content:)`                          | In-place truncation/edit. Preserves `tool_calls`, `token_usage`, and `id`. Empty `content` delegates to `remove_message`.                          |
-| `agent.remove_message(id:)`                                               | Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` (use `replace_tool_result`). |
-| `agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)` | Replace a tool result in place, preserving `name` and `id`.                                                                                        |
-| `agent.synthesize_missing_tool_results {                                  | tc                                                                                                                                                 | Riffer::Tools::Response.error(...) }` | Fill any orphan `tool_use` in history. Returns the `call_id`s that were synthesized. |
+- **`agent.replace_assistant_content(id:, content:)`** — In-place truncation/edit. Preserves `tool_calls`, `token_usage`, and `id`. Empty `content` delegates to `remove_message`.
+- **`agent.remove_message(id:)`** — Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` (use `replace_tool_result`).
+- **`agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)`** — Replace a tool result in place, preserving `name` and `id`.
+- **`agent.synthesize_missing_tool_results(&block)`** — Fill any orphan `tool_use` in history. The block is called once per orphan with the originating `Riffer::Messages::Assistant::ToolCall` and must return a `Riffer::Tools::Response`. Returns the `call_id`s that were synthesized.
+
+```ruby
+agent.synthesize_missing_tool_results do |tool_call|
+  Riffer::Tools::Response.error("interrupted", type: :interrupted)
+end
+```
 
 Read accessors that pair with the mutators:
 
@@ -282,6 +286,8 @@ agent.orphaned_tool_call_ids      # => Array[String]   (zero-cost validation)
 ```
 
 Mutating history while a `stream` enumerator is being consumed is undefined; mutators are intended for use between turns.
+
+Mutators do **not** fire `on_message` — that callback is reserved for messages produced by inference (LLM responses, tool execution results). Consumers learn that synthesis happened via `Response#synthesized_tool_call_ids` (and `StreamEvents::Interrupt#synthesized_tool_call_ids`).
 
 ### token_usage
 
@@ -304,17 +310,18 @@ Returns `nil` if the provider doesn't report usage, or a `Riffer::TokenUsage` ob
 
 `Riffer::Agent::Response` is returned by `generate`:
 
-| Attribute           | Type                        | Description                                        |
-| ------------------- | --------------------------- | -------------------------------------------------- |
-| `content`           | `String`                    | The response text                                  |
-| `structured_output` | `Hash` / `nil`              | Parsed and validated structured output (see below) |
-| `blocked?`          | `Boolean`                   | `true` if a guardrail tripwire fired               |
-| `tripwire`          | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request    |
-| `modified?`         | `Boolean`                   | `true` if a guardrail modified the content         |
-| `modifications`     | `Array`                     | List of guardrail modifications applied            |
-| `interrupted?`      | `Boolean`                   | `true` if the loop was interrupted                 |
-| `interrupt_reason`  | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`     |
-| `messages`          | `Array`                     | Full message history from the conversation         |
+| Attribute                   | Type                        | Description                                                                            |
+| --------------------------- | --------------------------- | -------------------------------------------------------------------------------------- |
+| `content`                   | `String`                    | The response text                                                                      |
+| `structured_output`         | `Hash` / `nil`              | Parsed and validated structured output (see below)                                     |
+| `blocked?`                  | `Boolean`                   | `true` if a guardrail tripwire fired                                                   |
+| `tripwire`                  | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request                                        |
+| `modified?`                 | `Boolean`                   | `true` if a guardrail modified the content                                             |
+| `modifications`             | `Array`                     | List of guardrail modifications applied                                                |
+| `interrupted?`              | `Boolean`                   | `true` if the loop was interrupted                                                     |
+| `interrupt_reason`          | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`                                         |
+| `messages`                  | `Array`                     | Full message history from the conversation                                             |
+| `synthesized_tool_call_ids` | `Array[String]`             | `tool_call` ids filled with synthesized results during interrupt synthesis (else `[]`) |
 
 ### response.structured_output
 

--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -327,3 +327,7 @@ end
 ```
 
 Subclasses implement `role` and optionally extend `to_h` with additional fields.
+
+## Editing history after the fact
+
+The agent's `messages` array is mutable, but the message value objects themselves are immutable. To edit recorded history — truncate an assistant message, replace a tool result, fill an orphan `tool_use` — use the mutators on `Riffer::Agent`. Each mutator enforces the `tool_use` ↔ `tool_result` invariant. See [Mutating history](04_AGENT_LIFECYCLE.md#mutating-history) for the full list.

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -150,7 +150,7 @@ end
 | `:raise`            | Raise `Riffer::ArgumentError` on the first violation, naming the offending `call_id`.                                                         |
 | `:strip`            | Silently drop offending exchanges (orphaned `tool_use` + their siblings, parentless `Tool` messages) and proceed with the surviving messages. |
 
-Pending tool calls on the **last** assistant message are not violations — riffer's cross-process resume path executes them via `execute_pending_tool_calls` before the next LLM call.
+Pending tool calls are not a violation when they sit on the **resume boundary** — the last assistant whose subsequent messages are purely `Tool` results (or none). That's the cross-process resume shape, and riffer's `execute_pending_tool_calls` will run those pending calls before the next LLM call. An assistant followed by a `User` (or another `Assistant`) is past the boundary and its orphans are real violations.
 
 Per-call override:
 

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -65,11 +65,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value                           | Description                                                                                        |
-| ------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `Riffer::ToolRuntime` subclass  | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`)  |
-| `Riffer::ToolRuntime` instance  | Custom runtime with specific options                                                               |
-| `Proc`                          | Dynamic resolution                                                                                 |
+| Value                          | Description                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `Riffer::ToolRuntime` subclass | Instantiated automatically (e.g., `Riffer::ToolRuntime::Inline`, `Riffer::ToolRuntime::Threaded`) |
+| `Riffer::ToolRuntime` instance | Custom runtime with specific options                                                              |
+| `Proc`                         | Dynamic resolution                                                                                |
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
@@ -133,6 +133,31 @@ agent.generate([
 Missing ids raise `Riffer::ArgumentError` with the offending index.
 
 See [Messages — IDs](08_MESSAGES.md#ids) for more details.
+
+### Invalid Seed Strategy
+
+Controls how `agent.generate(messages_array)` handles seeded history that violates the `tool_use` ↔ `tool_result` invariant — e.g. an assistant `tool_call` with no matching tool result deeper in history, or a `Riffer::Messages::Tool` whose `tool_call_id` has no parent assistant.
+
+```ruby
+Riffer.configure do |config|
+  config.on_invalid_seed = :strip
+end
+```
+
+| Value               | Description                                                                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:ignore` (default) | Pass the seed through untouched. The pre-validation behavior — preserved as the default to avoid breaking existing callers.                   |
+| `:raise`            | Raise `Riffer::ArgumentError` on the first violation, naming the offending `call_id`.                                                         |
+| `:strip`            | Silently drop offending exchanges (orphaned `tool_use` + their siblings, parentless `Tool` messages) and proceed with the surviving messages. |
+
+Pending tool calls on the **last** assistant message are not violations — riffer's cross-process resume path executes them via `execute_pending_tool_calls` before the next LLM call.
+
+Per-call override:
+
+```ruby
+agent.generate(messages, on_invalid_seed: :strip)
+agent.stream(messages, on_invalid_seed: :strip)
+```
 
 ## Agent-Level Configuration
 

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -134,30 +134,26 @@ Missing ids raise `Riffer::ArgumentError` with the offending index.
 
 See [Messages — IDs](08_MESSAGES.md#ids) for more details.
 
-### Invalid Seed Strategy
+### Experimental: History Healing
 
-Controls how `agent.generate(messages_array)` handles seeded history that violates the `tool_use` ↔ `tool_result` invariant — e.g. an assistant `tool_call` with no matching tool result deeper in history, or a `Riffer::Messages::Tool` whose `tool_call_id` has no parent assistant.
+> **Warning:** This feature is experimental and may change without notice.
+
+Opts the agent into keeping the `tool_use` ↔ `tool_result` invariant intact on its own:
 
 ```ruby
 Riffer.configure do |config|
-  config.on_invalid_seed = :strip
+  config.experimental_history_healing = true
 end
 ```
 
-| Value               | Description                                                                                                                                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `:ignore` (default) | Pass the seed through untouched. The pre-validation behavior — preserved as the default to avoid breaking existing callers.                   |
-| `:raise`            | Raise `Riffer::ArgumentError` on the first violation, naming the offending `call_id`.                                                         |
-| `:strip`            | Silently drop offending exchanges (orphaned `tool_use` + their siblings, parentless `Tool` messages) and proceed with the surviving messages. |
+When enabled, two repairs run automatically:
 
-Pending tool calls are not a violation when they sit on the **resume boundary** — the last assistant whose subsequent messages are purely `Tool` results (or none). That's the cross-process resume shape, and riffer's `execute_pending_tool_calls` will run those pending calls before the next LLM call. An assistant followed by a `User` (or another `Assistant`) is past the boundary and its orphans are real violations.
+1. **Seeded history.** `agent.generate(messages_array)` silently drops orphaned `tool_use` exchanges (assistant `tool_call` with no matching `Tool` result) and parentless `Tool` messages from the seed before the run begins. Pending tool calls on the **resume boundary** — the last assistant whose tail is purely `Tool` results (or none) — are preserved; `execute_pending_tool_calls` runs them on the next LLM call.
+2. **Interrupts.** Any orphan `tool_use` left when the loop is interrupted (caller-issued `interrupt!` or the built-in `INTERRUPT_MAX_STEPS` ceiling) is filled with a placeholder `Riffer::Messages::Tool` carrying `error_type: :interrupted` and the content `"Tool call interrupted before completion."`. Filled `call_id`s are exposed on `Riffer::Agent::Response#healed_tool_call_ids` (and `Riffer::StreamEvents::Interrupt#healed_tool_call_ids` when streaming).
 
-Per-call override:
+Defaults to `false` — pre-healing behavior. Seeded arrays pass through untouched, and orphan `tool_use` left by an interrupt remain in history for `execute_pending_tool_calls` to re-run on the next call.
 
-```ruby
-agent.generate(messages, on_invalid_seed: :strip)
-agent.stream(messages, on_invalid_seed: :strip)
-```
+There is no per-call override and no customizable placeholder. Callers needing finer control can call the `replace_tool_result` mutator after the interrupt returns to upgrade a placeholder in place. See [Agent Lifecycle — Healing pending tool results on interrupt](04_AGENT_LIFECYCLE.md#healing-pending-tool-results-on-interrupt-experimental).
 
 ## Agent-Level Configuration
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -26,13 +26,11 @@ class Riffer::Agent
   DEFAULT_MAX_STEPS = 16 #: Integer
   INTERRUPT_MAX_STEPS = :max_steps #: Symbol
 
-  # Built-in synthesizer used when the +max_steps+ ceiling fires
-  # mid-tool-use, leaving orphan +tool_use+ blocks. Fills them with a
-  # +:interrupted+ tool error so the next inference call has valid history.
-  # Caller-initiated interrupts supply their own synthesizer via
-  # +interrupt!(synthesize:)+.
-  MAX_STEPS_INTERRUPT_SYNTHESIZER = ->(_tool_call) {
-    Riffer::Tools::Response.error("Step budget exhausted before tool execution completed.", type: :interrupted)
+  # Placeholder used to fill orphan +tool_use+ blocks when
+  # +Riffer.config.experimental_history_healing+ is enabled and an
+  # interrupt fires mid-tool-use.
+  HEALING_PLACEHOLDER = ->(_tool_call) {
+    Riffer::Tools::Response.error("Tool call interrupted before completion.", type: :interrupted)
   } #: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
 
   # Gets or sets the agent identifier.
@@ -354,17 +352,17 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
-  # call only. Used when seeding an array of messages that may violate the
-  # +tool_use+ ↔ +tool_result+ invariant.
+  # When +Riffer.config.experimental_history_healing+ is enabled, seeded
+  # message arrays that violate the +tool_use+ ↔ +tool_result+ invariant
+  # are silently repaired before the run begins.
   #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, files: nil, context: nil, on_invalid_seed: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate(prompt_or_messages, files: nil, context: nil)
     @context = context
     prepare_run
     @structured_output = resolve_structured_output
-    initialize_messages(prompt_or_messages, files: files, on_invalid_seed: on_invalid_seed)
+    initialize_messages(prompt_or_messages, files: files)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
 
@@ -379,17 +377,17 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
-  # call only. See +#generate+.
+  # See +#generate+ for the +experimental_history_healing+ behavior on
+  # seeded arrays.
   #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, files: nil, context: nil, on_invalid_seed: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt_or_messages, files: nil, context: nil)
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @context = context
     prepare_run
-    initialize_messages(prompt_or_messages, files: files, on_invalid_seed: on_invalid_seed)
+    initialize_messages(prompt_or_messages, files: files)
 
     Enumerator.new do |yielder|
       tripwire, modifications = run_before_guardrails
@@ -447,17 +445,16 @@ class Riffer::Agent
   # Call from an +on_message+ callback to cleanly interrupt the loop.
   # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
-  # When +synthesize:+ is given, riffer fills any orphaned +tool_use+ on the
-  # way out by calling the block once per orphan. Each block invocation
-  # receives the originating +Riffer::Messages::Assistant::ToolCall+ and must
-  # return a +Riffer::Tools::Response+. The list of synthesized call_ids is
-  # exposed on +Riffer::Agent::Response#synthesized_tool_call_ids+ (and the
-  # streaming +Riffer::StreamEvents::Interrupt+ event).
+  # When +Riffer.config.experimental_history_healing+ is enabled, riffer
+  # fills any orphaned +tool_use+ on the way out with a placeholder
+  # +Riffer::Messages::Tool+ carrying +error_type: :interrupted+. The
+  # filled call_ids are exposed on
+  # +Riffer::Agent::Response#healed_tool_call_ids+ (and the streaming
+  # +Riffer::StreamEvents::Interrupt+ event).
   #
   #--
-  #: (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
-  def interrupt!(reason = nil, synthesize: nil)
-    @interrupt_synthesizer = synthesize
+  #: (?(String | Symbol)?) -> void
+  def interrupt!(reason = nil)
     throw :riffer_interrupt, reason
   end
 
@@ -597,34 +594,23 @@ class Riffer::Agent
     replacement
   end
 
-  # Fills any orphaned +tool_use+ in history with a synthesized
-  # +Riffer::Messages::Tool+ message. The block is called once per orphan
-  # in conversation order, receives the originating
-  # +Riffer::Messages::Assistant::ToolCall+, and must return a
-  # +Riffer::Tools::Response+. Each synthesized Tool message is inserted
-  # immediately after its parent assistant message.
+  private
+
+  # Fills any orphaned +tool_use+ in history with the +HEALING_PLACEHOLDER+
+  # response. Each placeholder Tool message is inserted immediately after
+  # its parent assistant message. Returns the array of call_ids that were
+  # filled, in order; +[]+ when there are no orphans.
   #
-  # Returns the array of call_ids that were synthesized, in order. Returns
-  # an empty array when there are no orphans.
-  #
-  # Raises Riffer::ArgumentError when the block returns a value that is not
-  # a +Riffer::Tools::Response+.
-  #
-  # Synthesized Tool messages do *not* fire +on_message+ — they are
-  # caller-driven mutations (just like the other history mutators), not
-  # results of inference. Consumers learn that synthesis happened via the
-  # structured +Riffer::Agent::Response#synthesized_tool_call_ids+ field
-  # (and the streaming +Interrupt+ event's matching field). That signal
-  # carries the intent — placeholders, not real tool executions — which
-  # +on_message+ alone can't convey.
+  # Bypasses +on_message+ — placeholders are not inference output.
+  # Consumers learn that healing happened via the structured
+  # +Riffer::Agent::Response#healed_tool_call_ids+ field (and the streaming
+  # +Interrupt+ event's matching field).
   #
   #--
-  #: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
-  def synthesize_missing_tool_results(&block)
-    raise Riffer::ArgumentError, "synthesize_missing_tool_results requires a block" unless block
-
+  #: () -> Array[String]
+  def heal_orphan_tool_calls
     result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
-    synthesized = [] #: Array[String]
+    healed = [] #: Array[String]
     new_messages = [] #: Array[Riffer::Messages::Base]
 
     @messages.each do |m|
@@ -634,12 +620,7 @@ class Riffer::Agent
       m.tool_calls.each do |tc|
         next if result_ids.include?(tc.call_id)
 
-        response = block.call(tc)
-        unless response.is_a?(Riffer::Tools::Response)
-          raise Riffer::ArgumentError,
-            "synthesize_missing_tool_results block must return a Riffer::Tools::Response, got #{response.class}"
-        end
-
+        response = HEALING_PLACEHOLDER.call(tc)
         new_messages << Riffer::Messages::Tool.new(
           response.content,
           tool_call_id: tc.call_id,
@@ -647,15 +628,13 @@ class Riffer::Agent
           error: response.error_message,
           error_type: response.error_type
         )
-        synthesized << tc.call_id
+        healed << tc.call_id
       end
     end
 
     @messages = new_messages
-    synthesized
+    healed
   end
-
-  private
 
   #--
   #: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
@@ -693,10 +672,10 @@ class Riffer::Agent
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
     @interrupted = true
-    synthesized = run_interrupt_synthesizer(reason)
+    healed = Riffer.config.experimental_history_healing ? heal_orphan_tool_calls : []
     response = extract_final_response
 
-    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response), synthesized_tool_call_ids: synthesized)
+    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response), healed_tool_call_ids: healed)
   end
 
   #--
@@ -715,14 +694,14 @@ class Riffer::Agent
   end
 
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
-  def initialize_messages(prompt_or_messages, files: nil, on_invalid_seed: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  def initialize_messages(prompt_or_messages, files: nil)
     if prompt_or_messages.is_a?(Array)
       raise Riffer::ArgumentError, "cannot pass an array of messages on an agent with existing messages; use a string to continue the conversation or a new agent instance to start fresh" if @messages.any?
       raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
       validate_seed_ids!(prompt_or_messages)
       converted = prompt_or_messages.map { |item| convert_to_message_object(item) }
-      @messages = enforce_seed_invariant!(converted, strategy: on_invalid_seed || Riffer.config.on_invalid_seed)
+      @messages = Riffer.config.experimental_history_healing ? heal_seeded_history(converted) : converted
     elsif @messages.any?
       file_parts = (files || []).map { |f| convert_to_file_part(f) }
       @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
@@ -755,29 +734,21 @@ class Riffer::Agent
     end
   end
 
-  # Enforces the +tool_use+ ↔ +tool_result+ invariant on a seeded message
-  # array. With +:ignore+ (the default), the seed is passed through
-  # untouched. With +:raise+, raises +Riffer::ArgumentError+ on the first
-  # violation. With +:strip+, returns a new array with offending exchanges
-  # removed.
+  # Repairs a seeded message array so the +tool_use+ ↔ +tool_result+
+  # invariant holds. Drops orphaned tool exchanges (assistant +tool_call+
+  # with no matching Tool result) and parentless Tool messages. Returns a
+  # new array; the input is not mutated.
   #
-  # Pending tool_calls on the *last* assistant message are not a violation
-  # — they are handled by +execute_pending_tool_calls+ at the start of the
-  # next generate/stream call (the cross-process resume path).
+  # Pending tool_calls on the resume boundary — the last assistant whose
+  # tail is purely Tool results (or empty) — are preserved. They get swept
+  # up by +execute_pending_tool_calls+ at the start of the next
+  # generate/stream call.
+  #
+  # Only invoked when +Riffer.config.experimental_history_healing+ is on.
   #
   #--
-  #: (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
-  def enforce_seed_invariant!(messages, strategy:)
-    unless Riffer::Config::VALID_ON_INVALID_SEED.include?(strategy)
-      raise Riffer::ArgumentError,
-        "on_invalid_seed must be one of #{Riffer::Config::VALID_ON_INVALID_SEED.inspect}, got #{strategy.inspect}"
-    end
-    return messages if strategy == :ignore
-
-    # Resume boundary: the last assistant whose tail is purely Tool messages
-    # (or empty). Anything past that boundary moved on without resolving the
-    # tool exchange, so its orphans are real violations — not pending state
-    # that +execute_pending_tool_calls+ will sweep up on the next call.
+  #: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
+  def heal_seeded_history(messages)
     resume_boundary = (messages.length - 1).downto(0).find { |idx|
       m = messages[idx]
       m.is_a?(Riffer::Messages::Assistant) &&
@@ -789,47 +760,23 @@ class Riffer::Agent
       m.is_a?(Riffer::Messages::Assistant) ? m.tool_calls.map(&:call_id) : []
     }
 
-    orphan_call_ids = messages.each_with_index.flat_map { |m, idx|
-      next [] unless m.is_a?(Riffer::Messages::Assistant)
-      next [] if idx == resume_boundary # pending: handled by execute_pending_tool_calls
-      m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
-    }
-    parentless_tools = messages.select { |m|
-      m.is_a?(Riffer::Messages::Tool) && !parent_ids.include?(m.tool_call_id)
+    strip_offenders = messages.each_with_index.flat_map { |m, idx|
+      next [] unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
+      next [] if idx == resume_boundary # preserve pending exchange
+      next [] if m.tool_calls.all? { |tc| result_ids.include?(tc.call_id) }
+      m.tool_calls.map(&:call_id)
     }
 
-    return messages if orphan_call_ids.empty? && parentless_tools.empty?
-
-    case strategy
-    when :raise
-      if orphan_call_ids.any?
-        raise Riffer::ArgumentError,
-          "seeded history has orphaned tool_use call_ids: #{orphan_call_ids.inspect} (set Riffer.config.on_invalid_seed = :strip to drop them)"
+    messages.reject { |m|
+      case m
+      when Riffer::Messages::Assistant
+        !m.tool_calls.empty? && m.tool_calls.any? { |tc| strip_offenders.include?(tc.call_id) }
+      when Riffer::Messages::Tool
+        strip_offenders.include?(m.tool_call_id) || !parent_ids.include?(m.tool_call_id)
+      else
+        false
       end
-      raise Riffer::ArgumentError,
-        "seeded history has parentless tool_result messages: #{parentless_tools.map(&:tool_call_id).inspect} (set Riffer.config.on_invalid_seed = :strip to drop them)"
-    when :strip
-      strip_offenders = messages.each_with_index.flat_map { |m, idx|
-        next [] unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
-        next [] if idx == resume_boundary # preserve pending exchange on last assistant
-        next [] if m.tool_calls.all? { |tc| result_ids.include?(tc.call_id) }
-        m.tool_calls.map(&:call_id)
-      }
-      messages.reject { |m|
-        case m
-        when Riffer::Messages::Assistant
-          !m.tool_calls.empty? && m.tool_calls.any? { |tc| strip_offenders.include?(tc.call_id) }
-        when Riffer::Messages::Tool
-          strip_offenders.include?(m.tool_call_id) || !parent_ids.include?(m.tool_call_id)
-        else
-          false
-        end
-      }
-    else
-      # Unreachable — strategy was validated at method entry. Defensive
-      # branch keeps the type checker happy.
-      raise Riffer::ArgumentError, "unreachable: invalid on_invalid_seed strategy #{strategy.inspect}"
-    end
+    }
   end
 
   #--
@@ -926,28 +873,9 @@ class Riffer::Agent
 
     unless completed == :completed
       @interrupted = true
-      synthesized = run_interrupt_synthesizer(completed)
-      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed, synthesized_tool_call_ids: synthesized)
+      healed = Riffer.config.experimental_history_healing ? heal_orphan_tool_calls : []
+      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed, healed_tool_call_ids: healed)
     end
-  end
-
-  # Resolves the synthesizer to use for an interrupt and runs it. Returns
-  # the call_ids that were filled, or +[]+ when no synthesis applies.
-  #
-  # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
-  # +INTERRUPT_MAX_STEPS+ falls back to +MAX_STEPS_INTERRUPT_SYNTHESIZER+.
-  # Existing tests using raw <tt>throw :riffer_interrupt</tt> bypass
-  # +interrupt!+ and get no synthesis — preserves backward compatibility.
-  #
-  #--
-  #: ((String | Symbol)?) -> Array[String]
-  def run_interrupt_synthesizer(reason)
-    synthesizer = @interrupt_synthesizer
-    synthesizer ||= MAX_STEPS_INTERRUPT_SYNTHESIZER if reason == INTERRUPT_MAX_STEPS
-    return [] unless synthesizer
-
-    @interrupt_synthesizer = nil
-    synthesize_missing_tool_results(&synthesizer)
   end
 
   #--
@@ -1059,7 +987,6 @@ class Riffer::Agent
     @resolved_tool_runtime = nil
     clear_resolved_model
     @interrupted = false
-    @interrupt_synthesizer = nil
     resolve_model
     @skills_state = resolve_skills
     @context = (@context || {}).merge(skills: @skills_state) if @skills_state
@@ -1302,8 +1229,8 @@ class Riffer::Agent
   end
 
   #--
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
-  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, synthesized_tool_call_ids: [])
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze, synthesized_tool_call_ids: synthesized_tool_call_ids)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, healed_tool_call_ids: [])
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze, healed_tool_call_ids: healed_tool_call_ids)
   end
 end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -26,10 +26,12 @@ class Riffer::Agent
   DEFAULT_MAX_STEPS = 16 #: Integer
   INTERRUPT_MAX_STEPS = :max_steps #: Symbol
 
-  # Built-in synthesizer used when riffer interrupts itself (today: only the
-  # +max_steps+ ceiling). Caller-initiated interrupts go through
-  # +interrupt!(synthesize:)+ and supply their own synthesizer.
-  DEFAULT_INTERRUPT_SYNTHESIZER = ->(_tool_call) {
+  # Built-in synthesizer used when the +max_steps+ ceiling fires
+  # mid-tool-use, leaving orphan +tool_use+ blocks. Fills them with a
+  # +:interrupted+ tool error so the next inference call has valid history.
+  # Caller-initiated interrupts supply their own synthesizer via
+  # +interrupt!(synthesize:)+.
+  MAX_STEPS_INTERRUPT_SYNTHESIZER = ->(_tool_call) {
     Riffer::Tools::Response.error("Step budget exhausted before tool execution completed.", type: :interrupted)
   } #: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
 
@@ -608,6 +610,14 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError when the block returns a value that is not
   # a +Riffer::Tools::Response+.
   #
+  # Synthesized Tool messages do *not* fire +on_message+ — they are
+  # caller-driven mutations (just like the other history mutators), not
+  # results of inference. Consumers learn that synthesis happened via the
+  # structured +Riffer::Agent::Response#synthesized_tool_call_ids+ field
+  # (and the streaming +Interrupt+ event's matching field). That signal
+  # carries the intent — placeholders, not real tool executions — which
+  # +on_message+ alone can't convey.
+  #
   #--
   #: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
   def synthesize_missing_tool_results(&block)
@@ -758,9 +768,22 @@ class Riffer::Agent
   #--
   #: (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
   def enforce_seed_invariant!(messages, strategy:)
+    unless Riffer::Config::VALID_ON_INVALID_SEED.include?(strategy)
+      raise Riffer::ArgumentError,
+        "on_invalid_seed must be one of #{Riffer::Config::VALID_ON_INVALID_SEED.inspect}, got #{strategy.inspect}"
+    end
     return messages if strategy == :ignore
 
-    last_assistant_idx = messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
+    # Resume boundary: the last assistant whose tail is purely Tool messages
+    # (or empty). Anything past that boundary moved on without resolving the
+    # tool exchange, so its orphans are real violations — not pending state
+    # that +execute_pending_tool_calls+ will sweep up on the next call.
+    resume_boundary = (messages.length - 1).downto(0).find { |idx|
+      m = messages[idx]
+      m.is_a?(Riffer::Messages::Assistant) &&
+        messages[(idx + 1)..].all? { |later| later.is_a?(Riffer::Messages::Tool) }
+    }
+
     result_ids = messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
     parent_ids = messages.flat_map { |m|
       m.is_a?(Riffer::Messages::Assistant) ? m.tool_calls.map(&:call_id) : []
@@ -768,7 +791,7 @@ class Riffer::Agent
 
     orphan_call_ids = messages.each_with_index.flat_map { |m, idx|
       next [] unless m.is_a?(Riffer::Messages::Assistant)
-      next [] if idx == last_assistant_idx # pending: handled by execute_pending_tool_calls
+      next [] if idx == resume_boundary # pending: handled by execute_pending_tool_calls
       m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
     }
     parentless_tools = messages.select { |m|
@@ -788,7 +811,7 @@ class Riffer::Agent
     when :strip
       strip_offenders = messages.each_with_index.flat_map { |m, idx|
         next [] unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
-        next [] if idx == last_assistant_idx # preserve pending exchange on last assistant
+        next [] if idx == resume_boundary # preserve pending exchange on last assistant
         next [] if m.tool_calls.all? { |tc| result_ids.include?(tc.call_id) }
         m.tool_calls.map(&:call_id)
       }
@@ -803,8 +826,9 @@ class Riffer::Agent
         end
       }
     else
-      raise Riffer::ArgumentError,
-        "on_invalid_seed must be one of #{Riffer::Config::VALID_ON_INVALID_SEED.inspect}, got #{strategy.inspect}"
+      # Unreachable — strategy was validated at method entry. Defensive
+      # branch keeps the type checker happy.
+      raise Riffer::ArgumentError, "unreachable: invalid on_invalid_seed strategy #{strategy.inspect}"
     end
   end
 
@@ -911,16 +935,15 @@ class Riffer::Agent
   # the call_ids that were filled, or +[]+ when no synthesis applies.
   #
   # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
-  # riffer-initiated interrupts (today: +INTERRUPT_MAX_STEPS+) fall back to
-  # +DEFAULT_INTERRUPT_SYNTHESIZER+. Existing tests using raw
-  # <tt>throw :riffer_interrupt</tt> bypass +interrupt!+ and get no
-  # synthesis — preserves backward compatibility.
+  # +INTERRUPT_MAX_STEPS+ falls back to +MAX_STEPS_INTERRUPT_SYNTHESIZER+.
+  # Existing tests using raw <tt>throw :riffer_interrupt</tt> bypass
+  # +interrupt!+ and get no synthesis — preserves backward compatibility.
   #
   #--
   #: ((String | Symbol)?) -> Array[String]
   def run_interrupt_synthesizer(reason)
     synthesizer = @interrupt_synthesizer
-    synthesizer ||= DEFAULT_INTERRUPT_SYNTHESIZER if reason == INTERRUPT_MAX_STEPS
+    synthesizer ||= MAX_STEPS_INTERRUPT_SYNTHESIZER if reason == INTERRUPT_MAX_STEPS
     return [] unless synthesizer
 
     @interrupt_synthesizer = nil

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -26,6 +26,13 @@ class Riffer::Agent
   DEFAULT_MAX_STEPS = 16 #: Integer
   INTERRUPT_MAX_STEPS = :max_steps #: Symbol
 
+  # Built-in synthesizer used when riffer interrupts itself (today: only the
+  # +max_steps+ ceiling). Caller-initiated interrupts go through
+  # +interrupt!(synthesize:)+ and supply their own synthesizer.
+  DEFAULT_INTERRUPT_SYNTHESIZER = ->(_tool_call) {
+    Riffer::Tools::Response.error("Step budget exhausted before tool execution completed.", type: :interrupted)
+  } #: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+
   # Gets or sets the agent identifier.
   #
   #--
@@ -345,13 +352,17 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
+  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
+  # call only. Used when seeding an array of messages that may violate the
+  # +tool_use+ ↔ +tool_result+ invariant.
+  #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, files: nil, context: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
+  def generate(prompt_or_messages, files: nil, context: nil, on_invalid_seed: nil)
     @context = context
     prepare_run
     @structured_output = resolve_structured_output
-    initialize_messages(prompt_or_messages, files: files)
+    initialize_messages(prompt_or_messages, files: files, on_invalid_seed: on_invalid_seed)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
 
@@ -366,14 +377,17 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
+  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
+  # call only. See +#generate+.
+  #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, files: nil, context: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt_or_messages, files: nil, context: nil, on_invalid_seed: nil)
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
 
     @context = context
     prepare_run
-    initialize_messages(prompt_or_messages, files: files)
+    initialize_messages(prompt_or_messages, files: files, on_invalid_seed: on_invalid_seed)
 
     Enumerator.new do |yielder|
       tripwire, modifications = run_before_guardrails
@@ -431,10 +445,204 @@ class Riffer::Agent
   # Call from an +on_message+ callback to cleanly interrupt the loop.
   # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
+  # When +synthesize:+ is given, riffer fills any orphaned +tool_use+ on the
+  # way out by calling the block once per orphan. Each block invocation
+  # receives the originating +Riffer::Messages::Assistant::ToolCall+ and must
+  # return a +Riffer::Tools::Response+. The list of synthesized call_ids is
+  # exposed on +Riffer::Agent::Response#synthesized_tool_call_ids+ (and the
+  # streaming +Riffer::StreamEvents::Interrupt+ event).
+  #
   #--
-  #: (?(String | Symbol)?) -> void
-  def interrupt!(reason = nil)
+  #: (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
+  def interrupt!(reason = nil, synthesize: nil)
+    @interrupt_synthesizer = synthesize
     throw :riffer_interrupt, reason
+  end
+
+  # Returns the message with the given id, or +nil+ when no message matches.
+  #
+  #--
+  #: (String) -> Riffer::Messages::Base?
+  def message_by_id(id)
+    @messages.find { |m| m.id == id }
+  end
+
+  # Returns the +Riffer::Messages::Tool+ message that satisfies +tool_call_id+,
+  # or +nil+ when no such tool result exists in history.
+  #
+  #--
+  #: (String) -> Riffer::Messages::Tool?
+  # TODO: Replace with rfind when minimum Ruby is 4.0+
+  # rubocop:disable Style/ReverseFind
+  def tool_message_for(tool_call_id)
+    @messages.reverse.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == tool_call_id } #: Riffer::Messages::Tool?
+  end
+  # rubocop:enable Style/ReverseFind
+
+  # Returns the most recent +Riffer::Messages::Assistant+ in history, or
+  # +nil+ when no assistant message has been recorded yet.
+  #
+  #--
+  #: () -> Riffer::Messages::Assistant?
+  # TODO: Replace with rfind when minimum Ruby is 4.0+
+  # rubocop:disable Style/ReverseFind
+  def last_assistant
+    @messages.reverse.find { |m| m.is_a?(Riffer::Messages::Assistant) } #: Riffer::Messages::Assistant?
+  end
+  # rubocop:enable Style/ReverseFind
+
+  # Returns the call_ids of every +tool_call+ on any assistant message that
+  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
+  #
+  # Zero-cost validation hook for callers that want to check the
+  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
+  #
+  #--
+  #: () -> Array[String]
+  def orphaned_tool_call_ids
+    result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
+    @messages.flat_map { |m|
+      next [] unless m.is_a?(Riffer::Messages::Assistant)
+      m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
+    }
+  end
+
+  # Replaces the content of an assistant message in place. Preserves +id+,
+  # +tool_calls+, +token_usage+, and +structured_output+. Lookup is by id.
+  #
+  # When +content+ is empty, delegates to +remove_message+ — including the
+  # cascade that drops dependent +Riffer::Messages::Tool+ children.
+  #
+  # Raises Riffer::ArgumentError when no assistant message has the given id.
+  #
+  #--
+  #: (id: String, content: String) -> Riffer::Messages::Base?
+  def replace_assistant_content(id:, content:)
+    return remove_message(id: id) if content.empty?
+
+    idx = @messages.index { |m| m.is_a?(Riffer::Messages::Assistant) && m.id == id }
+    raise Riffer::ArgumentError, "no assistant message with id #{id.inspect}" unless idx
+
+    old = @messages[idx] #: Riffer::Messages::Assistant
+    replacement = Riffer::Messages::Assistant.new(
+      content,
+      id: old.id,
+      tool_calls: old.tool_calls,
+      token_usage: old.token_usage,
+      structured_output: old.structured_output
+    )
+    @messages[idx] = replacement
+    replacement
+  end
+
+  # Removes a message by id. When the target is an assistant message that
+  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches one of those calls is removed atomically — keeping
+  # the +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
+  # message — that would orphan the parent's +tool_use+. Use
+  # +replace_tool_result+ instead.
+  #
+  # Returns the removed message, or +nil+ when no message has the given id
+  # (idempotent).
+  #
+  #--
+  #: (id: String) -> Riffer::Messages::Base?
+  def remove_message(id:)
+    idx = @messages.index { |m| m.id == id }
+    return nil unless idx
+
+    target = @messages[idx]
+    if target.is_a?(Riffer::Messages::Tool)
+      raise Riffer::ArgumentError,
+        "remove_message cannot drop a Tool message (would orphan the parent's tool_use); use replace_tool_result instead"
+    end
+
+    if target.is_a?(Riffer::Messages::Assistant) && !target.tool_calls.empty?
+      child_ids = target.tool_calls.map(&:call_id)
+      @messages.reject! { |m| m.is_a?(Riffer::Messages::Tool) && child_ids.include?(m.tool_call_id) }
+      @messages.delete(target)
+    else
+      @messages.delete_at(idx)
+    end
+    target
+  end
+
+  # Replaces a tool result's content (and optional error fields) in place.
+  # Lookup is by +tool_call_id+. Preserves the existing message's +name+ and
+  # +id+.
+  #
+  # Raises Riffer::ArgumentError when no Tool message exists for the given
+  # +tool_call_id+.
+  #
+  #--
+  #: (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
+  def replace_tool_result(tool_call_id:, content:, error: nil, error_type: nil)
+    idx = @messages.index { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == tool_call_id }
+    raise Riffer::ArgumentError, "no tool result for tool_call_id #{tool_call_id.inspect}" unless idx
+
+    old = @messages[idx] #: Riffer::Messages::Tool
+    replacement = Riffer::Messages::Tool.new(
+      content,
+      id: old.id,
+      tool_call_id: old.tool_call_id,
+      name: old.name,
+      error: error,
+      error_type: error_type
+    )
+    @messages[idx] = replacement
+    replacement
+  end
+
+  # Fills any orphaned +tool_use+ in history with a synthesized
+  # +Riffer::Messages::Tool+ message. The block is called once per orphan
+  # in conversation order, receives the originating
+  # +Riffer::Messages::Assistant::ToolCall+, and must return a
+  # +Riffer::Tools::Response+. Each synthesized Tool message is inserted
+  # immediately after its parent assistant message.
+  #
+  # Returns the array of call_ids that were synthesized, in order. Returns
+  # an empty array when there are no orphans.
+  #
+  # Raises Riffer::ArgumentError when the block returns a value that is not
+  # a +Riffer::Tools::Response+.
+  #
+  #--
+  #: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
+  def synthesize_missing_tool_results(&block)
+    raise Riffer::ArgumentError, "synthesize_missing_tool_results requires a block" unless block
+
+    result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
+    synthesized = [] #: Array[String]
+    new_messages = [] #: Array[Riffer::Messages::Base]
+
+    @messages.each do |m|
+      new_messages << m
+      next unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
+
+      m.tool_calls.each do |tc|
+        next if result_ids.include?(tc.call_id)
+
+        response = block.call(tc)
+        unless response.is_a?(Riffer::Tools::Response)
+          raise Riffer::ArgumentError,
+            "synthesize_missing_tool_results block must return a Riffer::Tools::Response, got #{response.class}"
+        end
+
+        new_messages << Riffer::Messages::Tool.new(
+          response.content,
+          tool_call_id: tc.call_id,
+          name: tc.name,
+          error: response.error_message,
+          error_type: response.error_type
+        )
+        synthesized << tc.call_id
+      end
+    end
+
+    @messages = new_messages
+    synthesized
   end
 
   private
@@ -475,9 +683,10 @@ class Riffer::Agent
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
     @interrupted = true
+    synthesized = run_interrupt_synthesizer(reason)
     response = extract_final_response
 
-    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response))
+    build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response), synthesized_tool_call_ids: synthesized)
   end
 
   #--
@@ -496,13 +705,14 @@ class Riffer::Agent
   end
 
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
-  def initialize_messages(prompt_or_messages, files: nil)
+  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
+  def initialize_messages(prompt_or_messages, files: nil, on_invalid_seed: nil)
     if prompt_or_messages.is_a?(Array)
       raise Riffer::ArgumentError, "cannot pass an array of messages on an agent with existing messages; use a string to continue the conversation or a new agent instance to start fresh" if @messages.any?
       raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
       validate_seed_ids!(prompt_or_messages)
-      @messages = prompt_or_messages.map { |item| convert_to_message_object(item) }
+      converted = prompt_or_messages.map { |item| convert_to_message_object(item) }
+      @messages = enforce_seed_invariant!(converted, strategy: on_invalid_seed || Riffer.config.on_invalid_seed)
     elsif @messages.any?
       file_parts = (files || []).map { |f| convert_to_file_part(f) }
       @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
@@ -532,6 +742,69 @@ class Riffer::Agent
       next unless raw_id.nil?
       raise Riffer::ArgumentError,
         "seeded message at index #{idx} is missing :id (required when Riffer.config.message_id_strategy = #{strategy.inspect})"
+    end
+  end
+
+  # Enforces the +tool_use+ ↔ +tool_result+ invariant on a seeded message
+  # array. With +:ignore+ (the default), the seed is passed through
+  # untouched. With +:raise+, raises +Riffer::ArgumentError+ on the first
+  # violation. With +:strip+, returns a new array with offending exchanges
+  # removed.
+  #
+  # Pending tool_calls on the *last* assistant message are not a violation
+  # — they are handled by +execute_pending_tool_calls+ at the start of the
+  # next generate/stream call (the cross-process resume path).
+  #
+  #--
+  #: (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
+  def enforce_seed_invariant!(messages, strategy:)
+    return messages if strategy == :ignore
+
+    last_assistant_idx = messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
+    result_ids = messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
+    parent_ids = messages.flat_map { |m|
+      m.is_a?(Riffer::Messages::Assistant) ? m.tool_calls.map(&:call_id) : []
+    }
+
+    orphan_call_ids = messages.each_with_index.flat_map { |m, idx|
+      next [] unless m.is_a?(Riffer::Messages::Assistant)
+      next [] if idx == last_assistant_idx # pending: handled by execute_pending_tool_calls
+      m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
+    }
+    parentless_tools = messages.select { |m|
+      m.is_a?(Riffer::Messages::Tool) && !parent_ids.include?(m.tool_call_id)
+    }
+
+    return messages if orphan_call_ids.empty? && parentless_tools.empty?
+
+    case strategy
+    when :raise
+      if orphan_call_ids.any?
+        raise Riffer::ArgumentError,
+          "seeded history has orphaned tool_use call_ids: #{orphan_call_ids.inspect} (set Riffer.config.on_invalid_seed = :strip to drop them)"
+      end
+      raise Riffer::ArgumentError,
+        "seeded history has parentless tool_result messages: #{parentless_tools.map(&:tool_call_id).inspect} (set Riffer.config.on_invalid_seed = :strip to drop them)"
+    when :strip
+      strip_offenders = messages.each_with_index.flat_map { |m, idx|
+        next [] unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
+        next [] if idx == last_assistant_idx # preserve pending exchange on last assistant
+        next [] if m.tool_calls.all? { |tc| result_ids.include?(tc.call_id) }
+        m.tool_calls.map(&:call_id)
+      }
+      messages.reject { |m|
+        case m
+        when Riffer::Messages::Assistant
+          !m.tool_calls.empty? && m.tool_calls.any? { |tc| strip_offenders.include?(tc.call_id) }
+        when Riffer::Messages::Tool
+          strip_offenders.include?(m.tool_call_id) || !parent_ids.include?(m.tool_call_id)
+        else
+          false
+        end
+      }
+    else
+      raise Riffer::ArgumentError,
+        "on_invalid_seed must be one of #{Riffer::Config::VALID_ON_INVALID_SEED.inspect}, got #{strategy.inspect}"
     end
   end
 
@@ -629,8 +902,29 @@ class Riffer::Agent
 
     unless completed == :completed
       @interrupted = true
-      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed)
+      synthesized = run_interrupt_synthesizer(completed)
+      yielder << Riffer::StreamEvents::Interrupt.new(reason: completed, synthesized_tool_call_ids: synthesized)
     end
+  end
+
+  # Resolves the synthesizer to use for an interrupt and runs it. Returns
+  # the call_ids that were filled, or +[]+ when no synthesis applies.
+  #
+  # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
+  # riffer-initiated interrupts (today: +INTERRUPT_MAX_STEPS+) fall back to
+  # +DEFAULT_INTERRUPT_SYNTHESIZER+. Existing tests using raw
+  # <tt>throw :riffer_interrupt</tt> bypass +interrupt!+ and get no
+  # synthesis — preserves backward compatibility.
+  #
+  #--
+  #: ((String | Symbol)?) -> Array[String]
+  def run_interrupt_synthesizer(reason)
+    synthesizer = @interrupt_synthesizer
+    synthesizer ||= DEFAULT_INTERRUPT_SYNTHESIZER if reason == INTERRUPT_MAX_STEPS
+    return [] unless synthesizer
+
+    @interrupt_synthesizer = nil
+    synthesize_missing_tool_results(&synthesizer)
   end
 
   #--
@@ -742,6 +1036,7 @@ class Riffer::Agent
     @resolved_tool_runtime = nil
     clear_resolved_model
     @interrupted = false
+    @interrupt_synthesizer = nil
     resolve_model
     @skills_state = resolve_skills
     @context = (@context || {}).merge(skills: @skills_state) if @skills_state
@@ -984,8 +1279,8 @@ class Riffer::Agent
   end
 
   #--
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil)
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze)
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, synthesized_tool_call_ids: [])
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze, synthesized_tool_call_ids: synthesized_tool_call_ids)
   end
 end

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -31,6 +31,12 @@ class Riffer::Agent::Response
   # The full message history from the agent conversation.
   attr_reader :messages #: Array[Riffer::Messages::Base]
 
+  # Call ids of tool_use blocks that were filled with synthesized tool
+  # results during this turn — typically because an interrupt left them
+  # unanswered. Empty unless the turn ended in an interrupt with a
+  # synthesizer (caller-provided or riffer's max_steps default).
+  attr_reader :synthesized_tool_call_ids #: Array[String]
+
   # Creates a new response.
   #
   # [content] the response content.
@@ -40,10 +46,11 @@ class Riffer::Agent::Response
   # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
   # [structured_output] parsed structured output when structured output is configured.
   # [messages] the full message history from the agent conversation.
+  # [synthesized_tool_call_ids] call ids filled with synthesized tool results.
   #
   #--
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [])
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [], synthesized_tool_call_ids: [])
     @content = content
     @tripwire = tripwire
     @modifications = modifications
@@ -51,6 +58,7 @@ class Riffer::Agent::Response
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output
     @messages = messages
+    @synthesized_tool_call_ids = synthesized_tool_call_ids
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -31,11 +31,11 @@ class Riffer::Agent::Response
   # The full message history from the agent conversation.
   attr_reader :messages #: Array[Riffer::Messages::Base]
 
-  # Call ids of tool_use blocks that were filled with synthesized tool
-  # results during this turn — typically because an interrupt left them
-  # unanswered. Empty unless the turn ended in an interrupt with a
-  # synthesizer (caller-provided or riffer's max_steps default).
-  attr_reader :synthesized_tool_call_ids #: Array[String]
+  # Call ids of tool_use blocks that riffer filled with placeholder
+  # results during this turn — populated when an interrupt left them
+  # unanswered and +Riffer.config.experimental_history_healing+ is on.
+  # Empty otherwise.
+  attr_reader :healed_tool_call_ids #: Array[String]
 
   # Creates a new response.
   #
@@ -46,11 +46,12 @@ class Riffer::Agent::Response
   # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
   # [structured_output] parsed structured output when structured output is configured.
   # [messages] the full message history from the agent conversation.
-  # [synthesized_tool_call_ids] call ids filled with synthesized tool results.
+  # [healed_tool_call_ids] call ids filled with placeholder tool results
+  #   when history healing is enabled.
   #
   #--
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [], synthesized_tool_call_ids: [])
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
+  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [], healed_tool_call_ids: [])
     @content = content
     @tripwire = tripwire
     @modifications = modifications
@@ -58,7 +59,7 @@ class Riffer::Agent::Response
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output
     @messages = messages
-    @synthesized_tool_call_ids = synthesized_tool_call_ids
+    @healed_tool_call_ids = healed_tool_call_ids
   end
 
   # Returns true if the response was blocked by a guardrail.

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -75,6 +75,7 @@ class Riffer::Config
   end
 
   VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
+  VALID_ON_INVALID_SEED = %i[ignore raise strip].freeze
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader :amazon_bedrock #: Riffer::Config::AmazonBedrock
@@ -151,6 +152,33 @@ class Riffer::Config
     @message_id_strategy = value
   end
 
+  # Strategy for handling seeded message arrays that violate the
+  # +tool_use+ ↔ +tool_result+ invariant. One of +:ignore+ (default —
+  # pass the seed through untouched, preserving pre-validation behavior),
+  # +:raise+ (raise +Riffer::ArgumentError+ on the first violation), or
+  # +:strip+ (silently drop orphaned tool exchanges and parentless tool
+  # messages).
+  #
+  # The two violation kinds detected:
+  # - **orphaned tool_use**: an assistant +tool_call+ with no matching
+  #   +Riffer::Messages::Tool+ result.
+  # - **parentless tool**: a +Riffer::Messages::Tool+ whose +tool_call_id+
+  #   has no matching assistant +tool_call+.
+  attr_reader :on_invalid_seed #: Symbol
+
+  # Sets the +on_invalid_seed+ strategy. Raises +Riffer::ArgumentError+ if
+  # the value is not one of +:ignore+, +:raise+, or +:strip+.
+  #
+  #--
+  #: (Symbol) -> void
+  def on_invalid_seed=(value)
+    unless VALID_ON_INVALID_SEED.include?(value)
+      raise Riffer::ArgumentError,
+        "on_invalid_seed must be one of #{VALID_ON_INVALID_SEED.inspect}, got #{value.inspect}"
+    end
+    @on_invalid_seed = value
+  end
+
   #--
   #: () -> void
   def initialize
@@ -164,5 +192,6 @@ class Riffer::Config
     @tool_runtime = Riffer::ToolRuntime::Inline.new
     @skills = Skills.new
     @message_id_strategy = :none
+    @on_invalid_seed = :ignore
   end
 end

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -169,7 +169,28 @@ class Riffer::Config
   #
   # Defaults to +false+ — the pre-healing behavior. Experimental: the
   # surface and default may change without notice.
-  attr_accessor :experimental_history_healing #: bool
+  attr_reader :experimental_history_healing #: bool
+
+  # Sets the +experimental_history_healing+ flag.
+  #
+  # Coerces common boolean representations so values pulled from
+  # environment variables don't silently enable healing — the string
+  # +"false"+ is truthy in Ruby and would otherwise flip the flag on.
+  # Accepts +true+/+false+, +"true"+/+"false"+, +1+/+0+, +"1"+/+"0"+, and
+  # +nil+ (treated as +false+, the default). Raises
+  # +Riffer::ArgumentError+ for any other value.
+  #
+  #--
+  #: (untyped) -> void
+  def experimental_history_healing=(value)
+    @experimental_history_healing = case value
+    when true, "true", 1, "1" then true
+    when false, "false", 0, "0", nil then false
+    else
+      raise Riffer::ArgumentError,
+        "experimental_history_healing must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
+    end
+  end
 
   #--
   #: () -> void

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -75,7 +75,6 @@ class Riffer::Config
   end
 
   VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
-  VALID_ON_INVALID_SEED = %i[ignore raise strip].freeze
 
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader :amazon_bedrock #: Riffer::Config::AmazonBedrock
@@ -152,32 +151,25 @@ class Riffer::Config
     @message_id_strategy = value
   end
 
-  # Strategy for handling seeded message arrays that violate the
-  # +tool_use+ ↔ +tool_result+ invariant. One of +:ignore+ (default —
-  # pass the seed through untouched, preserving pre-validation behavior),
-  # +:raise+ (raise +Riffer::ArgumentError+ on the first violation), or
-  # +:strip+ (silently drop orphaned tool exchanges and parentless tool
-  # messages).
+  # Experimental: when +true+, riffer keeps the +tool_use+ ↔ +tool_result+
+  # invariant intact on its own.
   #
-  # The two violation kinds detected:
-  # - **orphaned tool_use**: an assistant +tool_call+ with no matching
-  #   +Riffer::Messages::Tool+ result.
-  # - **parentless tool**: a +Riffer::Messages::Tool+ whose +tool_call_id+
-  #   has no matching assistant +tool_call+.
-  attr_reader :on_invalid_seed #: Symbol
-
-  # Sets the +on_invalid_seed+ strategy. Raises +Riffer::ArgumentError+ if
-  # the value is not one of +:ignore+, +:raise+, or +:strip+.
+  # - On +Riffer::Agent#generate(messages_array)+, orphaned +tool_use+
+  #   exchanges and parentless +Riffer::Messages::Tool+ messages are
+  #   silently stripped from the seed. Pending tool calls on the resume
+  #   boundary (last assistant whose tail is purely Tool results) are
+  #   preserved for +execute_pending_tool_calls+.
+  # - On any interrupt (caller-issued +interrupt!+ or
+  #   +INTERRUPT_MAX_STEPS+), riffer fills any orphaned +tool_use+ with a
+  #   placeholder +Riffer::Messages::Tool+ carrying
+  #   +error_type: :interrupted+, leaving history valid for the next turn.
+  #   Filled call_ids are exposed on
+  #   +Riffer::Agent::Response#healed_tool_call_ids+ (and the streaming
+  #   +Riffer::StreamEvents::Interrupt+ event).
   #
-  #--
-  #: (Symbol) -> void
-  def on_invalid_seed=(value)
-    unless VALID_ON_INVALID_SEED.include?(value)
-      raise Riffer::ArgumentError,
-        "on_invalid_seed must be one of #{VALID_ON_INVALID_SEED.inspect}, got #{value.inspect}"
-    end
-    @on_invalid_seed = value
-  end
+  # Defaults to +false+ — the pre-healing behavior. Experimental: the
+  # surface and default may change without notice.
+  attr_accessor :experimental_history_healing #: bool
 
   #--
   #: () -> void
@@ -192,6 +184,6 @@ class Riffer::Config
     @tool_runtime = Riffer::ToolRuntime::Inline.new
     @skills = Skills.new
     @message_id_strategy = :none
-    @on_invalid_seed = :ignore
+    @experimental_history_healing = false
   end
 end

--- a/lib/riffer/stream_events/interrupt.rb
+++ b/lib/riffer/stream_events/interrupt.rb
@@ -8,17 +8,17 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader :reason #: (String | Symbol)?
 
-  # Call ids of tool_use blocks that were filled with synthesized tool
-  # results when the interrupt fired. Empty when no synthesizer was
-  # configured for this turn.
-  attr_reader :synthesized_tool_call_ids #: Array[String]
+  # Call ids of tool_use blocks that riffer filled with placeholder
+  # results when the interrupt fired. Populated only when
+  # +Riffer.config.experimental_history_healing+ is on.
+  attr_reader :healed_tool_call_ids #: Array[String]
 
   #--
-  #: (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
-  def initialize(reason: nil, synthesized_tool_call_ids: [])
+  #: (?reason: (String | Symbol)?, ?healed_tool_call_ids: Array[String]) -> void
+  def initialize(reason: nil, healed_tool_call_ids: [])
     super(role: :system)
     @reason = reason
-    @synthesized_tool_call_ids = synthesized_tool_call_ids
+    @healed_tool_call_ids = healed_tool_call_ids
   end
 
   # Converts the event to a hash.
@@ -28,7 +28,7 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   def to_h
     h = {role: @role, interrupt: true}
     h[:reason] = @reason if @reason
-    h[:synthesized_tool_call_ids] = @synthesized_tool_call_ids unless @synthesized_tool_call_ids.empty?
+    h[:healed_tool_call_ids] = @healed_tool_call_ids unless @healed_tool_call_ids.empty?
     h
   end
 end

--- a/lib/riffer/stream_events/interrupt.rb
+++ b/lib/riffer/stream_events/interrupt.rb
@@ -8,11 +8,17 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader :reason #: (String | Symbol)?
 
+  # Call ids of tool_use blocks that were filled with synthesized tool
+  # results when the interrupt fired. Empty when no synthesizer was
+  # configured for this turn.
+  attr_reader :synthesized_tool_call_ids #: Array[String]
+
   #--
-  #: (?reason: (String | Symbol)?) -> void
-  def initialize(reason: nil)
+  #: (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
+  def initialize(reason: nil, synthesized_tool_call_ids: [])
     super(role: :system)
     @reason = reason
+    @synthesized_tool_call_ids = synthesized_tool_call_ids
   end
 
   # Converts the event to a hash.
@@ -22,6 +28,7 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   def to_h
     h = {role: @role, interrupt: true}
     h[:reason] = @reason if @reason
+    h[:synthesized_tool_call_ids] = @synthesized_tool_call_ids unless @synthesized_tool_call_ids.empty?
     h
   end
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -25,6 +25,11 @@ class Riffer::Agent
 
   INTERRUPT_MAX_STEPS: Symbol
 
+  # Built-in synthesizer used when riffer interrupts itself (today: only the
+  # +max_steps+ ceiling). Caller-initiated interrupts go through
+  # +interrupt!(synthesize:)+ and supply their own synthesizer.
+  DEFAULT_INTERRUPT_SYNTHESIZER: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+
   # Gets or sets the agent identifier.
   #
   # --
@@ -220,17 +225,24 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
+  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
+  # call only. Used when seeding an array of messages that may violate the
+  # +tool_use+ ↔ +tool_result+ invariant.
+  #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
+  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
+  # call only. See +#generate+.
+  #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a callback to be invoked when messages are added during generation.
   #
@@ -267,9 +279,106 @@ class Riffer::Agent
   # Call from an +on_message+ callback to cleanly interrupt the loop.
   # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
+  # When +synthesize:+ is given, riffer fills any orphaned +tool_use+ on the
+  # way out by calling the block once per orphan. Each block invocation
+  # receives the originating +Riffer::Messages::Assistant::ToolCall+ and must
+  # return a +Riffer::Tools::Response+. The list of synthesized call_ids is
+  # exposed on +Riffer::Agent::Response#synthesized_tool_call_ids+ (and the
+  # streaming +Riffer::StreamEvents::Interrupt+ event).
+  #
   # --
-  # : (?(String | Symbol)?) -> void
-  def interrupt!: (?(String | Symbol)?) -> void
+  # : (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
+  def interrupt!: (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
+
+  # Returns the message with the given id, or +nil+ when no message matches.
+  #
+  # --
+  # : (String) -> Riffer::Messages::Base?
+  def message_by_id: (String) -> Riffer::Messages::Base?
+
+  # Returns the +Riffer::Messages::Tool+ message that satisfies +tool_call_id+,
+  # or +nil+ when no such tool result exists in history.
+  #
+  # --
+  # : (String) -> Riffer::Messages::Tool?
+  # TODO: Replace with rfind when minimum Ruby is 4.0+
+  # rubocop:disable Style/ReverseFind
+  def tool_message_for: (String) -> Riffer::Messages::Tool?
+
+  # Returns the most recent +Riffer::Messages::Assistant+ in history, or
+  # +nil+ when no assistant message has been recorded yet.
+  #
+  # --
+  # : () -> Riffer::Messages::Assistant?
+  # TODO: Replace with rfind when minimum Ruby is 4.0+
+  # rubocop:disable Style/ReverseFind
+  def last_assistant: () -> Riffer::Messages::Assistant?
+
+  # Returns the call_ids of every +tool_call+ on any assistant message that
+  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
+  #
+  # Zero-cost validation hook for callers that want to check the
+  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
+  #
+  # --
+  # : () -> Array[String]
+  def orphaned_tool_call_ids: () -> Array[String]
+
+  # Replaces the content of an assistant message in place. Preserves +id+,
+  # +tool_calls+, +token_usage+, and +structured_output+. Lookup is by id.
+  #
+  # When +content+ is empty, delegates to +remove_message+ — including the
+  # cascade that drops dependent +Riffer::Messages::Tool+ children.
+  #
+  # Raises Riffer::ArgumentError when no assistant message has the given id.
+  #
+  # --
+  # : (id: String, content: String) -> Riffer::Messages::Base?
+  def replace_assistant_content: (id: String, content: String) -> Riffer::Messages::Base?
+
+  # Removes a message by id. When the target is an assistant message that
+  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches one of those calls is removed atomically — keeping
+  # the +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
+  # message — that would orphan the parent's +tool_use+. Use
+  # +replace_tool_result+ instead.
+  #
+  # Returns the removed message, or +nil+ when no message has the given id
+  # (idempotent).
+  #
+  # --
+  # : (id: String) -> Riffer::Messages::Base?
+  def remove_message: (id: String) -> Riffer::Messages::Base?
+
+  # Replaces a tool result's content (and optional error fields) in place.
+  # Lookup is by +tool_call_id+. Preserves the existing message's +name+ and
+  # +id+.
+  #
+  # Raises Riffer::ArgumentError when no Tool message exists for the given
+  # +tool_call_id+.
+  #
+  # --
+  # : (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
+  def replace_tool_result: (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
+
+  # Fills any orphaned +tool_use+ in history with a synthesized
+  # +Riffer::Messages::Tool+ message. The block is called once per orphan
+  # in conversation order, receives the originating
+  # +Riffer::Messages::Assistant::ToolCall+, and must return a
+  # +Riffer::Tools::Response+. Each synthesized Tool message is inserted
+  # immediately after its parent assistant message.
+  #
+  # Returns the array of call_ids that were synthesized, in order. Returns
+  # an empty array when there are no orphans.
+  #
+  # Raises Riffer::ArgumentError when the block returns a value that is not
+  # a +Riffer::Tools::Response+.
+  #
+  # --
+  # : () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
+  def synthesize_missing_tool_results: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
 
   private
 
@@ -286,12 +395,26 @@ class Riffer::Agent
   def track_token_usage: (Riffer::TokenUsage?) -> void
 
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
-  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
+  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
 
   # --
   # : (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
   def validate_seed_ids!: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
+
+  # Enforces the +tool_use+ ↔ +tool_result+ invariant on a seeded message
+  # array. With +:ignore+ (the default), the seed is passed through
+  # untouched. With +:raise+, raises +Riffer::ArgumentError+ on the first
+  # violation. With +:strip+, returns a new array with offending exchanges
+  # removed.
+  #
+  # Pending tool_calls on the *last* assistant message are not a violation
+  # — they are handled by +execute_pending_tool_calls+ at the start of the
+  # next generate/stream call (the cross-process resume path).
+  #
+  # --
+  # : (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
+  def enforce_seed_invariant!: (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
 
   # --
   # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
@@ -308,6 +431,19 @@ class Riffer::Agent
   # --
   # : (Enumerator::Yielder) -> void
   def run_stream_loop: (Enumerator::Yielder) -> void
+
+  # Resolves the synthesizer to use for an interrupt and runs it. Returns
+  # the call_ids that were filled, or +[]+ when no synthesis applies.
+  #
+  # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
+  # riffer-initiated interrupts (today: +INTERRUPT_MAX_STEPS+) fall back to
+  # +DEFAULT_INTERRUPT_SYNTHESIZER+. Existing tests using raw
+  # <tt>throw :riffer_interrupt</tt> bypass +interrupt!+ and get no
+  # synthesis — preserves backward compatibility.
+  #
+  # --
+  # : ((String | Symbol)?) -> Array[String]
+  def run_interrupt_synthesizer: ((String | Symbol)?) -> Array[String]
 
   # --
   # : () -> Riffer::Messages::Assistant
@@ -441,6 +577,6 @@ class Riffer::Agent
   def merged_model_options: () -> Hash[Symbol, untyped]
 
   # --
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -25,12 +25,10 @@ class Riffer::Agent
 
   INTERRUPT_MAX_STEPS: Symbol
 
-  # Built-in synthesizer used when the +max_steps+ ceiling fires
-  # mid-tool-use, leaving orphan +tool_use+ blocks. Fills them with a
-  # +:interrupted+ tool error so the next inference call has valid history.
-  # Caller-initiated interrupts supply their own synthesizer via
-  # +interrupt!(synthesize:)+.
-  MAX_STEPS_INTERRUPT_SYNTHESIZER: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+  # Placeholder used to fill orphan +tool_use+ blocks when
+  # +Riffer.config.experimental_history_healing+ is enabled and an
+  # interrupt fires mid-tool-use.
+  HEALING_PLACEHOLDER: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
 
   # Gets or sets the agent identifier.
   #
@@ -227,24 +225,24 @@ class Riffer::Agent
 
   # Generates a response from the agent.
   #
-  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
-  # call only. Used when seeding an array of messages that may violate the
-  # +tool_use+ ↔ +tool_result+ invariant.
+  # When +Riffer.config.experimental_history_healing+ is enabled, seeded
+  # message arrays that violate the +tool_use+ ↔ +tool_result+ invariant
+  # are silently repaired before the run begins.
   #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Riffer::Agent::Response
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # +on_invalid_seed:+ overrides +Riffer.config.on_invalid_seed+ for this
-  # call only. See +#generate+.
+  # See +#generate+ for the +experimental_history_healing+ behavior on
+  # seeded arrays.
   #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?, ?on_invalid_seed: Symbol?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a callback to be invoked when messages are added during generation.
   #
@@ -281,16 +279,16 @@ class Riffer::Agent
   # Call from an +on_message+ callback to cleanly interrupt the loop.
   # Equivalent to <tt>throw :riffer_interrupt, reason</tt>.
   #
-  # When +synthesize:+ is given, riffer fills any orphaned +tool_use+ on the
-  # way out by calling the block once per orphan. Each block invocation
-  # receives the originating +Riffer::Messages::Assistant::ToolCall+ and must
-  # return a +Riffer::Tools::Response+. The list of synthesized call_ids is
-  # exposed on +Riffer::Agent::Response#synthesized_tool_call_ids+ (and the
-  # streaming +Riffer::StreamEvents::Interrupt+ event).
+  # When +Riffer.config.experimental_history_healing+ is enabled, riffer
+  # fills any orphaned +tool_use+ on the way out with a placeholder
+  # +Riffer::Messages::Tool+ carrying +error_type: :interrupted+. The
+  # filled call_ids are exposed on
+  # +Riffer::Agent::Response#healed_tool_call_ids+ (and the streaming
+  # +Riffer::StreamEvents::Interrupt+ event).
   #
   # --
-  # : (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
-  def interrupt!: (?(String | Symbol)?, ?synthesize: (^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response)?) -> void
+  # : (?(String | Symbol)?) -> void
+  def interrupt!: (?(String | Symbol)?) -> void
 
   # Returns the message with the given id, or +nil+ when no message matches.
   #
@@ -365,32 +363,21 @@ class Riffer::Agent
   # : (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
   def replace_tool_result: (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
 
-  # Fills any orphaned +tool_use+ in history with a synthesized
-  # +Riffer::Messages::Tool+ message. The block is called once per orphan
-  # in conversation order, receives the originating
-  # +Riffer::Messages::Assistant::ToolCall+, and must return a
-  # +Riffer::Tools::Response+. Each synthesized Tool message is inserted
-  # immediately after its parent assistant message.
+  private
+
+  # Fills any orphaned +tool_use+ in history with the +HEALING_PLACEHOLDER+
+  # response. Each placeholder Tool message is inserted immediately after
+  # its parent assistant message. Returns the array of call_ids that were
+  # filled, in order; +[]+ when there are no orphans.
   #
-  # Returns the array of call_ids that were synthesized, in order. Returns
-  # an empty array when there are no orphans.
-  #
-  # Raises Riffer::ArgumentError when the block returns a value that is not
-  # a +Riffer::Tools::Response+.
-  #
-  # Synthesized Tool messages do *not* fire +on_message+ — they are
-  # caller-driven mutations (just like the other history mutators), not
-  # results of inference. Consumers learn that synthesis happened via the
-  # structured +Riffer::Agent::Response#synthesized_tool_call_ids+ field
-  # (and the streaming +Interrupt+ event's matching field). That signal
-  # carries the intent — placeholders, not real tool executions — which
-  # +on_message+ alone can't convey.
+  # Bypasses +on_message+ — placeholders are not inference output.
+  # Consumers learn that healing happened via the structured
+  # +Riffer::Agent::Response#healed_tool_call_ids+ field (and the streaming
+  # +Interrupt+ event's matching field).
   #
   # --
-  # : () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
-  def synthesize_missing_tool_results: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
-
-  private
+  # : () -> Array[String]
+  def heal_orphan_tool_calls: () -> Array[String]
 
   # --
   # : (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
@@ -405,26 +392,28 @@ class Riffer::Agent
   def track_token_usage: (Riffer::TokenUsage?) -> void
 
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
-  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?on_invalid_seed: Symbol?) -> void
+  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
   # --
   # : (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
   def validate_seed_ids!: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
 
-  # Enforces the +tool_use+ ↔ +tool_result+ invariant on a seeded message
-  # array. With +:ignore+ (the default), the seed is passed through
-  # untouched. With +:raise+, raises +Riffer::ArgumentError+ on the first
-  # violation. With +:strip+, returns a new array with offending exchanges
-  # removed.
+  # Repairs a seeded message array so the +tool_use+ ↔ +tool_result+
+  # invariant holds. Drops orphaned tool exchanges (assistant +tool_call+
+  # with no matching Tool result) and parentless Tool messages. Returns a
+  # new array; the input is not mutated.
   #
-  # Pending tool_calls on the *last* assistant message are not a violation
-  # — they are handled by +execute_pending_tool_calls+ at the start of the
-  # next generate/stream call (the cross-process resume path).
+  # Pending tool_calls on the resume boundary — the last assistant whose
+  # tail is purely Tool results (or empty) — are preserved. They get swept
+  # up by +execute_pending_tool_calls+ at the start of the next
+  # generate/stream call.
+  #
+  # Only invoked when +Riffer.config.experimental_history_healing+ is on.
   #
   # --
-  # : (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
-  def enforce_seed_invariant!: (Array[Riffer::Messages::Base], strategy: Symbol) -> Array[Riffer::Messages::Base]
+  # : (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
+  def heal_seeded_history: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
 
   # --
   # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
@@ -441,18 +430,6 @@ class Riffer::Agent
   # --
   # : (Enumerator::Yielder) -> void
   def run_stream_loop: (Enumerator::Yielder) -> void
-
-  # Resolves the synthesizer to use for an interrupt and runs it. Returns
-  # the call_ids that were filled, or +[]+ when no synthesis applies.
-  #
-  # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
-  # +INTERRUPT_MAX_STEPS+ falls back to +MAX_STEPS_INTERRUPT_SYNTHESIZER+.
-  # Existing tests using raw <tt>throw :riffer_interrupt</tt> bypass
-  # +interrupt!+ and get no synthesis — preserves backward compatibility.
-  #
-  # --
-  # : ((String | Symbol)?) -> Array[String]
-  def run_interrupt_synthesizer: ((String | Symbol)?) -> Array[String]
 
   # --
   # : () -> Riffer::Messages::Assistant
@@ -586,6 +563,6 @@ class Riffer::Agent
   def merged_model_options: () -> Hash[Symbol, untyped]
 
   # --
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
-  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?synthesized_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
 end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -25,10 +25,12 @@ class Riffer::Agent
 
   INTERRUPT_MAX_STEPS: Symbol
 
-  # Built-in synthesizer used when riffer interrupts itself (today: only the
-  # +max_steps+ ceiling). Caller-initiated interrupts go through
-  # +interrupt!(synthesize:)+ and supply their own synthesizer.
-  DEFAULT_INTERRUPT_SYNTHESIZER: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
+  # Built-in synthesizer used when the +max_steps+ ceiling fires
+  # mid-tool-use, leaving orphan +tool_use+ blocks. Fills them with a
+  # +:interrupted+ tool error so the next inference call has valid history.
+  # Caller-initiated interrupts supply their own synthesizer via
+  # +interrupt!(synthesize:)+.
+  MAX_STEPS_INTERRUPT_SYNTHESIZER: ^(Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response
 
   # Gets or sets the agent identifier.
   #
@@ -376,6 +378,14 @@ class Riffer::Agent
   # Raises Riffer::ArgumentError when the block returns a value that is not
   # a +Riffer::Tools::Response+.
   #
+  # Synthesized Tool messages do *not* fire +on_message+ — they are
+  # caller-driven mutations (just like the other history mutators), not
+  # results of inference. Consumers learn that synthesis happened via the
+  # structured +Riffer::Agent::Response#synthesized_tool_call_ids+ field
+  # (and the streaming +Interrupt+ event's matching field). That signal
+  # carries the intent — placeholders, not real tool executions — which
+  # +on_message+ alone can't convey.
+  #
   # --
   # : () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
   def synthesize_missing_tool_results: () { (Riffer::Messages::Assistant::ToolCall) -> Riffer::Tools::Response } -> Array[String]
@@ -436,10 +446,9 @@ class Riffer::Agent
   # the call_ids that were filled, or +[]+ when no synthesis applies.
   #
   # Caller-initiated interrupts pass a synthesizer through +interrupt!+;
-  # riffer-initiated interrupts (today: +INTERRUPT_MAX_STEPS+) fall back to
-  # +DEFAULT_INTERRUPT_SYNTHESIZER+. Existing tests using raw
-  # <tt>throw :riffer_interrupt</tt> bypass +interrupt!+ and get no
-  # synthesis — preserves backward compatibility.
+  # +INTERRUPT_MAX_STEPS+ falls back to +MAX_STEPS_INTERRUPT_SYNTHESIZER+.
+  # Existing tests using raw <tt>throw :riffer_interrupt</tt> bypass
+  # +interrupt!+ and get no synthesis — preserves backward compatibility.
   #
   # --
   # : ((String | Symbol)?) -> Array[String]

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -30,6 +30,12 @@ class Riffer::Agent::Response
   # The full message history from the agent conversation.
   attr_reader messages: Array[Riffer::Messages::Base]
 
+  # Call ids of tool_use blocks that were filled with synthesized tool
+  # results during this turn — typically because an interrupt left them
+  # unanswered. Empty unless the turn ended in an interrupt with a
+  # synthesizer (caller-provided or riffer's max_steps default).
+  attr_reader synthesized_tool_call_ids: Array[String]
+
   # Creates a new response.
   #
   # [content] the response content.
@@ -39,10 +45,11 @@ class Riffer::Agent::Response
   # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
   # [structured_output] parsed structured output when structured output is configured.
   # [messages] the full message history from the agent conversation.
+  # [synthesized_tool_call_ids] call ids filled with synthesized tool results.
   #
   # --
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base]) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -30,11 +30,11 @@ class Riffer::Agent::Response
   # The full message history from the agent conversation.
   attr_reader messages: Array[Riffer::Messages::Base]
 
-  # Call ids of tool_use blocks that were filled with synthesized tool
-  # results during this turn — typically because an interrupt left them
-  # unanswered. Empty unless the turn ended in an interrupt with a
-  # synthesizer (caller-provided or riffer's max_steps default).
-  attr_reader synthesized_tool_call_ids: Array[String]
+  # Call ids of tool_use blocks that riffer filled with placeholder
+  # results during this turn — populated when an interrupt left them
+  # unanswered and +Riffer.config.experimental_history_healing+ is on.
+  # Empty otherwise.
+  attr_reader healed_tool_call_ids: Array[String]
 
   # Creates a new response.
   #
@@ -45,11 +45,12 @@ class Riffer::Agent::Response
   # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
   # [structured_output] parsed structured output when structured output is configured.
   # [messages] the full message history from the agent conversation.
-  # [synthesized_tool_call_ids] call ids filled with synthesized tool results.
+  # [healed_tool_call_ids] call ids filled with placeholder tool results
+  #   when history healing is enabled.
   #
   # --
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?synthesized_tool_call_ids: Array[String]) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -198,7 +198,20 @@ class Riffer::Config
   #
   # Defaults to +false+ — the pre-healing behavior. Experimental: the
   # surface and default may change without notice.
-  attr_accessor experimental_history_healing: bool
+  attr_reader experimental_history_healing: bool
+
+  # Sets the +experimental_history_healing+ flag.
+  #
+  # Coerces common boolean representations so values pulled from
+  # environment variables don't silently enable healing — the string
+  # +"false"+ is truthy in Ruby and would otherwise flip the flag on.
+  # Accepts +true+/+false+, +"true"+/+"false"+, +1+/+0+, +"1"+/+"0"+, and
+  # +nil+ (treated as +false+, the default). Raises
+  # +Riffer::ArgumentError+ for any other value.
+  #
+  # --
+  # : (untyped) -> void
+  def experimental_history_healing=: (untyped) -> void
 
   # --
   # : () -> void

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -115,6 +115,8 @@ class Riffer::Config
 
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
+  VALID_ON_INVALID_SEED: untyped
+
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader amazon_bedrock: Riffer::Config::AmazonBedrock
 
@@ -179,6 +181,27 @@ class Riffer::Config
   # --
   # : (Symbol) -> void
   def message_id_strategy=: (Symbol) -> void
+
+  # Strategy for handling seeded message arrays that violate the
+  # +tool_use+ ↔ +tool_result+ invariant. One of +:ignore+ (default —
+  # pass the seed through untouched, preserving pre-validation behavior),
+  # +:raise+ (raise +Riffer::ArgumentError+ on the first violation), or
+  # +:strip+ (silently drop orphaned tool exchanges and parentless tool
+  # messages).
+  #
+  # The two violation kinds detected:
+  # - **orphaned tool_use**: an assistant +tool_call+ with no matching
+  #   +Riffer::Messages::Tool+ result.
+  # - **parentless tool**: a +Riffer::Messages::Tool+ whose +tool_call_id+
+  #   has no matching assistant +tool_call+.
+  attr_reader on_invalid_seed: Symbol
+
+  # Sets the +on_invalid_seed+ strategy. Raises +Riffer::ArgumentError+ if
+  # the value is not one of +:ignore+, +:raise+, or +:strip+.
+  #
+  # --
+  # : (Symbol) -> void
+  def on_invalid_seed=: (Symbol) -> void
 
   # --
   # : () -> void

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -115,8 +115,6 @@ class Riffer::Config
 
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
-  VALID_ON_INVALID_SEED: untyped
-
   # Amazon Bedrock configuration (Struct with +api_token+ and +region+).
   attr_reader amazon_bedrock: Riffer::Config::AmazonBedrock
 
@@ -182,26 +180,25 @@ class Riffer::Config
   # : (Symbol) -> void
   def message_id_strategy=: (Symbol) -> void
 
-  # Strategy for handling seeded message arrays that violate the
-  # +tool_use+ ↔ +tool_result+ invariant. One of +:ignore+ (default —
-  # pass the seed through untouched, preserving pre-validation behavior),
-  # +:raise+ (raise +Riffer::ArgumentError+ on the first violation), or
-  # +:strip+ (silently drop orphaned tool exchanges and parentless tool
-  # messages).
+  # Experimental: when +true+, riffer keeps the +tool_use+ ↔ +tool_result+
+  # invariant intact on its own.
   #
-  # The two violation kinds detected:
-  # - **orphaned tool_use**: an assistant +tool_call+ with no matching
-  #   +Riffer::Messages::Tool+ result.
-  # - **parentless tool**: a +Riffer::Messages::Tool+ whose +tool_call_id+
-  #   has no matching assistant +tool_call+.
-  attr_reader on_invalid_seed: Symbol
-
-  # Sets the +on_invalid_seed+ strategy. Raises +Riffer::ArgumentError+ if
-  # the value is not one of +:ignore+, +:raise+, or +:strip+.
+  # - On +Riffer::Agent#generate(messages_array)+, orphaned +tool_use+
+  #   exchanges and parentless +Riffer::Messages::Tool+ messages are
+  #   silently stripped from the seed. Pending tool calls on the resume
+  #   boundary (last assistant whose tail is purely Tool results) are
+  #   preserved for +execute_pending_tool_calls+.
+  # - On any interrupt (caller-issued +interrupt!+ or
+  #   +INTERRUPT_MAX_STEPS+), riffer fills any orphaned +tool_use+ with a
+  #   placeholder +Riffer::Messages::Tool+ carrying
+  #   +error_type: :interrupted+, leaving history valid for the next turn.
+  #   Filled call_ids are exposed on
+  #   +Riffer::Agent::Response#healed_tool_call_ids+ (and the streaming
+  #   +Riffer::StreamEvents::Interrupt+ event).
   #
-  # --
-  # : (Symbol) -> void
-  def on_invalid_seed=: (Symbol) -> void
+  # Defaults to +false+ — the pre-healing behavior. Experimental: the
+  # surface and default may change without notice.
+  attr_accessor experimental_history_healing: bool
 
   # --
   # : () -> void

--- a/sig/generated/riffer/stream_events/interrupt.rbs
+++ b/sig/generated/riffer/stream_events/interrupt.rbs
@@ -7,9 +7,14 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader reason: (String | Symbol)?
 
+  # Call ids of tool_use blocks that were filled with synthesized tool
+  # results when the interrupt fired. Empty when no synthesizer was
+  # configured for this turn.
+  attr_reader synthesized_tool_call_ids: Array[String]
+
   # --
-  # : (?reason: (String | Symbol)?) -> void
-  def initialize: (?reason: (String | Symbol)?) -> void
+  # : (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
+  def initialize: (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
 
   # Converts the event to a hash.
   #

--- a/sig/generated/riffer/stream_events/interrupt.rbs
+++ b/sig/generated/riffer/stream_events/interrupt.rbs
@@ -7,14 +7,14 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   # The reason provided with the interrupt, if any.
   attr_reader reason: (String | Symbol)?
 
-  # Call ids of tool_use blocks that were filled with synthesized tool
-  # results when the interrupt fired. Empty when no synthesizer was
-  # configured for this turn.
-  attr_reader synthesized_tool_call_ids: Array[String]
+  # Call ids of tool_use blocks that riffer filled with placeholder
+  # results when the interrupt fired. Populated only when
+  # +Riffer.config.experimental_history_healing+ is on.
+  attr_reader healed_tool_call_ids: Array[String]
 
   # --
-  # : (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
-  def initialize: (?reason: (String | Symbol)?, ?synthesized_tool_call_ids: Array[String]) -> void
+  # : (?reason: (String | Symbol)?, ?healed_tool_call_ids: Array[String]) -> void
+  def initialize: (?reason: (String | Symbol)?, ?healed_tool_call_ids: Array[String]) -> void
 
   # Converts the event to a hash.
   #

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3926,88 +3926,22 @@ describe Riffer::Agent do
         expect { agent.replace_tool_result(tool_call_id: "missing", content: "x") }.must_raise Riffer::ArgumentError
       end
     end
-
-    describe "#synthesize_missing_tool_results" do
-      let(:orphan_tc) { Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}") }
-      let(:orphan_assistant) { Riffer::Messages::Assistant.new("", id: "a_orphan", tool_calls: [orphan_tc]) }
-
-      it "returns [] when there are no orphans" do
-        result = agent.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("nope") }
-        expect(result).must_equal []
-      end
-
-      it "fills a single orphan and returns its call_id" do
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [user, orphan_assistant])
-        result = a.synthesize_missing_tool_results { |tc|
-          Riffer::Tools::Response.error("interrupted: #{tc.name}", type: :interrupted)
-        }
-        expect(result).must_equal ["c_orphan"]
-        tool = a.tool_message_for("c_orphan")
-        refute_nil tool
-        expect(tool.content).must_equal "interrupted: t"
-        expect(tool.error_type).must_equal :interrupted
-      end
-
-      it "inserts the synthesized Tool message immediately after its parent" do
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [user, orphan_assistant])
-        a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("x") }
-        ids = a.messages.map(&:id)
-        parent_idx = ids.index("a_orphan")
-        expect(a.messages[parent_idx + 1]).must_be_kind_of Riffer::Messages::Tool
-        expect(a.messages[parent_idx + 1].tool_call_id).must_equal "c_orphan"
-      end
-
-      it "skips siblings that already have a result" do
-        tc_a = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
-        tc_b = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
-        asst = Riffer::Messages::Assistant.new("", id: "a_xy", tool_calls: [tc_a, tc_b])
-        result_a = Riffer::Messages::Tool.new("done", id: "t_a", tool_call_id: "c_a", name: "t")
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [asst, result_a])
-        result = a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("interrupted") }
-        expect(result).must_equal ["c_b"]
-      end
-
-      it "raises when the block returns a non-Response value" do
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [orphan_assistant])
-        expect { a.synthesize_missing_tool_results { |_tc| "just a string" } }.must_raise Riffer::ArgumentError
-      end
-
-      it "raises when called without a block" do
-        expect { agent.synthesize_missing_tool_results }.must_raise Riffer::ArgumentError
-      end
-
-      it "does not fire on_message for synthesized Tool messages (caller-driven mutation)" do
-        # Synthesized results aren't real tool executions — they are caller-
-        # driven history mutations like replace_assistant_content and
-        # remove_message, which also bypass on_message. Consumers learn
-        # synthesis happened via Response#synthesized_tool_call_ids.
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [user, orphan_assistant])
-        seen = []
-        a.on_message { |msg| seen << msg }
-
-        a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("interrupted") }
-
-        expect(seen).must_equal []
-      end
-    end
   end
 
-  describe "#interrupt! with synthesize:" do
+  describe "interrupt! with experimental_history_healing" do
     let(:tool_class) do
       Class.new(Riffer::Tool) do
         description "Slow tool"
         def call(context:)
           text("done")
         end
-      end.tap { |t| t.identifier("interrupt_synth_tool") }
+      end.tap { |t| t.identifier("interrupt_heal_tool") }
     end
 
-    it "fills orphans and exposes synthesized_tool_call_ids on the response" do
+    after { Riffer.config.experimental_history_healing = false }
+
+    it "fills orphans and exposes healed_tool_call_ids when healing is on" do
+      Riffer.config.experimental_history_healing = true
       tc = tool_class
       custom_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
@@ -4017,29 +3951,26 @@ describe Riffer::Agent do
       agent = custom_class.new
       provider = agent.send(:provider_instance)
       provider.stub_response("", tool_calls: [
-        {name: "interrupt_synth_tool", arguments: "{}"},
-        {name: "interrupt_synth_tool", arguments: "{}"}
+        {name: "interrupt_heal_tool", arguments: "{}"},
+        {name: "interrupt_heal_tool", arguments: "{}"}
       ])
 
       agent.on_message do |msg|
-        if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
-          agent.interrupt!(:user_interrupt, synthesize: ->(call) {
-            Riffer::Tools::Response.error("synth #{call.call_id}", type: :interrupted)
-          })
-        end
+        agent.interrupt!(:user_interrupt) if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
       end
 
       result = agent.generate("Call tools")
 
       expect(result.interrupted?).must_equal true
-      expect(result.synthesized_tool_call_ids.length).must_equal 2
+      expect(result.healed_tool_call_ids.length).must_equal 2
       expect(agent.orphaned_tool_call_ids).must_equal []
       tools = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tools.length).must_equal 2
       expect(tools.first.error_type).must_equal :interrupted
+      expect(tools.first.content).must_equal "Tool call interrupted before completion."
     end
 
-    it "preserves the legacy no-synthesize path when interrupt! is called without a block" do
+    it "leaves orphans in place when healing is off (default)" do
       tc = tool_class
       custom_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
@@ -4048,7 +3979,7 @@ describe Riffer::Agent do
 
       agent = custom_class.new
       provider = agent.send(:provider_instance)
-      provider.stub_response("", tool_calls: [{name: "interrupt_synth_tool", arguments: "{}"}])
+      provider.stub_response("", tool_calls: [{name: "interrupt_heal_tool", arguments: "{}"}])
 
       agent.on_message do |msg|
         agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
@@ -4057,22 +3988,51 @@ describe Riffer::Agent do
       result = agent.generate("Call tools")
 
       expect(result.interrupted?).must_equal true
-      expect(result.synthesized_tool_call_ids).must_equal []
+      expect(result.healed_tool_call_ids).must_equal []
       expect(agent.orphaned_tool_call_ids.length).must_equal 1
+    end
+
+    it "does not fire on_message for placeholder tool messages" do
+      Riffer.config.experimental_history_healing = true
+      tc = tool_class
+      custom_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tc]
+      end
+
+      agent = custom_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "interrupt_heal_tool", arguments: "{}"}])
+
+      seen = []
+      agent.on_message do |msg|
+        seen << msg
+        agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
+      end
+
+      agent.generate("Call tools")
+
+      # The assistant message is observed, but the placeholder Tool result
+      # is not — placeholders bypass on_message because they aren't
+      # inference output.
+      expect(seen.count { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal 0
     end
   end
 
-  describe "max_steps interrupt synthesizes orphans" do
+  describe "max_steps interrupt with experimental_history_healing" do
     let(:tool_class) do
       Class.new(Riffer::Tool) do
         description "Loop tool"
         def call(context:)
           text("ok")
         end
-      end.tap { |t| t.identifier("max_steps_synth_tool") }
+      end.tap { |t| t.identifier("max_steps_heal_tool") }
     end
 
-    it "fills orphan tool_use with the built-in synthesizer when the step budget is hit" do
+    after { Riffer.config.experimental_history_healing = false }
+
+    it "fills orphan tool_use with the placeholder when healing is on" do
+      Riffer.config.experimental_history_healing = true
       tc = tool_class
       custom_class = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
@@ -4082,28 +4042,48 @@ describe Riffer::Agent do
 
       agent = custom_class.new
       provider = agent.send(:provider_instance)
-      # Two responses: the first hits max_steps, leaving the orphan.
-      provider.stub_response("", tool_calls: [{name: "max_steps_synth_tool", arguments: "{}"}])
-      provider.stub_response("", tool_calls: [{name: "max_steps_synth_tool", arguments: "{}"}])
+      provider.stub_response("", tool_calls: [{name: "max_steps_heal_tool", arguments: "{}"}])
+      provider.stub_response("", tool_calls: [{name: "max_steps_heal_tool", arguments: "{}"}])
 
       result = agent.generate("Loop forever")
 
       expect(result.interrupted?).must_equal true
       expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
-      expect(result.synthesized_tool_call_ids.length).must_equal 1
+      expect(result.healed_tool_call_ids.length).must_equal 1
       expect(agent.orphaned_tool_call_ids).must_equal []
       synth = agent.messages.last
       expect(synth).must_be_kind_of Riffer::Messages::Tool
       expect(synth.error_type).must_equal :interrupted
     end
+
+    it "leaves orphan tool_use when healing is off" do
+      tc = tool_class
+      custom_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tc]
+        max_steps 1
+      end
+
+      agent = custom_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "max_steps_heal_tool", arguments: "{}"}])
+      provider.stub_response("", tool_calls: [{name: "max_steps_heal_tool", arguments: "{}"}])
+
+      result = agent.generate("Loop forever")
+
+      expect(result.interrupted?).must_equal true
+      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.healed_tool_call_ids).must_equal []
+      expect(agent.orphaned_tool_call_ids.length).must_equal 1
+    end
   end
 
-  describe "seeded history validation" do
+  describe "seeded history with experimental_history_healing" do
     let(:custom_class) { Class.new(Riffer::Agent) { model "mock/riffer-1" } }
 
-    after { Riffer.config.on_invalid_seed = :ignore }
+    after { Riffer.config.experimental_history_healing = false }
 
-    it "ignores invariant violations by default (preserves legacy behavior)" do
+    it "passes seeded history through untouched when healing is off (default)" do
       tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
       messages = [
         Riffer::Messages::User.new("hi"),
@@ -4116,8 +4096,6 @@ describe Riffer::Agent do
       agent.send(:provider_instance).stub_response("Hello!")
       agent.generate(messages)
 
-      # All seeded messages survived untouched — including the parentless
-      # Tool and the orphaned tool_use.
       assistant_with_orphan = agent.messages.find { |m|
         m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_orphan" }
       }
@@ -4128,52 +4106,41 @@ describe Riffer::Agent do
       refute_nil parentless
     end
 
-    it "raises with :raise when a non-last assistant has an orphaned tool_use" do
-      Riffer.config.on_invalid_seed = :raise
-      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
+    it "strips orphaned tool exchanges from non-last assistants when healing is on" do
+      Riffer.config.experimental_history_healing = true
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_drop", name: "t", arguments: "{}")
       messages = [
+        Riffer::Messages::User.new("hi"),
         Riffer::Messages::Assistant.new("", tool_calls: [tc]),
         Riffer::Messages::User.new("anyway"),
-        Riffer::Messages::Assistant.new("ok")
+        Riffer::Messages::Assistant.new("never mind")
       ]
-      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages)
+
+      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_drop" } }).must_equal true
     end
 
-    it "raises with :raise when the trailing assistant has an orphan but the tail contains non-Tool messages" do
-      # The orphan-bearing assistant is the very last Assistant in history,
-      # but it is followed by a User message — so it is NOT the resume
-      # boundary (that's the "execute_pending_tool_calls will sweep this up"
-      # case). Validator must catch the orphan here.
-      Riffer.config.on_invalid_seed = :raise
-      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
+    it "strips parentless tool messages when healing is on" do
+      Riffer.config.experimental_history_healing = true
       messages = [
         Riffer::Messages::User.new("hi"),
-        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
-        Riffer::Messages::User.new("never mind")
+        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
+        Riffer::Messages::User.new("follow-up")
       ]
-      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages)
+
+      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
     end
 
-    it "raises immediately on an unknown strategy even when the seed is clean" do
-      messages = [Riffer::Messages::User.new("hi")]
-      err = expect {
-        custom_class.new.generate(messages, on_invalid_seed: :raze)
-      }.must_raise Riffer::ArgumentError
-      expect(err.message).must_include "on_invalid_seed"
-    end
-
-    it "raises with :raise when a parentless tool_result is in the seed" do
-      Riffer.config.on_invalid_seed = :raise
-      messages = [
-        Riffer::Messages::User.new("hi"),
-        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t")
-      ]
-      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
-    end
-
-    it "allows a pending tool_use on the LAST assistant (cross-process resume)" do
-      Riffer.config.on_invalid_seed = :raise
-      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_pending", name: "t", arguments: "{}")
+    it "preserves a pending tool_use on the resume boundary even when healing is on" do
+      Riffer.config.experimental_history_healing = true
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_pending", name: "pending_seed_tool", arguments: "{}")
       messages = [
         Riffer::Messages::User.new("Call tool"),
         Riffer::Messages::Assistant.new("", tool_calls: [tc])
@@ -4188,58 +4155,11 @@ describe Riffer::Agent do
         model "mock/riffer-1"
         uses_tools [tool]
       end
-      tc.name = "pending_seed_tool"
-      provider = with_tools.new.send(:provider_instance)
-      provider.stub_response("All done!")
 
       agent = with_tools.new
       agent.send(:provider_instance).stub_response("All done!")
       result = agent.generate(messages)
       expect(result.interrupted?).must_equal false
-    end
-
-    it ":strip drops orphaned tool exchanges from non-last assistants" do
-      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_drop", name: "t", arguments: "{}")
-      messages = [
-        Riffer::Messages::User.new("hi"),
-        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
-        Riffer::Messages::User.new("anyway"),
-        Riffer::Messages::Assistant.new("never mind")
-      ]
-
-      agent = custom_class.new
-      agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages, on_invalid_seed: :strip)
-
-      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_drop" } }).must_equal true
-    end
-
-    it ":strip drops parentless tool messages" do
-      messages = [
-        Riffer::Messages::User.new("hi"),
-        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
-        Riffer::Messages::User.new("follow-up")
-      ]
-      provider = custom_class.new.send(:provider_instance)
-      provider.stub_response("Hello!")
-
-      agent = custom_class.new
-      agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages, on_invalid_seed: :strip)
-
-      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
-    end
-
-    it "honors the global Riffer.config.on_invalid_seed default" do
-      Riffer.config.on_invalid_seed = :strip
-      messages = [
-        Riffer::Messages::User.new("hi"),
-        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t")
-      ]
-      agent = custom_class.new
-      agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages)
-      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
     end
   end
 end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3767,4 +3767,441 @@ describe Riffer::Agent do
       expect(klass.resolved_tool_classes).must_equal [good_tool]
     end
   end
+
+  describe "history read accessors" do
+    let(:user) { Riffer::Messages::User.new("hi", id: "u_1") }
+    let(:assistant) { Riffer::Messages::Assistant.new("hello", id: "a_1") }
+    let(:assistant_with_tool) do
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "t", arguments: "{}")
+      Riffer::Messages::Assistant.new("", id: "a_2", tool_calls: [tc])
+    end
+    let(:tool_msg) { Riffer::Messages::Tool.new("ok", id: "t_1", tool_call_id: "c_1", name: "t") }
+
+    let(:agent) do
+      a = agent_class.new
+      a.instance_variable_set(:@messages, [user, assistant, assistant_with_tool, tool_msg])
+      a
+    end
+
+    describe "#message_by_id" do
+      it "returns the matching message" do
+        expect(agent.message_by_id("a_1")).must_equal assistant
+      end
+
+      it "returns nil when no message matches" do
+        expect(agent.message_by_id("missing")).must_be_nil
+      end
+    end
+
+    describe "#tool_message_for" do
+      it "returns the tool message for the call_id" do
+        expect(agent.tool_message_for("c_1")).must_equal tool_msg
+      end
+
+      it "returns nil when no tool result exists for the call_id" do
+        expect(agent.tool_message_for("missing")).must_be_nil
+      end
+    end
+
+    describe "#last_assistant" do
+      it "returns the most recent assistant message" do
+        expect(agent.last_assistant).must_equal assistant_with_tool
+      end
+
+      it "returns nil when there is no assistant message" do
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [user])
+        expect(a.last_assistant).must_be_nil
+      end
+    end
+
+    describe "#orphaned_tool_call_ids" do
+      it "returns [] when every tool_call has a matching tool result" do
+        expect(agent.orphaned_tool_call_ids).must_equal []
+      end
+
+      it "returns the unmatched call_ids" do
+        tc1 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
+        tc2 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
+        asst = Riffer::Messages::Assistant.new("", id: "a_x", tool_calls: [tc1, tc2])
+        result = Riffer::Messages::Tool.new("ok", id: "t_x", tool_call_id: "c_a", name: "t")
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [asst, result])
+        expect(a.orphaned_tool_call_ids).must_equal ["c_b"]
+      end
+
+      it "returns [] for an empty agent" do
+        expect(agent_class.new.orphaned_tool_call_ids).must_equal []
+      end
+    end
+  end
+
+  describe "history mutators" do
+    let(:user) { Riffer::Messages::User.new("hi", id: "u_1") }
+    let(:plain_assistant) { Riffer::Messages::Assistant.new("hello", id: "a_1") }
+    let(:tc) { Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "weather", arguments: "{}") }
+    let(:tool_assistant) { Riffer::Messages::Assistant.new("", id: "a_2", tool_calls: [tc]) }
+    let(:tool_msg) { Riffer::Messages::Tool.new("sunny", id: "t_1", tool_call_id: "c_1", name: "weather") }
+
+    let(:agent) do
+      a = agent_class.new
+      a.instance_variable_set(:@messages, [user, plain_assistant, tool_assistant, tool_msg])
+      a
+    end
+
+    describe "#replace_assistant_content" do
+      it "replaces content while preserving id, tool_calls, token_usage" do
+        result = agent.replace_assistant_content(id: "a_2", content: "I checked.")
+        expect(result.content).must_equal "I checked."
+        expect(result.id).must_equal "a_2"
+        expect(result.tool_calls).must_equal [tc]
+        expect(agent.message_by_id("a_2").content).must_equal "I checked."
+      end
+
+      it "raises Riffer::ArgumentError on unknown id" do
+        expect { agent.replace_assistant_content(id: "missing", content: "x") }.must_raise Riffer::ArgumentError
+      end
+
+      it "delegates to #remove_message when content is empty" do
+        agent.replace_assistant_content(id: "a_1", content: "")
+        expect(agent.message_by_id("a_1")).must_be_nil
+      end
+
+      it "removes Tool children when content is empty and the assistant has tool_calls" do
+        agent.replace_assistant_content(id: "a_2", content: "")
+        expect(agent.message_by_id("a_2")).must_be_nil
+        expect(agent.tool_message_for("c_1")).must_be_nil
+      end
+    end
+
+    describe "#remove_message" do
+      it "removes a plain assistant message" do
+        result = agent.remove_message(id: "a_1")
+        expect(result).must_equal plain_assistant
+        expect(agent.message_by_id("a_1")).must_be_nil
+      end
+
+      it "cascades to Tool children when the target carries tool_calls" do
+        agent.remove_message(id: "a_2")
+        expect(agent.message_by_id("a_2")).must_be_nil
+        expect(agent.tool_message_for("c_1")).must_be_nil
+      end
+
+      it "removes user and system messages" do
+        sys_msg = Riffer::Messages::System.new("hi", id: "s_1")
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [sys_msg, user])
+        a.remove_message(id: "u_1")
+        expect(a.message_by_id("u_1")).must_be_nil
+        a.remove_message(id: "s_1")
+        expect(a.message_by_id("s_1")).must_be_nil
+      end
+
+      it "raises Riffer::ArgumentError when called on a Tool message" do
+        expect { agent.remove_message(id: "t_1") }.must_raise Riffer::ArgumentError
+      end
+
+      it "returns nil when no message matches" do
+        expect(agent.remove_message(id: "missing")).must_be_nil
+      end
+    end
+
+    describe "#replace_tool_result" do
+      it "replaces content; preserves name and id" do
+        result = agent.replace_tool_result(tool_call_id: "c_1", content: "rainy")
+        expect(result.content).must_equal "rainy"
+        expect(result.tool_call_id).must_equal "c_1"
+        expect(result.name).must_equal "weather"
+        expect(result.id).must_equal "t_1"
+      end
+
+      it "plumbs error and error_type" do
+        result = agent.replace_tool_result(tool_call_id: "c_1", content: "boom", error: "failed", error_type: :execution_error)
+        expect(result.error).must_equal "failed"
+        expect(result.error_type).must_equal :execution_error
+        expect(result.error?).must_equal true
+      end
+
+      it "raises Riffer::ArgumentError on unknown tool_call_id" do
+        expect { agent.replace_tool_result(tool_call_id: "missing", content: "x") }.must_raise Riffer::ArgumentError
+      end
+    end
+
+    describe "#synthesize_missing_tool_results" do
+      let(:orphan_tc) { Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}") }
+      let(:orphan_assistant) { Riffer::Messages::Assistant.new("", id: "a_orphan", tool_calls: [orphan_tc]) }
+
+      it "returns [] when there are no orphans" do
+        result = agent.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("nope") }
+        expect(result).must_equal []
+      end
+
+      it "fills a single orphan and returns its call_id" do
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [user, orphan_assistant])
+        result = a.synthesize_missing_tool_results { |tc|
+          Riffer::Tools::Response.error("interrupted: #{tc.name}", type: :interrupted)
+        }
+        expect(result).must_equal ["c_orphan"]
+        tool = a.tool_message_for("c_orphan")
+        refute_nil tool
+        expect(tool.content).must_equal "interrupted: t"
+        expect(tool.error_type).must_equal :interrupted
+      end
+
+      it "inserts the synthesized Tool message immediately after its parent" do
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [user, orphan_assistant])
+        a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("x") }
+        ids = a.messages.map(&:id)
+        parent_idx = ids.index("a_orphan")
+        expect(a.messages[parent_idx + 1]).must_be_kind_of Riffer::Messages::Tool
+        expect(a.messages[parent_idx + 1].tool_call_id).must_equal "c_orphan"
+      end
+
+      it "skips siblings that already have a result" do
+        tc_a = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
+        tc_b = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
+        asst = Riffer::Messages::Assistant.new("", id: "a_xy", tool_calls: [tc_a, tc_b])
+        result_a = Riffer::Messages::Tool.new("done", id: "t_a", tool_call_id: "c_a", name: "t")
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [asst, result_a])
+        result = a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("interrupted") }
+        expect(result).must_equal ["c_b"]
+      end
+
+      it "raises when the block returns a non-Response value" do
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [orphan_assistant])
+        expect { a.synthesize_missing_tool_results { |_tc| "just a string" } }.must_raise Riffer::ArgumentError
+      end
+
+      it "raises when called without a block" do
+        expect { agent.synthesize_missing_tool_results }.must_raise Riffer::ArgumentError
+      end
+    end
+  end
+
+  describe "#interrupt! with synthesize:" do
+    let(:tool_class) do
+      Class.new(Riffer::Tool) do
+        description "Slow tool"
+        def call(context:)
+          text("done")
+        end
+      end.tap { |t| t.identifier("interrupt_synth_tool") }
+    end
+
+    it "fills orphans and exposes synthesized_tool_call_ids on the response" do
+      tc = tool_class
+      custom_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tc]
+      end
+
+      agent = custom_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("", tool_calls: [
+        {name: "interrupt_synth_tool", arguments: "{}"},
+        {name: "interrupt_synth_tool", arguments: "{}"}
+      ])
+
+      agent.on_message do |msg|
+        if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
+          agent.interrupt!(:user_interrupt, synthesize: ->(call) {
+            Riffer::Tools::Response.error("synth #{call.call_id}", type: :interrupted)
+          })
+        end
+      end
+
+      result = agent.generate("Call tools")
+
+      expect(result.interrupted?).must_equal true
+      expect(result.synthesized_tool_call_ids.length).must_equal 2
+      expect(agent.orphaned_tool_call_ids).must_equal []
+      tools = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      expect(tools.length).must_equal 2
+      expect(tools.first.error_type).must_equal :interrupted
+    end
+
+    it "preserves the legacy no-synthesize path when interrupt! is called without a block" do
+      tc = tool_class
+      custom_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tc]
+      end
+
+      agent = custom_class.new
+      provider = agent.send(:provider_instance)
+      provider.stub_response("", tool_calls: [{name: "interrupt_synth_tool", arguments: "{}"}])
+
+      agent.on_message do |msg|
+        agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
+      end
+
+      result = agent.generate("Call tools")
+
+      expect(result.interrupted?).must_equal true
+      expect(result.synthesized_tool_call_ids).must_equal []
+      expect(agent.orphaned_tool_call_ids.length).must_equal 1
+    end
+  end
+
+  describe "max_steps interrupt synthesizes orphans" do
+    let(:tool_class) do
+      Class.new(Riffer::Tool) do
+        description "Loop tool"
+        def call(context:)
+          text("ok")
+        end
+      end.tap { |t| t.identifier("max_steps_synth_tool") }
+    end
+
+    it "fills orphan tool_use with the built-in synthesizer when the step budget is hit" do
+      tc = tool_class
+      custom_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tc]
+        max_steps 1
+      end
+
+      agent = custom_class.new
+      provider = agent.send(:provider_instance)
+      # Two responses: the first hits max_steps, leaving the orphan.
+      provider.stub_response("", tool_calls: [{name: "max_steps_synth_tool", arguments: "{}"}])
+      provider.stub_response("", tool_calls: [{name: "max_steps_synth_tool", arguments: "{}"}])
+
+      result = agent.generate("Loop forever")
+
+      expect(result.interrupted?).must_equal true
+      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.synthesized_tool_call_ids.length).must_equal 1
+      expect(agent.orphaned_tool_call_ids).must_equal []
+      synth = agent.messages.last
+      expect(synth).must_be_kind_of Riffer::Messages::Tool
+      expect(synth.error_type).must_equal :interrupted
+    end
+  end
+
+  describe "seeded history validation" do
+    let(:custom_class) { Class.new(Riffer::Agent) { model "mock/riffer-1" } }
+
+    after { Riffer.config.on_invalid_seed = :ignore }
+
+    it "ignores invariant violations by default (preserves legacy behavior)" do
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
+        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
+        Riffer::Messages::User.new("follow up"),
+        Riffer::Messages::Assistant.new("ok")
+      ]
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages)
+
+      # All seeded messages survived untouched — including the parentless
+      # Tool and the orphaned tool_use.
+      assistant_with_orphan = agent.messages.find { |m|
+        m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_orphan" }
+      }
+      refute_nil assistant_with_orphan
+      parentless = agent.messages.find { |m|
+        m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_missing"
+      }
+      refute_nil parentless
+    end
+
+    it "raises with :raise when a non-last assistant has an orphaned tool_use" do
+      Riffer.config.on_invalid_seed = :raise
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
+      messages = [
+        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
+        Riffer::Messages::User.new("anyway"),
+        Riffer::Messages::Assistant.new("ok")
+      ]
+      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises with :raise when a parentless tool_result is in the seed" do
+      Riffer.config.on_invalid_seed = :raise
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t")
+      ]
+      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+    end
+
+    it "allows a pending tool_use on the LAST assistant (cross-process resume)" do
+      Riffer.config.on_invalid_seed = :raise
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_pending", name: "t", arguments: "{}")
+      messages = [
+        Riffer::Messages::User.new("Call tool"),
+        Riffer::Messages::Assistant.new("", tool_calls: [tc])
+      ]
+      tool = Class.new(Riffer::Tool) do
+        description "Pending tool"
+        def call(context:)
+          text("done")
+        end
+      end.tap { |t| t.identifier("pending_seed_tool") }
+      with_tools = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        uses_tools [tool]
+      end
+      tc.name = "pending_seed_tool"
+      provider = with_tools.new.send(:provider_instance)
+      provider.stub_response("All done!")
+
+      agent = with_tools.new
+      agent.send(:provider_instance).stub_response("All done!")
+      result = agent.generate(messages)
+      expect(result.interrupted?).must_equal false
+    end
+
+    it ":strip drops orphaned tool exchanges from non-last assistants" do
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_drop", name: "t", arguments: "{}")
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
+        Riffer::Messages::User.new("anyway"),
+        Riffer::Messages::Assistant.new("never mind")
+      ]
+
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages, on_invalid_seed: :strip)
+
+      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_drop" } }).must_equal true
+    end
+
+    it ":strip drops parentless tool messages" do
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
+        Riffer::Messages::User.new("follow-up")
+      ]
+      provider = custom_class.new.send(:provider_instance)
+      provider.stub_response("Hello!")
+
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages, on_invalid_seed: :strip)
+
+      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
+    end
+
+    it "honors the global Riffer.config.on_invalid_seed default" do
+      Riffer.config.on_invalid_seed = :strip
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t")
+      ]
+      agent = custom_class.new
+      agent.send(:provider_instance).stub_response("Hello!")
+      agent.generate(messages)
+      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
+    end
+  end
 end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -3979,6 +3979,21 @@ describe Riffer::Agent do
       it "raises when called without a block" do
         expect { agent.synthesize_missing_tool_results }.must_raise Riffer::ArgumentError
       end
+
+      it "does not fire on_message for synthesized Tool messages (caller-driven mutation)" do
+        # Synthesized results aren't real tool executions — they are caller-
+        # driven history mutations like replace_assistant_content and
+        # remove_message, which also bypass on_message. Consumers learn
+        # synthesis happened via Response#synthesized_tool_call_ids.
+        a = agent_class.new
+        a.instance_variable_set(:@messages, [user, orphan_assistant])
+        seen = []
+        a.on_message { |msg| seen << msg }
+
+        a.synthesize_missing_tool_results { |_tc| Riffer::Tools::Response.error("interrupted") }
+
+        expect(seen).must_equal []
+      end
     end
   end
 
@@ -4122,6 +4137,29 @@ describe Riffer::Agent do
         Riffer::Messages::Assistant.new("ok")
       ]
       expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises with :raise when the trailing assistant has an orphan but the tail contains non-Tool messages" do
+      # The orphan-bearing assistant is the very last Assistant in history,
+      # but it is followed by a User message — so it is NOT the resume
+      # boundary (that's the "execute_pending_tool_calls will sweep this up"
+      # case). Validator must catch the orphan here.
+      Riffer.config.on_invalid_seed = :raise
+      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
+      messages = [
+        Riffer::Messages::User.new("hi"),
+        Riffer::Messages::Assistant.new("", tool_calls: [tc]),
+        Riffer::Messages::User.new("never mind")
+      ]
+      expect { custom_class.new.generate(messages) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises immediately on an unknown strategy even when the seed is clean" do
+      messages = [Riffer::Messages::User.new("hi")]
+      err = expect {
+        custom_class.new.generate(messages, on_invalid_seed: :raze)
+      }.must_raise Riffer::ArgumentError
+      expect(err.message).must_include "on_invalid_seed"
     end
 
     it "raises with :raise when a parentless tool_result is in the seed" do

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -99,6 +99,58 @@ describe Riffer::Config do
     end
   end
 
+  describe "experimental_history_healing" do
+    it "defaults to false" do
+      expect(Riffer::Config.new.experimental_history_healing).must_equal false
+    end
+
+    it "accepts true and false" do
+      config = Riffer::Config.new
+      config.experimental_history_healing = true
+      expect(config.experimental_history_healing).must_equal true
+      config.experimental_history_healing = false
+      expect(config.experimental_history_healing).must_equal false
+    end
+
+    it "coerces ENV-style truthy strings" do
+      config = Riffer::Config.new
+      config.experimental_history_healing = "true"
+      expect(config.experimental_history_healing).must_equal true
+      config.experimental_history_healing = "1"
+      expect(config.experimental_history_healing).must_equal true
+      config.experimental_history_healing = 1
+      expect(config.experimental_history_healing).must_equal true
+    end
+
+    it "coerces ENV-style falsy strings" do
+      config = Riffer::Config.new
+      config.experimental_history_healing = true
+      config.experimental_history_healing = "false"
+      expect(config.experimental_history_healing).must_equal false
+      config.experimental_history_healing = "0"
+      expect(config.experimental_history_healing).must_equal false
+      config.experimental_history_healing = 0
+      expect(config.experimental_history_healing).must_equal false
+    end
+
+    it "treats nil as false (ENV-not-set)" do
+      config = Riffer::Config.new
+      config.experimental_history_healing = true
+      config.experimental_history_healing = nil
+      expect(config.experimental_history_healing).must_equal false
+    end
+
+    it "raises for other strings" do
+      config = Riffer::Config.new
+      expect { config.experimental_history_healing = "yes" }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises for unrelated values" do
+      config = Riffer::Config.new
+      expect { config.experimental_history_healing = :on }.must_raise Riffer::ArgumentError
+    end
+  end
+
   describe "mcp namespace" do
     it "initializes credentials to nil" do
       config = Riffer::Config.new


### PR DESCRIPTION
## Summary

- Adds in-place history mutators to `Riffer::Agent` — `replace_assistant_content`, `remove_message` (cascades to its `Tool` children), and `replace_tool_result` — each enforcing the `tool_use` ↔ `tool_result` invariant.
- Adds read accessors that pair with the mutators: `message_by_id`, `tool_message_for`, `last_assistant`, `orphaned_tool_call_ids`.
- Adds `Riffer.config.experimental_history_healing` (default `false`). When on, riffer keeps the invariant intact on its own:
  - **Seed**: `agent.generate(messages_array)` silently strips orphaned `tool_use` exchanges and parentless `Tool` messages. Pending tool_use on the **resume boundary** (last assistant whose tail is purely `Tool` results) is preserved for `execute_pending_tool_calls`.
  - **Interrupts**: any orphan `tool_use` left when the loop is interrupted (caller-issued `interrupt!` or `INTERRUPT_MAX_STEPS`) is filled with a placeholder `Riffer::Messages::Tool` carrying `error_type: :interrupted` and content `"Tool call interrupted before completion."`. Filled `call_id`s are exposed on `Response#healed_tool_call_ids` and `StreamEvents::Interrupt#healed_tool_call_ids`.

The change is additive at the existing-API level: with the flag off (default), every existing test passes unchanged. Downstream callers (e.g. maestro's voice orchestrator) can flip the flag, drop their `rebuild_riffer_with!` + 7-helper invariant-enforcement cluster, and use the mutators directly for the truncate-on-barge-in flow.

There is no per-call override and no customizable placeholder — callers needing finer placeholder content can call `replace_tool_result` after the interrupt returns to upgrade a placeholder in place.

## Test plan

- [x] `bundle exec rake` is green (1422 runs, 2212 assertions, 0 failures, 0 errors, 0 type errors)
- [x] New tests cover every mutator, read accessor, both interrupt paths (caller-initiated and `max_steps`) under healing on/off, and the seed-stripping path under healing on/off
- [x] Existing interrupt + tool-call tests still pass — confirms `execute_pending_tool_calls` semantics are preserved when healing is off
- [ ] Smoke-test the API end-to-end by drafting (not merging) the maestro migration: flip `experimental_history_healing` on, replace `rebuild_riffer_with!` and `sanitize_seeded_history` with the new mutators, confirm `truncate_last_message` / `interrupt` / `inject_tool_result` collapse cleanly. Any awkwardness is feedback for a follow-up patch before maestro merges.

## Docs

- `docs/04_AGENT_LIFECYCLE.md` — new "Healing pending tool results on interrupt (experimental)" and "Mutating history" subsections; `healed_tool_call_ids` row added to the Response Attributes table.
- `docs/10_CONFIGURATION.md` — new "Experimental: History Healing" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experimental history healing mode: unanswered tool calls are automatically replaced with error placeholders on interrupt.
  * New APIs to inspect and mutate agent message history after generation, including viewing messages by ID, replacing content, removing messages, and updating tool results.
  * New configuration option to enable experimental history healing.

* **Documentation**
  * Updated agent lifecycle, message, and configuration guides documenting history healing behavior and new message history inspection and mutation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->