### PR TITLE
refactor: remove dead @interrupted ivar on Agent

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -338,7 +338,6 @@ class Riffer::Agent
     @messages = []
     @message_callbacks = []
     @token_usage = nil
-    @interrupted = false
     @model_config = self.class.model
     @instructions_config = self.class.instructions
 
@@ -671,7 +670,6 @@ class Riffer::Agent
 
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
-    @interrupted = true
     healed = Riffer.config.experimental_history_healing ? heal_orphan_tool_calls : []
     response = extract_final_response
 
@@ -872,7 +870,6 @@ class Riffer::Agent
     end
 
     unless completed == :completed
-      @interrupted = true
       healed = Riffer.config.experimental_history_healing ? heal_orphan_tool_calls : []
       yielder << Riffer::StreamEvents::Interrupt.new(reason: completed, healed_tool_call_ids: healed)
     end
@@ -973,7 +970,6 @@ class Riffer::Agent
     @resolved_tools = nil
     @resolved_tool_runtime = nil
     clear_resolved_model
-    @interrupted = false
     resolve_model
     @skills_state = resolve_skills
     @context = (@context || {}).merge(skills: @skills_state) if @skills_state


### PR DESCRIPTION
## Summary

- Deletes the dead `@interrupted` instance variable on `Riffer::Agent`. It was written in four places (`#initialize`, the non-streaming catch-block after `throw :riffer_interrupt`, the streaming completion check, and `#prepare_run`) but never read — no `attr_*`, no method, no callers.
- The real interruption signal lives on `Riffer::Agent::Response#interrupted?`, which is populated via the explicit `interrupted:` keyword argument to `build_response` (and via `StreamEvents::Interrupt` on the streaming path). Both signal paths are unchanged.
- No behavior change. Phase 0 quick-win from the Riffer & AI SDK v1.0.0 refactor.

Jira: [CL2-774](https://jira-jane.atlassian.net/browse/CL2-774)

## Test plan

- [x] `bundle exec rake` — full test suite (1429 runs, 2224 assertions, 0 failures) + Steep type check + StandardRB lint all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CL2-774]: https://jira-jane.atlassian.net/browse/CL2-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal interrupt handling mechanisms while maintaining existing behavior and API compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->