### PR TITLE
chore(steep): clean type diagnostics in lib/riffer/agent.rb

### DIFF
--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -88,7 +88,7 @@ class Riffer::Agent
   # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
   #--
-  #: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
+  #: (?Riffer::Params?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
   def self.structured_output(params = nil, &block)
     if block
       params = Riffer::Params.new
@@ -156,7 +156,7 @@ class Riffer::Agent
   #   end
   #
   #--
-  #: () ?{ () -> void } -> Riffer::Skills::Config?
+  #: () ?{ (Riffer::Skills::Config) [self: Riffer::Skills::Config] -> void } -> Riffer::Skills::Config?
   def self.skills(&block)
     if block
       skills_config = Riffer::Skills::Config.new
@@ -387,8 +387,9 @@ class Riffer::Agent
   #--
   #: () -> Riffer::Messages::System?
   def build_skills_message
-    return nil unless @context.skills&.system_prompt
-    Riffer::Messages::System.new(@context.skills.system_prompt)
+    skills = @context.skills
+    return nil unless skills&.system_prompt
+    Riffer::Messages::System.new(skills.system_prompt)
   end
 
   # Resolves +Config#model+ to a "provider/model" string (calling the Proc
@@ -473,8 +474,10 @@ class Riffer::Agent
   def resolve_tools
     tools = Riffer::Helpers::CallOrValue.resolve(@config.tools_config, context: @context, default: [])
 
-    if @config.skills_config
-      skill_activate_tool_class = @config.skills_config.activate_tool || Riffer.config.skills.default_activate_tool
+    skills_config = @config.skills_config
+
+    if skills_config
+      skill_activate_tool_class = skills_config.activate_tool || Riffer.config.skills.default_activate_tool
 
       if tools.any? { |t| t.name == skill_activate_tool_class.name }
         raise Riffer::ArgumentError, "Tool name conflict with skill tools: #{skill_activate_tool_class.name}"
@@ -514,7 +517,7 @@ class Riffer::Agent
   #
   #: (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
   def gather_mcp_registrations_with_tags(configs)
-    by_reg = {}
+    by_reg = {} #: Hash[Riffer::Mcp::Registration, Array[Symbol]]
     configs.each do |cfg|
       Riffer::Mcp::Registry.find_by_tags(cfg[:tags]).each do |reg|
         (by_reg[reg] ||= []).concat(cfg[:tags] & reg.manifest.tags)
@@ -523,7 +526,7 @@ class Riffer::Agent
     by_reg
   end
 
-  #: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
+  #: (Riffer::Mcp::Registration, Array[Symbol], (^(manifest: Riffer::Mcp::Manifest, matched_tags: Array[Symbol], context: Riffer::Agent::Context) -> Hash[Symbol, untyped]?)?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
   def mcp_tools_for_registration(reg, matched_tags, cred, ctx)
     return reg.tools unless cred
     return [] if cred.call(manifest: reg.manifest, matched_tags: matched_tags, context: ctx).nil?

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -73,8 +73,8 @@ class Riffer::Agent
   # Accepts a Riffer::Params instance or a block evaluated against a new Params.
   #
   # --
-  # : (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
-  def self.structured_output: (?Riffer::Params?) ?{ () -> void } -> Riffer::Params?
+  # : (?Riffer::Params?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def self.structured_output: (?Riffer::Params?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
 
   # Gets or sets the maximum number of LLM call steps in the tool-use loop.
   #
@@ -124,8 +124,8 @@ class Riffer::Agent
   #   end
   #
   # --
-  # : () ?{ () -> void } -> Riffer::Skills::Config?
-  def self.skills: () ?{ () -> void } -> Riffer::Skills::Config?
+  # : () ?{ (Riffer::Skills::Config) [self: Riffer::Skills::Config] -> void } -> Riffer::Skills::Config?
+  def self.skills: () ?{ (Riffer::Skills::Config) [self: Riffer::Skills::Config] -> void } -> Riffer::Skills::Config?
 
   # Finds an agent class by identifier.
   #
