### PR TITLE
refactor: extract Riffer::Session and rework Agent constructor (CL2-776)

### DIFF
--- a/docs/03_AGENTS.md
+++ b/docs/03_AGENTS.md
@@ -84,7 +84,7 @@ end
 MyAgent.generate('Hello!', context: { name: 'Jane' })
 ```
 
-The lambda is re-evaluated on each `generate` or `stream` call, so instructions can change between calls based on runtime context.
+The lambda is evaluated once at `Agent.new` time using the context passed to the constructor. To change instructions for a new context, construct a new agent.
 
 ### identifier
 

--- a/docs/04_AGENT_LIFECYCLE.md
+++ b/docs/04_AGENT_LIFECYCLE.md
@@ -211,16 +211,16 @@ agent.stream.each do |event|
 end
 ```
 
-### Building System Messages for Persistence
+### Reading System Messages for Persistence
 
-Use `generate_instruction_message` and `generate_skills_message` to generate system messages independently. This is useful for database persistence workflows where you need to store and later reconstruct message histories.
+Read the agent's instruction and skills system messages from `agent.instruction_message` and `agent.skills_message`. Both are built once at `Agent.new` time using the constructor `context:` and cached — they reflect the agent's configured `instructions` and `skills` DSL output. Useful for database persistence workflows where you need to store and later reconstruct message histories.
 
-Both methods return a `Riffer::Messages::System` or `nil` (when unconfigured). They accept an optional `context:` keyword that overrides the agent's init context for a one-off evaluation.
+Both return `Riffer::Messages::System` or `nil` (when unconfigured / empty).
 
 ```ruby
 agent = MyAgent.new(context: ctx)
-sys = agent.generate_instruction_message              # => Riffer::Messages::System or nil
-skills = agent.generate_skills_message                # => Riffer::Messages::System or nil
+sys = agent.instruction_message     # => Riffer::Messages::System or nil
+skills = agent.skills_message       # => Riffer::Messages::System or nil
 
 # Store in DB, then later resume in a new process:
 session = Riffer::Session.new(messages: [sys, skills, user_msg].compact)

--- a/docs/04_AGENT_LIFECYCLE.md
+++ b/docs/04_AGENT_LIFECYCLE.md
@@ -1,69 +1,64 @@
 # Agent Lifecycle
 
+## Construction
+
+### Agent.new
+
+```ruby
+Agent.new(session: nil, context: nil)
+```
+
+- **`session:`** — an existing `Riffer::Session`. When given, the agent uses it as-is (no system/skills seeding). Typical use case: cross-process resume from persisted history. With `Riffer.config.experimental_history_healing` on, a provided session is healed at construction time so the `tool_use` ↔ `tool_result` invariant holds before the next inference call.
+- **`context:`** — a `Hash` carried for the lifetime of the agent. Used to evaluate Proc-based `instructions`, `model`, `uses_tools`, and skill activation at construction time, and threaded through tool execution and guardrails on every `generate`/`stream` call.
+
+When `session:` is omitted, the agent constructs a fresh session and seeds it with `[instruction_message, skills_message].compact` eagerly. To swap context, construct a new agent — context is fixed for the lifetime of an agent instance.
+
 ## Instance Methods
 
 ### generate
 
 Generates a response synchronously. Returns a `Riffer::Agent::Response` object.
 
-The behavior depends on what you pass and the agent's current state:
-
-| Input      | Agent state                    | Behavior                                                                                                                                                              |
-| ---------- | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **String** | No prior messages              | **New conversation.** Builds system messages (instructions + skills), adds user message, calls the LLM.                                                               |
-| **String** | Has messages from a prior call | **Continue conversation.** Appends the user message to the existing history and re-enters the LLM loop. Pending tool calls from a prior interrupt are executed first. |
-| **Array**  | No prior messages              | **Restore from persisted data.** Uses the array as-is (no system messages added). Pending tool calls are executed. This is for cross-process resume.                  |
-| **Array**  | Has messages from a prior call | **Raises `Riffer::ArgumentError`.** Use a string to continue, or a new agent instance to start from a persisted array.                                                |
-
-**State reset per call:** Each call to `generate` or `stream` resets `context`, tools, tool runtime, model, skills state, and the interrupted flag. This means `context:` must be passed on every call — it is not carried over from a previous call. The only state that persists across calls is the message history and cumulative `token_usage`.
-
 ```ruby
-agent.generate('Hello', context: {user_id: 123})
-agent.generate('Follow up')  # context is nil here — pass it again if needed
-agent.generate('More', context: {user_id: 123})  # context is restored
+agent.generate(prompt = nil, files: nil)
 ```
+
+- **`prompt`** — when given, a new `Riffer::Messages::User` is silently appended to the session (no `on_message` callbacks fire for user inputs) and the inference loop runs.
+- **`prompt` omitted** — the loop runs against the current session. Useful when the seeded session's last turn is already a user message, or when picking up pending tool calls from a prior interrupt.
+- **`files:`** — requires `prompt`. Attached to the new user message.
 
 ```ruby
 # New conversation (class method — recommended for simple calls)
-response = MyAgent.generate('Hello')
+response = MyAgent.generate('Hello', context: {user_id: 123})
 puts response.content       # Access the response text
 puts response.blocked?      # Check if guardrail blocked (always false without guardrails)
 puts response.interrupted?  # Check if a callback interrupted the loop
 
 # New conversation (instance method — when you need message history or callbacks)
-agent = MyAgent.new
-agent.on_message { |msg| log(msg) }
+agent = MyAgent.new(context: {user_id: 123})
+agent.session.on_message { |msg| log(msg) }
 response = agent.generate('Hello')
-agent.messages  # Access message history
+agent.session.messages  # Access message history
 
 # Multi-turn conversation
 agent = MyAgent.new
 agent.generate('Hello')
 agent.generate('Tell me more')   # continues with full history
 
-# Restore from persisted messages (cross-process resume)
-agent = MyAgent.new
-response = agent.generate(persisted_messages, context: {user_id: 123})
+# Resume from persisted messages (cross-process)
+session = Riffer::Session.new(messages: persisted_messages)
+agent = MyAgent.new(session: session, context: {user_id: 123})
+response = agent.generate  # no prompt — session already has the last user message
 
-# With context
-response = MyAgent.generate('Look up my orders', context: {user_id: 123})
-
-# With files (string prompt + files shorthand)
+# With files
 response = MyAgent.generate('What is in this image?', files: [
   {data: base64_data, media_type: 'image/jpeg'}
-])
-
-# With files in messages array (per-message)
-response = MyAgent.generate([
-  {role: 'user', content: 'Describe this document', files: [
-    {url: 'https://example.com/report.pdf', media_type: 'application/pdf'}
-  ]}
 ])
 ```
 
 ### stream
 
-Streams a response as an Enumerator. Follows the same input rules as `generate` — a string starts a new conversation or continues an existing one, an array restores from persisted data.
+Streams a response as an Enumerator. Same prompt/files semantics as `generate`.
 
 ```ruby
 # New conversation (class method — recommended for simple calls)
@@ -80,9 +75,9 @@ end
 
 # New conversation (instance method — when you need message history or callbacks)
 agent = MyAgent.new
-agent.on_message { |msg| persist_message(msg) }
+agent.session.on_message { |msg| persist_message(msg) }
 agent.stream('Tell me a story').each { |event| handle(event) }
-agent.messages  # Access message history
+agent.session.messages  # Access message history
 
 # Multi-turn conversation
 agent = MyAgent.new
