### PR TITLE
chore(steep): clean diagnostics in remaining lib/ files

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -10,12 +10,14 @@ target :lib do
   library "aws-sdk-bedrockruntime"
   library "aws-sdk-core"
   library "base64"
+  library "cgi"
   library "json"
   library "logger"
   library "net-http"
   library "openai"
   library "securerandom"
   library "uri"
+  library "yaml"
 
   configure_code_diagnostics(D::Ruby.lenient)
 end

--- a/lib/riffer/agent/session.rb
+++ b/lib/riffer/agent/session.rb
@@ -182,9 +182,9 @@ class Riffer::Agent::Session
     assistant = @messages[last_assistant_idx] #: Riffer::Messages::Assistant
     return [assistant, []] if assistant.tool_calls.empty?
 
-    executed_ids = @messages[(last_assistant_idx + 1)..].select { |m|
-      m.is_a?(Riffer::Messages::Tool)
-    }.map(&:tool_call_id)
+    executed_ids = (@messages[(last_assistant_idx + 1)..] || []).filter_map { |m|
+      m.tool_call_id if m.is_a?(Riffer::Messages::Tool)
+    }
 
     [assistant, assistant.tool_calls.reject { |tc| executed_ids.include?(tc.call_id) }]
   end
@@ -193,6 +193,7 @@ class Riffer::Agent::Session
   #: () -> Enumerator[Riffer::Messages::Base, self]
   #: () { (Riffer::Messages::Base) -> void } -> untyped
   def each(&block)
+    return @messages.each unless block
     @messages.each(&block)
   end
 

--- a/lib/riffer/agent/session/repair.rb
+++ b/lib/riffer/agent/session/repair.rb
@@ -83,7 +83,7 @@ module Riffer::Agent::Session::Repair
     resume_boundary = (messages.length - 1).downto(0).find { |idx|
       m = messages[idx]
       m.is_a?(Riffer::Messages::Assistant) &&
-        messages[(idx + 1)..].all? { |later| later.is_a?(Riffer::Messages::Tool) }
+        (messages[(idx + 1)..] || []).all? { |later| later.is_a?(Riffer::Messages::Tool) }
     }
 
     result_ids = messages.filter_map { |m| m.tool_call_id if m.is_a?(Riffer::Messages::Tool) }

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -31,7 +31,11 @@ class Riffer::Evals::Evaluator
     #--
     #: (?bool?) -> bool
     def higher_is_better(value = nil)
-      return @higher_is_better.nil? || @higher_is_better if value.nil?
+      if value.nil?
+        current = @higher_is_better
+        return true if current.nil?
+        return current
+      end
       @higher_is_better = value
     end
 
@@ -87,8 +91,14 @@ class Riffer::Evals::Evaluator
     return input if input.is_a?(String)
 
     input.map do |msg|
-      role = msg.is_a?(Hash) ? (msg[:role] || msg["role"]) : msg.role
-      content = msg.is_a?(Hash) ? (msg[:content] || msg["content"]) : msg.content
+      if msg.is_a?(Hash)
+        hash = msg #: Hash[untyped, untyped]
+        role = hash[:role] || hash["role"]
+        content = hash[:content] || hash["content"]
+      else
+        role = msg.role
+        content = msg.content
+      end
       "#{role}: #{content}"
     end.join("\n\n")
   end

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -30,7 +30,7 @@ class Riffer::Evals::Judge
     end
 
     #--
-    #: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
+    #: (context: Riffer::Agent::Context?, score: Float, reason: String) -> Riffer::Tools::Response
     def call(context:, score:, reason:)
       json({score: score, reason: reason})
     end
@@ -94,7 +94,7 @@ class Riffer::Evals::Judge
   #--
   #: (input: String, output: String, ?ground_truth: String?) -> String
   def build_user_message(input:, output:, ground_truth: nil)
-    parts = []
+    parts = [] #: Array[String]
     parts << "## Input\n\n#{input}"
     parts << "## Output\n\n#{output}"
     parts << "## Ground Truth\n\n#{ground_truth}" if ground_truth

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -40,7 +40,8 @@ class Riffer::Evals::RunResult
       end
     end
 
-    totals.each_with_object({}) do |(evaluator, total), hash|
+    averages = {} #: Hash[singleton(Riffer::Evals::Evaluator), Float]
+    totals.each_with_object(averages) do |(evaluator, total), hash|
       hash[evaluator] = total / counts[evaluator]
     end
   end

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -47,7 +47,8 @@ class Riffer::Evals::ScenarioResult
   #--
   #: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores
