### PR TITLE
feat: add bin/ wrappers for common dev commands

### DIFF
--- a/.agents/code-style.md
+++ b/.agents/code-style.md
@@ -4,7 +4,7 @@
 
 - Use StandardRB for linting and formatting
 - Custom rules are defined in `.standard.yml`
-- Run `bundle exec rake standard` to check, `bundle exec rake standard:fix` to auto-fix
+- Run `bin/lint` to check, `bin/lint --fix` to auto-fix
 
 ## Required Header
 

--- a/.agents/rbs-inline.md
+++ b/.agents/rbs-inline.md
@@ -116,8 +116,8 @@ DEFAULTS = {}.freeze #: Hash[Symbol, untyped]
 
 After changing type annotations:
 
-1. Run `bundle exec rake rbs:generate` to regenerate `sig/generated/` files
+1. Run `bin/rbs` to regenerate `sig/generated/` files
 2. Commit both the source changes and the generated `.rbs` files
 3. CI checks for drift between source annotations and committed `.rbs` files
 
-Use `bundle exec rake rbs:watch` during development to auto-regenerate on file changes.
+Use `bin/rbs-watch` during development to auto-regenerate on file changes.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -46,11 +46,15 @@ Record external API interactions in `test/fixtures/vcr_cassettes/`.
 
 ```bash
 # Run all tests
-bundle exec rake test
+bin/test
 
-# Run a single test file
-bundle exec ruby -Ilib:test test/riffer/agent_test.rb
+# Run a single test file (or multiple files)
+bin/test test/riffer/agent_test.rb
+bin/test test/riffer/agent_test.rb test/riffer/config_test.rb
 
-# Run a specific test by name
-bundle exec ruby -Ilib:test test/riffer/agent_test.rb --name "test_something"
+# Filter by test name (regex or substring)
+bin/test test/riffer/agent_test.rb --name /generates/
+
+# Filter across the whole suite
+bin/test --name /generates/
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle exec rake standard
+      - run: bin/lint
 
   test:
     runs-on: ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake test
+      - run: bin/test
 
   rbs:
     runs-on: ubuntu-latest
@@ -43,8 +43,8 @@ jobs:
         with:
           bundler-cache: true
       - name: Generate RBS files
-        run: bundle exec rake rbs:generate
+        run: bin/rbs
       - name: Check for RBS drift
         run: git diff --exit-code sig/generated/
       - name: Run Steep type check
-        run: bundle exec steep check
+        run: bin/typecheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           bundler-cache: true
       - uses: rubygems/configure-rubygems-credentials@v2.0.0
-      - run: bundle exec rake build
+      - run: bin/build
       - run: gem push pkg/riffer-*.gem
 
   docs:
@@ -46,7 +46,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - run: bundle exec rake rdoc
+      - run: bin/docs
       - uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
         with:
           branch: gh-pages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Ruby gem framework for building AI-powered agents with LLM provider adapters.
 ## Quick Reference
 
 - **Ruby**: 3.3.0+ (CI: 3.3, 3.4, 4.0)
-- **Lint + Test**: `bundle exec rake`
+- **Lint + Test**: `bin/rake` (runs the default task: test + standard + steep:check)
 - **Autoloading**: Zeitwerk (file paths must match module/class names)
 - **Model format**: `provider/model` (e.g., `openai/gpt-4`)
 - **Docs**: when adding a public config option or message attribute, update the matching page in `docs/` (e.g., `docs/10_CONFIGURATION.md`, `docs/08_MESSAGES.md`). RDoc ≠ user docs.
@@ -21,12 +21,19 @@ Ruby gem framework for building AI-powered agents with LLM provider adapters.
 
 ## Commands
 
-| Command                         | Description                    |
-| ------------------------------- | ------------------------------ |
-| `bundle exec rake`              | Run tests + lint (default)     |
-| `bundle exec rake test`         | Run tests only                 |
-| `bundle exec rake standard`     | Check code style               |
-| `bundle exec rake standard:fix` | Auto-fix style issues          |
-| `bundle exec rake rbs:generate` | Generate RBS type signatures   |
-| `bundle exec rake rbs:watch`    | Watch and regenerate RBS files |
-| `bin/console`                   | Interactive console            |
+All wrappers `exec bundle exec …` under the hood.
+
+| Command         | Description                                  |
+| --------------- | -------------------------------------------- |
+| `bin/rake`      | Default task: test + standard + steep:check  |
+| `bin/test`      | Run tests                                    |
+| `bin/lint`      | Check code style (pass `--fix` to auto-fix)  |
+| `bin/typecheck` | Run Steep type checker                       |
+| `bin/rbs`       | Generate RBS type signatures                 |
+| `bin/rbs-watch` | Watch and regenerate RBS files               |
+| `bin/docs`      | Build RDoc HTML                              |
+| `bin/build`     | Build the gem package                        |
+| `bin/console`   | Interactive console                          |
+| `bin/setup`     | Install dependencies                         |
+
+`bin/rake <task>` is the escape hatch for any rake task without a named wrapper.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For comprehensive documentation, see the [docs](docs/) directory:
 Generate the full API documentation with:
 
 ```bash