@@ -95,7 +90,9 @@ MyAgent.stream('What is in this image?', files: [{data: base64_data, media_type:
 end
 ```
 
-### messages
+### session
+
+Conversation state lives on `agent.session` — a `Riffer::Session` instance that owns the message array, the `on_message` callback list, and the `tool_use` ↔ `tool_result` invariant. The methods below are all on the session, not on the agent itself.
 
 Access the message history after a generate/stream call:
 
@@ -103,9 +100,16 @@ Access the message history after a generate/stream call:
 agent = MyAgent.new
 agent.generate('Hello')
 
-agent.messages.each do |msg|
+agent.session.messages.each do |msg|
   puts "#{msg.role}: #{msg.content}"
 end
+```
+
+`Riffer::Session` includes `Enumerable`, so `find`, `select`, `count`, `reverse_each` all work directly on the session:
+
+```ruby
+agent.session.find { |m| m.id == 'a_1' }
+agent.session.count { |m| m.is_a?(Riffer::Messages::Assistant) }
 ```
 
 ### on_message
@@ -113,7 +117,7 @@ end
 Registers a callback to receive messages as they're added during generation:
 
 ```ruby
-agent.on_message do |message|
+agent.session.on_message do |message|
   case message.role
   when :assistant
     puts "[Assistant] #{message.content}"
@@ -126,10 +130,10 @@ end
 Multiple callbacks can be registered. Returns `self` for method chaining:
 
 ```ruby
-agent
+agent.session
   .on_message { |msg| persist_message(msg) }
   .on_message { |msg| log_message(msg) }
-  .generate('Hello')
+agent.generate('Hello')
 ```
 
 Works with both `generate` and `stream`. Only emits agent-generated messages (Assistant, Tool), not inputs (System, User).
@@ -144,7 +148,7 @@ An optional reason can be passed to `interrupt!`. It is available via `interrupt
 
 ```ruby
 agent = MyAgent.new
-agent.on_message do |msg|
+agent.session.on_message do |msg|
   if msg.is_a?(Riffer::Messages::Tool)
     agent.interrupt!("needs human approval")
   end
@@ -160,7 +164,7 @@ response.content           # => last assistant content before interrupt
 
 ```ruby
 agent = MyAgent.new
-agent.on_message { |msg| throw :riffer_interrupt, "budget exceeded" }
+agent.session.on_message { |msg| throw :riffer_interrupt, "budget exceeded" }
 
 agent.stream('Hello').each do |event|
   case event
@@ -176,53 +180,51 @@ end
 
 There are two ways to resume after an interrupt, depending on whether the agent is still in memory or you're restoring from persisted data.
 
-**In-memory resume** — call `generate` (or `stream`) again with a string. The agent keeps its message history, so a new string appends a user message and continues the loop. Pending tool calls from the interrupt are automatically executed first.
+**In-memory resume** — call `generate` (or `stream`) again. With a prompt, the new user message is appended and the loop runs. Without a prompt, the loop runs against the current session — useful for picking up pending tool calls after the user has approved.
 
 ```ruby
-agent = MyAgent.new
-agent.on_message { |msg| throw :riffer_interrupt if needs_approval?(msg) }
+agent = MyAgent.new(context: {user_id: 123})
+agent.session.on_message { |msg| throw :riffer_interrupt if needs_approval?(msg) }
 
 response = agent.generate('Do something risky')
 
 if response.interrupted?
-  approve_action(agent.messages)
+  approve_action(agent.session.messages)
   response = agent.generate('Approved, go ahead')  # executes pending tools, then calls the LLM
+  # or: agent.generate                              # resume without a new turn
 end
 ```
 
-You can also resume without adding a new user message by passing a continuation like `'Continue'` — the LLM will pick up from the existing context.
-
-**Cross-process resume** — when the agent is gone (process restart, async approval, etc.), create a new agent and pass the persisted messages as an array. Array input uses messages as-is (no system messages added) and executes any pending tool calls.
+**Cross-process resume** — when the agent is gone (process restart, async approval, etc.), construct a `Riffer::Session` from the persisted messages and pass it to a new agent. The agent uses the session as-is (no system messages added). Pending tool calls on the resume boundary are executed on the next `generate`/`stream`.
 
 ```ruby
-# During generation, persist messages via on_message callback
+# During generation, persist each new message via on_message
 # Later, in a new process:
-agent = MyAgent.new
-response = agent.generate(persisted_messages, context: {user_id: 123})
+session = Riffer::Session.new(messages: persisted_messages)
+agent = MyAgent.new(session: session, context: {user_id: 123})
+response = agent.generate  # session already has the last user turn
 
 # Or resume in streaming mode:
-agent = MyAgent.new
-agent.stream(persisted_messages).each do |event|
+agent = MyAgent.new(session: session, context: {user_id: 123})
+agent.stream.each do |event|
   # handle stream events
 end
 ```
-
-**Important:** You cannot pass an array to an agent that already has messages. This raises `Riffer::ArgumentError` because it would silently discard the existing history. Use a string to continue, or create a new agent instance for cross-process resume.
 
 ### Building System Messages for Persistence
 
 Use `generate_instruction_message` and `generate_skills_message` to generate system messages independently. This is useful for database persistence workflows where you need to store and later reconstruct message histories.
 
-Both methods return a `Riffer::Messages::System` or `nil` (when unconfigured). They accept an optional `context:` keyword, just like `generate`.
+Both methods return a `Riffer::Messages::System` or `nil` (when unconfigured). They accept an optional `context:` keyword that overrides the agent's init context for a one-off evaluation.
 
 ```ruby
-agent = MyAgent.new
-sys = agent.generate_instruction_message(context: ctx)     # => Riffer::Messages::System or nil
-skills = agent.generate_skills_message(context: ctx)        # => Riffer::Messages::System or nil
+agent = MyAgent.new(context: ctx)
+sys = agent.generate_instruction_message              # => Riffer::Messages::System or nil
+skills = agent.generate_skills_message                # => Riffer::Messages::System or nil
 
 # Store in DB, then later resume in a new process:
-messages = [sys, skills, user_msg].compact
-MyAgent.new.generate(messages, context: ctx)
+session = Riffer::Session.new(messages: [sys, skills, user_msg].compact)
+MyAgent.new(session: session, context: ctx).generate
 ```
 
 ### interrupt!
@@ -230,7 +232,7 @@ MyAgent.new.generate(messages, context: ctx)
 Interrupts the agent loop from an `on_message` callback. Equivalent to `throw :riffer_interrupt, reason`:
 
 ```ruby
-agent.on_message do |msg|
+agent.session.on_message do |msg|
   agent.interrupt!(:needs_approval) if requires_approval?(msg)
 end
 ```
@@ -244,7 +246,7 @@ When the interrupt represents a course-change rather than a pause — e.g. a voi
 ```ruby
 Riffer.configure { |c| c.experimental_history_healing = true }
 
-agent.on_message do |msg|
+agent.session.on_message do |msg|
   agent.interrupt!(:user_interrupt) if msg.is_a?(Riffer::Messages::Assistant) && barge_in?
 end
 
@@ -256,25 +258,25 @@ The placeholder content is fixed: `"Tool call interrupted before completion."` w
 
 Healing covers all interrupts uniformly — caller-issued `interrupt!` and the built-in `INTERRUPT_MAX_STEPS` ceiling alike. When the flag is off (the default), orphans remain in history and `execute_pending_tool_calls` re-runs them on the next `generate` call.
 
-If you need finer control over placeholder content (per-call shape, structured metadata, etc.), use the `replace_tool_result` mutator below to upgrade a placeholder after the interrupt returns.
+If you need finer control over placeholder content (per-call shape, structured metadata, etc.), use the `update` mutator below to upgrade a placeholder after the interrupt returns.
 
 ### Mutating history
 
-The agent exposes a small set of in-place mutators that enforce the `tool_use` ↔ `tool_result` invariant on every operation. Use these to align the agent's history with external state (persisted transcript, partial output that wasn't actually delivered, etc.) without rebuilding the agent.
+The session exposes a small set of in-place mutators that enforce the `tool_use` ↔ `tool_result` invariant on every operation. Use these to align history with external state (persisted transcript, partial output that wasn't actually delivered, etc.) without rebuilding the agent.
 
-- **`agent.replace_assistant_content(id:, content:)`** — In-place truncation/edit. Preserves `tool_calls`, `token_usage`, and `id`. Empty `content` delegates to `remove_message`.
-- **`agent.remove_message(id:)`** — Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` (use `replace_tool_result`).
-- **`agent.replace_tool_result(tool_call_id:, content:, error:, error_type:)`** — Replace a tool result in place, preserving `name` and `id`. Use this to upgrade an interrupt-time placeholder once the real result is available.
+- **`agent.session.update(id:, **attrs)`** — In-place partial update. Looks up by message `id:`; builds a replacement of the same type with `attrs` overlaid on the existing fields. Use this to edit assistant content (`update(id:, content:)`), restate a system message, etc. When the target is an assistant and the update drops entries from `tool_calls`, matching `Tool` children are removed atomically.
+- **`agent.session.update(tool_call_id:, **attrs)`** — Same as above but looks up the tool result by `tool_call_id:`. Preserves `name` and `id`. Use this to upgrade an interrupt-time placeholder once the real result is available (`update(tool_call_id:, content:, error: nil, error_type: nil)`).
+- **`agent.session.remove(id:)`** — Removes a message; cascades to its `Tool` children when the target carries `tool_calls`. Raises if called on a `Tool` message (use `update(tool_call_id:, ...)` to rewrite a tool result instead).
 
 Bulk filling of orphan `tool_use` blocks is handled by `Riffer.config.experimental_history_healing` (see "Healing pending tool results on interrupt" above) — there is no public synthesizer hook.
 
-Read accessors that pair with the mutators:
+Lookup patterns that pair with the mutators (via `Enumerable`):
 
 ```ruby
-agent.message_by_id(id)           # => Riffer::Messages::Base or nil
-agent.tool_message_for(call_id)   # => Riffer::Messages::Tool or nil
-agent.last_assistant              # => Riffer::Messages::Assistant or nil
-agent.orphaned_tool_call_ids      # => Array[String]   (zero-cost validation)
+agent.session.find { |m| m.id == id }                                           # message by id
+agent.session.reverse_each.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == call_id }
+agent.session.reverse_each.find { |m| m.is_a?(Riffer::Messages::Assistant) }    # last assistant
+agent.session.orphaned_tool_call_ids                                            # Array[String], zero-cost validation
 ```
 
 Mutating history while a `stream` enumerator is being consumed is undefined; mutators are intended for use between turns.
@@ -333,7 +335,7 @@ The assistant message in the message history stores the parsed hash, so you can 
 agent = SentimentAgent.new
 agent.generate('Analyze: "I love this!"')
 
-msg = agent.messages.last
+msg = agent.session.messages.last
 msg.structured_output?    # => true
 msg.structured_output     # => {sentiment: "positive", score: 0.95}
 ```

--- a/docs/05_AGENT_LOOP.md
+++ b/docs/05_AGENT_LOOP.md
@@ -58,7 +58,7 @@ Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :r
 
 ```ruby
 agent = MyAgent.new
-agent.on_message do |msg|
+agent.session.on_message do |msg|
   agent.interrupt!("approval needed") if requires_approval?(msg)
 end
 

--- a/docs/06_TOOLS.md
+++ b/docs/06_TOOLS.md
@@ -176,7 +176,7 @@ class UserOrdersTool < Riffer::Tool
 end
 
 # Usage
-agent.generate("Show my orders", context: {user_id: 123})
+MyAgent.new(context: {user_id: 123}).generate("Show my orders")
 ```
 
 ## Response Objects

--- a/docs/06_TOOLS.md
+++ b/docs/06_TOOLS.md
@@ -158,7 +158,7 @@ end
 
 ### Accessing Context
 
-The `context` argument receives whatever was passed as `context:` to `generate`:
+The `context` argument receives whatever was passed as `context:` to `Agent.new`:
 
 ```ruby
 class UserOrdersTool < Riffer::Tool

--- a/docs/07_TOOL_ADVANCED.md
+++ b/docs/07_TOOL_ADVANCED.md
@@ -145,7 +145,7 @@ class MyAgent < Riffer::Agent
   }
 end
 
-agent.generate("Do work", context: {parallel: true})
+MyAgent.new(context: {parallel: true}).generate("Do work")
 ```
 
 When the lambda accepts a parameter, it receives the `context`. Zero-arity lambdas are also supported.

--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -183,45 +183,38 @@ This creates a `User` message internally.
 
 ### Message Arrays
 
-For multi-turn conversations, pass an array of messages:
+For multi-turn conversations restored from persisted state, construct a `Riffer::Session` with the message history and hand it to a new agent:
 
 ```ruby
-messages = [
-  {role: :user, content: "What's the weather?"},
-  {role: :assistant, content: "I'll check that for you."},
-  {role: :user, content: "Thanks, I meant in Tokyo specifically."}
-]
+session = Riffer::Session.new(messages: [
+  Riffer::Messages::User.new("What's the weather?"),
+  Riffer::Messages::Assistant.new("I'll check that for you."),
+  Riffer::Messages::User.new("Thanks, I meant in Tokyo specifically.")
+])
 
-response = agent.generate(messages)
+agent = MyAgent.new(session: session)
+response = agent.generate   # session already carries the last user turn
 ```
 
-Messages can be hashes or `Riffer::Messages::Base` objects:
-
-```ruby
-messages = [
-  Riffer::Messages::User.new("Hello"),
-  Riffer::Messages::Assistant.new("Hi there!"),
-  Riffer::Messages::User.new("How are you?")
-]
-
-response = agent.generate(messages)
-```
+`Riffer::Session.new(messages:)` accepts `Riffer::Messages::Base` objects. If your persistence layer hands back hashes, normalize them first via `Riffer::Messages::Converter#convert_to_message_object` or your own adapter (e.g. jane's `to_riffer`).
 
 ### Accessing Message History
 
-After calling `generate` or `stream`, access the full conversation:
+Conversation state lives on `agent.session` — a `Riffer::Session` instance. After calling `generate` or `stream`, access the full conversation:
 
 ```ruby
 agent = MyAgent.new
 agent.generate("Hello!")
 
-agent.messages.each do |msg|
+agent.session.messages.each do |msg|
   puts "[#{msg.role}] #{msg.content}"
 end
 # [system] You are a helpful assistant.
 # [user] Hello!
 # [assistant] Hi there! How can I help you today?
 ```
+
+`Riffer::Session` includes `Enumerable`, so `find`, `select`, `count`, `reverse_each` etc. work directly on the session without going through `.messages`.
 
 ## Tool Call Structure
 
@@ -264,19 +257,19 @@ Without this step, the same model can receive different input depending on the p
 When a context message is injected before the user's turn, two consecutive user messages are merged into one:
 
 ```ruby
-messages = [
+session = Riffer::Session.new(messages: [
   Riffer::Messages::System.new("You are a code reviewer."),
   Riffer::Messages::User.new("The repository uses RSpec for testing."),
   Riffer::Messages::User.new("Review this pull request.")
-]
+])
 
-agent.generate(messages)
+MyAgent.new(session: session).generate
 # The provider receives two messages:
 #   1. System  — "You are a code reviewer."
 #   2. User    — "The repository uses RSpec for testing.\n\nReview this pull request."
 ```
 
-Merging happens at serialization time only. The agent's `messages` array still contains the original separate messages for logging, evals, and debugging.
+Merging happens at serialization time only. The session's `messages` array still contains the original separate messages for logging, evals, and debugging.
 
 ## IDs
 
@@ -330,4 +323,4 @@ Subclasses implement `role` and optionally extend `to_h` with additional fields.
 
 ## Editing history after the fact
 
-The agent's `messages` array is mutable, but the message value objects themselves are immutable. To edit recorded history — truncate an assistant message, replace a tool result, fill an orphan `tool_use` — use the mutators on `Riffer::Agent`. Each mutator enforces the `tool_use` ↔ `tool_result` invariant. See [Mutating history](04_AGENT_LIFECYCLE.md#mutating-history) for the full list.
+The session's `messages` array is mutable, but the message value objects themselves are immutable. To edit recorded history — truncate an assistant message, rewrite a tool result, fill an orphan `tool_use` — use the mutators on `agent.session` (`update`, `remove`). Each one enforces the `tool_use` ↔ `tool_result` invariant. See [Mutating history](04_AGENT_LIFECYCLE.md#mutating-history) for the full list.

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -119,18 +119,7 @@ end
 
 When the strategy is not `:none`, every `Riffer::Messages::Base` instance — user prompts, system instructions, assistant responses, and tool results — gets an auto-generated `id` at construction time. IDs are included in `message.to_h` when present and omitted when `nil`. Provider API payloads are unaffected; the `id` stays on the Ruby side.
 
-Seeded messages passed to `agent.generate([...])` must carry their own `:id` when the strategy is enabled — Riffer never fabricates identifiers for pre-existing history:
-
-```ruby
-Riffer.configure { |c| c.message_id_strategy = :uuidv7 }
-
-agent.generate([
-  {role: :user, content: "Hi", id: "msg-001"},
-  {role: :assistant, content: "Hello!", id: "msg-002"}
-])
-```
-
-Missing ids raise `Riffer::ArgumentError` with the offending index.
+When constructing a `Riffer::Session` from persisted history with the strategy enabled, supply ids on every seeded message yourself — Riffer never fabricates identifiers for pre-existing history. Messages built via the `Riffer::Messages::*` constructors auto-generate ids per the strategy, so as long as those constructors are used at message-creation time, ids flow through.
 
 See [Messages — IDs](08_MESSAGES.md#ids) for more details.
 
@@ -148,12 +137,12 @@ end
 
 When enabled, two repairs run automatically:
 
-1. **Seeded history.** `agent.generate(messages_array)` silently drops orphaned `tool_use` exchanges (assistant `tool_call` with no matching `Tool` result) and parentless `Tool` messages from the seed before the run begins. Pending tool calls on the **resume boundary** — the last assistant whose tail is purely `Tool` results (or none) — are preserved; `execute_pending_tool_calls` runs them on the next LLM call.
+1. **Seeded session.** Passing a pre-populated `Riffer::Session` to `Agent.new(session: ...)` silently drops orphaned `tool_use` exchanges (assistant `tool_call` with no matching `Tool` result) and parentless `Tool` messages before the next inference call. Pending tool calls on the **resume boundary** — the last assistant whose tail is purely `Tool` results (or none) — are preserved; `execute_pending_tool_calls` runs them on the next LLM call.
 2. **Interrupts.** Any orphan `tool_use` left when the loop is interrupted (caller-issued `interrupt!` or the built-in `INTERRUPT_MAX_STEPS` ceiling) is filled with a placeholder `Riffer::Messages::Tool` carrying `error_type: :interrupted` and the content `"Tool call interrupted before completion."`. Filled `call_id`s are exposed on `Riffer::Agent::Response#healed_tool_call_ids` (and `Riffer::StreamEvents::Interrupt#healed_tool_call_ids` when streaming).
 
-Defaults to `false` — pre-healing behavior. Seeded arrays pass through untouched, and orphan `tool_use` left by an interrupt remain in history for `execute_pending_tool_calls` to re-run on the next call.
+Defaults to `false` — pre-healing behavior. Seeded sessions pass through untouched, and orphan `tool_use` left by an interrupt remain in history for `execute_pending_tool_calls` to re-run on the next call.
 
-There is no per-call override and no customizable placeholder. Callers needing finer control can call the `replace_tool_result` mutator after the interrupt returns to upgrade a placeholder in place. See [Agent Lifecycle — Healing pending tool results on interrupt](04_AGENT_LIFECYCLE.md#healing-pending-tool-results-on-interrupt-experimental).
+There is no per-call override and no customizable placeholder. Callers needing finer control can call `agent.session.update(tool_call_id:, ...)` after the interrupt returns to upgrade a placeholder in place. See [Agent Lifecycle — Healing pending tool results on interrupt](04_AGENT_LIFECYCLE.md#healing-pending-tool-results-on-interrupt-experimental).
 
 ## Agent-Level Configuration
 

--- a/docs/providers/06_MOCK_PROVIDER.md
+++ b/docs/providers/06_MOCK_PROVIDER.md
@@ -121,7 +121,8 @@ class MyAgentTest < Minitest::Test
     ])
     @provider.stub_response("Done.")
 
-    @agent.generate("Do something", context: {user_id: 123})
+    agent = TestableAgent.new(context: {user_id: 123})
+    agent.generate("Do something")
 
     # Tool receives the context
   end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -774,9 +774,9 @@ class Riffer::Agent
   end
 
   #--
-  #: (?Hash[Symbol, untyped]?) -> String?
-  def generate_instructions(context = @context)
-    Riffer::Helpers::CallOrValue.resolve(@instructions_config, context: context)
+  #: () -> String?
+  def generate_instructions
+    Riffer::Helpers::CallOrValue.resolve(@instructions_config, context: @context)
   end
 
   attr_reader :resolved_model #: String?

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -323,6 +323,16 @@ class Riffer::Agent
   # The conversation handle. See Riffer::Session.
   attr_reader :session #: Riffer::Session
 
+  # The system message built from the configured +instructions+, or +nil+
+  # when no instructions are configured. Built once at +Agent.new+ using the
+  # constructor +context:+ and cached. Useful for persistence flows.
+  attr_reader :instruction_message #: Riffer::Messages::System?
+
+  # The system message describing the configured skills catalog, or +nil+
+  # when skills are unconfigured or the catalog is empty. Built once at
+  # +Agent.new+ and cached.
+  attr_reader :skills_message #: Riffer::Messages::System?
+
   # Cumulative token usage across all LLM calls.
   attr_reader :token_usage #: Riffer::TokenUsage?
 
@@ -363,7 +373,10 @@ class Riffer::Agent
     @skills_state = resolve_skills
     @context = (@context || {}).merge(skills: @skills_state) if @skills_state
 
-    @session = session || build_initial_session
+    @instruction_message = build_instruction_message
+    @skills_message = build_skills_message
+
+    @session = session || Riffer::Session.new(messages: [@instruction_message, @skills_message].compact)
     apply_seed_healing if session && Riffer.config.experimental_history_healing
   end
 
@@ -420,32 +433,6 @@ class Riffer::Agent
 
       run_stream_loop(yielder)
     end
-  end
-
-  # Generates the instruction system message for this agent.
-  #
-  # Useful for database persistence workflows where the system messages
-  # need to be stored independently.
-  #
-  # Returns +nil+ when no instructions are configured.
-  #
-  #--
-  #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def generate_instruction_message(context: nil)
-    build_instruction_message(context)
-  end
-
-  # Generates the skills catalog system message for this agent.
-  #
-  # Useful for database persistence workflows where the system messages
-  # need to be stored independently.
-  #
-  # Returns +nil+ when no skills are configured or the catalog is empty.
-  #
-  #--
-  #: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def generate_skills_message(context: nil)
-    build_skills_message(resolve_skills(context))
   end
 
   # Interrupts the agent loop.
@@ -558,14 +545,6 @@ class Riffer::Agent
   end
 
   #--
-  #: () -> Riffer::Session
-  def build_initial_session
-    sys = build_instruction_message
-    skills = build_skills_message
-    Riffer::Session.new(messages: [sys, skills].compact)
-  end
-
-  #--
   #: () -> void
   def apply_seed_healing
     @session.set(heal_seeded_history(@session.messages))
@@ -624,17 +603,17 @@ class Riffer::Agent
   end
 
   #--
-  #: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def build_instruction_message(context = @context)
-    content = generate_instructions(context)
+  #: () -> Riffer::Messages::System?
+  def build_instruction_message
+    content = generate_instructions
     return nil if content.nil? || content.empty?
     Riffer::Messages::System.new(content)
   end
 
   #--
-  #: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
-  def build_skills_message(skills_state = @skills_state)
-    content = skills_state&.system_prompt
+  #: () -> Riffer::Messages::System?
+  def build_skills_message
+    content = @skills_state&.system_prompt
     return nil if content.nil? || content.empty?
     Riffer::Messages::System.new(content)
   end

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -261,22 +261,24 @@ class Riffer::Agent
 
   # Generates a response using a new agent instance.
   #
-  # See #generate for parameters and return value.
+  # +context:+ is threaded into +new+; +prompt+ and +files:+ are forwarded
+  # to +#generate+.
   #
   #--
-  #: (*untyped, **untyped) -> Riffer::Agent::Response
-  def self.generate(...)
-    new.generate(...)
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def self.generate(prompt = nil, files: nil, context: nil)
+    new(context: context).generate(prompt, files: files)
   end
 
   # Streams a response using a new agent instance.
   #
-  # See #stream for parameters and return value.
+  # +context:+ is threaded into +new+; +prompt+ and +files:+ are forwarded
+  # to +#stream+.
   #
   #--
-  #: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def self.stream(...)
-    new.stream(...)
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def self.stream(prompt = nil, files: nil, context: nil)
+    new(context: context).stream(prompt, files: files)
   end
 
   # Registers a guardrail for input, output, or both phases.
@@ -318,25 +320,37 @@ class Riffer::Agent
     @guardrails[phase] || []
   end
 
-  # The message history for the agent.
-  attr_reader :messages #: Array[Riffer::Messages::Base]
+  # The conversation handle. See Riffer::Session.
+  attr_reader :session #: Riffer::Session
 
   # Cumulative token usage across all LLM calls.
   attr_reader :token_usage #: Riffer::TokenUsage?
 
   # Initializes a new agent.
   #
+  # When +session:+ is omitted, a fresh +Riffer::Session+ is built and seeded
+  # with the system instruction message and skills catalog (when configured),
+  # using +context:+. When +session:+ is provided, the agent uses it as-is —
+  # the caller is responsible for the session's contents (typical use case:
+  # cross-process resume from persisted history). With
+  # +Riffer.config.experimental_history_healing+ on, a provided session is
+  # healed at construction time so the +tool_use+ ↔ +tool_result+ invariant
+  # holds before the next inference call.
+  #
+  # +context:+ flows through Proc-based instructions, model, skills resolution,
+  # tool resolution, guardrails, and tool runtime. It is fixed for the
+  # lifetime of the agent.
+  #
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
   #--
-  #: () -> void
-  def initialize
-    @messages = []
-    @message_callbacks = []
+  #: (?session: Riffer::Session?, ?context: Hash[Symbol, untyped]?) -> void
+  def initialize(session: nil, context: nil)
     @token_usage = nil
     @model_config = self.class.model
     @instructions_config = self.class.instructions
+    @context = context
 
     if @model_config.is_a?(Proc)
       @provider_name = nil
@@ -344,21 +358,33 @@ class Riffer::Agent
     else
       parse_model_string!(@model_config)
     end
+
+    resolve_model
+    @skills_state = resolve_skills
+    @context = (@context || {}).merge(skills: @skills_state) if @skills_state
+
+    @session = session || build_initial_session
+    apply_seed_healing if session && Riffer.config.experimental_history_healing
   end
 
   # Generates a response from the agent.
   #
-  # When +Riffer.config.experimental_history_healing+ is enabled, seeded
-  # message arrays that violate the +tool_use+ ↔ +tool_result+ invariant
-  # are silently repaired before the run begins.
+  # When +prompt+ is given, a new +Riffer::Messages::User+ is appended to the
+  # session (silently — +on_message+ does not fire for user inputs) and then
+  # the inference loop runs. When +prompt+ is omitted, the loop runs against
+  # the current session — useful for resuming a persisted conversation whose
+  # last turn is already a user message, or for picking up pending tool calls
+  # after an interrupt.
+  #
+  # +files:+ requires +prompt+. Pass files to attach to the new user message.
   #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate(prompt_or_messages, files: nil, context: nil)
-    @context = context
-    prepare_run
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Riffer::Agent::Response
+  def generate(prompt = nil, files: nil)
+    raise Riffer::ArgumentError, "files: requires a prompt" if files && !files.empty? && prompt.nil?
+
+    append_user_message(prompt, files: files) if prompt
     @structured_output = resolve_structured_output
-    initialize_messages(prompt_or_messages, files: files)
 
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
 
@@ -373,17 +399,15 @@ class Riffer::Agent
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # See +#generate+ for the +experimental_history_healing+ behavior on
-  # seeded arrays.
+  # See +#generate+ for prompt/files semantics.
   #
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream(prompt_or_messages, files: nil, context: nil)
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream(prompt = nil, files: nil)
     raise Riffer::ArgumentError, "Structured output is not supported with streaming. Use #generate instead." if self.class.structured_output
+    raise Riffer::ArgumentError, "files: requires a prompt" if files && !files.empty? && prompt.nil?
 
-    @context = context
-    prepare_run
-    initialize_messages(prompt_or_messages, files: files)
+    append_user_message(prompt, files: files) if prompt
 
     Enumerator.new do |yielder|
       tripwire, modifications = run_before_guardrails
@@ -396,18 +420,6 @@ class Riffer::Agent
 
       run_stream_loop(yielder)
     end
-  end
-
-  # Registers a callback to be invoked when messages are added during generation.
-  #
-  # Raises Riffer::ArgumentError if no block is given.
-  #
-  #--
-  #: () { (Riffer::Messages::Base) -> void } -> self
-  def on_message(&block)
-    raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
-    @message_callbacks << block
-    self
   end
 
   # Generates the instruction system message for this agent.
@@ -454,142 +466,6 @@ class Riffer::Agent
     throw :riffer_interrupt, reason
   end
 
-  # Returns the message with the given id, or +nil+ when no message matches.
-  #
-  #--
-  #: (String) -> Riffer::Messages::Base?
-  def message_by_id(id)
-    @messages.find { |m| m.id == id }
-  end
-
-  # Returns the +Riffer::Messages::Tool+ message that satisfies +tool_call_id+,
-  # or +nil+ when no such tool result exists in history.
-  #
-  #--
-  #: (String) -> Riffer::Messages::Tool?
-  # TODO: Replace with rfind when minimum Ruby is 4.0+
-  # rubocop:disable Style/ReverseFind
-  def tool_message_for(tool_call_id)
-    @messages.reverse.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == tool_call_id } #: Riffer::Messages::Tool?
-  end
-  # rubocop:enable Style/ReverseFind
-
-  # Returns the most recent +Riffer::Messages::Assistant+ in history, or
-  # +nil+ when no assistant message has been recorded yet.
-  #
-  #--
-  #: () -> Riffer::Messages::Assistant?
-  # TODO: Replace with rfind when minimum Ruby is 4.0+
-  # rubocop:disable Style/ReverseFind
-  def last_assistant
-    @messages.reverse.find { |m| m.is_a?(Riffer::Messages::Assistant) } #: Riffer::Messages::Assistant?
-  end
-  # rubocop:enable Style/ReverseFind
-
-  # Returns the call_ids of every +tool_call+ on any assistant message that
-  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
-  #
-  # Zero-cost validation hook for callers that want to check the
-  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
-  #
-  #--
-  #: () -> Array[String]
-  def orphaned_tool_call_ids
-    result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
-    @messages.flat_map { |m|
-      next [] unless m.is_a?(Riffer::Messages::Assistant)
-      m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
-    }
-  end
-
-  # Replaces the content of an assistant message in place. Preserves +id+,
-  # +tool_calls+, +token_usage+, and +structured_output+. Lookup is by id.
-  #
-  # When +content+ is empty, delegates to +remove_message+ — including the
-  # cascade that drops dependent +Riffer::Messages::Tool+ children.
-  #
-  # Raises Riffer::ArgumentError when no assistant message has the given id.
-  #
-  #--
-  #: (id: String, content: String) -> Riffer::Messages::Base?
-  def replace_assistant_content(id:, content:)
-    return remove_message(id: id) if content.empty?
-
-    idx = @messages.index { |m| m.is_a?(Riffer::Messages::Assistant) && m.id == id }
-    raise Riffer::ArgumentError, "no assistant message with id #{id.inspect}" unless idx
-
-    old = @messages[idx] #: Riffer::Messages::Assistant
-    replacement = Riffer::Messages::Assistant.new(
-      content,
-      id: old.id,
-      tool_calls: old.tool_calls,
-      token_usage: old.token_usage,
-      structured_output: old.structured_output
-    )
-    @messages[idx] = replacement
-    replacement
-  end
-
-  # Removes a message by id. When the target is an assistant message that
-  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
-  # +tool_call_id+ matches one of those calls is removed atomically — keeping
-  # the +tool_use+ ↔ +tool_result+ invariant intact.
-  #
-  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
-  # message — that would orphan the parent's +tool_use+. Use
-  # +replace_tool_result+ instead.
-  #
-  # Returns the removed message, or +nil+ when no message has the given id
-  # (idempotent).
-  #
-  #--
-  #: (id: String) -> Riffer::Messages::Base?
-  def remove_message(id:)
-    idx = @messages.index { |m| m.id == id }
-    return nil unless idx
-
-    target = @messages[idx]
-    if target.is_a?(Riffer::Messages::Tool)
-      raise Riffer::ArgumentError,
-        "remove_message cannot drop a Tool message (would orphan the parent's tool_use); use replace_tool_result instead"
-    end
-
-    if target.is_a?(Riffer::Messages::Assistant) && !target.tool_calls.empty?
-      child_ids = target.tool_calls.map(&:call_id)
-      @messages.reject! { |m| m.is_a?(Riffer::Messages::Tool) && child_ids.include?(m.tool_call_id) }
-      @messages.delete(target)
-    else
-      @messages.delete_at(idx)
-    end
-    target
-  end
-
-  # Replaces a tool result's content (and optional error fields) in place.
-  # Lookup is by +tool_call_id+. Preserves the existing message's +name+ and
-  # +id+.
-  #
-  # Raises Riffer::ArgumentError when no Tool message exists for the given
-  # +tool_call_id+.
-  #
-  #--
-  #: (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
-  def replace_tool_result(tool_call_id:, content:, error: nil, error_type: nil)
-    idx = @messages.index { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == tool_call_id }
-    raise Riffer::ArgumentError, "no tool result for tool_call_id #{tool_call_id.inspect}" unless idx
-
-    old = @messages[idx] #: Riffer::Messages::Tool
-    replacement = Riffer::Messages::Tool.new(
-      content,
-      id: old.id,
-      tool_call_id: old.tool_call_id,
-      name: old.name,
-      error: error,
-      error_type: error_type
-    )
-    @messages[idx] = replacement
-    replacement
-  end
-
   private
 
   # Fills any orphaned +tool_use+ in history with the +HEALING_PLACEHOLDER+
@@ -605,11 +481,11 @@ class Riffer::Agent
   #--
   #: () -> Array[String]
   def heal_orphan_tool_calls
-    result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
+    result_ids = @session.messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
     healed = [] #: Array[String]
     new_messages = [] #: Array[Riffer::Messages::Base]
 
-    @messages.each do |m|
+    @session.messages.each do |m|
       new_messages << m
       next unless m.is_a?(Riffer::Messages::Assistant) && !m.tool_calls.empty?
 
@@ -628,14 +504,14 @@ class Riffer::Agent
       end
     end
 
-    @messages = new_messages
+    @session.set(new_messages)
     healed
   end
 
   #--
   #: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
   def run_generate_loop(all_modifications = [])
-    step = count_assistant_messages
+    step = @session.count { |m| m.is_a?(Riffer::Messages::Assistant) }
 
     reason = catch(:riffer_interrupt) do
       execute_pending_tool_calls
@@ -651,7 +527,7 @@ class Riffer::Agent
 
         return build_response("", tripwire: tripwire, modifications: all_modifications) if tripwire
 
-        add_message(processed_response)
+        @session.add(processed_response)
 
         break unless has_tool_calls?(processed_response)
 
@@ -660,7 +536,7 @@ class Riffer::Agent
         execute_tool_calls(processed_response)
       end
 
-      response = extract_final_response
+      response = final_assistant_message
 
       return build_response(response&.content || "", modifications: all_modifications, structured_output: validate_structured_output(response))
     end
@@ -668,16 +544,9 @@ class Riffer::Agent
     # catch returns the thrown value when throw :riffer_interrupt fires;
     # the return above exits on the successful (non-interrupted) path.
     healed = Riffer.config.experimental_history_healing ? heal_orphan_tool_calls : []
-    response = extract_final_response
+    response = final_assistant_message
 
     build_response(response&.content || "", modifications: all_modifications, interrupted: true, interrupt_reason: reason, structured_output: validate_structured_output(response), healed_tool_call_ids: healed)
-  end
-
-  #--
-  #: (Riffer::Messages::Base) -> void
-  def add_message(message)
-    @messages << message
-    @message_callbacks.each { |callback| callback.call(message) }
   end
 
   #--
@@ -689,44 +558,24 @@ class Riffer::Agent
   end
 
   #--
-  #: ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
-  def initialize_messages(prompt_or_messages, files: nil)
-    if prompt_or_messages.is_a?(Array)
-      raise Riffer::ArgumentError, "cannot pass an array of messages on an agent with existing messages; use a string to continue the conversation or a new agent instance to start fresh" if @messages.any?
-      raise Riffer::ArgumentError, "cannot provide both files and messages; attach files to individual messages instead" if files && !files.empty?
-      validate_seed_ids!(prompt_or_messages)
-      converted = prompt_or_messages.map { |item| convert_to_message_object(item) }
-      @messages = Riffer.config.experimental_history_healing ? heal_seeded_history(converted) : converted
-    elsif @messages.any?
-      file_parts = (files || []).map { |f| convert_to_file_part(f) }
-      @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
-    else
-      @messages = []
-      sys = build_instruction_message
-      @messages << sys if sys
-      skills = build_skills_message
-      @messages << skills if skills
-      file_parts = (files || []).map { |f| convert_to_file_part(f) }
-      @messages << Riffer::Messages::User.new(prompt_or_messages, files: file_parts)
-    end
+  #: () -> Riffer::Session
+  def build_initial_session
+    sys = build_instruction_message
+    skills = build_skills_message
+    Riffer::Session.new(messages: [sys, skills].compact)
   end
 
   #--
-  #: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
-  def validate_seed_ids!(items)
-    strategy = Riffer.config.message_id_strategy
-    return if strategy == :none
+  #: () -> void
+  def apply_seed_healing
+    @session.set(heal_seeded_history(@session.messages))
+  end
 
-    items.each_with_index do |item, idx|
-      raw_id = case item
-      when Hash then item[:id]
-      when Riffer::Messages::Base then item.id
-      else next # type errors surface later via convert_to_message_object
-      end
-      next unless raw_id.nil?
-      raise Riffer::ArgumentError,
-        "seeded message at index #{idx} is missing :id (required when Riffer.config.message_id_strategy = #{strategy.inspect})"
-    end
+  #--
+  #: (String, files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  def append_user_message(prompt, files:)
+    file_parts = (files || []).map { |f| convert_to_file_part(f) }
+    @session.set(@session.messages + [Riffer::Messages::User.new(prompt, files: file_parts)])
   end
 
   # Repairs a seeded message array so the +tool_use+ ↔ +tool_result+
@@ -791,15 +640,9 @@ class Riffer::Agent
   end
 
   #--
-  #: () -> Integer
-  def count_assistant_messages
-    @messages.count { |m| m.is_a?(Riffer::Messages::Assistant) }
-  end
-
-  #--
   #: (Enumerator::Yielder) -> void
   def run_stream_loop(yielder)
-    step = count_assistant_messages
+    step = @session.count { |m| m.is_a?(Riffer::Messages::Assistant) }
 
     if @skills_state
       @skills_state.on_activate = ->(name) { yielder << Riffer::StreamEvents::SkillActivation.new(name) }
@@ -855,7 +698,7 @@ class Riffer::Agent
           break
         end
 
-        add_message(processed_response)
+        @session.add(processed_response)
 
         break unless has_tool_calls?(processed_response)
 
@@ -876,7 +719,7 @@ class Riffer::Agent
   #: () -> Riffer::Messages::Assistant
   def call_llm
     provider_instance.generate_text(
-      messages: @messages,
+      messages: @session.messages,
       model: @model_name,
       tools: resolved_tools,
       **merged_model_options
@@ -887,7 +730,7 @@ class Riffer::Agent
   #: () -> Enumerator[Riffer::StreamEvents::Base, void]
   def call_llm_stream
     provider_instance.stream_text(
-      messages: @messages,
+      messages: @session.messages,
       model: @model_name,
       tools: resolved_tools,
       **merged_model_options
@@ -915,7 +758,7 @@ class Riffer::Agent
     results = runtime.execute(tool_calls, tools: resolved_tools, context: @context, assistant_message: assistant_message)
 
     results.each do |tool_call, result|
-      add_message(Riffer::Messages::Tool.new(
+      @session.add(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.call_id,
         name: tool_call.name,
@@ -937,39 +780,8 @@ class Riffer::Agent
   #--
   #: () -> void
   def execute_pending_tool_calls
-    assistant_message, pending = pending_tool_calls
+    assistant_message, pending = @session.pending_tool_calls
     execute_tool_calls(assistant_message, tool_calls: pending) if assistant_message
-  end
-
-  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
-  # When there is no assistant message or no pending calls, the second
-  # element is an empty array.
-  #
-  #--
-  #: () -> [untyped, Array[Riffer::Messages::Assistant::ToolCall]]
-  def pending_tool_calls
-    last_assistant_idx = @messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
-    return [nil, []] unless last_assistant_idx
-
-    assistant = @messages[last_assistant_idx]
-    return [assistant, []] if assistant.tool_calls.empty?
-
-    executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
-      m.is_a?(Riffer::Messages::Tool)
-    }.map(&:tool_call_id)
-
-    [assistant, assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }]
-  end
-
-  #--
-  #: () -> void
-  def prepare_run
-    @resolved_tools = nil
-    @resolved_tool_runtime = nil
-    clear_resolved_model
-    resolve_model
-    @skills_state = resolve_skills
-    @context = (@context || {}).merge(skills: @skills_state) if @skills_state
   end
 
   #--
@@ -980,13 +792,6 @@ class Riffer::Agent
     raise Riffer::ArgumentError, "Invalid model string: #{model_string}" unless [provider_name, model_name].all? { |part| part.is_a?(String) && !part.strip.empty? }
     @provider_name = provider_name
     @model_name = model_name
-  end
-
-  #--
-  #: () -> void
-  def clear_resolved_model
-    @resolved_model = nil
-    @provider_instance = nil if @model_config.is_a?(Proc)
   end
 
   #--
@@ -1126,10 +931,10 @@ class Riffer::Agent
 
   #--
   #: () -> Riffer::Messages::Assistant?
-  def extract_final_response
+  def final_assistant_message
     # TODO: Replace with rfind when minimum Ruby is 4.0+
     # rubocop:disable Style/ReverseFind
-    @messages.reverse.find { |msg| msg.is_a?(Riffer::Messages::Assistant) } #: Riffer::Messages::Assistant?
+    @session.reverse_each.find { |msg| msg.is_a?(Riffer::Messages::Assistant) } #: Riffer::Messages::Assistant?
     # rubocop:enable Style/ReverseFind
   end
 
@@ -1140,8 +945,8 @@ class Riffer::Agent
     return [nil, []] if guardrails.empty?
 
     runner = Riffer::Guardrails::Runner.new(guardrails, phase: :before, context: @context)
-    processed_messages, tripwire, modifications = runner.run(@messages)
-    @messages = processed_messages unless tripwire
+    processed_messages, tripwire, modifications = runner.run(@session.messages)
+    @session.set(processed_messages) unless tripwire
     [tripwire, modifications]
   end
 
@@ -1152,9 +957,9 @@ class Riffer::Agent
     return [response, nil, []] if guardrails.empty?
 
     runner = Riffer::Guardrails::Runner.new(guardrails, phase: :after, context: @context)
-    processed_response, tripwire, modifications = runner.run(response, messages: @messages)
+    processed_response, tripwire, modifications = runner.run(response, messages: @session.messages)
 
-    response_index = @messages.length
+    response_index = @session.messages.length
     modifications.each { |m| m.message_indices.map! { response_index } }
 
     [processed_response, tripwire, modifications]
@@ -1186,6 +991,7 @@ class Riffer::Agent
   #--
   #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
   def build_response(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, healed_tool_call_ids: [])
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: @messages.frozen? ? @messages : @messages.dup.freeze, healed_tool_call_ids: healed_tool_call_ids)
+    messages = @session.messages
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: messages.frozen? ? messages : messages.dup.freeze, healed_tool_call_ids: healed_tool_call_ids)
   end
 end

--- a/lib/riffer/session.rb
+++ b/lib/riffer/session.rb
@@ -185,6 +185,7 @@ class Riffer::Session
   end
 
   #--
+  #: () -> Enumerator[Riffer::Messages::Base, self]
   #: () { (Riffer::Messages::Base) -> void } -> untyped
   def each(&block)
     @messages.each(&block)

--- a/lib/riffer/session.rb
+++ b/lib/riffer/session.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Riffer::Session owns the conversation handle for an agent: the message
+# array, the +on_message+ callback list, and the +tool_use+ ↔ +tool_result+
+# invariant that keeps tool calls and their results consistent.
+#
+# Access via +agent.session+. Sessions are constructed by +Riffer::Agent+
+# and live for the lifetime of the agent.
+#
+#   agent.session.add(msg)                  # append + fire callbacks
+#   agent.session.set([msg1, msg2])         # bulk replace (silent)
+#   agent.session.unset                     # clear (silent)
+#   agent.session.remove(id: "a_1")
+#   agent.session.update(id: "a_1", content: "...")
+#   agent.session.find { |m| m.id == "a_1" }
+#
+class Riffer::Session
+  include Enumerable #[Riffer::Messages::Base]
+
+  # The message history.
+  attr_reader :messages #: Array[Riffer::Messages::Base]
+
+  #--
+  #: (?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize(messages: [])
+    @messages = messages
+    @callbacks = [] #: Array[^(Riffer::Messages::Base) -> void]
+  end
+
+  # Registers a callback invoked once per message appended via +#add+.
+  #
+  # Callbacks do NOT fire for +#set+, +#unset+, +#remove+, or +#update+.
+  # Returns +self+ to allow chaining.
+  #
+  # Raises Riffer::ArgumentError if no block is given.
+  #
+  #--
+  #: () { (Riffer::Messages::Base) -> void } -> self
+  def on_message(&block)
+    raise Riffer::ArgumentError, "on_message requires a block" unless block_given?
+    @callbacks << block
+    self
+  end
+
+  # Appends +message+ and fires every registered callback once with it.
+  #
+  #--
+  #: (Riffer::Messages::Base) -> Riffer::Messages::Base
+  def add(message)
+    @messages << message
+    @callbacks.each { |callback| callback.call(message) }
+    message
+  end
+
+  # Replaces the message history wholesale. Does NOT fire +on_message+
+  # callbacks; registered callbacks persist across the swap.
+  #
+  # Used for seeding, guardrail rewrites, and history healing — cases
+  # where firing callbacks would double-emit messages that subscribers
+  # have already observed (or never produced).
+  #
+  #--
+  #: (Array[Riffer::Messages::Base]) -> self
+  def set(messages)
+    @messages = messages
+    self
+  end
+
+  # Clears the session. Does NOT fire +on_message+ callbacks; registered
+  # callbacks persist.
+  #
+  #--
+  #: () -> self
+  def unset
+    @messages = []
+    self
+  end
+
+  # Removes a message by id. When the target is an assistant message that
+  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches one of those calls is removed atomically — keeping
+  # the +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
+  # message — that would orphan the parent's +tool_use+. Use
+  # +#update+ to rewrite a tool result instead.
+  #
+  # Returns the removed message, or +nil+ when no message has the given id
+  # (idempotent).
+  #
+  #--
+  #: (id: String) -> Riffer::Messages::Base?
+  def remove(id:)
+    idx = @messages.index { |m| m.id == id }
+    return nil unless idx
+
+    target = @messages[idx]
+    if target.is_a?(Riffer::Messages::Tool)
+      raise Riffer::ArgumentError,
+        "remove cannot drop a Tool message (would orphan the parent's tool_use); use #update instead"
+    end
+
+    if target.is_a?(Riffer::Messages::Assistant) && !target.tool_calls.empty?
+      child_ids = target.tool_calls.map(&:call_id)
+      @messages.reject! { |m| m.is_a?(Riffer::Messages::Tool) && child_ids.include?(m.tool_call_id) }
+      @messages.delete(target)
+    else
+      @messages.delete_at(idx)
+    end
+    target
+  end
+
+  # Partial in-place update. Looks up a message by either +id:+ or
+  # +tool_call_id:+ (exactly one required), constructs a replacement of the
+  # same concrete type with +attrs+ overlaid on the existing fields, and
+  # swaps it in place.
+  #
+  # When the target is an assistant message and the update drops one or more
+  # entries from +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches a dropped call is removed atomically — keeping the
+  # +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when neither or both lookup keys are
+  # provided, or when no message matches.
+  #
+  #--
+  #: (?id: String?, ?tool_call_id: String?, **untyped) -> Riffer::Messages::Base
+  def update(id: nil, tool_call_id: nil, **attrs)
+    raise Riffer::ArgumentError, "update requires either id: or tool_call_id:" if id.nil? && tool_call_id.nil?
+    raise Riffer::ArgumentError, "update accepts id: or tool_call_id:, not both" if id && tool_call_id
+
+    idx = if id
+      @messages.index { |m| m.id == id }
+    else
+      @messages.index { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == tool_call_id }
+    end
+
+    unless idx
+      key = id ? "id #{id.inspect}" : "tool_call_id #{tool_call_id.inspect}"
+      raise Riffer::ArgumentError, "no message found for #{key}"
+    end
+
+    old = @messages[idx] #: Riffer::Messages::Base
+    replacement = rebuild_message(old, attrs)
+    @messages[idx] = replacement
+    cascade_dropped_tool_calls(old, replacement)
+    replacement
+  end
+
+  # Returns the call_ids of every +tool_call+ on any assistant message that
+  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
+  #
+  # Zero-cost validation hook for callers that want to check the
+  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
+  #
+  #--
+  #: () -> Array[String]
+  def orphaned_tool_call_ids
+    result_ids = @messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }
+    @messages.flat_map { |m|
+      next [] unless m.is_a?(Riffer::Messages::Assistant)
+      m.tool_calls.reject { |tc| result_ids.include?(tc.call_id) }.map(&:call_id)
+    }
+  end
+
+  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
+  # When there is no assistant message or no pending calls, the second
+  # element is an empty array.
+  #
+  #--
+  #: () -> [Riffer::Messages::Assistant?, Array[Riffer::Messages::Assistant::ToolCall]]
+  def pending_tool_calls
+    last_assistant_idx = @messages.rindex { |m| m.is_a?(Riffer::Messages::Assistant) }
+    return [nil, []] unless last_assistant_idx
+
+    assistant = @messages[last_assistant_idx] #: Riffer::Messages::Assistant
+    return [assistant, []] if assistant.tool_calls.empty?
+
+    executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
+      m.is_a?(Riffer::Messages::Tool)
+    }.map(&:tool_call_id)
+
+    [assistant, assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }]
+  end
+
+  #--
+  #: () { (Riffer::Messages::Base) -> void } -> untyped
+  def each(&block)
+    @messages.each(&block)
+  end
+
+  private
+
+  #: (Riffer::Messages::Base, Riffer::Messages::Base) -> void
+  def cascade_dropped_tool_calls(old, replacement)
+    return unless old.is_a?(Riffer::Messages::Assistant)
+    return unless replacement.is_a?(Riffer::Messages::Assistant)
+
+    removed_ids = old.tool_calls.map(&:call_id) - replacement.tool_calls.map(&:call_id)
+    return if removed_ids.empty?
+
+    @messages.reject! { |m| m.is_a?(Riffer::Messages::Tool) && removed_ids.include?(m.tool_call_id) }
+  end
+
+  #: (Riffer::Messages::Base, Hash[Symbol, untyped]) -> Riffer::Messages::Base
+  def rebuild_message(old, attrs)
+    case old
+    when Riffer::Messages::Assistant
+      Riffer::Messages::Assistant.new(
+        attrs.fetch(:content, old.content),
+        id: attrs.fetch(:id, old.id),
+        tool_calls: attrs.fetch(:tool_calls, old.tool_calls),
+        token_usage: attrs.fetch(:token_usage, old.token_usage),
+        structured_output: attrs.fetch(:structured_output, old.structured_output)
+      )
+    when Riffer::Messages::Tool
+      Riffer::Messages::Tool.new(
+        attrs.fetch(:content, old.content),
+        tool_call_id: old.tool_call_id,
+        name: attrs.fetch(:name, old.name),
+        id: attrs.fetch(:id, old.id),
+        error: attrs.fetch(:error, old.error),
+        error_type: attrs.fetch(:error_type, old.error_type)
+      )
+    when Riffer::Messages::User
+      Riffer::Messages::User.new(
+        attrs.fetch(:content, old.content),
+        id: attrs.fetch(:id, old.id),
+        files: attrs.fetch(:files, old.files)
+      )
+    else
+      old.class.new(
+        attrs.fetch(:content, old.content),
+        id: attrs.fetch(:id, old.id)
+      )
+    end
+  end
+end

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -387,8 +387,8 @@ class Riffer::Agent
   def parse_model_string!: (untyped) -> void
 
   # --