-    results.each_with_object({}) do |result, hash|
+    acc = {} #: Hash[singleton(Riffer::Evals::Evaluator), Float]
+    results.each_with_object(acc) do |result, hash|
       hash[result.evaluator] = result.score
     end
   end

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -80,7 +80,8 @@ class Riffer::Guardrails::Runner
   #--
   #: (Hash[Symbol, untyped]) -> Riffer::Guardrail
   def instantiate_guardrail(config)
-    config[:class].new(**config[:options])
+    options = config[:options] #: Hash[Symbol, untyped]
+    config[:class].new(**options)
   end
 
   #--
@@ -101,7 +102,7 @@ class Riffer::Guardrails::Runner
     when :before
       guardrail.process_input(data, context: context)
     when :after
-      guardrail.process_output(data, messages: messages, context: context)
+      guardrail.process_output(data, messages: messages || [], context: context)
     else
       raise Riffer::Error, "Unexpected guardrail phase: #{phase}. Valid phases: #{Riffer::Guardrails::PHASES.join(", ")}"
     end

--- a/lib/riffer/mcp/authenticated_tool.rb
+++ b/lib/riffer/mcp/authenticated_tool.rb
@@ -23,6 +23,9 @@ module Riffer::Mcp::AuthenticatedTool
     tags = matched_tags
 
     Class.new(Riffer::Tool) do
+      # steep cannot type the body of a dynamically created anonymous class:
+      # its ivars and `self` inside define_method are unresolvable.
+      # steep:ignore:start
       @identifier = inner.identifier
 
       define_singleton_method(:name) { inner.name }
@@ -60,6 +63,7 @@ module Riffer::Mcp::AuthenticatedTool
         client = build_call_client(man.endpoint, headers)
         text(client.tools_call(inner.mcp_server_tool_name, kwargs))
       end
+      # steep:ignore:end
     end
   end
 end

--- a/lib/riffer/mcp/registration.rb
+++ b/lib/riffer/mcp/registration.rb
@@ -23,7 +23,7 @@ class Riffer::Mcp::Registration
   def initialize(manifest)
     @manifest = manifest
     @cancelled = false
-    @tools = []
+    @tools = [] #: Array[singleton(Riffer::Tool)]
     @mutex = Mutex.new
     run_discovery
   end
@@ -62,8 +62,7 @@ class Riffer::Mcp::Registration
       tools = Riffer::Mcp::ToolFactory.build(@manifest.name, client, tool_defs)
 
       @mutex.synchronize do
-        next if @cancelled
-        @tools = tools.freeze
+        @tools = tools.freeze unless @cancelled
       end
     end
   end

--- a/lib/riffer/mcp/registry.rb
+++ b/lib/riffer/mcp/registry.rb
@@ -18,7 +18,9 @@ module Riffer::Mcp::Registry
     #--
     #: ((Hash[Symbol, untyped] | Riffer::Mcp::Manifest)) -> Riffer::Mcp::Registration
     def register(manifest_or_hash)
-      manifest = manifest_or_hash.is_a?(Riffer::Mcp::Manifest) ? manifest_or_hash : Riffer::Mcp::Manifest.new(**manifest_or_hash)
+      # steep cannot verify that an untyped Hash splat supplies Manifest's
+      # required name:/endpoint: keywords; Manifest validates them at runtime.
+      manifest = manifest_or_hash.is_a?(Riffer::Mcp::Manifest) ? manifest_or_hash : Riffer::Mcp::Manifest.new(**manifest_or_hash) # steep:ignore InsufficientKeywordArguments
       registration = Riffer::Mcp::Registration.new(manifest)
       old = @mutex.synchronize do
         previous = @store[manifest.name]

--- a/lib/riffer/mcp/tool_factory.rb
+++ b/lib/riffer/mcp/tool_factory.rb
@@ -31,7 +31,11 @@ module Riffer::Mcp::ToolFactory
   private_class_method def self.build_tool_class(manifest_name, client, td)
     prefixed = "#{sanitize_name_component(manifest_name)}__#{sanitize_name_component(td[:name])}"
 
+    # steep cannot type the body of a dynamically created anonymous class:
+    # its ivars and `self` inside define_method are unresolvable, so the
+    # block is ignored wholesale (cf. AuthenticatedTool.wrap_one).
     Class.new(Riffer::Tool) do
+      # steep:ignore:start
       @mcp_client = client
       @mcp_server_tool_name = td[:name]
       # Set @identifier directly so .identifier does not fall back to
@@ -49,6 +53,7 @@ module Riffer::Mcp::ToolFactory
         )
         text(result)
       end
