### PR TITLE
chore(steep): enforce strict diagnostics in CI

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -19,5 +19,5 @@ target :lib do
   library "uri"
   library "yaml"
 
-  configure_code_diagnostics(D::Ruby.lenient)
+  configure_code_diagnostics(D::Ruby.strict)
 end


### PR DESCRIPTION
## Problem

This is the final ticket in the Steep cleanup series. Throughout the series the `lib/` tree was cleaned up, but the `Steepfile` kept `configure_code_diagnostics(D::Ruby.lenient)` so CI wouldn't gate on the in-progress backlog. With the predecessors merged, that override now serves no purpose and actively masks regressions: `lenient` downgrades real type errors (`NoMethod`, `ReturnTypeMismatch`, etc.) to `:information`, so they render as editor squigglies that CI silently ignores — editor and CI are out of sync.

## Solution

Swap the preset from `D::Ruby.lenient` to `D::Ruby.strict`. The existing `bundle exec steep check` in the CI `rbs` job already exits non-zero on `:warning`+, so this immediately gates the build on the cleaned-up diagnostics.

`strict` (rather than the `default` fallback) is deliberate: the `lib/` tree already passes `strict` cleanly — verified empirically — so the prior series effectively cleaned to that bar. Enforcing only `default` would leave a tier of diagnostics (`FalseAssertion`, `IncompatibleAssignment`, `UnexpectedJump`, …) as non-gating hints, i.e. editor-only squigglies CI won't fail on. `strict` pulls those up to gating errors, keeping the editor's Steep LSP and CI in lockstep (both read this same Steepfile). No code or signature changes were required.

## Proof

CI is sufficient — the `rbs` job runs `bin/typecheck` (strict `steep check`) and the RBS drift check, and `bundle exec rake` runs the full default task. Verified locally on this branch:

- `bin/typecheck` → `No type error detected. 🫖` under `D::Ruby.strict`
- `bin/rbs` + `git diff --exit-code sig/generated/` → no drift
- `bin/rake` → 1557 runs, 0 failures, 0 errors; standard lint clean; steep clean
- Confirmed via a throwaway probe that a `NoMethod` and a `FalseAssertion` both surface as gating `[error]`s under `strict` (the latter is only a non-gating `[hint]` under `default`), then removed the probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened Ruby code diagnostics from lenient to strict, resulting in stricter checks and potentially more reported issues during validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/janeapp/riffer/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->