-  # : (?Hash[Symbol, untyped]?) -> String?
-  def generate_instructions: (?Hash[Symbol, untyped]?) -> String?
+  # : () -> String?
+  def generate_instructions: () -> String?
 
   attr_reader resolved_model: String?
 

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -213,6 +213,16 @@ class Riffer::Agent
   # The conversation handle. See Riffer::Session.
   attr_reader session: Riffer::Session
 
+  # The system message built from the configured +instructions+, or +nil+
+  # when no instructions are configured. Built once at +Agent.new+ using the
+  # constructor +context:+ and cached. Useful for persistence flows.
+  attr_reader instruction_message: Riffer::Messages::System?
+
+  # The system message describing the configured skills catalog, or +nil+
+  # when skills are unconfigured or the catalog is empty. Built once at
+  # +Agent.new+ and cached.
+  attr_reader skills_message: Riffer::Messages::System?
+
   # Cumulative token usage across all LLM calls.
   attr_reader token_usage: Riffer::TokenUsage?
 
@@ -263,28 +273,6 @@ class Riffer::Agent
   # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # Generates the instruction system message for this agent.
-  #
-  # Useful for database persistence workflows where the system messages
-  # need to be stored independently.
-  #
-  # Returns +nil+ when no instructions are configured.
-  #
-  # --
-  # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def generate_instruction_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-
-  # Generates the skills catalog system message for this agent.
-  #
-  # Useful for database persistence workflows where the system messages
-  # need to be stored independently.
-  #
-  # Returns +nil+ when no skills are configured or the catalog is empty.
-  #
-  # --
-  # : (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def generate_skills_message: (?context: Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-
   # Interrupts the agent loop.
   #
   # Call from an +on_message+ callback to cleanly interrupt the loop.
