### PR TITLE
refactor: unify execute_tool_calls and execute_pending_tool_calls

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -913,10 +913,12 @@ class Riffer::Agent
   end
 
   #--
-  #: (Riffer::Messages::Assistant) -> void
-  def execute_tool_calls(response)
+  #: (Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
+  def execute_tool_calls(assistant_message, tool_calls: assistant_message.tool_calls)
+    return if tool_calls.empty?
+
     runtime = resolve_tool_runtime
-    results = runtime.execute(response.tool_calls, tools: resolved_tools, context: @context, assistant_message: response)
+    results = runtime.execute(tool_calls, tools: resolved_tools, context: @context, assistant_message: assistant_message)
 
     results.each do |tool_call, result|
       add_message(Riffer::Messages::Tool.new(
@@ -935,29 +937,14 @@ class Riffer::Agent
   # from the last assistant message may not have been executed yet. This
   # method detects those gaps by comparing the tool call ids requested by the
   # last assistant message against the tool result messages that follow it,
-  # then executes any that are missing.
+  # then executes any that are missing. Safe to call unconditionally —
+  # returns immediately when there is nothing pending.
   #
   #--
   #: () -> void
-  # Executes tool calls from the last assistant message that don't yet
-  # have a corresponding tool result. Safe to call unconditionally —
-  # returns immediately when there is nothing pending.
   def execute_pending_tool_calls
-    assistant, pending = pending_tool_calls
-    return if pending.empty?
-
-    runtime = resolve_tool_runtime
-    results = runtime.execute(pending, tools: resolved_tools, context: @context, assistant_message: assistant)
-
-    results.each do |tool_call, result|
-      add_message(Riffer::Messages::Tool.new(
-        result.content,
-        tool_call_id: tool_call.call_id,
-        name: tool_call.name,
-        error: result.error_message,
-        error_type: result.error_type
-      ))
-    end
+    assistant_message, pending = pending_tool_calls
+    execute_tool_calls(assistant_message, tool_calls: pending) if assistant_message
   end
 
   # Returns +[assistant, pending_tool_calls]+ for the last assistant message.

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -448,8 +448,8 @@ class Riffer::Agent
   def has_tool_calls?: (Riffer::Messages::Assistant) -> bool
 
   # --
-  # : (Riffer::Messages::Assistant) -> void
-  def execute_tool_calls: (Riffer::Messages::Assistant) -> void
+  # : (Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
+  def execute_tool_calls: (Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
 
   # Executes tool calls left unfinished by a prior interrupt.
   #
@@ -457,13 +457,11 @@ class Riffer::Agent
   # from the last assistant message may not have been executed yet. This
   # method detects those gaps by comparing the tool call ids requested by the
   # last assistant message against the tool result messages that follow it,
-  # then executes any that are missing.
+  # then executes any that are missing. Safe to call unconditionally —
+  # returns immediately when there is nothing pending.
   #
   # --
   # : () -> void
-  # Executes tool calls from the last assistant message that don't yet
-  # have a corresponding tool result. Safe to call unconditionally —
-  # returns immediately when there is nothing pending.
   def execute_pending_tool_calls: () -> void
 
   # Returns +[assistant, pending_tool_calls]+ for the last assistant message.


### PR DESCRIPTION
## Summary
- Collapses the ~90% duplicate between `execute_tool_calls` and `execute_pending_tool_calls` in `lib/riffer/agent.rb` by parameterising the former with an optional `tool_calls:` keyword arg.
- `execute_pending_tool_calls` becomes a 3-line wrapper that resolves the pending pair via the existing `pending_tool_calls` helper and delegates.
- No call sites change; no new `Riffer.config.X` reads introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tool call execution logic by consolidating duplicate code and enhancing flexibility in method parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->