+      # steep:ignore:end
     end
   end
 end

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -60,7 +60,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content}
+    hash = {role: role, content: content} #: Hash[Symbol, untyped]
     hash[:id] = id unless id.nil?
     hash[:tool_calls] = tool_calls.map(&:to_h) unless tool_calls.empty?
     hash[:token_usage] = token_usage.to_h if token_usage

--- a/lib/riffer/messages/file_part.rb
+++ b/lib/riffer/messages/file_part.rb
@@ -66,7 +66,7 @@ class Riffer::Messages::FilePart
   #: (String, ?media_type: String?) -> Riffer::Messages::FilePart
   def self.from_url(url, media_type: nil)
     unless media_type
-      ext = ::File.extname(URI.parse(url).path).downcase
+      ext = ::File.extname(URI.parse(url).path.to_s).downcase
       media_type = MEDIA_TYPES[ext]
       raise Riffer::ArgumentError, "Cannot detect media type from URL; provide media_type explicitly" unless media_type
     end
@@ -114,7 +114,7 @@ class Riffer::Messages::FilePart
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {media_type: media_type}
+    hash = {media_type: media_type} #: Hash[Symbol, untyped]
     hash[:data] = @data if @data
     hash[:url] = @url_string if @url_string
     hash[:filename] = filename if filename

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -54,7 +54,7 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content, tool_call_id: tool_call_id, name: name}
+    hash = {role: role, content: content, tool_call_id: tool_call_id, name: name} #: Hash[Symbol, untyped]
     hash[:id] = id unless id.nil?
     if error?
       hash[:error] = error

--- a/lib/riffer/messages/user.rb
+++ b/lib/riffer/messages/user.rb
@@ -38,7 +38,7 @@ class Riffer::Messages::User < Riffer::Messages::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    hash = {role: role, content: content}
+    hash = {role: role, content: content} #: Hash[Symbol, untyped]
     hash[:id] = id unless id.nil?
     hash[:files] = files.map(&:to_h) unless files.empty?
     hash

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -23,7 +23,7 @@ class Riffer::Params
   # Defines a required parameter.
   #
   #--