@@ -326,10 +314,6 @@ class Riffer::Agent
   def track_token_usage: (Riffer::TokenUsage?) -> void
 
   # --
-  # : () -> Riffer::Session
-  def build_initial_session: () -> Riffer::Session
-
-  # --
   # : () -> void
   def apply_seed_healing: () -> void
 
@@ -354,12 +338,12 @@ class Riffer::Agent
   def heal_seeded_history: (Array[Riffer::Messages::Base]) -> Array[Riffer::Messages::Base]
 
   # --
-  # : (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
-  def build_instruction_message: (?Hash[Symbol, untyped]?) -> Riffer::Messages::System?
+  # : () -> Riffer::Messages::System?
+  def build_instruction_message: () -> Riffer::Messages::System?
 
   # --
-  # : (?Riffer::Skills::Context?) -> Riffer::Messages::System?
-  def build_skills_message: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
+  # : () -> Riffer::Messages::System?
+  def build_skills_message: () -> Riffer::Messages::System?
 
   # --
   # : (Enumerator::Yielder) -> void

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -175,19 +175,21 @@ class Riffer::Agent
 
   # Generates a response using a new agent instance.
   #
-  # See #generate for parameters and return value.
+  # +context:+ is threaded into +new+; +prompt+ and +files:+ are forwarded
+  # to +#generate+.
   #
   # --
-  # : (*untyped, **untyped) -> Riffer::Agent::Response
-  def self.generate: (*untyped, **untyped) -> Riffer::Agent::Response
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  def self.generate: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
 
   # Streams a response using a new agent instance.
   #
-  # See #stream for parameters and return value.
+  # +context:+ is threaded into +new+; +prompt+ and +files:+ are forwarded
+  # to +#stream+.
   #
   # --
-  # : (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def self.stream: (*untyped, **untyped) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def self.stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Registers a guardrail for input, output, or both phases.
   #
@@ -208,49 +210,58 @@ class Riffer::Agent
   # : (Symbol) -> Array[Hash[Symbol, untyped]]
   def self.guardrails_for: (Symbol) -> Array[Hash[Symbol, untyped]]
 
-  # The message history for the agent.
-  attr_reader messages: Array[Riffer::Messages::Base]
+  # The conversation handle. See Riffer::Session.
+  attr_reader session: Riffer::Session
 
   # Cumulative token usage across all LLM calls.
   attr_reader token_usage: Riffer::TokenUsage?
 
   # Initializes a new agent.
   #
+  # When +session:+ is omitted, a fresh +Riffer::Session+ is built and seeded
+  # with the system instruction message and skills catalog (when configured),
+  # using +context:+. When +session:+ is provided, the agent uses it as-is —
+  # the caller is responsible for the session's contents (typical use case:
+  # cross-process resume from persisted history). With
+  # +Riffer.config.experimental_history_healing+ on, a provided session is
+  # healed at construction time so the +tool_use+ ↔ +tool_result+ invariant
+  # holds before the next inference call.
+  #
+  # +context:+ flows through Proc-based instructions, model, skills resolution,
+  # tool resolution, guardrails, and tool runtime. It is fixed for the
+  # lifetime of the agent.
+  #
   # Raises Riffer::ArgumentError if the configured model string is invalid
   # (must be "provider/model" format).
   #
   # --
-  # : () -> void
-  def initialize: () -> void
+  # : (?session: Riffer::Session?, ?context: Hash[Symbol, untyped]?) -> void
+  def initialize: (?session: Riffer::Session?, ?context: Hash[Symbol, untyped]?) -> void
 
   # Generates a response from the agent.
   #
-  # When +Riffer.config.experimental_history_healing+ is enabled, seeded
-  # message arrays that violate the +tool_use+ ↔ +tool_result+ invariant
-  # are silently repaired before the run begins.
+  # When +prompt+ is given, a new +Riffer::Messages::User+ is appended to the
+  # session (silently — +on_message+ does not fire for user inputs) and then
+  # the inference loop runs. When +prompt+ is omitted, the loop runs against
+  # the current session — useful for resuming a persisted conversation whose
+  # last turn is already a user message, or for picking up pending tool calls
+  # after an interrupt.
+  #
+  # +files:+ requires +prompt+. Pass files to attach to the new user message.
   #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
-  def generate: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Riffer::Agent::Response
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Riffer::Agent::Response
+  def generate: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Riffer::Agent::Response
 
   # Streams a response from the agent.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
-  # See +#generate+ for the +experimental_history_healing+ behavior on
-  # seeded arrays.
+  # See +#generate+ for prompt/files semantics.
   #
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
-
-  # Registers a callback to be invoked when messages are added during generation.
-  #
-  # Raises Riffer::ArgumentError if no block is given.
-  #
-  # --
-  # : () { (Riffer::Messages::Base) -> void } -> self
-  def on_message: () { (Riffer::Messages::Base) -> void } -> self
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Enumerator[Riffer::StreamEvents::Base, void]
+  def stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # Generates the instruction system message for this agent.
   #
@@ -290,79 +301,6 @@ class Riffer::Agent
   # : (?(String | Symbol)?) -> void
   def interrupt!: (?(String | Symbol)?) -> void
 
-  # Returns the message with the given id, or +nil+ when no message matches.
-  #
-  # --
-  # : (String) -> Riffer::Messages::Base?
-  def message_by_id: (String) -> Riffer::Messages::Base?
-
-  # Returns the +Riffer::Messages::Tool+ message that satisfies +tool_call_id+,
-  # or +nil+ when no such tool result exists in history.
-  #
-  # --
-  # : (String) -> Riffer::Messages::Tool?
-  # TODO: Replace with rfind when minimum Ruby is 4.0+
-  # rubocop:disable Style/ReverseFind
-  def tool_message_for: (String) -> Riffer::Messages::Tool?
-
-  # Returns the most recent +Riffer::Messages::Assistant+ in history, or
-  # +nil+ when no assistant message has been recorded yet.
-  #
-  # --
-  # : () -> Riffer::Messages::Assistant?
-  # TODO: Replace with rfind when minimum Ruby is 4.0+
-  # rubocop:disable Style/ReverseFind
-  def last_assistant: () -> Riffer::Messages::Assistant?
-
-  # Returns the call_ids of every +tool_call+ on any assistant message that
-  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
-  #
-  # Zero-cost validation hook for callers that want to check the
-  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
-  #
-  # --
-  # : () -> Array[String]
-  def orphaned_tool_call_ids: () -> Array[String]
-
-  # Replaces the content of an assistant message in place. Preserves +id+,
-  # +tool_calls+, +token_usage+, and +structured_output+. Lookup is by id.
-  #
-  # When +content+ is empty, delegates to +remove_message+ — including the
-  # cascade that drops dependent +Riffer::Messages::Tool+ children.
-  #
-  # Raises Riffer::ArgumentError when no assistant message has the given id.
-  #
-  # --
-  # : (id: String, content: String) -> Riffer::Messages::Base?
-  def replace_assistant_content: (id: String, content: String) -> Riffer::Messages::Base?
-
-  # Removes a message by id. When the target is an assistant message that
-  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
-  # +tool_call_id+ matches one of those calls is removed atomically — keeping
-  # the +tool_use+ ↔ +tool_result+ invariant intact.
-  #
-  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
-  # message — that would orphan the parent's +tool_use+. Use
-  # +replace_tool_result+ instead.
-  #
-  # Returns the removed message, or +nil+ when no message has the given id
-  # (idempotent).
-  #
-  # --
-  # : (id: String) -> Riffer::Messages::Base?
-  def remove_message: (id: String) -> Riffer::Messages::Base?
-
-  # Replaces a tool result's content (and optional error fields) in place.
-  # Lookup is by +tool_call_id+. Preserves the existing message's +name+ and
-  # +id+.
-  #
-  # Raises Riffer::ArgumentError when no Tool message exists for the given
-  # +tool_call_id+.
-  #
-  # --
-  # : (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
-  def replace_tool_result: (tool_call_id: String, content: String, ?error: String?, ?error_type: Symbol?) -> Riffer::Messages::Tool
-
   private
 
   # Fills any orphaned +tool_use+ in history with the +HEALING_PLACEHOLDER+
