### PR TITLE
chore: restore singleton signatures for extend-self modules (CL2-794)

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -2,6 +2,7 @@ D = Steep::Diagnostic
 
 target :lib do
   signature "sig/generated"
+  signature "sig/stubs"
 
   check "lib"
 

--- a/sig/stubs/extend_self.rbs
+++ b/sig/stubs/extend_self.rbs
@@ -1,0 +1,11 @@
+# rbs-inline does not emit `extend self` for modules that use it, so their
+# instance methods aren't visible as singleton methods. Reopening each module
+# here to `extend` itself restores that, matching the runtime behaviour.
+
+module Riffer::Helpers::CallOrValue
+  extend ::Riffer::Helpers::CallOrValue
+end
+
+module Riffer::Agent::Run
+  extend ::Riffer::Agent::Run
+end


### PR DESCRIPTION
## Problem

`rbs-inline` emits only **instance** method signatures for modules that use `extend self`, so Steep flags every call site as `Type singleton(Module) does not have method foo`. On this codebase that produces 9 `Ruby::NoMethod` hints rooted at `singleton(::Riffer::Helpers::CallOrValue)` and `singleton(::Riffer::Agent::Run)` across `lib/riffer/agent.rb` (lines 340, 356, 382, 403, 430, 444, 474, 495) and `lib/riffer/mcp/client.rb:26`.

## Solution

Mirror the pattern shipping in [bottrall/riffer-code's `sig/stubs/extend_self.rbs`](https://github.com/bottrall/riffer-code/blob/main/sig/stubs/extend_self.rbs): leave the Ruby source untouched and add a small hand-written RBS stub that reopens each `extend self` module to `extend` itself. That single `extend ::Module` line carries every instance signature onto the singleton — including methods picked up via `include Riffer::Messages::Converter` on `Agent::Run` — matching runtime semantics exactly with no duplicated method signatures.

Two changes:
- `sig/stubs/extend_self.rbs` (new) — one re-open per affected module.
- `Steepfile` — adds `signature "sig/stubs"` to the load path.

Adding a future `extend self` module costs three lines in the same stub file.

## Proof

- `bin/typecheck --severity-level=hint`: the 9 `Ruby::NoMethod` hints at `singleton(::Riffer::Helpers::CallOrValue)` / `singleton(::Riffer::Agent::Run)` are gone; total hints drop 46 → 37 with no new diagnostics. The remaining 37 hints are pre-existing and unrelated.
- `bin/rake` (test + standard + steep): green. 1504 tests / 2300 assertions, 0 failures; Steep reports `No type error detected.`
- `bin/rbs`: regenerates 0 files (no drift — the stub doesn't repeat signatures, just the `extend` relation).

CI is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated type signature configuration with additional stub references
  * Added module self-extension type declarations for improved method visibility in type signatures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->