-bundle exec rake docs
+bin/docs
 ```
 
 Then open `doc/index.html` in your browser.
@@ -81,24 +81,23 @@ After checking out the repo, run:
 bin/setup
 ```
 
-Run the test suite:
+Common workflows are wrapped in `bin/`. Each is a thin `exec bundle exec …` script — use them
+instead of typing `bundle exec` yourself:
 
-```bash
-bundle exec rake test
-```
+| Command         | Description                                  |
+| --------------- | -------------------------------------------- |
+| `bin/rake`      | Default task: test + standard + steep:check  |
+| `bin/test`      | Run tests                                    |
+| `bin/lint`      | Check code style (pass `--fix` to auto-fix)  |
+| `bin/typecheck` | Run Steep type checker                       |
+| `bin/rbs`       | Generate RBS type signatures                 |
+| `bin/rbs-watch` | Watch and regenerate RBS files               |
+| `bin/docs`      | Build RDoc HTML                              |
+| `bin/build`     | Build the gem package                        |
+| `bin/console`   | Interactive console                          |
 
-Check and fix code style:
-
-```bash
-bundle exec rake standard
-bundle exec rake standard:fix
-```
-
-Run the interactive console:
-
-```bash
-bin/console
-```
+`bin/rake <task>` is the escape hatch for any rake task without a named wrapper (e.g.
+`bin/rake test:slow`, `bin/rake release`).
 
 ### Recording VCR Cassettes
 
@@ -125,7 +124,7 @@ VCR records the HTTP interactions to `test/fixtures/vcr_cassettes/` on the first
 ## Contributing
 
 1. Fork the repository and create your branch: `git checkout -b feature/foo`