@@ -384,20 +322,20 @@ class Riffer::Agent
   def run_generate_loop: (?Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
 
   # --
-  # : (Riffer::Messages::Base) -> void
-  def add_message: (Riffer::Messages::Base) -> void
-
-  # --
   # : (Riffer::TokenUsage?) -> void
   def track_token_usage: (Riffer::TokenUsage?) -> void
 
   # --
-  # : ((String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base]), ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
-  def initialize_messages: (String | Array[Hash[Symbol, untyped] | Riffer::Messages::Base], ?files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  # : () -> Riffer::Session
+  def build_initial_session: () -> Riffer::Session
 
   # --
-  # : (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
-  def validate_seed_ids!: (Array[Hash[Symbol, untyped] | Riffer::Messages::Base]) -> void
+  # : () -> void
+  def apply_seed_healing: () -> void
+
+  # --
+  # : (String, files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
+  def append_user_message: (String, files: Array[Hash[Symbol, untyped] | Riffer::FilePart]?) -> void
 
   # Repairs a seeded message array so the +tool_use+ ↔ +tool_result+
   # invariant holds. Drops orphaned tool exchanges (assistant +tool_call+
@@ -422,10 +360,6 @@ class Riffer::Agent
   # --
   # : (?Riffer::Skills::Context?) -> Riffer::Messages::System?
   def build_skills_message: (?Riffer::Skills::Context?) -> Riffer::Messages::System?
-
-  # --
-  # : () -> Integer
-  def count_assistant_messages: () -> Integer
 
   # --
   # : (Enumerator::Yielder) -> void
@@ -464,25 +398,9 @@ class Riffer::Agent
   # : () -> void
   def execute_pending_tool_calls: () -> void
 
-  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
-  # When there is no assistant message or no pending calls, the second
-  # element is an empty array.
-  #
-  # --
-  # : () -> [untyped, Array[Riffer::Messages::Assistant::ToolCall]]
-  def pending_tool_calls: () -> [ untyped, Array[Riffer::Messages::Assistant::ToolCall] ]
-
-  # --
-  # : () -> void
-  def prepare_run: () -> void
-
   # --
   # : (untyped) -> void
   def parse_model_string!: (untyped) -> void
-
-  # --
-  # : () -> void
-  def clear_resolved_model: () -> void
 
   # --
   # : (?Hash[Symbol, untyped]?) -> String?
@@ -534,7 +452,7 @@ class Riffer::Agent
 
   # --
   # : () -> Riffer::Messages::Assistant?
-  def extract_final_response: () -> Riffer::Messages::Assistant?
+  def final_assistant_message: () -> Riffer::Messages::Assistant?
 
   # --
   # : () -> [Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]

--- a/sig/generated/riffer/session.rbs
+++ b/sig/generated/riffer/session.rbs
@@ -1,0 +1,123 @@
+# Generated from lib/riffer/session.rb with RBS::Inline
+
+# Riffer::Session owns the conversation handle for an agent: the message
+# array, the +on_message+ callback list, and the +tool_use+ ↔ +tool_result+
+# invariant that keeps tool calls and their results consistent.
+#
+# Access via +agent.session+. Sessions are constructed by +Riffer::Agent+
+# and live for the lifetime of the agent.
+#
+#   agent.session.add(msg)                  # append + fire callbacks
+#   agent.session.set([msg1, msg2])         # bulk replace (silent)
+#   agent.session.unset                     # clear (silent)
+#   agent.session.remove(id: "a_1")
+#   agent.session.update(id: "a_1", content: "...")
+#   agent.session.find { |m| m.id == "a_1" }
+class Riffer::Session
+  include Enumerable[Riffer::Messages::Base]
+
+  # The message history.
+  attr_reader messages: Array[Riffer::Messages::Base]
+
+  # --
+  # : (?messages: Array[Riffer::Messages::Base]) -> void
+  def initialize: (?messages: Array[Riffer::Messages::Base]) -> void
+
+  # Registers a callback invoked once per message appended via +#add+.
+  #
+  # Callbacks do NOT fire for +#set+, +#unset+, +#remove+, or +#update+.
+  # Returns +self+ to allow chaining.
+  #
+  # Raises Riffer::ArgumentError if no block is given.
+  #
+  # --
+  # : () { (Riffer::Messages::Base) -> void } -> self
+  def on_message: () { (Riffer::Messages::Base) -> void } -> self
+
+  # Appends +message+ and fires every registered callback once with it.
+  #
+  # --
+  # : (Riffer::Messages::Base) -> Riffer::Messages::Base
+  def add: (Riffer::Messages::Base) -> Riffer::Messages::Base
+
+  # Replaces the message history wholesale. Does NOT fire +on_message+
+  # callbacks; registered callbacks persist across the swap.
+  #
+  # Used for seeding, guardrail rewrites, and history healing — cases
+  # where firing callbacks would double-emit messages that subscribers
+  # have already observed (or never produced).
+  #
+  # --
+  # : (Array[Riffer::Messages::Base]) -> self
+  def set: (Array[Riffer::Messages::Base]) -> self
+
+  # Clears the session. Does NOT fire +on_message+ callbacks; registered
+  # callbacks persist.
+  #
+  # --
+  # : () -> self
+  def unset: () -> self
+
+  # Removes a message by id. When the target is an assistant message that
+  # carries +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches one of those calls is removed atomically — keeping
+  # the +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when called on a +Riffer::Messages::Tool+
+  # message — that would orphan the parent's +tool_use+. Use
+  # +#update+ to rewrite a tool result instead.
+  #
+  # Returns the removed message, or +nil+ when no message has the given id
+  # (idempotent).
+  #
+  # --
+  # : (id: String) -> Riffer::Messages::Base?
+  def remove: (id: String) -> Riffer::Messages::Base?
+
+  # Partial in-place update. Looks up a message by either +id:+ or
+  # +tool_call_id:+ (exactly one required), constructs a replacement of the
+  # same concrete type with +attrs+ overlaid on the existing fields, and
+  # swaps it in place.
+  #
+  # When the target is an assistant message and the update drops one or more
+  # entries from +tool_calls+, every +Riffer::Messages::Tool+ result whose
+  # +tool_call_id+ matches a dropped call is removed atomically — keeping the
+  # +tool_use+ ↔ +tool_result+ invariant intact.
+  #
+  # Raises Riffer::ArgumentError when neither or both lookup keys are
+  # provided, or when no message matches.
+  #
+  # --
+  # : (?id: String?, ?tool_call_id: String?, **untyped) -> Riffer::Messages::Base
+  def update: (?id: String?, ?tool_call_id: String?, **untyped) -> Riffer::Messages::Base
+
+  # Returns the call_ids of every +tool_call+ on any assistant message that
+  # has no matching +Riffer::Messages::Tool+ result anywhere in history.
+  #
+  # Zero-cost validation hook for callers that want to check the
+  # +tool_use+ ↔ +tool_result+ invariant before mutating or persisting.
+  #
+  # --
+  # : () -> Array[String]
+  def orphaned_tool_call_ids: () -> Array[String]
+
+  # Returns +[assistant, pending_tool_calls]+ for the last assistant message.
+  # When there is no assistant message or no pending calls, the second
+  # element is an empty array.
+  #
+  # --
+  # : () -> [Riffer::Messages::Assistant?, Array[Riffer::Messages::Assistant::ToolCall]]
+  def pending_tool_calls: () -> [ Riffer::Messages::Assistant?, Array[Riffer::Messages::Assistant::ToolCall] ]
+
+  # --
+  # : () { (Riffer::Messages::Base) -> void } -> untyped
+  def each: () { (Riffer::Messages::Base) -> void } -> untyped
+
+  private
+
+  # : (Riffer::Messages::Base, Riffer::Messages::Base) -> void
+  def cascade_dropped_tool_calls: (Riffer::Messages::Base, Riffer::Messages::Base) -> void
+
+  # : (Riffer::Messages::Base, Hash[Symbol, untyped]) -> Riffer::Messages::Base
+  def rebuild_message: (Riffer::Messages::Base, Hash[Symbol, untyped]) -> Riffer::Messages::Base
+end

--- a/sig/generated/riffer/session.rbs
+++ b/sig/generated/riffer/session.rbs
@@ -110,8 +110,10 @@ class Riffer::Session
   def pending_tool_calls: () -> [ Riffer::Messages::Assistant?, Array[Riffer::Messages::Assistant::ToolCall] ]
 
   # --
+  # : () -> Enumerator[Riffer::Messages::Base, self]
   # : () { (Riffer::Messages::Base) -> void } -> untyped
-  def each: () { (Riffer::Messages::Base) -> void } -> untyped
+  def each: () -> Enumerator[Riffer::Messages::Base, self]
+          | () { (Riffer::Messages::Base) -> void } -> untyped
 
   private
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -2334,12 +2334,12 @@ describe Riffer::Agent do
           end
         end
 
-        agent = klass.new
+        session = Riffer::Session.new(messages: [Riffer::Messages::User.new("Analyze sentiment")])
+        agent = klass.new(session: session)
         provider = agent.send(:provider_instance)
         provider.stub_response('{"sentiment":"positive"}')
 
-        messages = [Riffer::Messages::User.new("Analyze sentiment")]
-        result = agent.generate(messages)
+        result = agent.generate
         expect(result.structured_output).must_equal({sentiment: "positive"})
       end
     end
@@ -2398,32 +2398,22 @@ describe Riffer::Agent do
       expect(interrupt_event).must_be_nil
     end
 
-    describe "with persisted messages" do
-      it "resumes from message objects" do
-        agent = agent_class.new
-        messages = [
+    describe "with a seeded session" do
+      it "resumes from a session constructed with persisted messages" do
+        session = Riffer::Session.new(messages: [
           Riffer::Messages::System.new("You are a helpful assistant."),
           Riffer::Messages::User.new("Hello")
-        ]
-        events = agent.stream(messages).to_a
+        ])
+        agent = agent_class.new(session: session)
+        events = agent.stream.to_a
         text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
         expect(text_events).wont_be_empty
       end
 
-      it "resumes from hashes" do
-        agent = agent_class.new
-        messages = [
-          {role: "system", content: "You are a helpful assistant."},
-          {role: "user", content: "Hello"}
-        ]
-        events = agent.stream(messages).to_a
-        expect(events).wont_be_empty
-      end
-
-      it "does not require prior interruption" do
-        agent = agent_class.new
-        messages = [Riffer::Messages::User.new("Hello")]
-        events = agent.stream(messages).to_a
+      it "runs the stream loop without a prompt when the session already has the last user message" do
+        session = Riffer::Session.new(messages: [Riffer::Messages::User.new("Hello")])
+        agent = agent_class.new(session: session)
+        events = agent.stream.to_a
         interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
         expect(interrupt_event).must_be_nil
       end
@@ -3238,30 +3228,27 @@ describe Riffer::Agent do
     end
   end
 
-  describe "#generate_instruction_message" do
+  describe "#instruction_message" do
     it "returns a System message with instructions" do
       agent = agent_class.new
-      msg = agent.generate_instruction_message
-      expect(msg).must_be_instance_of Riffer::Messages::System
-      expect(msg.content).must_equal "You are a helpful assistant."
+      expect(agent.instruction_message).must_be_instance_of Riffer::Messages::System
+      expect(agent.instruction_message.content).must_equal "You are a helpful assistant."
     end
 
     it "returns nil when no instructions configured" do
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
       end
-      agent = klass.new
-      expect(agent.generate_instruction_message).must_be_nil
+      expect(klass.new.instruction_message).must_be_nil
     end
 
-    it "resolves dynamic instructions with context" do
+    it "resolves dynamic instructions using the init context" do
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         instructions ->(context) { "Helping #{context[:name]}" }
       end
-      agent = klass.new(context: {name: "init"})
-      msg = agent.generate_instruction_message(context: {name: "Alice"})
-      expect(msg.content).must_equal "Helping Alice"
+      agent = klass.new(context: {name: "Alice"})
+      expect(agent.instruction_message.content).must_equal "Helping Alice"
     end
 
     it "returns nil when Proc returns nil" do
@@ -3270,15 +3257,14 @@ describe Riffer::Agent do
         model "mock/riffer-1"
         instructions returner
       end
-      agent = klass.new
-      expect(agent.generate_instruction_message).must_be_nil
+      expect(klass.new.instruction_message).must_be_nil
     end
   end
 
-  describe "#generate_skills_message" do
+  describe "#skills_message" do
     it "returns nil when no skills configured" do
       agent = agent_class.new
-      expect(agent.generate_skills_message).must_be_nil
+      expect(agent.skills_message).must_be_nil
     end
 
     it "returns a System message when skills are configured" do
@@ -3289,9 +3275,8 @@ describe Riffer::Agent do
         end
       end
       agent = klass.new
-      msg = agent.generate_skills_message
-      expect(msg).must_be_instance_of Riffer::Messages::System
-      expect(msg.content).must_include "Available Skills"
+      expect(agent.skills_message).must_be_instance_of Riffer::Messages::System
+      expect(agent.skills_message.content).must_include "Available Skills"
     end
   end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -107,9 +107,22 @@ describe Riffer::Agent do
   end
 
   describe "#initialize" do
-    it "initializes with empty messages" do
+    it "seeds the session with the configured instruction system message" do
       agent = agent_class.new
-      expect(agent.messages).must_equal []
+      expect(agent.session.messages.map(&:role)).must_equal [:system]
+      expect(agent.session.messages.first.content).must_equal "You are a helpful assistant."
+    end
+
+    it "leaves the session empty when no instructions or skills are configured" do
+      bare = Class.new(Riffer::Agent) { model "mock/riffer-1" }.new
+      expect(bare.session.messages).must_equal []
+    end
+
+    it "uses the provided session as-is when passed" do
+      seeded = Riffer::Session.new(messages: [Riffer::Messages::User.new("Hi")])
+      agent = agent_class.new(session: seeded)
+      expect(agent.session).must_be_same_as seeded
+      expect(agent.session.messages.map(&:role)).must_equal [:user]
     end
 
     it "initializes with nil token_usage" do
@@ -260,21 +273,21 @@ describe Riffer::Agent do
       it "adds system message to messages when instructions are provided" do
         agent = agent_class.new
         agent.generate("Hello")
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).wont_be_nil
       end
 
       it "adds user message to messages" do
         agent = agent_class.new
         agent.generate("Hello")
-        user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+        user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
         expect(user_message).wont_be_nil
       end
 
       it "adds assistant message to messages" do
         agent = agent_class.new
         agent.generate("Hello")
-        assistant_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
+        assistant_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
         expect(assistant_message).wont_be_nil
       end
 
@@ -282,141 +295,6 @@ describe Riffer::Agent do
         agent = agent_class.new
         result = agent.generate("Hello")
         expect(result.content).must_be_instance_of String
-      end
-    end
-
-    describe "with an array of messages" do
-      it "accepts an array of messages" do
-        agent = agent_class.new
-        messages = [
-          Riffer::Messages::User.new("Hello"),
-          Riffer::Messages::Assistant.new("Hi there!"),
-          Riffer::Messages::User.new("How are you?")
-        ]
-        result = agent.generate(messages)
-        expect(result).must_be_instance_of Riffer::Agent::Response
-      end
-
-      it "uses messages as-is without prepending system message" do
-        agent = agent_class.new
-        messages = [Riffer::Messages::User.new("Hello")]
-        agent.generate(messages)
-        expect(agent.messages.first).must_be_instance_of Riffer::Messages::User
-      end
-
-      it "preserves all provided messages" do
-        agent = agent_class.new
-        messages = [
-          Riffer::Messages::User.new("First message"),
-          Riffer::Messages::Assistant.new("Response"),
-          Riffer::Messages::User.new("Second message")
-        ]
-        agent.generate(messages)
-        user_messages = agent.messages.select { |msg| msg.is_a?(Riffer::Messages::User) }
-        expect(user_messages.length).must_be :>=, 2
-      end
-
-      it "raises when passing an array on an agent with existing messages" do
-        agent = agent_class.new
-        agent.generate("Hello")
-        error = expect {
-          agent.generate([Riffer::Messages::User.new("Follow up")])
-        }.must_raise(Riffer::ArgumentError)
-        expect(error.message).must_match(/cannot pass an array/)
-      end
-    end
-
-    describe "seed id validation" do
-      before { @original_strategy = Riffer.config.message_id_strategy }
-      after { Riffer.config.message_id_strategy = @original_strategy }
-
-      it "does not require id when strategy is :none" do
-        Riffer.config.message_id_strategy = :none
-        agent = agent_class.new
-        agent.generate([{role: "user", content: "Hi"}])
-        expect(agent.messages.any? { |m| m.is_a?(Riffer::Messages::User) }).must_equal true
-      end
-
-      it "raises when a seeded hash lacks :id and strategy is set" do
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        error = expect {
-          agent.generate([{role: "user", content: "Hi"}])
-        }.must_raise(Riffer::ArgumentError)
-        expect(error.message).must_match(/index 0 is missing :id/)
-      end
-
-      it "preserves the seeded id when provided" do
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        agent.generate([{role: "user", content: "Hi", id: "seed-123"}])
-        user = agent.messages.find { |m| m.is_a?(Riffer::Messages::User) }
-        expect(user.id).must_equal "seed-123"
-      end
-
-      it "raises when a seeded message object has nil id and strategy is set" do
-        Riffer.config.message_id_strategy = :none
-        msg = Riffer::Messages::User.new("Hi") # built while strategy is :none → id is nil
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        error = expect {
-          agent.generate([msg])
-        }.must_raise(Riffer::ArgumentError)
-        expect(error.message).must_match(/index 0 is missing :id/)
-      end
-
-      it "reports the index of the offending seed message" do
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        error = expect {
-          agent.generate([
-            {role: "user", content: "first", id: "ok-1"},
-            {role: "assistant", content: "no-id-here"}
-          ])
-        }.must_raise(Riffer::ArgumentError)
-        expect(error.message).must_match(/index 1 is missing :id/)
-      end
-
-      it "raises ArgumentError (not NoMethodError) for invalid seed types" do
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        expect {
-          agent.generate([42])
-        }.must_raise(Riffer::ArgumentError)
-      end
-
-      it "assigns auto-generated ids to agent-created messages when strategy is set" do
-        Riffer.config.message_id_strategy = :uuidv7
-        agent = agent_class.new
-        agent.generate("Hello")
-        agent.messages.each do |msg|
-          expect(msg.id).wont_be_nil
-        end
-      end
-    end
-
-    describe "with an array of hashes" do
-      it "accepts an array of hashes and converts them to messages" do
-        agent = agent_class.new
-        messages = [
-          {role: "user", content: "Hello"},
-          {role: "assistant", content: "Hi there!"},
-          {role: "user", content: "How are you?"}
-        ]
-        result = agent.generate(messages)
-        expect(result).must_be_instance_of Riffer::Agent::Response
-      end
-
-      it "supports mixed hash and message objects" do
-        agent = agent_class.new
-        messages = [
-          {role: "user", content: "First"},
-          Riffer::Messages::Assistant.new("Second"),
-          {role: "user", content: "Third"}
-        ]
-        agent.generate(messages)
-        user_messages = agent.messages.select { |msg| msg.is_a?(Riffer::Messages::User) }
-        expect(user_messages.length).must_be :>=, 2
       end
     end
 
@@ -430,7 +308,7 @@ describe Riffer::Agent do
       it "does not add system message" do
         agent = no_instructions_agent_class.new
         agent.generate("Hello")
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).must_be_nil
       end
     end
@@ -444,7 +322,7 @@ describe Riffer::Agent do
 
         agent = klass.new
         agent.generate("Hello")
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message.content).must_equal "Dynamic instructions"
       end
 
@@ -454,9 +332,9 @@ describe Riffer::Agent do
           instructions ->(context) { "You are assisting #{context[:name]}" }
         end
 
-        agent = klass.new
-        agent.generate("Hello", context: {name: "Jane"})
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        agent = klass.new(context: {name: "Jane"})
+        agent.generate("Hello")
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message.content).must_equal "You are assisting Jane"
       end
 
@@ -468,7 +346,7 @@ describe Riffer::Agent do
 
         agent = klass.new
         agent.generate("Hello")
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message.content).must_equal "No context"
       end
 
@@ -481,7 +359,7 @@ describe Riffer::Agent do
 
         agent = klass.new
         agent.generate("Hello")
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).must_be_nil
       end
     end
@@ -622,62 +500,29 @@ describe Riffer::Agent do
       it "adds system message to messages when instructions are provided" do
         agent = agent_class.new
         agent.stream("Hello").each { |_| }
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).wont_be_nil
       end
 
       it "adds user message to messages" do
         agent = agent_class.new
         agent.stream("Hello").each { |_| }
-        user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+        user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
         expect(user_message).wont_be_nil
       end
 
       it "adds assistant message to messages" do
         agent = agent_class.new
         agent.stream("Hello").each { |_| }
-        assistant_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
+        assistant_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
         expect(assistant_message).wont_be_nil
       end
 
       it "accumulates content from TextDelta events" do
         agent = agent_class.new
         agent.stream("Hello").each { |_| }
-        assistant_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
+        assistant_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::Assistant) }
         expect(assistant_message.content).wont_be_empty
-      end
-    end
-
-    describe "with an array of messages" do
-      it "accepts an array of messages" do
-        agent = agent_class.new
-        messages = [
-          Riffer::Messages::User.new("Hello"),
-          Riffer::Messages::Assistant.new("Hi there!"),
-          Riffer::Messages::User.new("How are you?")
-        ]
-        result = agent.stream(messages)
-        expect(result).must_be_instance_of Enumerator
-      end
-
-      it "uses messages as-is without prepending system message" do
-        agent = agent_class.new
-        messages = [Riffer::Messages::User.new("Hello")]
-        agent.stream(messages).each { |_| }
-        expect(agent.messages.first).must_be_instance_of Riffer::Messages::User
-      end
-    end
-
-    describe "with an array of hashes" do
-      it "accepts an array of hashes and converts them to messages" do
-        agent = agent_class.new
-        messages = [
-          {role: "user", content: "Hello"},
-          {role: "assistant", content: "Hi there!"},
-          {role: "user", content: "How are you?"}
-        ]
-        result = agent.stream(messages)
-        expect(result).must_be_instance_of Enumerator
       end
     end
 
@@ -691,7 +536,7 @@ describe Riffer::Agent do
       it "does not add system message" do
         agent = no_instructions_agent_class.new
         agent.stream("Hello").each { |_| }
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message).must_be_nil
       end
     end
@@ -703,9 +548,9 @@ describe Riffer::Agent do
           instructions ->(context) { "You are assisting #{context[:name]}" }
         end
 
-        agent = klass.new
-        agent.stream("Hello", context: {name: "Jane"}).each { |_| }
-        system_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
+        agent = klass.new(context: {name: "Jane"})
+        agent.stream("Hello").each { |_| }
+        system_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::System) }
         expect(system_message.content).must_equal "You are assisting Jane"
       end
     end
@@ -832,7 +677,7 @@ describe Riffer::Agent do
       expect(result.structured_output).must_be_nil
     end
 
-    it "stores structured_output hash on the assistant message in agent.messages" do
+    it "stores structured_output hash on the assistant message in agent.session.messages" do
       klass = Class.new(Riffer::Agent) do
         model "mock/riffer-1"
         structured_output do
@@ -846,7 +691,7 @@ describe Riffer::Agent do
 
       agent.generate("Analyze sentiment")
       # TODO: Replace with rfind when minimum Ruby is 4.0+
-      last_assistant = agent.messages.reverse.find { |m| m.is_a?(Riffer::Messages::Assistant) } # rubocop:disable Style/ReverseFind
+      last_assistant = agent.session.messages.reverse.find { |m| m.is_a?(Riffer::Messages::Assistant) } # rubocop:disable Style/ReverseFind
       expect(last_assistant.structured_output?).must_equal true
       expect(last_assistant.structured_output).must_equal({sentiment: "positive"})
     end
@@ -864,7 +709,7 @@ describe Riffer::Agent do
       provider.stub_response('{"sentiment":"positive"}')
 
       callback_msg = nil
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         callback_msg = msg if msg.is_a?(Riffer::Messages::Assistant)
       end
       agent.generate("Analyze sentiment")
@@ -899,39 +744,30 @@ describe Riffer::Agent do
       agent = agent_class.new
       file = Riffer::FilePart.new(data: "aGVsbG8=", media_type: "image/png")
       agent.generate("Describe this", files: [file])
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+      user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
       expect(user_message.files.length).must_equal 1
     end
 
     it "converts file hashes to FilePart objects" do
       agent = agent_class.new
       agent.generate("Describe this", files: [{data: "aGVsbG8=", media_type: "image/png"}])
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+      user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
       expect(user_message.files.first).must_be_instance_of Riffer::FilePart
     end
 
     it "defaults to empty files when not provided" do
       agent = agent_class.new
       agent.generate("Hello")
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+      user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
       expect(user_message.files).must_equal []
     end
 
-    it "raises when files and messages array are both provided" do
+    it "raises when files: is provided without a prompt" do
       agent = agent_class.new
-      messages = [{role: "user", content: "Hello"}]
       error = expect {
-        agent.generate(messages, files: [{data: "aGVsbG8=", media_type: "image/png"}])
+        agent.generate(nil, files: [{data: "aGVsbG8=", media_type: "image/png"}])
       }.must_raise(Riffer::ArgumentError)
-      expect(error.message).must_match(/cannot provide both files and messages/)
-    end
-
-    it "supports files in messages array" do
-      agent = agent_class.new
-      messages = [{role: "user", content: "Describe this", files: [{data: "aGVsbG8=", media_type: "image/png"}]}]
-      agent.generate(messages)
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
-      expect(user_message.files.length).must_equal 1
+      expect(error.message).must_match(/files: requires a prompt/)
     end
   end
 
@@ -940,14 +776,14 @@ describe Riffer::Agent do
       agent = agent_class.new
       file = Riffer::FilePart.new(data: "aGVsbG8=", media_type: "image/png")
       agent.stream("Describe this", files: [file]).each { |_| }
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+      user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
       expect(user_message.files.length).must_equal 1
     end
 
     it "converts file hashes to FilePart objects" do
       agent = agent_class.new
       agent.stream("Describe this", files: [{data: "aGVsbG8=", media_type: "image/png"}]).each { |_| }
-      user_message = agent.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
+      user_message = agent.session.messages.find { |msg| msg.is_a?(Riffer::Messages::User) }
       expect(user_message.files.first).must_be_instance_of Riffer::FilePart
     end
   end
@@ -1291,7 +1127,7 @@ describe Riffer::Agent do
       expect(provider).must_be_instance_of Riffer::Providers::Mock
     end
 
-    it "re-evaluates lambda for each generate call" do
+    it "evaluates the model lambda once per agent instance" do
       call_count = 0
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model -> {
@@ -1300,13 +1136,12 @@ describe Riffer::Agent do
         }
       end
 
-      agent = dynamic_agent_class.new
-      agent.generate("Hello")
-      agent.generate("Hello again")
+      dynamic_agent_class.new
+      dynamic_agent_class.new
       expect(call_count).must_equal 2
     end
 
-    it "can change model between calls based on context" do
+    it "resolves model per agent instance based on context" do
       models_used = []
       dynamic_agent_class = Class.new(Riffer::Agent) do
         model ->(context) {
@@ -1316,9 +1151,8 @@ describe Riffer::Agent do
         }
       end
 
-      agent = dynamic_agent_class.new
-      agent.generate("Hello", context: {premium: false})
-      agent.generate("Hello", context: {premium: true})
+      dynamic_agent_class.new(context: {premium: false}).generate("Hello")
+      dynamic_agent_class.new(context: {premium: true}).generate("Hello")
       expect(models_used).must_equal ["mock/riffer-basic", "mock/riffer-premium"]
     end
 
@@ -1338,8 +1172,7 @@ describe Riffer::Agent do
         model -> { "invalid-format" }
       end
 
-      agent = dynamic_agent_class.new
-      error = expect { agent.generate("Hello") }.must_raise(Riffer::ArgumentError)
+      error = expect { dynamic_agent_class.new }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/Invalid model string: invalid-format/)
     end
 
@@ -1349,8 +1182,7 @@ describe Riffer::Agent do
         model -> { value }
       end
 
-      agent = dynamic_agent_class.new
-      error = expect { agent.generate("Hello") }.must_raise(Riffer::ArgumentError)
+      error = expect { dynamic_agent_class.new }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_match(/Invalid model string/)
     end
 
@@ -1411,7 +1243,7 @@ describe Riffer::Agent do
 
         agent.generate("What's the weather in Toronto?")
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
       end
 
@@ -1432,7 +1264,7 @@ describe Riffer::Agent do
 
         agent.generate("What's the weather in Toronto?")
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Weather in Toronto: 20 degrees"
       end
 
@@ -1464,16 +1296,16 @@ describe Riffer::Agent do
           uses_tools [tool_class]
         end
 
