### PR TITLE
refactor: remove duplicate instance-level resolve_uses_tools_config

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -1022,20 +1022,6 @@ class Riffer::Agent
 
   #--
   #: () -> Array[singleton(Riffer::Tool)]
-  def resolve_uses_tools_config
-    config = self.class.uses_tools
-
-    if config.nil?
-      []
-    elsif config.is_a?(Proc)
-      (config.arity == 0) ? config.call : config.call(@context)
-    else
-      config
-    end
-  end
-
-  #--
-  #: () -> Array[singleton(Riffer::Tool)]
   def resolve_mcp_tool_classes
     configs = self.class.mcp_configs
     return [] if configs.empty?

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -496,10 +496,6 @@ class Riffer::Agent
 
   # --
   # : () -> Array[singleton(Riffer::Tool)]
-  def resolve_uses_tools_config: () -> Array[singleton(Riffer::Tool)]
-
-  # --
-  # : () -> Array[singleton(Riffer::Tool)]
   def resolve_mcp_tool_classes: () -> Array[singleton(Riffer::Tool)]
 
   # Each matching MCP registration once, with tag symbols unioned across +use_mcp+ rows.


### PR DESCRIPTION
## Summary

- Removes the dead instance-level `Riffer::Agent#resolve_uses_tools_config` (formerly `lib/riffer/agent.rb:1023–1035`). It had zero callers — only the class-level `Agent.resolve_uses_tools_config(context)` (line 184) is used, via `Agent.resolved_tool_classes`.
- Regenerates `sig/generated/riffer/agent.rbs` so the duplicate signature drops out automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent tool resolution now supports MCP-registered tools, expanding available tool options.

* **Refactor**
  * Tool resolution mechanism has been streamlined and reorganized for improved maintainability.

* **Improvements**
  * Added automatic validation to detect and prevent duplicate tool names, reducing configuration conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->