-  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
+  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
   def required(name, type, description: nil, enum: nil, of: nil, &block)
     nested = build_nested(type, of, &block)
     @parameters << Riffer::Params::Param.new(
@@ -40,7 +40,7 @@ class Riffer::Params
   # Defines an optional parameter.
   #
   #--
-  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
+  #: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
   def optional(name, type, description: nil, enum: nil, default: nil, of: nil, &block)
     nested = build_nested(type, of, &block)
     @parameters << Riffer::Params::Param.new(
@@ -62,8 +62,8 @@ class Riffer::Params
   #--
   #: (Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def validate(arguments)
-    validated = {}
-    errors = []
+    validated = {} #: Hash[Symbol, untyped]
+    errors = [] #: Array[String]
 
     @parameters.each do |param|
       value = arguments[param.name]
@@ -107,8 +107,8 @@ class Riffer::Params
   #--
   #: (?strict: bool) -> Hash[Symbol, untyped]
   def to_json_schema(strict: false)
-    properties = {}
-    required_params = []
+    properties = {} #: Hash[String, untyped]
+    required_params = [] #: Array[String]
 
     @parameters.each do |param|
       properties[param.name.to_s] = param.to_json_schema(strict: strict)
@@ -126,7 +126,7 @@ class Riffer::Params
   private
 
   #--
-  #: (Class, Class?) ?{ () -> void } -> Riffer::Params?
+  #: (Class, Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
   def build_nested(type, of, &block)
     if of && block
       raise Riffer::ArgumentError, "cannot use both of: and a block"
@@ -171,7 +171,9 @@ class Riffer::Params
   #--
   #: (Riffer::Params::Param, Hash[Symbol, untyped], Array[String]) -> Hash[Symbol, untyped]
   def validate_nested_hash(param, value, errors)
-    param.nested_params.validate(value)
+    nested = param.nested_params
+    return value unless nested
+    nested.validate(value)
   rescue Riffer::ValidationError => e
     e.message.split("; ").each do |msg|
       errors << "#{param.name}.#{msg}"
@@ -182,12 +184,14 @@ class Riffer::Params
   #--
   #: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_nested_array_of_objects(param, value, errors)
+    nested = param.nested_params
+    return value unless nested
     value.map.with_index do |item, i|
       unless item.is_a?(Hash)
         errors << "#{param.name}[#{i}] must be an object"
         next item
       end
-      param.nested_params.validate(item)
+      nested.validate(item)
     rescue Riffer::ValidationError => e
       e.message.split("; ").each do |msg|
         errors << "#{param.name}[#{i}].#{msg}"
@@ -199,12 +203,14 @@ class Riffer::Params
   #--
   #: (Riffer::Params::Param, Array[untyped], Array[String]) -> void
   def validate_typed_array(param, value, errors)
-    type_name = Riffer::Params::Param::TYPE_MAPPINGS[param.item_type]
+    item_type = param.item_type
+    return unless item_type
+    type_name = Riffer::Params::Param::TYPE_MAPPINGS[item_type]
     value.each_with_index do |item, i|
-      valid = if param.item_type == Riffer::Params::Boolean || param.item_type == TrueClass || param.item_type == FalseClass
+      valid = if item_type == Riffer::Params::Boolean || item_type == TrueClass || item_type == FalseClass
         item == true || item == false
       else
-        item.is_a?(param.item_type)
+        item.is_a?(item_type)
       end
       errors << "#{param.name}[#{i}] must be a #{type_name}" unless valid
     end

--- a/lib/riffer/params/param.rb
+++ b/lib/riffer/params/param.rb
@@ -80,7 +80,7 @@ class Riffer::Params::Param
     nullable = strict && !required
 
     if nullable && enum
-      schema = {anyOf: [{type: type_name, enum: enum}, {type: "null"}]}
+      schema = {anyOf: [{type: type_name, enum: enum}, {type: "null"}]} #: Hash[Symbol, untyped]
       schema[:description] = description if description
       return schema
     end
@@ -88,7 +88,7 @@ class Riffer::Params::Param
     type = type_name
     type = [type, "null"] if nullable
 
-    schema = {type: type}
+    schema = {type: type} #: Hash[Symbol, untyped]
     schema[:description] = description if description
     schema[:enum] = enum if enum
 

--- a/lib/riffer/runner.rb
+++ b/lib/riffer/runner.rb
@@ -19,7 +19,7 @@ class Riffer::Runner
   # Raises NotImplementedError if not implemented by subclass.
   #
   #--
-  #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  #: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     raise NotImplementedError, "#{self.class} must implement #map"
   end

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -28,7 +28,7 @@ class Riffer::Runner::Fibers < Riffer::Runner
   end
 
   #--
-  #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  #: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     return [] if items.empty?
 
@@ -37,8 +37,9 @@ class Riffer::Runner::Fibers < Riffer::Runner
 
     Async do
       barrier = Async::Barrier.new
-      parent = if @max_concurrency
-        Async::Semaphore.new(@max_concurrency, parent: barrier)
+      max = @max_concurrency
+      parent = if max
+        Async::Semaphore.new(max, parent: barrier)
       else
         barrier
       end

--- a/lib/riffer/runner/sequential.rb
+++ b/lib/riffer/runner/sequential.rb
@@ -7,7 +7,7 @@
 #
 class Riffer::Runner::Sequential < Riffer::Runner
   #--
-  #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  #: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     items.map(&block)
   end

--- a/lib/riffer/runner/threaded.rb
+++ b/lib/riffer/runner/threaded.rb
@@ -25,7 +25,7 @@ class Riffer::Runner::Threaded < Riffer::Runner
   end
 
   #--
-  #: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  #: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
   def map(items, context:, &block)
     return [] if items.empty?
 

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -66,7 +66,7 @@ class Riffer::Skills::Context
   #: () -> String
   def system_prompt
     available = available_skills
-    parts = []
+    parts = [] #: Array[String]
     parts << @adapter.render_catalog(available) unless available.empty?
     @activated.each_value { |body| parts << body }
     parts.join("\n\n")

--- a/lib/riffer/skills/filesystem_backend.rb
+++ b/lib/riffer/skills/filesystem_backend.rb
@@ -31,8 +31,9 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def list_skills
-    @skills_cache = {}
-    frontmatters = []
+    cache = {} #: Hash[String, String]
+    @skills_cache = cache
+    frontmatters = [] #: Array[Riffer::Skills::Frontmatter]
 
     @paths.each do |path|
       next unless File.directory?(path)
@@ -45,10 +46,10 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
         frontmatter = Riffer::Skills::Frontmatter.parse_frontmatter(File.read(skill_file))
 
         validate_dirname_matches_name!(dirname, frontmatter.name)
-        next if @skills_cache.key?(frontmatter.name)
+        next if cache.key?(frontmatter.name)
 
         frontmatters << frontmatter
-        @skills_cache[frontmatter.name] = dir
+        cache[frontmatter.name] = dir
       end
     end
 
@@ -65,7 +66,8 @@ class Riffer::Skills::FilesystemBackend < Riffer::Skills::Backend
   #: (String) -> String
   def read_skill(name)
     list_skills unless @skills_cache
-    dir = @skills_cache[name]
+    cache = @skills_cache #: Hash[String, String]
+    dir = cache[name]
     raise Riffer::ArgumentError, "Skill not found: '#{name}'" unless dir
 
     _, body = Riffer::Skills::Frontmatter.parse(File.read(File.join(dir, SKILL_FILENAME)))

--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -15,7 +15,7 @@ class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
   #--
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
-    lines = []
+    lines = [] #: Array[String]
     lines << "## Available Skills"
     lines << ""
     lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."

--- a/lib/riffer/skills/xml_adapter.rb
+++ b/lib/riffer/skills/xml_adapter.rb
@@ -16,7 +16,7 @@ class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
   #--
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
-    lines = []
+    lines = [] #: Array[String]
     lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
     lines << ""
     lines << "<available_skills>"

--- a/lib/riffer/stream_events/interrupt.rb
+++ b/lib/riffer/stream_events/interrupt.rb
@@ -26,7 +26,7 @@ class Riffer::StreamEvents::Interrupt < Riffer::StreamEvents::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    h = {role: @role, interrupt: true}
+    h = {role: @role, interrupt: true} #: Hash[Symbol, untyped]
     h[:reason] = @reason if @reason
     h[:healed_tool_call_ids] = @healed_tool_call_ids unless @healed_tool_call_ids.empty?
     h

--- a/lib/riffer/stream_events/web_search_status.rb
+++ b/lib/riffer/stream_events/web_search_status.rb
@@ -26,7 +26,7 @@ class Riffer::StreamEvents::WebSearchStatus < Riffer::StreamEvents::Base
   #--
   #: () -> Hash[Symbol, untyped]
   def to_h
-    h = {role: @role, status: @status}
+    h = {role: @role, status: @status} #: Hash[Symbol, untyped]
     h[:url] = @url if @url
     h[:query] = @query if @query
     h

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -33,7 +33,7 @@ class Riffer::Tool
   # Raises NotImplementedError if not implemented by subclass.
   #
   #--
-  #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  #: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
   def call(context:, **kwargs)
     raise NotImplementedError, "#{self.class} must implement #call"
   end
@@ -69,7 +69,7 @@ class Riffer::Tool
   # Raises Riffer::Error if the tool does not return a Response object.
   #
   #--
-  #: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  #: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params
     validated_args = params_builder ? params_builder.validate(kwargs) : kwargs

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -38,7 +38,7 @@ class Riffer::Tools::Runtime
   #   instrumentation that needs the accompanying assistant text).
   #
   #--
-  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute(tool_calls, tools:, context:, assistant_message: nil)
     @runner.map(tool_calls, context: context) do |tool_call|
       result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
@@ -65,7 +65,7 @@ class Riffer::Tools::Runtime
   #   end
   #
   #--
-  #: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  #: (Riffer::Messages::Assistant::ToolCall, context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
   def around_tool_call(tool_call, context:, assistant_message: nil)
     yield
   end
@@ -82,7 +82,7 @@ class Riffer::Tools::Runtime
   #   call, when known.
   #
   #--
-  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
+  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
   def dispatch_tool_call(tool_call, tools:, context:, assistant_message: nil)
     tool_class = tools.find { |tc| tc.name == tool_call.name }
 

--- a/lib/riffer/tools/toolable.rb
+++ b/lib/riffer/tools/toolable.rb
@@ -31,8 +31,8 @@ module Riffer::Tools::Toolable
   #: (Module) -> void
   def self.extended(base)
     base.extend Riffer::Helpers::ClassNameConverter
-    @extenders ||= []
-    @extenders << base
+    extenders = (@extenders ||= []) #: Array[Module]
+    extenders << base
   end
 
   # Returns all classes that have extended Toolable.
@@ -82,11 +82,12 @@ module Riffer::Tools::Toolable
   # Defines parameters using the Params DSL.
   #
   #--
-  #: () ?{ () -> void } -> Riffer::Params?
+  #: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
   def params(&block)
     return @params_builder if block.nil?
-    @params_builder = Riffer::Params.new
-    @params_builder.instance_eval(&block)
+    builder = Riffer::Params.new
+    builder.instance_eval(&block)
+    @params_builder = builder
   end
 
   # Returns the JSON Schema for the tool's parameters.
@@ -135,6 +136,8 @@ module Riffer::Tools::Toolable
   private
 
   def empty_schema # :nodoc:
-    {type: "object", properties: {}, required: [], additionalProperties: false}
+    properties = {} #: Hash[Symbol, untyped]
+    required = [] #: Array[untyped]
+    {type: "object", properties: properties, required: required, additionalProperties: false}
   end
 end

--- a/sig/generated/riffer/evals/judge.rbs
+++ b/sig/generated/riffer/evals/judge.rbs
@@ -18,8 +18,8 @@ class Riffer::Evals::Judge
   # Internal tool for structured evaluation output.
   class EvaluationTool < Riffer::Tool
     # --
-    # : (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
-    def call: (context: Hash[Symbol, untyped]?, score: Float, reason: String) -> Riffer::Tools::Response
+    # : (context: Riffer::Agent::Context?, score: Float, reason: String) -> Riffer::Tools::Response
+    def call: (context: Riffer::Agent::Context?, score: Float, reason: String) -> Riffer::Tools::Response
   end
 
   # The model string (provider/model format).

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -19,14 +19,14 @@ class Riffer::Params
   # Defines a required parameter.
   #
   # --
-  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
-  def required: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ () -> void } -> void
+  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
+  def required: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
 
   # Defines an optional parameter.
   #
   # --
-  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
-  def optional: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ () -> void } -> void
+  # : (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
+  def optional: (Symbol, Class, ?description: String?, ?enum: Array[untyped]?, ?default: untyped, ?of: Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> void
 
   # Validates arguments against parameter definitions.
   #
@@ -49,8 +49,8 @@ class Riffer::Params
   private
 
   # --
-  # : (Class, Class?) ?{ () -> void } -> Riffer::Params?
-  def build_nested: (Class, Class?) ?{ () -> void } -> Riffer::Params?
+  # : (Class, Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def build_nested: (Class, Class?) ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
 
   # --
   # : (Riffer::Params::Param, untyped, Array[String]) -> untyped

--- a/sig/generated/riffer/runner.rbs
+++ b/sig/generated/riffer/runner.rbs
@@ -17,6 +17,6 @@ class Riffer::Runner
   # Raises NotImplementedError if not implemented by subclass.
   #
   # --
-  # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
-  def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  # : (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/fibers.rbs
+++ b/sig/generated/riffer/runner/fibers.rbs
@@ -22,6 +22,6 @@ class Riffer::Runner::Fibers < Riffer::Runner
   def initialize: (?max_concurrency: Integer?) -> void
 
   # --
-  # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
-  def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  # : (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/sequential.rbs
+++ b/sig/generated/riffer/runner/sequential.rbs
@@ -5,6 +5,6 @@
 # This is the default runner used when no concurrency is needed.
 class Riffer::Runner::Sequential < Riffer::Runner
   # --
-  # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
-  def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  # : (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/runner/threaded.rbs
+++ b/sig/generated/riffer/runner/threaded.rbs
@@ -21,6 +21,6 @@ class Riffer::Runner::Threaded < Riffer::Runner
   def initialize: (?max_concurrency: Integer) -> void
 
   # --
-  # : (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
-  def map: (Array[untyped], context: Hash[Symbol, untyped]?) { (untyped) -> untyped } -> Array[untyped]
+  # : (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
+  def map: (Array[untyped], context: Riffer::Agent::Context?) { (untyped) -> untyped } -> Array[untyped]
 end

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -27,8 +27,8 @@ class Riffer::Tool
   # Raises NotImplementedError if not implemented by subclass.
   #
   # --
-  # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
-  def call: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  # : (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
+  def call: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
 
   # Creates a text response. Shorthand for Riffer::Tools::Response.text.
   #
@@ -55,6 +55,6 @@ class Riffer::Tool
   # Raises Riffer::Error if the tool does not return a Response object.
   #
   # --
-  # : (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
-  def call_with_validation: (context: Hash[Symbol, untyped]?, **untyped) -> Riffer::Tools::Response
+  # : (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
+  def call_with_validation: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
 end

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -31,8 +31,8 @@ class Riffer::Tools::Runtime
   #   instrumentation that needs the accompanying assistant text).
   #
   # --
-  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
-  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
+  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
 
   # Hook that wraps each tool call execution. Override in subclasses
   # to customize. Must +yield+ to continue execution.
@@ -51,8 +51,8 @@ class Riffer::Tools::Runtime
   #   end
   #
   # --
-  # : (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
-  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  # : (Riffer::Messages::Assistant::ToolCall, context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
+  def around_tool_call: (Riffer::Messages::Assistant::ToolCall, context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) { () -> Riffer::Tools::Response } -> Riffer::Tools::Response
 
   private
 
@@ -66,8 +66,8 @@ class Riffer::Tools::Runtime
   #   call, when known.
   #
   # --
-  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
-  def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Hash[Symbol, untyped]?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
+  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
+  def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
 
   # --
   # : (String?) -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/tools/toolable.rbs
+++ b/sig/generated/riffer/tools/toolable.rbs
@@ -62,8 +62,8 @@ module Riffer::Tools::Toolable
   # Defines parameters using the Params DSL.
   #
   # --
-  # : () ?{ () -> void } -> Riffer::Params?
-  def params: () ?{ () -> void } -> Riffer::Params?
+  # : () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def params: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
 
   # Returns the JSON Schema for the tool's parameters.
   #

--- a/sig/stubs/async.rbs
+++ b/sig/stubs/async.rbs
@@ -1,0 +1,24 @@
+# Minimal signatures for the optional `async` gem, which ships no RBS.
+#
+# Only the surface used by Riffer::Runner::Fibers is declared; the gem is
+# loaded lazily via depends_on, so this stub keeps Steep aware of the
+# constants without adding a hard `library` dependency.
+module Async
+  class Barrier
+    def initialize: () -> void
+
+    def async: () { () -> void } -> untyped
+
+    def wait: () -> void
+  end
+
+  class Semaphore
+    def initialize: (Integer, ?parent: untyped) -> void
+
+    def async: () { () -> void } -> untyped
+  end
+end
+
+module Kernel
+  def Async: () { () -> void } -> untyped
+end

--- a/sig/stubs/lib_ivars.rbs
+++ b/sig/stubs/lib_ivars.rbs
@@ -1,0 +1,101 @@
+# Instance/module variable declarations for non-provider lib/ classes.
+#
+# rbs-inline's `#:` syntax types an assignment expression (a Steep assertion)
+# but doesn't declare the instance variable itself, so we stub the ivar types
+# here instead (mirrors sig/stubs/agent_ivars.rbs and provider_ivars.rbs).
+
+class Riffer::Mcp::Registration
+  @cancelled: bool
+  @tools: Array[singleton(Riffer::Tool)]
+  @mutex: Thread::Mutex
+end
+
+module Riffer::Mcp::Registry
+  self.@mutex: Thread::Mutex
+  self.@store: Hash[String, Riffer::Mcp::Registration]
+end
+
+class Riffer::Mcp::Client
+  @client: untyped
+end
+
+# Toolable is extended onto tool classes; its instance methods run as class
+# methods on the extender, which is also extended with ClassNameConverter
+# (see Toolable.extended). The include models that method availability for Steep.
+module Riffer::Tools::Toolable
+  include Riffer::Helpers::ClassNameConverter
+
+  self.@extenders: Array[Module]?
+  @description: String?
+  @identifier: String?
+  @timeout: (Integer | Float)?
+  @params_builder: Riffer::Params?
+  @kind: Symbol?
+end
+
+class Riffer::Evals::Judge
+  @provider_options: Hash[Symbol, untyped]
+  @provider_instance: Riffer::Providers::Base?
+  @provider_name: String?
+  @model_name: String?
+end
+
+class Riffer::Evals::Evaluator
+  self.@instructions: String?
+  self.@higher_is_better: bool?
+  self.@judge_model: String?
+  @judge: Riffer::Evals::Judge?
+end
+
+class Riffer::Skills::Context
+  @backend: Riffer::Skills::Backend
+  @activated: Hash[String, String]
+end
+
+class Riffer::Skills::Config
+  @backend: (Riffer::Skills::Backend | Proc)?
+  @adapter: singleton(Riffer::Skills::Adapter)?
+  @activate: (Array[String] | Proc)?
+  @activate_tool: singleton(Riffer::Tool)?
+end
+
+class Riffer::Skills::FilesystemBackend
+  @paths: Array[String]
+  @skills_cache: Hash[String, String]?
+end
+
+module Riffer
+  self.@config: Riffer::Config?
+end
+
+class Riffer::Agent::Session
+  @callbacks: Array[^(Riffer::Messages::Base) -> void]
+end
+
+class Riffer::Agent::Context
+  @data: Hash[Symbol, untyped]
+end
+
+class Riffer::Agent::Response
+  @interrupted: bool
+end
+
+class Riffer::Tools::Response
+  @success: bool
+end
+
+class Riffer::Tools::Runtime
+  @runner: Riffer::Runner
+end
+
+class Riffer::Runner::Threaded
+  @max_concurrency: Integer
+end
+
+class Riffer::Runner::Fibers
+  @max_concurrency: Integer?
+end
+
+class Riffer::Messages::FilePart
+  @url_string: String?
+end

--- a/sig/stubs/mcp_sdk.rbs
+++ b/sig/stubs/mcp_sdk.rbs
@@ -1,0 +1,22 @@
+# Minimal signatures for the optional `mcp` gem (v0.8+), which ships no RBS.
+#
+# Only the surface used by Riffer::Mcp::Client is declared; the gem is loaded
+# lazily via depends_on, so this stub keeps Steep aware of the constants
+# without adding a hard `library` dependency (mirrors provider_sdk_methods.rbs).
+module MCP
+  class Client
+    class HTTP
+      def initialize: (url: untyped, headers: untyped) -> void
+    end
+
+    class Tool
+      def initialize: (name: untyped, ?description: untyped, ?input_schema: untyped) -> void
+    end
+
+    def initialize: (transport: untyped) -> void
+
+    def tools: () -> untyped
+
+    def call_tool: (tool: untyped, arguments: untyped) -> untyped
+  end
+end

--- a/sig/stubs/zeitwerk.rbs
+++ b/sig/stubs/zeitwerk.rbs
@@ -1,0 +1,12 @@
+# Minimal signatures for the `zeitwerk` gem (autoloader), which ships no RBS.
+#
+# Only the surface used in lib/riffer.rb to set up the loader is declared.
+module Zeitwerk
+  class Loader
+    def self.for_gem: (*untyped) -> Zeitwerk::Loader
+
+    def inflector: () -> untyped
+
+    def setup: () -> void
+  end
+end


### PR DESCRIPTION
## Problem

The Steep diagnostic backlog under `lib/` needs to be cleared before we drops `D::Ruby.lenient` and enforces strict type-checking in CI. Previous PRs handled`agent.rb` and `providers/*`, the two largest concentrations; this PR clears the remaining non-provider files — ~38 files spanning `mcp/*`, `evals/*`, `skills/*`, `params*`, `tools/*`, `messages/*`, `runner/*`, `agent/*`, and the entry module.

## Solution

Applies the same per-diagnostic decision tree as the prior cleanups — **annotate / widen / fix** — all behavior-preserving:

- **Ivar declarations** live in a new `sig/stubs/lib_ivars.rbs` (rbs-inline's `#:` types an assignment, not the ivar itself), matching the `agent_ivars.rbs` / `provider_ivars.rbs` precedent.
- **No-RBS gems** loaded lazily get minimal stubs: `MCP` (`mcp_sdk.rbs`), `Async` (`async.rbs`), `Zeitwerk` (`zeitwerk.rbs`); `cgi` + `yaml` are added to the Steepfile libraries (stdlib, rbs ships them).
- **Empty collections** and `to_h`/payload hashes get inline `Hash[Symbol, untyped]` / `Array[T]` annotations.
- The **`params` DSL block** is bound to its `instance_eval` receiver (`[self: Riffer::Params]`, positional receiver), and heterogeneous schema hashes are widened.
- Nilable reads are **narrowed via local capture** (skills cache, `nested_params`, range slices, `@max_concurrency`) rather than blanket guards.
- **`Riffer::Agent::Context` is now typed through the whole tool-execution chain** (`Tool#call`, `Tools::Runtime`, `Runner#map`, `EvaluationTool`) instead of the stale `Hash[Symbol, untyped]?`.
- `steep:ignore` is used **only where genuinely unverifiable**: the dynamic anonymous-class bodies in `mcp/{tool_factory,authenticated_tool}` and the splat-into-required-kwargs in `mcp/registry`.

**Bar:** this targets **strict error-level clean** — `D::Ruby.strict` reports **zero errors**. A handful of information-level `UnreachableBranch` hints remain by design (they're sub-error under strict), keeping the diff minimal against the real CL2-798 goal rather than chasing literal hint-zero. Giving the MCP-generated tool classes a real type (so `inner.mcp_server_tool_name` checks without an ignore) will be done as a followup.

## Proof

CI is sufficient. `bin/rake` (test + standard + steep:check) is green: **1557 runs, 0 failures**, Standard clean, steep:check clean. The strict bar was verified by temporarily flipping the Steepfile to `D::Ruby.strict` and running `bin/typecheck --severity-level=error` → `No type error detected`, then reverting. No VCR cassettes were re-recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed nil-safety issue in repair logic to prevent failures when processing message boundaries.

* **Refactor**
  * Improved code clarity with explicit local variables throughout codebase.
  * Enhanced type safety with RBS annotations and Steep type-checking improvements.
  * Replaced generic `Hash` types with more specific `Context` type for consistency.

* **Chores**
  * Added configuration libraries to build setup.
  * Added RBS type stubs for external gems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->