-        agent = agent_class.new
+        agent = agent_class.new(context: {user_name: "Alice"})
         provider = agent.send(:provider_instance)
         provider.stub_response("", tool_calls: [
           {name: "context_tool", arguments: '{"field":"user_name"}'}
         ])
         provider.stub_response("Your name is Alice!")
 
-        agent.generate("Get my name", context: {user_name: "Alice"})
+        agent.generate("Get my name")
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Alice"
       end
 
@@ -1492,7 +1324,7 @@ describe Riffer::Agent do
 
         agent.generate("Call nonexistent tool")
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_match(/Unknown tool/)
       end
 
@@ -1511,7 +1343,7 @@ describe Riffer::Agent do
 
         agent.generate("Call nonexistent tool")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal true
         expect(tool_message.error).must_equal "Unknown tool 'nonexistent_tool'"
         expect(tool_message.error_type).must_equal :unknown_tool
@@ -1534,7 +1366,7 @@ describe Riffer::Agent do
 
         agent.generate("What's the weather?")
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_match(/city is required/)
       end
 
@@ -1555,7 +1387,7 @@ describe Riffer::Agent do
 
         agent.generate("What's the weather?")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal true
         expect(tool_message.error_type).must_equal :validation_error
       end
@@ -1577,7 +1409,7 @@ describe Riffer::Agent do
 
         agent.generate("What's the weather in Toronto?")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal false
         expect(tool_message.error).must_be_nil
         expect(tool_message.error_type).must_be_nil
@@ -1653,7 +1485,7 @@ describe Riffer::Agent do
 
         agent.stream("What's the weather?").each { |_| }
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
       end
 
@@ -1665,16 +1497,16 @@ describe Riffer::Agent do
           uses_tools [tool_class]
         end
 
-        agent = agent_class.new
+        agent = agent_class.new(context: {user_id: "12345"})
         provider = agent.send(:provider_instance)
         provider.stub_response("", tool_calls: [
           {name: "context_tool", arguments: '{"field":"user_id"}'}
         ])
         provider.stub_response("Your ID is 12345!")
 
-        agent.stream("Get my id", context: {user_id: "12345"}).each { |_| }
+        agent.stream("Get my id").each { |_| }
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "12345"
       end
     end
@@ -1720,7 +1552,7 @@ describe Riffer::Agent do
 
         agent.generate("Run the slow tool")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal true
       end
 
@@ -1742,7 +1574,7 @@ describe Riffer::Agent do
 
         agent.generate("Run the slow tool")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.content).must_match(/timed out/)
         expect(tool_message.error_type).must_equal :timeout_error
       end
@@ -1765,7 +1597,7 @@ describe Riffer::Agent do
 
         agent.generate("Run the slow tool")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal true
         expect(tool_message.error).must_match(/0\.01 seconds/)
       end
@@ -1788,7 +1620,7 @@ describe Riffer::Agent do
 
         agent.generate("Run the fast tool")
 
-        tool_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_message.error?).must_equal false
         expect(tool_message.content).must_equal "fast result"
       end
@@ -1827,9 +1659,9 @@ describe Riffer::Agent do
           }
         end
 
-        agent = agent_class.new
         context = {user_id: 123, admin: true}
-        agent.generate("Hello", context: context)
+        agent = agent_class.new(context: context)
+        agent.generate("Hello")
 
         expect(received_context).must_equal context
       end
@@ -1856,23 +1688,23 @@ describe Riffer::Agent do
           }
         end
 
-        admin_agent = agent_class.new
+        admin_agent = agent_class.new(context: {admin: true})
         provider = admin_agent.send(:provider_instance)
         provider.stub_response("Done")
-        admin_agent.generate("Hello", context: {admin: true})
+        admin_agent.generate("Hello")
         admin_tools = provider.calls.last[:tools]
 
-        regular_agent = agent_class.new
+        regular_agent = agent_class.new(context: {admin: false})
         provider2 = regular_agent.send(:provider_instance)
         provider2.stub_response("Done")
-        regular_agent.generate("Hello", context: {admin: false})
+        regular_agent.generate("Hello")
         regular_tools = provider2.calls.last[:tools]
 
         expect(admin_tools.length).must_equal 2
         expect(regular_tools.length).must_equal 1
       end
 
-      it "re-evaluates lambda for each generate call" do
+      it "evaluates lambda once per agent instance" do
         tool_class = weather_tool_class
         tool_class.identifier("weather_tool")
         contexts_received = []
@@ -1885,48 +1717,12 @@ describe Riffer::Agent do
           }
         end
 
-        agent = agent_class.new
-        agent.generate("Hello", context: {call: 1})
-        agent.generate("Hello again", context: {call: 2})
+        agent_class.new(context: {call: 1}).generate("Hello")
+        agent_class.new(context: {call: 2}).generate("Hello again")
 
         expect(contexts_received.length).must_equal 2
         expect(contexts_received[0]).must_equal({call: 1})
         expect(contexts_received[1]).must_equal({call: 2})
-      end
-    end
-  end
-
-  describe "#on_message" do
-    it "raises error without block" do
-      agent = agent_class.new
-      error = expect { agent.on_message }.must_raise(Riffer::ArgumentError)
-      expect(error.message).must_match(/on_message requires a block/)
-    end
-
-    it "returns self for chaining" do
-      agent = agent_class.new
-      result = agent.on_message { |_| }
-      expect(result).must_equal agent
-    end
-
-    describe "with multiple callbacks" do
-      let(:callbacks_called) { [] }
-      let(:agent) do
-        a = agent_class.new
-        a.on_message { |_| callbacks_called << 1 }
-        a.on_message { |_| callbacks_called << 2 }
-        a.generate("Hello")
-        a
-      end
-
-      it "calls first callback" do
-        agent
-        expect(callbacks_called).must_include 1
-      end
-
-      it "calls second callback" do
-        agent
-        expect(callbacks_called).must_include 2
       end
     end
   end
@@ -1936,7 +1732,7 @@ describe Riffer::Agent do
       let(:emitted) { [] }
       let(:agent) do
         a = agent_class.new
-        a.on_message { |msg| emitted << msg }
+        a.session.on_message { |msg| emitted << msg }
         a.generate("Hello")
         a
       end
@@ -1980,7 +1776,7 @@ describe Riffer::Agent do
         ])
         provider.stub_response("The weather is nice!")
 
-        a.on_message { |msg| emitted << msg }
+        a.session.on_message { |msg| emitted << msg }
         a.generate("What's the weather?")
         a
       end
@@ -2039,7 +1835,7 @@ describe Riffer::Agent do
         ])
         provider.stub_response("Tool failed.")
 
-        agent.on_message { |msg| emitted << msg }
+        agent.session.on_message { |msg| emitted << msg }
         agent.generate("Call tool")
 
         emitted.find { |m| m.is_a?(Riffer::Messages::Tool) }
@@ -2058,21 +1854,21 @@ describe Riffer::Agent do
   describe "interruptible callbacks with #generate" do
     it "returns response with interrupted? true" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt }
+      agent.session.on_message { |_msg| throw :riffer_interrupt }
       result = agent.generate("Hello")
       expect(result.interrupted?).must_equal true
     end
 
     it "returns accumulated content" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt }
+      agent.session.on_message { |_msg| throw :riffer_interrupt }
       result = agent.generate("Hello")
       expect(result.content).must_be_instance_of String
     end
 
     it "captures interrupt reason" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt, "needs approval" }
+      agent.session.on_message { |_msg| throw :riffer_interrupt, "needs approval" }
       result = agent.generate("Hello")
       expect(result.interrupted?).must_equal true
       expect(result.interrupt_reason).must_equal "needs approval"
@@ -2080,7 +1876,7 @@ describe Riffer::Agent do
 
     it "returns nil interrupt_reason when no reason given" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt }
+      agent.session.on_message { |_msg| throw :riffer_interrupt }
       result = agent.generate("Hello")
       expect(result.interrupt_reason).must_be_nil
     end
@@ -2111,7 +1907,7 @@ describe Riffer::Agent do
         provider.stub_response("Done!")
 
         tool_count = 0
-        agent.on_message do |msg|
+        agent.session.on_message do |msg|
           if msg.is_a?(Riffer::Messages::Tool)
             tool_count += 1
             throw :riffer_interrupt if tool_count == 1
@@ -2121,12 +1917,12 @@ describe Riffer::Agent do
         result = agent.generate("Call tools")
 
         expect(result.interrupted?).must_equal true
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
 
         result = agent.generate("Continue")
         expect(result.interrupted?).must_equal false
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
       end
 
@@ -2146,7 +1942,7 @@ describe Riffer::Agent do
         provider.stub_response("Done!")
 
         interrupted_once = false
-        agent.on_message do |msg|
+        agent.session.on_message do |msg|
           if msg.is_a?(Riffer::Messages::Assistant) && !interrupted_once
             interrupted_once = true
             throw :riffer_interrupt
@@ -2156,12 +1952,12 @@ describe Riffer::Agent do
         result = agent.generate("Call tools")
 
         expect(result.interrupted?).must_equal true
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 0
 
         result = agent.generate("Continue")
         expect(result.interrupted?).must_equal false
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 2
       end
     end
@@ -2170,8 +1966,8 @@ describe Riffer::Agent do
       it "earlier callbacks still fire" do
         agent = agent_class.new
         first_called = false
-        agent.on_message { |_msg| first_called = true }
-        agent.on_message { |_msg| throw :riffer_interrupt }
+        agent.session.on_message { |_msg| first_called = true }
+        agent.session.on_message { |_msg| throw :riffer_interrupt }
         agent.generate("Hello")
         expect(first_called).must_equal true
       end
@@ -2180,21 +1976,21 @@ describe Riffer::Agent do
     describe "#interrupt!" do
       it "interrupts the agent loop" do
         agent = agent_class.new
-        agent.on_message { |_msg| agent.interrupt! }
+        agent.session.on_message { |_msg| agent.interrupt! }
         result = agent.generate("Hello")
         expect(result.interrupted?).must_equal true
       end
 
       it "passes reason to interrupt_reason" do
         agent = agent_class.new
-        agent.on_message { |_msg| agent.interrupt!(:needs_approval) }
+        agent.session.on_message { |_msg| agent.interrupt!(:needs_approval) }
         result = agent.generate("Hello")
         expect(result.interrupt_reason).must_equal :needs_approval
       end
 
       it "defaults reason to nil" do
         agent = agent_class.new
-        agent.on_message { |_msg| agent.interrupt! }
+        agent.session.on_message { |_msg| agent.interrupt! }
         result = agent.generate("Hello")
         expect(result.interrupt_reason).must_be_nil
       end
@@ -2213,7 +2009,7 @@ describe Riffer::Agent do
     it "returns a Response" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2227,7 +2023,7 @@ describe Riffer::Agent do
     it "returns non-interrupted response on successful resume" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2241,7 +2037,7 @@ describe Riffer::Agent do
     it "returns nil interrupt_reason on successful resume" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt, "needs approval"
@@ -2255,22 +2051,22 @@ describe Riffer::Agent do
     it "preserves messages from original generate" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
         end
       end
       agent.generate("Hello")
-      messages_before = agent.messages.length
+      messages_before = agent.session.messages.length
       agent.generate("Continue")
-      expect(agent.messages.length).must_be :>, messages_before
+      expect(agent.session.messages.length).must_be :>, messages_before
     end
 
     it "does not duplicate system message" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2278,7 +2074,7 @@ describe Riffer::Agent do
       end
       agent.generate("Hello")
       agent.generate("Continue")
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       expect(system_messages.length).must_equal 1
     end
 
@@ -2310,7 +2106,7 @@ describe Riffer::Agent do
         provider.stub_response("The weather is nice!")
 
         interrupted_once = false
-        agent.on_message do |msg|
+        agent.session.on_message do |msg|
           if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
             interrupted_once = true
             throw :riffer_interrupt
@@ -2326,39 +2122,36 @@ describe Riffer::Agent do
       end
     end
 
-    describe "with persisted messages" do
-      it "resumes from message objects" do
-        agent = agent_class.new
+    describe "with a seeded session" do
+      it "resumes from a session constructed with persisted messages" do
         messages = [
           Riffer::Messages::System.new("You are a helpful assistant."),
           Riffer::Messages::User.new("Hello"),
           Riffer::Messages::Assistant.new("Hi there!")
         ]
-        result = agent.generate(messages)
+        agent = agent_class.new(session: Riffer::Session.new(messages: messages))
+        result = agent.generate
         expect(result).must_be_instance_of Riffer::Agent::Response
       end
 
-      it "resumes from hashes" do
-        agent = agent_class.new
-        messages = [
-          {role: "system", content: "You are a helpful assistant."},
-          {role: "user", content: "Hello"},
-          {role: "assistant", content: "Hi there!"}
-        ]
-        result = agent.generate(messages)
-        expect(result).must_be_instance_of Riffer::Agent::Response
-      end
-
-      it "does not require prior interruption" do
-        agent = agent_class.new
-        messages = [
-          Riffer::Messages::User.new("Hello")
-        ]
-        result = agent.generate(messages)
+      it "runs the loop without a prompt when the session already has the last user message" do
+        agent = agent_class.new(session: Riffer::Session.new(messages: [Riffer::Messages::User.new("Hello")]))
+        result = agent.generate
         expect(result.interrupted?).must_equal false
       end
 
-      it "sets context" do
+      it "accepts a new prompt to continue the seeded conversation" do
+        agent = agent_class.new(session: Riffer::Session.new(messages: [
+          Riffer::Messages::User.new("Hi"),
+          Riffer::Messages::Assistant.new("Hello!")
+        ]))
+        agent.generate("How are you?")
+        user_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+        expect(user_messages.length).must_equal 2
+        expect(user_messages.last.content).must_equal "How are you?"
+      end
+
+      it "uses init context for tool execution" do
         context_tool = Class.new(Riffer::Tool) do
           description "Gets user info"
           params do
@@ -2375,33 +2168,33 @@ describe Riffer::Agent do
           uses_tools [tc]
         end
 
-        agent = custom_agent_class.new
+        session = Riffer::Session.new(messages: [Riffer::Messages::User.new("Get my name")])
+        agent = custom_agent_class.new(session: session, context: {user_name: "Alice"})
         provider = agent.send(:provider_instance)
         provider.stub_response("", tool_calls: [
           {name: "resume_context_tool", arguments: '{"field":"user_name"}'}
         ])
         provider.stub_response("Your name is Alice!")
 
-        messages = [Riffer::Messages::User.new("Get my name")]
-        agent.generate(messages, context: {user_name: "Alice"})
+        agent.generate
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.first.content).must_equal "Alice"
       end
 
-      it "does not prepend system message" do
-        agent = agent_class.new
+      it "does not prepend the agent's configured instructions" do
         messages = [
           Riffer::Messages::System.new("Custom instructions."),
           Riffer::Messages::User.new("Hello")
         ]
-        agent.generate(messages)
-        system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+        agent = agent_class.new(session: Riffer::Session.new(messages: messages))
+        agent.generate
+        system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
         expect(system_messages.length).must_equal 1
         expect(system_messages.first.content).must_equal "Custom instructions."
       end
 
-      it "executes pending tool calls from hash-serialized messages" do
+      it "executes pending tool calls left by a prior interrupt" do
         tc = Class.new(Riffer::Tool) do
           description "Simple tool"
           def call(context:)
@@ -2415,29 +2208,27 @@ describe Riffer::Agent do
           uses_tools [tool]
         end
 
-        agent = custom_agent_class.new
+        messages = [
+          Riffer::Messages::User.new("Call tool"),
+          Riffer::Messages::Assistant.new("", tool_calls: [
+            Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}")
+          ])
+        ]
+        agent = custom_agent_class.new(session: Riffer::Session.new(messages: messages))
         provider = agent.send(:provider_instance)
         provider.stub_response("All done!")
 
-        messages = [
-          {role: "user", content: "Call tool"},
-          {role: "assistant", content: "", tool_calls: [{call_id: "c_1", name: "cross_process_pending_tool", arguments: "{}"}]}
-        ]
-        result = agent.generate(messages)
+        result = agent.generate
         expect(result.interrupted?).must_equal false
 
-        tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+        tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
         expect(tool_messages.length).must_equal 1
         expect(tool_messages.first.content).must_equal "done"
       end
 
-      it "clears context when not provided on cross-process resume" do
-        agent = agent_class.new
-        agent.generate([Riffer::Messages::User.new("Hello")], context: {user: "Alice"})
-
-        fresh_agent = agent_class.new
-        fresh_agent.generate([Riffer::Messages::User.new("Hello")])
-        expect(fresh_agent.send(:instance_variable_get, :@context)).must_be_nil
+      it "defaults context to nil when not provided" do
+        agent = agent_class.new(session: Riffer::Session.new(messages: [Riffer::Messages::User.new("Hello")]))
+        expect(agent.send(:instance_variable_get, :@context)).must_be_nil
       end
     end
 
@@ -2465,7 +2256,7 @@ describe Riffer::Agent do
 
         # First generate: runs 2 steps then gets interrupted by callback
         interrupted_once = false
-        agent.on_message do |msg|
+        agent.session.on_message do |msg|
           if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
             interrupted_once = true
             throw :riffer_interrupt
@@ -2489,18 +2280,19 @@ describe Riffer::Agent do
           uses_tools [tc]
         end
 
-        agent = custom_agent_class.new
-        provider = agent.send(:provider_instance)
-        # Only 1 more step fits before max_steps (3 prior + 1 = 4)
-        provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}])
-
-        result = agent.generate([
+        seeded = Riffer::Session.new(messages: [
           Riffer::Messages::User.new("Original prompt"),
           Riffer::Messages::Assistant.new("Step 1", tool_calls: []),
           Riffer::Messages::Assistant.new("Step 2", tool_calls: []),
           Riffer::Messages::Assistant.new("Step 3", tool_calls: []),
           Riffer::Messages::User.new("Continue")
         ])
+        agent = custom_agent_class.new(session: seeded)
+        provider = agent.send(:provider_instance)
+        # Only 1 more step fits before max_steps (3 prior + 1 = 4)
+        provider.stub_response("", tool_calls: [{name: "resume_step_tool", arguments: "{}"}])
+
+        result = agent.generate
         expect(result.interrupted?).must_equal true
         expect(result.interrupt_reason).must_equal :max_steps
       end
@@ -2520,7 +2312,7 @@ describe Riffer::Agent do
         provider.stub_response('{"sentiment":"positive"}')
 
         interrupted_once = false
-        agent.on_message do |_msg|
+        agent.session.on_message do |_msg|
           unless interrupted_once
             interrupted_once = true
             throw :riffer_interrupt
@@ -2565,7 +2357,7 @@ describe Riffer::Agent do
     it "returns an Enumerator" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2579,7 +2371,7 @@ describe Riffer::Agent do
     it "yields stream events on in-memory resume" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2594,7 +2386,7 @@ describe Riffer::Agent do
     it "does not yield Interrupt event on successful resume" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2642,18 +2434,18 @@ describe Riffer::Agent do
     it "continues conversation when calling generate with a string on an agent with existing messages" do
       agent = agent_class.new
       agent.generate("Hello")
-      messages_before = agent.messages.length
+      messages_before = agent.session.messages.length
 
       result = agent.generate("Follow up")
       expect(result).must_be_instance_of Riffer::Agent::Response
-      expect(agent.messages.length).must_be :>, messages_before
+      expect(agent.session.messages.length).must_be :>, messages_before
     end
 
     it "does not duplicate system messages on continuation" do
       agent = agent_class.new
       agent.generate("Hello")
       agent.generate("Follow up")
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       expect(system_messages.length).must_equal 1
     end
 
@@ -2661,7 +2453,7 @@ describe Riffer::Agent do
       agent = agent_class.new
       agent.generate("Hello")
       agent.generate("Follow up")
-      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      user_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::User) }
       expect(user_messages.length).must_equal 2
       expect(user_messages.last.content).must_equal "Follow up"
     end
