### PR TITLE
chore(steep): add RBS stubs for provider SDK constants

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -9,9 +9,12 @@ target :lib do
   library "anthropic"
   library "aws-sdk-bedrockruntime"
   library "aws-sdk-core"
+  library "base64"
+  library "json"
   library "logger"
   library "net-http"
   library "openai"
+  library "securerandom"
   library "uri"
 
   configure_code_diagnostics(D::Ruby.lenient)

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -26,7 +26,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
 
     api_key ||= Riffer.config.anthropic.api_key
 
-    @client = Anthropic::Client.new(api_key: api_key, **options)
+    @client = ::Anthropic::Client.new(api_key: api_key, **options)
   end
 
   private
@@ -154,24 +154,24 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     begin
       stream.each do |event|
         case event
-        when Anthropic::Models::RawContentBlockStartEvent
+        when ::Anthropic::Models::RawContentBlockStartEvent
           handle_raw_content_block_start(event, state: current_state)
-        when Anthropic::Models::RawContentBlockDeltaEvent
+        when ::Anthropic::Models::RawContentBlockDeltaEvent
           handle_raw_content_block_delta(event, state: current_state)
-        when Anthropic::Streaming::TextEvent
+        when ::Anthropic::Helpers::Streaming::TextEvent
           handle_text_event(event, state: current_state, yielder: yielder)
-        when Anthropic::Streaming::ThinkingEvent
+        when ::Anthropic::Helpers::Streaming::ThinkingEvent
           handle_thinking_event(event, state: current_state, yielder: yielder)
-        when Anthropic::Streaming::InputJsonEvent
+        when ::Anthropic::Helpers::Streaming::InputJsonEvent
           handle_input_json_event(event, state: current_state, yielder: yielder)
-        when Anthropic::Streaming::ContentBlockStopEvent
+        when ::Anthropic::Helpers::Streaming::ContentBlockStopEvent
           block_type = event.content_block&.type.to_s
           handle_content_block_stop_text(event, state: current_state, yielder: yielder) if block_type == "text" && current_state[:text]
           handle_content_block_stop_tool_use(event, state: current_state, yielder: yielder) if block_type == "tool_use"
           handle_content_block_stop_thinking(event, state: current_state, yielder: yielder) if block_type == "thinking" && current_state[:reasoning]
           handle_content_block_stop_server_tool_use(event, state: current_state, yielder: yielder) if block_type == "server_tool_use"
           handle_content_block_stop_web_search_result(event, state: current_state, yielder: yielder) if block_type == "web_search_tool_result"
-        when Anthropic::Streaming::MessageStopEvent
+        when ::Anthropic::Helpers::Streaming::MessageStopEvent
           handle_message_stop(event, accumulated_message: stream.accumulated_message, yielder: yielder)
         end
       end

--- a/sig/stubs/aws-sdk-core/seahorse_request_context.rbs
+++ b/sig/stubs/aws-sdk-core/seahorse_request_context.rbs
@@ -1,0 +1,7 @@
+module Seahorse
+  module Client
+    class RequestContext
+      def initialize: (operation_name: Symbol) -> void
+    end
+  end
+end

--- a/sig/stubs/aws-sdk-core/static_token_provider.rbs
+++ b/sig/stubs/aws-sdk-core/static_token_provider.rbs
@@ -1,0 +1,5 @@
+module Aws
+  class StaticTokenProvider
+    def initialize: (String token) -> void
+  end
+end

--- a/sig/stubs/aws-sdk-core/static_token_provider.rbs
+++ b/sig/stubs/aws-sdk-core/static_token_provider.rbs
@@ -1,5 +1,5 @@
 module Aws
   class StaticTokenProvider
-    def initialize: (String token) -> void
+    def initialize: (String token, ?Time? expiration) -> void
   end
 end


### PR DESCRIPTION
## Problem

`bin/typecheck --severity-level=hint` was emitting ~18 `Ruby::UnknownConstant` diagnostics across `lib/riffer/providers/{anthropic,amazon_bedrock,gemini}.rb`, plus cascading `UnknownInstanceVariable` / `ArgumentTypeMismatch` noise downstream. The follow-up providers cleanup ticket can't land cleanly until that noise is gone.

Investigation showed the hints came from three distinct sources, not one:

1. Stdlib `JSON`, `SecureRandom`, `Base64` are referenced by all three providers but weren't declared in the `Steepfile`'s `library` list.
2. `Aws::StaticTokenProvider` and `Seahorse::Client::RequestContext` are missing from the shipped AWS RBS — `grep -rn` across every installed `aws-sdk-*/sig/` tree returns zero matches, yet both exist at runtime.
3. The Anthropic gem declares `Anthropic::Streaming` as a **value-typed constant alias** (`Streaming: singleton(Anthropic::Helpers::Streaming)`), so RBS can't navigate `Anthropic::Streaming::TextEvent`. Compounding this, inside `class Riffer::Providers::Anthropic` the bare token `Anthropic` shadows the SDK module, causing even `Anthropic::Client` to resolve against the wrong namespace.

## Solution

Three small, contained changes:

- **`Steepfile`**: declare the three stdlib libraries and add `signature "sig/stubs"` alongside the existing `signature "sig/generated"`.
- **`sig/stubs/aws-sdk-core/`**: two minimal hand-rolled stubs, each shaped exactly to the call site — `Aws::StaticTokenProvider#initialize(String)` and `Seahorse::Client::RequestContext#initialize(operation_name: Symbol)`. Nothing speculative.
- **`lib/riffer/providers/anthropic.rb`**: prefix the eight value-position `Anthropic::*` references with `::` to bypass scope shadowing, and route the streaming `case`/`when` branches through `::Anthropic::Helpers::Streaming::*` (the canonical namespace where the gem actually declares the event classes). At runtime these are the same class objects via the gem's constant alias, so `case`/`when` matching is identical; this is purely a Steep-resolution clarification. Matches the convention already used in `lib/riffer/providers/open_ai.rb:18` (`::OpenAI::Client.new`).

No new gem dependencies. No `rbs_collection.yaml` introduced. Other non-`UnknownConstant` hints surfaced at `--severity-level=hint` (empty-collection annotations, instance-variable declarations, `Enumerator::Yielder` argument mismatches) are explicitly out of scope — they belong to the providers cleanup ticket that depends on this one landing.

## Proof

CI is sufficient for correctness — the entire change is type-system metadata plus a behavior-neutral constant-path clarification. Locally verified:

- `bin/typecheck` — clean, no errors at default severity.
- `bin/typecheck --severity-level=hint 2>&1 | grep -E "lib/riffer/providers/(anthropic|amazon_bedrock|gemini)" | grep UnknownConstant` — **0 lines**. (Before: ~18.) Remaining `UnknownConstant` hints in the codebase live in unrelated files — `mcp/client.rb`, `runner/fibers.rb`, `skills/xml_adapter.rb`, etc. — and are not in this ticket's scope.
- `bin/test` — 1504 runs, 2300 assertions, 0 failures, 0 errors, 0 skips.
- `bin/rake` (default task: test + standard + steep:check) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded type-checking configuration with additional standard-library dependency declarations.
  * Added type definitions for cloud client integrations, including a request-context type and a token provider with optional expiration.
  * Improved third-party API provider integration for more robust runtime interactions and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->