@@ -359,8 +359,8 @@ class Riffer::Agent
   # : (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
   def gather_mcp_registrations_with_tags: (Array[Hash[Symbol, untyped]]) -> Hash[Riffer::Mcp::Registration, Array[Symbol]]
 
-  # : (Riffer::Mcp::Registration, Array[Symbol], Proc?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
-  def mcp_tools_for_registration: (Riffer::Mcp::Registration, Array[Symbol], Proc?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
+  # : (Riffer::Mcp::Registration, Array[Symbol], (^(manifest: Riffer::Mcp::Manifest, matched_tags: Array[Symbol], context: Riffer::Agent::Context) -> Hash[Symbol, untyped]?)?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
+  def mcp_tools_for_registration: (Riffer::Mcp::Registration, Array[Symbol], (^(manifest: Riffer::Mcp::Manifest, matched_tags: Array[Symbol], context: Riffer::Agent::Context) -> Hash[Symbol, untyped]?)?, Riffer::Agent::Context) -> Array[singleton(Riffer::Tool)]
 
   # Raises if two or more tool classes share the same +.name+ (ambiguous dispatch).
   #

--- a/sig/stubs/agent_ivars.rbs
+++ b/sig/stubs/agent_ivars.rbs
@@ -1,0 +1,7 @@
+# Class-level instance variable declarations for Riffer::Agent.
+#
+# The `#:` inline syntax used in lib/ can't declare class-level ivars, so we
+# stub them here instead.
+class Riffer::Agent
+  self.@config: Riffer::Agent::Config?
+end


### PR DESCRIPTION
## Problem

`lib/riffer/agent.rb` was historically the largest single source of Steep noise. With the companion tickets landed (extend-self singletons, third-party SDK stubs), the file is already clean at the default Steep level but still carried **9 residual diagnostics** that surface via `bin/typecheck --severity-level=hint`. Clearing them makes future agent changes type-check cleanly and removes the last meaningful chunk of hint-level noise from the central type.

## Solution

All fixes are annotation-only or behavior-preserving local-variable refactors — no runtime behavior changes:

- **Class-level `@config` ivar** (`UnknownInstanceVariable`): the `#:` inline syntax can't declare class-level instance variables, so the type is declared in a new `sig/stubs/agent_ivars.rbs` (consistent with the repo's existing first-party stub for `extend self`).
- **`structured_output` / `skills` `instance_eval` blocks** (`BlockTypeMismatch`): widened the block annotations to bind `self` (`(T) [self: T] -> void`), matching what `instance_eval` expects.
- **`build_skills_message` / `resolve_tools`** (`NoMethod` on `Skills::Context?` / `Skills::Config?`): captured `@context.skills` / `@config.skills_config` in locals so Steep can narrow the nil guards instead of re-reading the method on each access.
- **`gather_mcp_registrations_with_tags`** (`UnannotatedEmptyCollection`): annotated the empty `by_reg` hash.
- **`mcp_tools_for_registration`** (`UnknownRecordKey` ×3): typed the credentials param as a precise proc `^(manifest:, matched_tags:, context:) -> Hash[Symbol, untyped]?` instead of bare `Proc`, so the keyword call site type-checks.

`sig/generated/riffer/agent.rbs` is regenerated via `bin/rbs` and committed alongside the source.

## Proof

CI is sufficient. `bin/rake` (test + standard + steep:check) is green locally — 1504 runs, 0 failures/errors, no type errors — and `bin/typecheck --severity-level=hint` reports **0** diagnostics for `lib/riffer/agent.rb` with no new diagnostics introduced elsewhere. No new tests were added because no real bug surfaced; the existing suite covers the refactored paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced type declarations for method blocks to improve clarity and type safety.
  * Added type annotations for agent configuration to better document internal interfaces.

* **Refactor**
  * Simplified internal variable handling and assignment to reduce ambiguity.
  * Tightened typing around credential callbacks and accumulators for more predictable behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->