@@ -2669,7 +2461,7 @@ describe Riffer::Agent do
     it "resumes after interrupt with a new user message" do
       agent = agent_class.new
       interrupted_once = false
-      agent.on_message do |_msg|
+      agent.session.on_message do |_msg|
         unless interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2681,7 +2473,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Continue please")
       expect(result.interrupted?).must_equal false
-      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      user_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::User) }
       expect(user_messages.length).must_equal 2
     end
 
@@ -2708,7 +2500,7 @@ describe Riffer::Agent do
       provider.stub_response("Done!")
 
       tool_count = 0
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         if msg.is_a?(Riffer::Messages::Tool)
           tool_count += 1
           throw :riffer_interrupt if tool_count == 1
@@ -2717,12 +2509,12 @@ describe Riffer::Agent do
 
       result = agent.generate("Call tools")
       expect(result.interrupted?).must_equal true
-      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 1
 
       result = agent.generate("Go ahead")
       expect(result.interrupted?).must_equal false
-      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 2
     end
 
@@ -2746,7 +2538,7 @@ describe Riffer::Agent do
       3.times { provider.stub_response("", tool_calls: [{name: "continuation_step_tool", arguments: "{}"}]) }
 
       interrupted_once = false
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         if msg.is_a?(Riffer::Messages::Tool) && !interrupted_once
           interrupted_once = true
           throw :riffer_interrupt
@@ -2769,7 +2561,7 @@ describe Riffer::Agent do
       text_events = events.select { |e| e.is_a?(Riffer::StreamEvents::TextDelta) }
       expect(text_events).wont_be_empty
 
-      user_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::User) }
+      user_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::User) }
       expect(user_messages.length).must_equal 2
     end
   end
@@ -2798,7 +2590,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Call tool")
       expect(result.interrupted?).must_equal false
-      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 1
     end
   end
@@ -2827,7 +2619,7 @@ describe Riffer::Agent do
       provider.stub_response("Done!")
 
       tool_count = 0
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         if msg.is_a?(Riffer::Messages::Tool)
           tool_count += 1
           throw :riffer_interrupt if tool_count == 1
@@ -2837,13 +2629,13 @@ describe Riffer::Agent do
       events = agent.stream("Call tools").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).wont_be_nil
-      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 1
 
       events = agent.stream("Continue").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).must_be_nil
-      tool_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      tool_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tool_messages.length).must_equal 2
     end
   end
@@ -2851,7 +2643,7 @@ describe Riffer::Agent do
   describe "interruptible callbacks with #stream" do
     it "yields Interrupt event" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt }
+      agent.session.on_message { |_msg| throw :riffer_interrupt }
       events = agent.stream("Hello").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event).wont_be_nil
@@ -2859,7 +2651,7 @@ describe Riffer::Agent do
 
     it "yields Interrupt event with reason" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt, "budget exceeded" }
+      agent.session.on_message { |_msg| throw :riffer_interrupt, "budget exceeded" }
       events = agent.stream("Hello").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event.reason).must_equal "budget exceeded"
@@ -2867,7 +2659,7 @@ describe Riffer::Agent do
 
     it "yields Interrupt event with nil reason when none given" do
       agent = agent_class.new
-      agent.on_message { |_msg| throw :riffer_interrupt }
+      agent.session.on_message { |_msg| throw :riffer_interrupt }
       events = agent.stream("Hello").to_a
       interrupt_event = events.find { |e| e.is_a?(Riffer::StreamEvents::Interrupt) }
       expect(interrupt_event.reason).must_be_nil
@@ -2879,7 +2671,7 @@ describe Riffer::Agent do
       let(:emitted) { [] }
       let(:agent) do
         a = agent_class.new
-        a.on_message { |msg| emitted << msg }
+        a.session.on_message { |msg| emitted << msg }
         a.stream("Hello").each { |_| }
         a
       end
@@ -2923,7 +2715,7 @@ describe Riffer::Agent do
         ])
         provider.stub_response("The weather is nice!")
 
-        a.on_message { |msg| emitted << msg }
+        a.session.on_message { |msg| emitted << msg }
         a.stream("What's the weather?").each { |_| }
         a
       end
@@ -3003,7 +2795,7 @@ describe Riffer::Agent do
       provider = agent.send(:provider_instance)
       provider.stub_response("Hello!", token_usage: token_usage)
       agent.generate("Hi")
-      assistant = agent.messages.find { |m| m.is_a?(Riffer::Messages::Assistant) }
+      assistant = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Assistant) }
       expect(assistant.token_usage).must_equal token_usage
     end
   end
@@ -3035,7 +2827,7 @@ describe Riffer::Agent do
       provider = agent.send(:provider_instance)
       provider.stub_response("Hello!", token_usage: token_usage)
       agent.stream("Hi").each { |_| }
-      assistant = agent.messages.find { |m| m.is_a?(Riffer::Messages::Assistant) }
+      assistant = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Assistant) }
       expect(assistant.token_usage).must_equal token_usage
     end
 
@@ -3286,7 +3078,7 @@ describe Riffer::Agent do
       it "transforms input messages" do
         agent = agent_with_transform.new
         agent.generate("Hello")
-        user_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::User) }
+        user_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::User) }
         expect(user_message.content).must_equal "[INPUT] Hello"
       end
 
@@ -3467,7 +3259,7 @@ describe Riffer::Agent do
         model "mock/riffer-1"
         instructions ->(context) { "Helping #{context[:name]}" }
       end
-      agent = klass.new
+      agent = klass.new(context: {name: "init"})
       msg = agent.generate_instruction_message(context: {name: "Alice"})
       expect(msg.content).must_equal "Helping Alice"
     end
@@ -3716,166 +3508,6 @@ describe Riffer::Agent do
     end
   end
 
-  describe "history read accessors" do
-    let(:user) { Riffer::Messages::User.new("hi", id: "u_1") }
-    let(:assistant) { Riffer::Messages::Assistant.new("hello", id: "a_1") }
-    let(:assistant_with_tool) do
-      tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "t", arguments: "{}")
-      Riffer::Messages::Assistant.new("", id: "a_2", tool_calls: [tc])
-    end
-    let(:tool_msg) { Riffer::Messages::Tool.new("ok", id: "t_1", tool_call_id: "c_1", name: "t") }
-
-    let(:agent) do
-      a = agent_class.new
-      a.instance_variable_set(:@messages, [user, assistant, assistant_with_tool, tool_msg])
-      a
-    end
-
-    describe "#message_by_id" do
-      it "returns the matching message" do
-        expect(agent.message_by_id("a_1")).must_equal assistant
-      end
-
-      it "returns nil when no message matches" do
-        expect(agent.message_by_id("missing")).must_be_nil
-      end
-    end
-
-    describe "#tool_message_for" do
-      it "returns the tool message for the call_id" do
-        expect(agent.tool_message_for("c_1")).must_equal tool_msg
-      end
-
-      it "returns nil when no tool result exists for the call_id" do
-        expect(agent.tool_message_for("missing")).must_be_nil
-      end
-    end
-
-    describe "#last_assistant" do
-      it "returns the most recent assistant message" do
-        expect(agent.last_assistant).must_equal assistant_with_tool
-      end
-
-      it "returns nil when there is no assistant message" do
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [user])
-        expect(a.last_assistant).must_be_nil
-      end
-    end
-
-    describe "#orphaned_tool_call_ids" do
-      it "returns [] when every tool_call has a matching tool result" do
-        expect(agent.orphaned_tool_call_ids).must_equal []
-      end
-
-      it "returns the unmatched call_ids" do
-        tc1 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
-        tc2 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
-        asst = Riffer::Messages::Assistant.new("", id: "a_x", tool_calls: [tc1, tc2])
-        result = Riffer::Messages::Tool.new("ok", id: "t_x", tool_call_id: "c_a", name: "t")
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [asst, result])
-        expect(a.orphaned_tool_call_ids).must_equal ["c_b"]
-      end
-
-      it "returns [] for an empty agent" do
-        expect(agent_class.new.orphaned_tool_call_ids).must_equal []
-      end
-    end
-  end
-
-  describe "history mutators" do
-    let(:user) { Riffer::Messages::User.new("hi", id: "u_1") }
-    let(:plain_assistant) { Riffer::Messages::Assistant.new("hello", id: "a_1") }
-    let(:tc) { Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "weather", arguments: "{}") }
-    let(:tool_assistant) { Riffer::Messages::Assistant.new("", id: "a_2", tool_calls: [tc]) }
-    let(:tool_msg) { Riffer::Messages::Tool.new("sunny", id: "t_1", tool_call_id: "c_1", name: "weather") }
-
-    let(:agent) do
-      a = agent_class.new
-      a.instance_variable_set(:@messages, [user, plain_assistant, tool_assistant, tool_msg])
-      a
-    end
-
-    describe "#replace_assistant_content" do
-      it "replaces content while preserving id, tool_calls, token_usage" do
-        result = agent.replace_assistant_content(id: "a_2", content: "I checked.")
-        expect(result.content).must_equal "I checked."
-        expect(result.id).must_equal "a_2"
-        expect(result.tool_calls).must_equal [tc]
-        expect(agent.message_by_id("a_2").content).must_equal "I checked."
-      end
-
-      it "raises Riffer::ArgumentError on unknown id" do
-        expect { agent.replace_assistant_content(id: "missing", content: "x") }.must_raise Riffer::ArgumentError
-      end
-
-      it "delegates to #remove_message when content is empty" do
-        agent.replace_assistant_content(id: "a_1", content: "")
-        expect(agent.message_by_id("a_1")).must_be_nil
-      end
-
-      it "removes Tool children when content is empty and the assistant has tool_calls" do
-        agent.replace_assistant_content(id: "a_2", content: "")
-        expect(agent.message_by_id("a_2")).must_be_nil
-        expect(agent.tool_message_for("c_1")).must_be_nil
-      end
-    end
-
-    describe "#remove_message" do
-      it "removes a plain assistant message" do
-        result = agent.remove_message(id: "a_1")
-        expect(result).must_equal plain_assistant
-        expect(agent.message_by_id("a_1")).must_be_nil
-      end
-
-      it "cascades to Tool children when the target carries tool_calls" do
-        agent.remove_message(id: "a_2")
-        expect(agent.message_by_id("a_2")).must_be_nil
-        expect(agent.tool_message_for("c_1")).must_be_nil
-      end
-
-      it "removes user and system messages" do
-        sys_msg = Riffer::Messages::System.new("hi", id: "s_1")
-        a = agent_class.new
-        a.instance_variable_set(:@messages, [sys_msg, user])
-        a.remove_message(id: "u_1")
-        expect(a.message_by_id("u_1")).must_be_nil
-        a.remove_message(id: "s_1")
-        expect(a.message_by_id("s_1")).must_be_nil
-      end
-
-      it "raises Riffer::ArgumentError when called on a Tool message" do
-        expect { agent.remove_message(id: "t_1") }.must_raise Riffer::ArgumentError
-      end
-
-      it "returns nil when no message matches" do
-        expect(agent.remove_message(id: "missing")).must_be_nil
-      end
-    end
-
-    describe "#replace_tool_result" do
-      it "replaces content; preserves name and id" do
-        result = agent.replace_tool_result(tool_call_id: "c_1", content: "rainy")
-        expect(result.content).must_equal "rainy"
-        expect(result.tool_call_id).must_equal "c_1"
-        expect(result.name).must_equal "weather"
-        expect(result.id).must_equal "t_1"
-      end
-
-      it "plumbs error and error_type" do
-        result = agent.replace_tool_result(tool_call_id: "c_1", content: "boom", error: "failed", error_type: :execution_error)
-        expect(result.error).must_equal "failed"
-        expect(result.error_type).must_equal :execution_error
-        expect(result.error?).must_equal true
-      end
-
-      it "raises Riffer::ArgumentError on unknown tool_call_id" do
-        expect { agent.replace_tool_result(tool_call_id: "missing", content: "x") }.must_raise Riffer::ArgumentError
-      end
-    end
-  end
-
   describe "interrupt! with experimental_history_healing" do
     let(:tool_class) do
       Class.new(Riffer::Tool) do
@@ -3903,7 +3535,7 @@ describe Riffer::Agent do
         {name: "interrupt_heal_tool", arguments: "{}"}
       ])
 
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         agent.interrupt!(:user_interrupt) if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
       end
 
@@ -3911,8 +3543,8 @@ describe Riffer::Agent do
 
       expect(result.interrupted?).must_equal true
       expect(result.healed_tool_call_ids.length).must_equal 2
-      expect(agent.orphaned_tool_call_ids).must_equal []
-      tools = agent.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
+      expect(agent.session.orphaned_tool_call_ids).must_equal []
+      tools = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) }
       expect(tools.length).must_equal 2
       expect(tools.first.error_type).must_equal :interrupted
       expect(tools.first.content).must_equal "Tool call interrupted before completion."
@@ -3929,7 +3561,7 @@ describe Riffer::Agent do
       provider = agent.send(:provider_instance)
       provider.stub_response("", tool_calls: [{name: "interrupt_heal_tool", arguments: "{}"}])
 
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
       end
 
@@ -3937,7 +3569,7 @@ describe Riffer::Agent do
 
       expect(result.interrupted?).must_equal true
       expect(result.healed_tool_call_ids).must_equal []
-      expect(agent.orphaned_tool_call_ids.length).must_equal 1
+      expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
 
     it "does not fire on_message for placeholder tool messages" do
@@ -3953,7 +3585,7 @@ describe Riffer::Agent do
       provider.stub_response("", tool_calls: [{name: "interrupt_heal_tool", arguments: "{}"}])
 
       seen = []
-      agent.on_message do |msg|
+      agent.session.on_message do |msg|
         seen << msg
         agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) && !msg.tool_calls.empty?
       end
@@ -3998,8 +3630,8 @@ describe Riffer::Agent do
       expect(result.interrupted?).must_equal true
       expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
       expect(result.healed_tool_call_ids.length).must_equal 1
-      expect(agent.orphaned_tool_call_ids).must_equal []
-      synth = agent.messages.last
+      expect(agent.session.orphaned_tool_call_ids).must_equal []
+      synth = agent.session.messages.last
       expect(synth).must_be_kind_of Riffer::Messages::Tool
       expect(synth.error_type).must_equal :interrupted
     end
@@ -4022,7 +3654,7 @@ describe Riffer::Agent do
       expect(result.interrupted?).must_equal true
       expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
       expect(result.healed_tool_call_ids).must_equal []
-      expect(agent.orphaned_tool_call_ids.length).must_equal 1
+      expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
   end
 
@@ -4033,22 +3665,22 @@ describe Riffer::Agent do
 
     it "passes seeded history through untouched when healing is off (default)" do
       tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_orphan", name: "t", arguments: "{}")
-      messages = [
+      seeded = Riffer::Session.new(messages: [
         Riffer::Messages::User.new("hi"),
         Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
         Riffer::Messages::Assistant.new("", tool_calls: [tc]),
         Riffer::Messages::User.new("follow up"),
         Riffer::Messages::Assistant.new("ok")
-      ]
-      agent = custom_class.new
+      ])
+      agent = custom_class.new(session: seeded)
       agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages)
+      agent.generate
 
-      assistant_with_orphan = agent.messages.find { |m|
+      assistant_with_orphan = agent.session.messages.find { |m|
         m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_orphan" }
       }
       refute_nil assistant_with_orphan
-      parentless = agent.messages.find { |m|
+      parentless = agent.session.messages.find { |m|
         m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_missing"
       }
       refute_nil parentless
@@ -4057,42 +3689,42 @@ describe Riffer::Agent do
     it "strips orphaned tool exchanges from non-last assistants when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_drop", name: "t", arguments: "{}")
-      messages = [
+      seeded = Riffer::Session.new(messages: [
         Riffer::Messages::User.new("hi"),
         Riffer::Messages::Assistant.new("", tool_calls: [tc]),
         Riffer::Messages::User.new("anyway"),
         Riffer::Messages::Assistant.new("never mind")
-      ]
+      ])
 
-      agent = custom_class.new
+      agent = custom_class.new(session: seeded)
       agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages)
+      agent.generate
 
-      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_drop" } }).must_equal true
+      expect(agent.session.messages.none? { |m| m.is_a?(Riffer::Messages::Assistant) && m.tool_calls.any? { |x| x.call_id == "c_drop" } }).must_equal true
     end
 
     it "strips parentless tool messages when healing is on" do
       Riffer.config.experimental_history_healing = true
-      messages = [
+      seeded = Riffer::Session.new(messages: [
         Riffer::Messages::User.new("hi"),
         Riffer::Messages::Tool.new("ghost", tool_call_id: "c_missing", name: "t"),
         Riffer::Messages::User.new("follow-up")
-      ]
+      ])
 
-      agent = custom_class.new
+      agent = custom_class.new(session: seeded)
       agent.send(:provider_instance).stub_response("Hello!")
-      agent.generate(messages)
+      agent.generate
 
-      expect(agent.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
+      expect(agent.session.messages.none? { |m| m.is_a?(Riffer::Messages::Tool) }).must_equal true
     end
 
     it "preserves a pending tool_use on the resume boundary even when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_pending", name: "pending_seed_tool", arguments: "{}")
-      messages = [
+      seeded = Riffer::Session.new(messages: [
         Riffer::Messages::User.new("Call tool"),
         Riffer::Messages::Assistant.new("", tool_calls: [tc])
-      ]
+      ])
       tool = Class.new(Riffer::Tool) do
         description "Pending tool"
         def call(context:)
@@ -4104,9 +3736,9 @@ describe Riffer::Agent do
         uses_tools [tool]
       end
 
-      agent = with_tools.new
+      agent = with_tools.new(session: seeded)
       agent.send(:provider_instance).stub_response("All done!")
-      result = agent.generate(messages)
+      result = agent.generate
       expect(result.interrupted?).must_equal false
     end
   end

--- a/test/riffer/session_test.rb
+++ b/test/riffer/session_test.rb
@@ -10,9 +10,7 @@ describe Riffer::Session do
   let(:tool_msg) { Riffer::Messages::Tool.new("sunny", id: "t_1", tool_call_id: "c_1", name: "weather") }
 
   let(:session) do
-    s = Riffer::Session.new
-    s.instance_variable_set(:@messages, [user, plain_assistant, tool_assistant, tool_msg])
-    s
+    Riffer::Session.new(messages: [user, plain_assistant, tool_assistant, tool_msg])
   end
 
   describe "#initialize" do