-2. Run tests and linters locally: `bundle exec rake`
+2. Run tests and linters locally: `bin/rake`
 3. Submit a pull request with a clear description of the change
 
 Please follow the [Code of Conduct](https://github.com/janeapp/riffer/blob/main/CODE_OF_CONDUCT.md).

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec rake build "$@"

--- a/bin/docs
+++ b/bin/docs
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec rake rdoc "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec standardrb "$@"

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec rake "$@"

--- a/bin/rbs
+++ b/bin/rbs
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec rake rbs:generate "$@"

--- a/bin/rbs-watch
+++ b/bin/rbs-watch
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec rake rbs:watch "$@"

--- a/bin/test
+++ b/bin/test
@@ -6,15 +6,21 @@ if [ $# -eq 0 ]; then
   exec bundle exec rake test
 fi
 
-# Split positional file args from flag args. Once we see a flag, everything
-# after it is treated as a flag/value (handles `--name /pattern/` correctly).
+# Split file args from flag args. Anything starting with `-` is a flag; for the
+# Minitest flags that take a value, consume the next arg as that value (so
+# `--name /pattern/` parses correctly regardless of file/flag ordering).
 files=()
 opts=()
-seen_flag=false
+expect_value=false
 for arg in "$@"; do
-  if $seen_flag || [[ "$arg" == -* ]]; then
-    seen_flag=true
+  if $expect_value; then
     opts+=("$arg")
+    expect_value=false
+  elif [[ "$arg" == -* ]]; then
+    opts+=("$arg")
+    case "$arg" in
+      --name|-n|--seed|-s|--exclude|-e|--include|-I) expect_value=true ;;
+    esac
   else
     files+=("$arg")
   fi

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# No args: run the full suite via rake.
+if [ $# -eq 0 ]; then
+  exec bundle exec rake test
+fi
+
+# Split positional file args from flag args. Once we see a flag, everything
+# after it is treated as a flag/value (handles `--name /pattern/` correctly).
+files=()
+opts=()
+seen_flag=false
+for arg in "$@"; do
+  if $seen_flag || [[ "$arg" == -* ]]; then
+    seen_flag=true
+    opts+=("$arg")
+  else
+    files+=("$arg")
+  fi
+done
+
+# Only flags, no files: run the full suite via rake, forwarding to Minitest.
+if [ ${#files[@]} -eq 0 ]; then
+  exec bundle exec rake test TESTOPTS="${opts[*]}"
+fi
+
+# Files (and optional flags): load each file via `ruby -r`, forward flags to Minitest.
+requires=()
+for f in "${files[@]}"; do
+  case "$f" in
+    /*) requires+=("-r" "$f") ;;
+    *)  requires+=("-r" "./$f") ;;
+  esac
+done
+
+exec bundle exec ruby -Ilib:test "${requires[@]}" -e "" -- "${opts[@]}"

--- a/bin/typecheck
+++ b/bin/typecheck
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+exec bundle exec steep check "$@"


### PR DESCRIPTION
## Problem

Every dev command in this repo requires the `bundle exec` prefix
(`bundle exec rake test`, `bundle exec rake standard`, `bundle exec steep check`, etc.). It
clutters muscle memory, makes the README and `.agents/` guides noisier than they need to be,
and there's no canonical "run a single test file" workflow — the docs hand-roll it as
`bundle exec ruby -Ilib:test test/foo_test.rb`. Different developers end up reaching for these
commands in different ways.

## Solution

Add eight hand-written bash wrappers in `bin/`, alongside the existing `bin/setup` and
`bin/console`:

| Wrapper        | Underlying command                              |
| -------------- | ----------------------------------------------- |
| `bin/test`     | `rake test`, or `ruby -Ilib:test` for file/name args |
| `bin/lint`     | `standardrb` (so `--fix` and other flags pass through natively) |
| `bin/typecheck`| `steep check`                                   |
| `bin/rbs`      | `rake rbs:generate`                             |
| `bin/rbs-watch`| `rake rbs:watch`                                |
| `bin/docs`     | `rake rdoc`                                     |
| `bin/build`    | `rake build`                                    |
| `bin/rake`     | generic `rake` passthrough (escape hatch for any other task) |

Each is a 2–3 line `exec bundle exec …` script so behaviour, signals, and exit codes pass
through transparently. `bin/test` is the only non-trivial one: with no args it runs the full
suite via rake; with file args it loads them via `ruby -r ./file` and forwards Minitest flags
(`--name`, `--seed`, …) — handling `--name /pattern/` correctly by treating everything after the
first flag as flag/value pairs.

Same change in two other places so the new wrappers don't drift:

- **CI workflows** (`.github/workflows/ci.yml`, `release.yml`) call the same `bin/` wrappers as
  devs do, giving us one source of truth.
- **Docs** (`README.md`, `AGENTS.md`, `.agents/*.md`) reference the wrappers instead of
  `bundle exec …`. The `bundle exec ruby -Itest …` examples in the VCR section stay as-is
  (they're cassette-recording one-offs not worth wrapping).

## Proof

- Manually ran each wrapper locally: `bin/test` (1486 runs, 0 failures), `bin/lint` (clean),
  `bin/typecheck` (no type errors), `bin/rbs` + `git diff sig/generated/` (no drift),
  `bin/rake -T` (lists all tasks).
- Manually verified `bin/test` modes: full suite, single file, multi-file, `<file> --name /pattern/`,
  and flag-only filter (`bin/test --name /pattern/`).
- **CI is the real proof for the workflow migration** — once this draft is opened, please
  confirm the lint / test / rbs jobs all pass with the new `bin/` invocations before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added command wrapper scripts for common dev tasks (test, lint, typecheck, rbs, rbs-watch, docs, build, rake) with fail-fast behavior and argument forwarding
* **Documentation**
  * Updated development, testing, and contributing guides and CI workflows to use the new wrappers
  * Linting guidance now documents an --fix auto-fix option and the test guide shows flexible invocation examples (single file, name/regex filters, full suite)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->