--- a/test/riffer/session_test.rb
+++ b/test/riffer/session_test.rb
@@ -1,0 +1,316 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Session do
+  let(:user) { Riffer::Messages::User.new("hi", id: "u_1") }
+  let(:plain_assistant) { Riffer::Messages::Assistant.new("hello", id: "a_1") }
+  let(:tc) { Riffer::Messages::Assistant::ToolCall.new(call_id: "c_1", name: "weather", arguments: "{}") }
+  let(:tool_assistant) { Riffer::Messages::Assistant.new("", id: "a_2", tool_calls: [tc]) }
+  let(:tool_msg) { Riffer::Messages::Tool.new("sunny", id: "t_1", tool_call_id: "c_1", name: "weather") }
+
+  let(:session) do
+    s = Riffer::Session.new
+    s.instance_variable_set(:@messages, [user, plain_assistant, tool_assistant, tool_msg])
+    s
+  end
+
+  describe "#initialize" do
+    it "defaults to an empty messages array" do
+      expect(Riffer::Session.new.messages).must_equal []
+    end
+
+    it "accepts a seeded messages array" do
+      expect(Riffer::Session.new(messages: [user]).messages).must_equal [user]
+    end
+  end
+
+  describe "#on_message" do
+    it "raises Riffer::ArgumentError when no block is given" do
+      error = expect { Riffer::Session.new.on_message }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_match(/on_message requires a block/)
+    end
+
+    it "returns self for chaining" do
+      s = Riffer::Session.new
+      expect(s.on_message { |_| }).must_be_same_as s
+    end
+
+    it "fires every registered callback in order on #add" do
+      calls = []
+      s = Riffer::Session.new
+      s.on_message { |m| calls << [1, m] }
+      s.on_message { |m| calls << [2, m] }
+      s.add(user)
+      expect(calls).must_equal [[1, user], [2, user]]
+    end
+
+    it "does not fire callbacks on #set" do
+      fired = []
+      s = Riffer::Session.new
+      s.on_message { |m| fired << m }
+      s.set([user, plain_assistant])
+      expect(fired).must_equal []
+    end
+
+    it "does not fire callbacks on #unset" do
+      fired = []
+      s = Riffer::Session.new(messages: [plain_assistant])
+      s.on_message { |m| fired << m }
+      s.unset
+      expect(fired).must_equal []
+    end
+
+    it "preserves registered callbacks across #set" do
+      fired = []
+      s = Riffer::Session.new
+      s.on_message { |m| fired << m }
+      s.set([user])
+      s.add(plain_assistant)
+      expect(fired).must_equal [plain_assistant]
+    end
+
+    it "does not fire callbacks on #update" do
+      fired = []
+      s = Riffer::Session.new(messages: [plain_assistant])
+      s.on_message { |m| fired << m }
+      s.update(id: "a_1", content: "new")
+      expect(fired).must_equal []
+    end
+
+    it "does not fire callbacks on #remove" do
+      fired = []
+      s = Riffer::Session.new(messages: [plain_assistant])
+      s.on_message { |m| fired << m }
+      s.remove(id: "a_1")
+      expect(fired).must_equal []
+    end
+  end
+
+  describe "#add" do
+    it "appends the message to #messages" do
+      s = Riffer::Session.new
+      s.add(user)
+      expect(s.messages).must_equal [user]
+    end
+
+    it "returns the appended message" do
+      s = Riffer::Session.new
+      expect(s.add(user)).must_be_same_as user
+    end
+  end
+
+  describe "#set" do
+    it "replaces the messages array with the given array" do
+      s = Riffer::Session.new(messages: [user])
+      s.set([plain_assistant])
+      expect(s.messages).must_equal [plain_assistant]
+    end
+
+    it "returns self for chaining" do
+      s = Riffer::Session.new
+      expect(s.set([user])).must_be_same_as s
+    end
+  end
+
+  describe "#unset" do
+    it "clears the session" do
+      s = Riffer::Session.new(messages: [user, plain_assistant])
+      s.unset
+      expect(s.messages).must_equal []
+    end
+
+    it "returns self for chaining" do
+      s = Riffer::Session.new(messages: [user])
+      expect(s.unset).must_be_same_as s
+    end
+  end
+
+  describe "#remove" do
+    it "removes a plain assistant message and returns it" do
+      result = session.remove(id: "a_1")
+      expect(result).must_equal plain_assistant
+      expect(session.find { |m| m.id == "a_1" }).must_be_nil
+    end
+
+    it "cascades to Tool children when the target carries tool_calls" do
+      session.remove(id: "a_2")
+      expect(session.find { |m| m.id == "a_2" }).must_be_nil
+      expect(session.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_1" }).must_be_nil
+    end
+
+    it "removes user and system messages" do
+      sys_msg = Riffer::Messages::System.new("hi", id: "s_1")
+      s = Riffer::Session.new(messages: [sys_msg, user])
+      s.remove(id: "u_1")
+      expect(s.find { |m| m.id == "u_1" }).must_be_nil
+      s.remove(id: "s_1")
+      expect(s.find { |m| m.id == "s_1" }).must_be_nil
+    end
+
+    it "raises Riffer::ArgumentError when called on a Tool message" do
+      expect { session.remove(id: "t_1") }.must_raise Riffer::ArgumentError
+    end
+
+    it "returns nil when no message matches" do
+      expect(session.remove(id: "missing")).must_be_nil
+    end
+  end
+
+  describe "#update with id:" do
+    it "replaces content preserving id, tool_calls, token_usage on assistant" do
+      usage = Riffer::TokenUsage.new(input_tokens: 1, output_tokens: 2)
+      a = Riffer::Messages::Assistant.new("old", id: "a_x", tool_calls: [tc], token_usage: usage)
+      s = Riffer::Session.new(messages: [a])
+      result = s.update(id: "a_x", content: "new")
+      expect(result.content).must_equal "new"
+      expect(result.id).must_equal "a_x"
+      expect(result.tool_calls).must_equal [tc]
+      expect(result.token_usage).must_be_same_as usage
+    end
+
+    it "preserves files on a user message" do
+      file = Riffer::FilePart.new(media_type: "text/plain", data: "x")
+      u = Riffer::Messages::User.new("old", id: "u_x", files: [file])
+      s = Riffer::Session.new(messages: [u])
+      result = s.update(id: "u_x", content: "new")
+      expect(result.content).must_equal "new"
+      expect(result.files).must_equal [file]
+    end
+
+    it "updates a system message in place" do
+      sys = Riffer::Messages::System.new("old", id: "s_x")
+      s = Riffer::Session.new(messages: [sys])
+      result = s.update(id: "s_x", content: "new")
+      expect(result.content).must_equal "new"
+      expect(result.id).must_equal "s_x"
+    end
+
+    it "raises Riffer::ArgumentError on unknown id" do
+      expect { session.update(id: "missing", content: "x") }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises Riffer::ArgumentError when both id: and tool_call_id: are given" do
+      expect { session.update(id: "a_1", tool_call_id: "c_1", content: "x") }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises Riffer::ArgumentError when neither id: nor tool_call_id: is given" do
+      expect { session.update(content: "x") }.must_raise Riffer::ArgumentError
+    end
+
+    it "cascades to Tool children when tool_calls is cleared" do
+      session.update(id: "a_2", tool_calls: [])
+      expect(session.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_1" }).must_be_nil
+    end
+
+    it "cascades to Tool children only for dropped call_ids" do
+      tc_a = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
+      tc_b = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
+      asst = Riffer::Messages::Assistant.new("", id: "a_x", tool_calls: [tc_a, tc_b])
+      tool_a = Riffer::Messages::Tool.new("a", id: "t_a", tool_call_id: "c_a", name: "t")
+      tool_b = Riffer::Messages::Tool.new("b", id: "t_b", tool_call_id: "c_b", name: "t")
+      s = Riffer::Session.new(messages: [asst, tool_a, tool_b])
+      s.update(id: "a_x", tool_calls: [tc_a])
+      expect(s.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_a" }).must_equal tool_a
+      expect(s.find { |m| m.is_a?(Riffer::Messages::Tool) && m.tool_call_id == "c_b" }).must_be_nil
+    end
+  end
+
+  describe "#update with tool_call_id:" do
+    it "replaces tool result content preserving name and id" do
+      result = session.update(tool_call_id: "c_1", content: "rainy")
+      expect(result.content).must_equal "rainy"
+      expect(result.tool_call_id).must_equal "c_1"
+      expect(result.name).must_equal "weather"
+      expect(result.id).must_equal "t_1"
+    end
+
+    it "plumbs error and error_type" do
+      result = session.update(tool_call_id: "c_1", content: "boom", error: "failed", error_type: :execution_error)
+      expect(result.error).must_equal "failed"
+      expect(result.error_type).must_equal :execution_error
+      expect(result.error?).must_equal true
+    end
+
+    it "raises Riffer::ArgumentError on unknown tool_call_id" do
+      expect { session.update(tool_call_id: "missing", content: "x") }.must_raise Riffer::ArgumentError
+    end
+  end
+
+  describe "#orphaned_tool_call_ids" do
+    it "returns [] when every tool_call has a matching tool result" do
+      expect(session.orphaned_tool_call_ids).must_equal []
+    end
+
+    it "returns the unmatched call_ids" do
+      tc1 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
+      tc2 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
+      asst = Riffer::Messages::Assistant.new("", id: "a_x", tool_calls: [tc1, tc2])
+      result = Riffer::Messages::Tool.new("ok", id: "t_x", tool_call_id: "c_a", name: "t")
+      s = Riffer::Session.new(messages: [asst, result])
+      expect(s.orphaned_tool_call_ids).must_equal ["c_b"]
+    end
+
+    it "returns [] for an empty session" do
+      expect(Riffer::Session.new.orphaned_tool_call_ids).must_equal []
+    end
+  end
+
+  describe "#pending_tool_calls" do
+    it "returns [nil, []] for an empty session" do
+      expect(Riffer::Session.new.pending_tool_calls).must_equal [nil, []]
+    end
+
+    it "returns [assistant, []] when the last assistant has no tool_calls" do
+      s = Riffer::Session.new(messages: [plain_assistant])
+      assistant, pending = s.pending_tool_calls
+      expect(assistant).must_equal plain_assistant
+      expect(pending).must_equal []
+    end
+
+    it "returns [assistant, []] when every tool_call has a matching result" do
+      assistant, pending = session.pending_tool_calls
+      expect(assistant).must_equal tool_assistant
+      expect(pending).must_equal []
+    end
+
+    it "returns [assistant, pending] when some calls are unanswered" do
+      tc1 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_a", name: "t", arguments: "{}")
+      tc2 = Riffer::Messages::Assistant::ToolCall.new(call_id: "c_b", name: "t", arguments: "{}")
+      asst = Riffer::Messages::Assistant.new("", id: "a_x", tool_calls: [tc1, tc2])
+      result = Riffer::Messages::Tool.new("ok", id: "t_x", tool_call_id: "c_a", name: "t")
+      s = Riffer::Session.new(messages: [asst, result])
+      assistant, pending = s.pending_tool_calls
+      expect(assistant).must_equal asst
+      expect(pending.map(&:call_id)).must_equal ["c_b"]
+    end
+  end
+
+  describe "Enumerable" do
+    it "yields each message via #each" do
+      collected = []
+      session.each { |m| collected << m }
+      expect(collected).must_equal [user, plain_assistant, tool_assistant, tool_msg]
+    end
+
+    it "supports #find" do
+      expect(session.find { |m| m.id == "a_1" }).must_equal plain_assistant
+    end
+
+    it "supports #count with a block" do
+      expect(session.count { |m| m.is_a?(Riffer::Messages::Assistant) }).must_equal 2
+    end
+
+    it "supports #reverse_each" do
+      # TODO: Replace with rfind when minimum Ruby is 4.0+
+      # rubocop:disable Style/ReverseFind
+      first_assistant_from_end = session.reverse_each.find { |m| m.is_a?(Riffer::Messages::Assistant) }
+      # rubocop:enable Style/ReverseFind
+      expect(first_assistant_from_end).must_equal tool_assistant
+    end
+
+    it "returns an Enumerator when #each is called without a block" do
+      expect(session.each).must_be_kind_of Enumerator
+    end
+  end
+end

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -18,7 +18,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       assert_equal 2, system_messages.length
       assert_includes system_messages[0].content, "You are helpful."
       assert_includes system_messages[1].content, "Available Skills"
@@ -37,7 +37,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_message = system_messages.find { |m| m.content.include?("Available Skills") }
       assert_includes skills_message.content, "## Available Skills"
       assert_includes skills_message.content, "- **code-review**"
@@ -55,7 +55,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_message = system_messages.find { |m| m.content.include?("available_skills") }
       assert_includes skills_message.content, "<available_skills>"
     end
@@ -71,7 +71,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_message = system_messages.find { |m| m.content.include?("<available_skills>") }
       refute_nil skills_message
       assert_includes skills_message.content, "<available_skills>"
@@ -91,7 +91,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_message = system_messages.find { |m| m.content.include?("Available Skills") }
       refute_nil skills_message
       assert_includes skills_message.content, "## Available Skills"
@@ -105,10 +105,10 @@ describe "Agent skills integration" do
         end
       end
 
-      # prepare_run resolves the model and skills without instantiating
-      # the AWS client, so we can assert the adapter without VCR.
+      # The constructor resolves model + skills eagerly without
+      # instantiating the AWS client, so we can assert the adapter
+      # without VCR.
       agent = agent_class.new
-      agent.send(:prepare_run)
 
       skills_state = agent.instance_variable_get(:@skills_state)
       refute_nil skills_state
@@ -124,7 +124,6 @@ describe "Agent skills integration" do
       end
 
       agent = agent_class.new
-      agent.send(:prepare_run)
 
       skills_state = agent.instance_variable_get(:@skills_state)
       refute_nil skills_state
@@ -218,7 +217,7 @@ describe "Agent skills integration" do
       agent.instance_variable_set(:@provider_instance, provider)
       agent.generate("Hello")
 
-      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "spy_tool" }
+      tool_msg = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "spy_tool" }
       refute_nil tool_msg
       assert_includes tool_msg.content, "code-review"
       assert_includes tool_msg.content, "data-analysis"
@@ -237,7 +236,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_msg = system_messages.find { |m| m.content.include?("code-review") }
       refute_nil skills_msg
     end
@@ -254,7 +253,7 @@ describe "Agent skills integration" do
         agent = agent_class.new
         agent.generate("Hello")
 
-        system_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) }
+        system_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::System) }
         assert_nil system_message
       end
     end
@@ -273,7 +272,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      skills_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
+      skills_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
       refute_nil skills_message
       assert_includes skills_message.content, "code-review"
     ensure
@@ -302,7 +301,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      skills_message = agent.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
+      skills_message = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Available Skills") }
       refute_nil skills_message
     ensure
       Riffer.config.skills.default_backend = original_default
@@ -406,7 +405,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       assert_equal 2, system_messages.length
       assert_includes system_messages[0].content, "Base instructions."
       skills_msg = system_messages[1]
@@ -429,7 +428,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_msg = system_messages.find { |m| m.content.include?("code review assistant") }
       refute_nil skills_msg
       refute_includes skills_msg.content, "Available Skills"
@@ -446,8 +445,7 @@ describe "Agent skills integration" do
         end
       end
 
-      agent = agent_class.new
-      error = assert_raises(Riffer::ArgumentError) { agent.generate("Hello") }
+      error = assert_raises(Riffer::ArgumentError) { agent_class.new }
       assert_match(/Unknown skill/, error.message)
     end
 
@@ -460,10 +458,10 @@ describe "Agent skills integration" do
         end
       end
 
-      agent = agent_class.new
-      agent.generate("Hello", context: {activate_skills: ["data-analysis"]})
+      agent = agent_class.new(context: {activate_skills: ["data-analysis"]})
+      agent.generate("Hello")
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       skills_msg = system_messages.find { |m| m.content.include?("data analysis assistant") }
       refute_nil skills_msg
     end
@@ -482,7 +480,7 @@ describe "Agent skills integration" do
       agent = agent_class.new
       agent.stream("Hello").each { |_| }
 
-      system_messages = agent.messages.select { |m| m.is_a?(Riffer::Messages::System) }
+      system_messages = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::System) }
       assert_equal 2, system_messages.length
       skills_msg = system_messages.find { |m| m.content.include?("Available Skills") }
       refute_nil skills_msg
@@ -554,7 +552,7 @@ describe "Agent skills integration" do
 
       assert_equal "Here is my review.", response.content
 
-      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      tool_msg = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
       refute_nil tool_msg
       assert_includes tool_msg.content, "code review assistant"
       refute tool_msg.error
@@ -576,7 +574,7 @@ describe "Agent skills integration" do
       agent.instance_variable_set(:@provider_instance, provider)
       agent.generate("Use nonexistent skill")
 
-      tool_msg = agent.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      tool_msg = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
       refute_nil tool_msg
       assert_includes tool_msg.content, "Unknown skill"
     end


### PR DESCRIPTION
## Summary

- Extract conversation state from `Riffer::Agent` into a new `Riffer::Session` class (`lib/riffer/session.rb`) with a uniform mutation API — `add`, `set`, `unset`, `remove`, `update(id:|tool_call_id:, **attrs)` — plus `Enumerable`, the `on_message` callback list, and the two invariant queries (`orphaned_tool_call_ids`, `pending_tool_calls`).
- Rework `Agent.new` to accept `session:` and `context:`. Without a session it eagerly seeds `[sys, skills].compact` using the constructor-time `context`. With a session it uses it as-is and applies `experimental_history_healing` at init when the flag is on.
- Simplify `Agent#generate` / `Agent#stream` to `(prompt = nil, files: nil)` — no more `prompt_or_messages` discriminated union, no more per-call `context:`. With a prompt, the new user message is silently appended; without one, the loop runs against the current session (resume case). Class-method `Agent.generate` / `Agent.stream` keep `context:` as a convenience that forwards into `new(context:)`.
- Delete `seed_session`, `seed_session_from_array`, `continue_session`, `start_session`, `validate_seed_ids!`, `prepare_run`, `clear_resolved_model`, `extract_final_response`, and all message-API methods on Agent — every caller goes through `agent.session.*` now.
- Cross-process resume: `Riffer::Session.new(messages: persisted)` → `Agent.new(session: session, context: ctx)` → `agent.generate`. The discriminated-union `agent.generate(array_or_string)` path is gone.
- Test sweep: deleted obsolete describe blocks (array-of-messages, array-of-hashes, seed-id-validation), rewrote `resume via generate -> with persisted messages` to use seeded `Riffer::Session`, swept ~110 `agent.messages` / `agent.on_message` references to `agent.session.*`, repointed ~14 `context:` call sites to constructor-context, added a `test/riffer/session_test.rb` covering the new API surface (40+ specs including `#set`/`#unset` callback contracts and Enumerable behavior).
- Docs sweep across `04_AGENT_LIFECYCLE.md`, `08_MESSAGES.md`, `10_CONFIGURATION.md`, `03_AGENTS.md`, `06_TOOLS.md`, `07_TOOL_ADVANCED.md`, `providers/06_MOCK_PROVIDER.md`.

**Breaking changes for consumers (maestro, jane):**

- `agent.messages` / `agent.add_message` / `agent.message_by_id` / `agent.tool_message_for` / `agent.last_assistant` / `agent.orphaned_tool_call_ids` / `agent.replace_assistant_content` / `agent.remove_message` / `agent.replace_tool_result` / `agent.on_message` → all moved to `agent.session.*`. `replace_assistant_content(id:, content:)` is now `session.update(id:, content:)` (with explicit `session.remove(id:)` if you want the old empty-content cascade-to-remove behavior). `replace_tool_result(tool_call_id:, ...)` is now `session.update(tool_call_id:, ...)`.
- `agent.generate(persisted_array, context: ctx)` → `Agent.new(session: Riffer::Session.new(messages: persisted_array), context: ctx).generate`.
- `agent.generate("prompt", context: ctx)` (per-call context) → `Agent.new(context: ctx).generate("prompt")` (context fixed at init). Class-method `MyAgent.generate("prompt", context: ctx)` still works.

The CL2-776 Jira DoD's "Maestro contract forwarders" clause does not match this PR — to be updated separately. Maestro sweep and Jira update are tracked as out-of-band closeout items.

## Test plan

- [ ] Update maestro to call `agent.session.*` instead of `agent.*` for the message API, and construct sessions via `Riffer::Session.new(messages: ...)` for cross-process resume. Coordinate the riffer release with maestro's update.
- [ ] Update Jira CL2-776 DoD to reflect the no-forwarders direction and Session-based resume.
- [ ] Check CL2-779 (Phase 3: Extract Riffer::Run) for any wording that assumed the Phase 1 forwarders would survive.

CI covers: full test suite (1441 tests, `bundle exec rake test`), standard lint (`bundle exec rake standard`), Steep type check, RBS generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-backed conversation model centralizes message history, pending tool-call tracking, and resume behavior.

* **Refactor**
  * Agents now hold context for their lifetime at initialization; per-call context removed.
  * Callbacks and history access are session-centric (register callbacks on the session; read/update/remove history via session APIs).
  * Supplying a prompt appends a user message; omitting it continues the current session.

* **Documentation**
  * Guides and examples updated for session-centric APIs, interrupt/resume, tools/context, and history mutation patterns.

* **Tests**
  * Test suites updated to assert session-based behavior and examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->