### PR TITLE
feat: report execution timings across guardrails, tools, and LLM calls

### DIFF
--- a/docs/05_AGENT_LOOP.md
+++ b/docs/05_AGENT_LOOP.md
@@ -102,3 +102,29 @@ If a guardrail, provider call, or other internal code raises an exception, it pr
 | Response flag | `blocked?`                           | `interrupted?`                       | `interrupted?`                       |
 | Stream event  | `GuardrailTripwire`                  | `Interrupt`                          | `Interrupt`                          |
 | Purpose       | Policy enforcement                   | Flow control                         | Runaway loop prevention              |
+
+## Timing
+
+`Riffer::Agent::Response#duration` (seconds, `Float`) reports the **total run time** for `generate` — from the start of the loop through the final response. It's measured with a monotonic clock and is **always populated**, regardless of `Riffer.config.report_timings`. (Streaming returns an `Enumerator`, not a `Response`, so time your own iteration there.)
+
+```ruby
+response = MyAgent.generate("Hello")
+puts "Took #{response.duration.round(3)}s"
+```
+
+Set `Riffer.config.report_timings = true` to also collect a per-call breakdown. Each LLM call in the loop produces a `:llm`-kind entry in `response.timings`:
+
+```ruby
+Riffer.config.report_timings = true
+response = MyAgent.generate("Plan a trip")
+
+response.timings.select { |t| t.kind == :llm }.each do |timing|
+  line = "step #{timing.step} (#{timing.model}): #{timing.duration_ms.round(2)}ms"
+  line += " — first token at #{timing.ttft_ms.round(2)}ms" if timing.ttft
+  puts line
+end
+```
+
+Each `Riffer::Providers::Timing` exposes `model`, `step` (which loop iteration produced the call), `duration`/`duration_ms`, and — for **streamed** calls — `ttft`/`ttft_ms`, the time to first token (the first generated text, reasoning, or tool-call delta). `ttft` is `nil` for non-streaming `generate`.
+
+These `:llm` timings interleave with `:guardrail` and `:tool` timings in `response.timings`, in execution order. See [Configuration — Timing Reporting](10_CONFIGURATION.md#timing-reporting) for the full model.

--- a/docs/06_TOOLS.md
+++ b/docs/06_TOOLS.md
@@ -108,7 +108,7 @@ Options:
 | `String`                   | `string`         |
 | `Integer`                  | `integer`        |
 | `Float`                    | `number`         |
-| `Riffer::Params::Boolean`          | `boolean`        |
+| `Riffer::Params::Boolean`  | `boolean`        |
 | `TrueClass` / `FalseClass` | `boolean`        |
 | `Array`                    | `array`          |
 | `Hash`                     | `object`         |
@@ -281,3 +281,24 @@ error_response.error?         # => true
 error_response.error_message  # => "failed"
 error_response.error_type     # => :not_found
 ```
+
+## Timing
+
+Set `Riffer.config.report_timings = true` to measure how long each tool call takes. Tool timings are the `:tool`-kind entries in `response.timings`:
+
+```ruby
+Riffer.config.report_timings = true
+
+response = MyAgent.generate("What's the weather in Toronto?")
+
+response.timings.select { |t| t.kind == :tool }.each do |timing|
+  status = timing.success? ? "ok" : timing.error_type
+  puts "#{timing.tool_name} (#{timing.call_id}): #{timing.duration_ms.round(2)}ms — #{status}"
+end
+```
+
+Each `Riffer::Tools::Timing` exposes `tool_name`, `call_id`, `duration`/`duration_ms`, `error_type` (`nil` on success), and `success?`. The duration spans the dispatch and any `around_tool_call` wrapper, and is captured per call — so it's correct under any tool runtime (sequential, threaded, or fibers). Because concurrent tool calls overlap, their durations are wall-clock per call.
+
+A tool that errors or times out is **still timed** (unlike a guardrail, whose raise aborts the run): the runtime captures the failure into a response, so `error_type` records the outcome and `duration` covers the failed attempt. The `call_id` disambiguates parallel calls to the same tool. MCP tool calls route through the same runtime, so they're timed too.
+
+During streaming, a `Riffer::StreamEvents::Timing` event with `kind: :tool` is emitted after each tool call. See [Configuration — Timing Reporting](10_CONFIGURATION.md#timing-reporting) for the full model.

--- a/docs/09_STREAM_EVENTS.md
+++ b/docs/09_STREAM_EVENTS.md
@@ -186,6 +186,22 @@ end
 
 See [Guardrails](12_GUARDRAILS.md) for more information.
 
+### Timing
+
+Emitted after each timed unit of work — a guardrail, a tool call, or an LLM call — when `Riffer.config.report_timings` is enabled. The wrapped `Riffer::Timing` carries the details; use `kind` to discriminate:
+
+```ruby
+agent.stream("Hello").each do |event|
+  case event
+  when Riffer::StreamEvents::Timing
+    puts "#{event.kind}: #{event.duration}s"   # :guardrail, :tool, or :llm
+    # event.timing is the full Riffer::Timing record
+  end
+end
+```
+
+Off by default. See [Configuration — Timing Reporting](10_CONFIGURATION.md#timing-reporting) for the timing model and the config flag.
+
 ### SkillActivation
 
 Emitted when a skill is activated during streaming. Fired when the LLM calls the skill activation tool:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -65,11 +65,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value                          | Description                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Value                             | Description                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `Riffer::Tools::Runtime` subclass | Instantiated automatically (e.g., `Riffer::Tools::Runtime::Inline`, `Riffer::Tools::Runtime::Threaded`) |
-| `Riffer::Tools::Runtime` instance | Custom runtime with specific options                                                              |
-| `Proc`                         | Dynamic resolution                                                                                |
+| `Riffer::Tools::Runtime` instance | Custom runtime with specific options                                                                    |
+| `Proc`                            | Dynamic resolution                                                                                      |
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
@@ -143,6 +143,49 @@ When enabled, two repairs run automatically:
 Defaults to `false` — pre-healing behavior. Seeded sessions pass through untouched, and orphan `tool_use` left by an interrupt remain in history for `execute_pending_tool_calls` to re-run on the next call.
 
 There is no per-call override and no customizable placeholder. Callers needing finer control can call `agent.session.update(tool_call_id:, ...)` after the interrupt returns to upgrade a placeholder in place. See [Agent Lifecycle — Healing pending tool results on interrupt](04_AGENT_LIFECYCLE.md#healing-pending-tool-results-on-interrupt-experimental).
+
+### Timing Reporting
+
+Measure how long each unit of work takes — guardrails, tool calls, and LLM calls:
+
+```ruby
+Riffer.configure do |config|
+  config.report_timings = true
+end
+```
+
+When enabled, Riffer times each unit (using a monotonic clock) and exposes one timing per unit, in execution order, on `Riffer::Agent::Response#timings`. When streaming, a `Riffer::StreamEvents::Timing` event is emitted after each unit completes.
+
+Defaults to `false`, in which case `response.timings` is empty and no per-unit timing is collected. The setter coerces common boolean representations (`true`/`false`, `"true"`/`"false"`, `1`/`0`, `"1"`/`"0"`, `nil`) so values pulled from environment variables behave predictably.
+
+> **Note:** This flag gates only the per-unit `timings` breakdown. The **total run time**, `Riffer::Agent::Response#duration` (seconds, `Float`), is always measured for `generate` regardless of this flag — it's two clock reads.
+
+#### The timing model
+
+Every entry in `response.timings` is a `Riffer::Timing`. Discriminate with `#kind`; each subclass adds its own fields:
+
+| `kind`       | Class                        | Fields beyond `duration`/`duration_ms`           |
+| ------------ | ---------------------------- | ------------------------------------------------ |
+| `:guardrail` | `Riffer::Guardrails::Timing` | `guardrail`, `phase`, `result_type`              |
+| `:tool`      | `Riffer::Tools::Timing`      | `tool_name`, `call_id`, `error_type`, `success?` |
+| `:llm`       | `Riffer::Providers::Timing`  | `model`, `step`, `ttft`, `ttft_ms`               |
+
+```ruby
+Riffer.config.report_timings = true
+response = MyAgent.generate("Hello")
+
+puts "Total: #{response.duration.round(3)}s"
+response.timings.each do |t|
+  puts "#{t.kind}: #{t.duration_ms.round(2)}ms"
+end
+
+# Filter to one kind:
+tool_timings = response.timings.select { |t| t.kind == :tool }
+```
+
+Because `timings` is in execution order, it reads as a timeline of the whole run (before-guardrails → LLM step 1 → tools → after-guardrails → LLM step 2 → …). Tool calls can run concurrently, so their durations are per-call wall-clock and may overlap.
+
+See [Guardrails — Timing](12_GUARDRAILS.md#timing), [Tools — Timing](06_TOOLS.md#timing), and [The Agent Loop — Timing](05_AGENT_LOOP.md#timing) for the per-unit details.
 
 ## Agent-Level Configuration
 

--- a/docs/12_GUARDRAILS.md
+++ b/docs/12_GUARDRAILS.md
@@ -244,6 +244,48 @@ MyAgent.stream("Hello").each do |event|
 end
 ```
 
+### Timing
+
+Set `Riffer.config.report_timings = true` to measure how long each guardrail takes (alongside tool and LLM calls). Guardrail timings are the `:guardrail`-kind entries in `response.timings`, in execution order:
+
+```ruby
+Riffer.config.report_timings = true
+
+response = MyAgent.generate("Hello")
+
+response.timings.select { |t| t.kind == :guardrail }.each do |timing|
+  puts "#{timing.guardrail} (#{timing.phase}): #{timing.duration_ms.round(2)}ms — #{timing.result_type}"
+end
+```
+
+Each `Riffer::Guardrails::Timing` exposes:
+
+| Method        | Description                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `guardrail`   | The guardrail class that ran.                                    |
+| `phase`       | `:before` or `:after`.                                           |
+| `duration`    | Execution time in seconds (monotonic clock), as a `Float`.       |
+| `duration_ms` | Convenience accessor for the duration in milliseconds.           |
+| `result_type` | What the guardrail returned: `:pass`, `:transform`, or `:block`. |
+
+The duration covers only the guardrail's `process_input`/`process_output` call, not its instantiation. When a guardrail blocks, its timing is recorded (with `result_type: :block`) and timing stops there, since later guardrails do not run. When the flag is off (the default), `response.timings` is empty and no per-unit timing is collected.
+
+During streaming, a `Riffer::StreamEvents::Timing` event is emitted after each guardrail runs (use `kind` to pick out guardrails):
+
+```ruby
+MyAgent.stream("Hello").each do |event|
+  case event
+  when Riffer::StreamEvents::Timing
+    next unless event.kind == :guardrail
+    puts "#{event.timing.guardrail} (#{event.timing.phase}): #{event.duration}s"
+  when Riffer::StreamEvents::TextDelta
+    print event.content
+  end
+end
+```
+
+See [Configuration — Timing Reporting](10_CONFIGURATION.md#timing-reporting) for the full timing model and the config flag.
+
 ## Streaming with Guardrails
 
 Guardrails work with streaming. If blocked, a `Riffer::StreamEvents::GuardrailTripwire` event is yielded:

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -22,6 +22,16 @@ class Riffer::Agent::Response
   # The modifications made by guardrails during processing.
   attr_reader :modifications #: Array[Riffer::Guardrails::Modification]
 
+  # The per-unit execution timings (guardrails, tool calls, and LLM calls), in
+  # execution order. Empty unless +Riffer.config.report_timings+ is enabled.
+  # Discriminate entries with +Riffer::Timing#kind+.
+  attr_reader :timings #: Array[Riffer::Timing]
+
+  # The total run time in seconds, measured with a monotonic clock. Always
+  # populated for +generate+ (independent of +Riffer.config.report_timings+);
+  # +nil+ for responses built outside the generation loop.
+  attr_reader :duration #: Float?
+
   # The reason provided with the interrupt, if any.
   attr_reader :interrupt_reason #: (String | Symbol)?
 
@@ -35,12 +45,29 @@ class Riffer::Agent::Response
   # turn (when an interrupt left them unanswered and history healing is on).
   attr_reader :healed_tool_call_ids #: Array[String]
 
+  # Creates a new response.
+  #
+  # [content] the response content.
+  # [tripwire] optional tripwire for blocked responses.
+  # [modifications] guardrail modifications applied during processing.
+  # [timings] per-unit execution timings (empty unless
+  #   +Riffer.config.report_timings+ is enabled).
+  # [duration] total run time in seconds (+nil+ outside the generation loop).
+  # [interrupted] whether the agent loop was interrupted by a callback.
+  # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
+  # [structured_output] parsed structured output when structured output is configured.
+  # [messages] the full message history from the agent conversation.
+  # [healed_tool_call_ids] call ids filled with placeholder tool results
+  #   when history healing is enabled.
+  #
   #--
-  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
-  def initialize(content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [], healed_tool_call_ids: [])
+  #: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?duration: Float?, ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
+  def initialize(content, tripwire: nil, modifications: [], timings: [], duration: nil, interrupted: false, interrupt_reason: nil, structured_output: nil, messages: [], healed_tool_call_ids: [])
     @content = content
     @tripwire = tripwire
     @modifications = modifications
+    @timings = timings
+    @duration = duration
     @interrupted = interrupted
     @interrupt_reason = interrupt_reason
     @structured_output = structured_output

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -31,9 +31,11 @@ module Riffer::Agent::Run
   #--
   #: (Riffer::Agent, ?stream_yielder: Enumerator::Yielder?) -> Riffer::Agent::Response
   def run_loop(agent, stream_yielder: nil)
+    started = monotonic_now
     all_modifications = [] #: Array[Riffer::Guardrails::Modification]
+    all_timings = [] #: Array[Riffer::Timing]
 
-    run_before_guardrails(agent, stream_yielder, all_modifications) { |tripped| return tripped }
+    run_before_guardrails(agent, stream_yielder, all_modifications, all_timings, started) { |tripped| return tripped }
 
     skills = agent.context.skills
 
@@ -44,14 +46,14 @@ module Riffer::Agent::Run
     step = agent.session.steps
 
     reason = catch(:riffer_interrupt) do
-      execute_pending_tool_calls(agent)
+      execute_pending_tool_calls(agent, stream_yielder, all_timings)
 
       loop do
-        response = stream_yielder ? accumulate_streamed_response(agent, stream_yielder) : call_llm(agent)
         step += 1
+        response = perform_llm_call(agent, step, stream_yielder, all_timings)
         track_token_usage(agent, response.token_usage)
 
-        processed_response = run_after_guardrails(agent, response, stream_yielder, all_modifications) { |tripped| return tripped }
+        processed_response = run_after_guardrails(agent, response, stream_yielder, all_modifications, all_timings, started) { |tripped| return tripped }
 
         agent.session.add(processed_response)
 
@@ -60,27 +62,72 @@ module Riffer::Agent::Run
         max_steps = agent.config.max_steps
         throw :riffer_interrupt, Riffer::Agent::INTERRUPT_MAX_STEPS if max_steps && step >= max_steps
 
-        execute_tool_calls(agent, processed_response)
+        execute_tool_calls(agent, processed_response, stream_yielder, all_timings)
       end
 
-      return final_response(agent, all_modifications)
+      return final_response(agent, all_modifications, all_timings, started)
     end
 
     new_messages, filled = Riffer::Agent::Session::Repair.fill_orphans(agent.session.messages)
     agent.session.set(new_messages)
     stream_yielder << Riffer::StreamEvents::Interrupt.new(reason: reason, healed_tool_call_ids: filled) if stream_yielder
-    final_response(agent, all_modifications, interrupted: true, interrupt_reason: reason, healed_tool_call_ids: filled)
+    final_response(agent, all_modifications, all_timings, started, interrupted: true, interrupt_reason: reason, healed_tool_call_ids: filled)
   end
 
+  # Returns the current monotonic clock reading, in seconds.
   #--
-  #: (Riffer::Agent, Enumerator::Yielder) -> Riffer::Messages::Assistant
-  def accumulate_streamed_response(agent, stream_yielder)
+  #: () -> Float
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  # Calls the LLM (streamed or not) and, when +Riffer.config.report_timings+ is
+  # enabled, records a Riffer::Providers::Timing for the call — total duration
+  # plus, for streamed calls, time-to-first-token.
+  #--
+  #: (Riffer::Agent, Integer, Enumerator::Yielder?, Array[Riffer::Timing]) -> Riffer::Messages::Assistant
+  def perform_llm_call(agent, step, stream_yielder, all_timings)
+    unless Riffer.config.report_timings
+      return stream_yielder ? accumulate_streamed_response(agent, stream_yielder) : call_llm(agent)
+    end
+
+    started = monotonic_now
+    first_content_at = nil #: Float?
+    response = if stream_yielder
+      accumulate_streamed_response(agent, stream_yielder, on_first_content: -> { first_content_at = monotonic_now })
+    else
+      call_llm(agent)
+    end
+
+    timing = Riffer::Providers::Timing.new(
+      model: agent.model_name,
+      step: step,
+      duration: monotonic_now - started,
+      ttft: first_content_at && (first_content_at - started)
+    )
+    record_timings!(stream_yielder, all_timings, [timing])
+    response
+  end
+
+  # Consumes the provider's stream, yielding each event downstream and
+  # accumulating the assistant message. When +on_first_content+ is given, it is
+  # invoked once, on the first generated-content event (text, reasoning, or
+  # tool-call delta) — used to capture time-to-first-token.
+  #--
+  #: (Riffer::Agent, Enumerator::Yielder, ?on_first_content: (^() -> void)?) -> Riffer::Messages::Assistant
+  def accumulate_streamed_response(agent, stream_yielder, on_first_content: nil)
     accumulated_content = ""
     accumulated_tool_calls = [] #: Array[Riffer::Messages::Assistant::ToolCall]
     accumulated_token_usage = nil #: Riffer::Providers::TokenUsage?
+    signaled_first = false
 
     call_llm_stream(agent).each do |event|
       stream_yielder << event
+
+      if on_first_content && !signaled_first && first_content_event?(event)
+        on_first_content.call
+        signaled_first = true
+      end
 
       case event
       when Riffer::StreamEvents::TextDelta
@@ -105,6 +152,16 @@ module Riffer::Agent::Run
     )
   end
 
+  # Returns true for the first generated-content events — text, reasoning, or
+  # tool-call deltas — used to mark time-to-first-token.
+  #--
+  #: (Riffer::StreamEvents::Base) -> bool
+  def first_content_event?(event)
+    event.is_a?(Riffer::StreamEvents::TextDelta) ||
+      event.is_a?(Riffer::StreamEvents::ReasoningDelta) ||
+      event.is_a?(Riffer::StreamEvents::ToolCallDelta)
+  end
+
   #--
   #: (Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Modification]) -> void
   def record_modifications!(stream_yielder, all_modifications, new_modifications)
@@ -112,18 +169,31 @@ module Riffer::Agent::Run
     new_modifications.each { |m| stream_yielder << Riffer::StreamEvents::GuardrailModification.new(m) } if stream_yielder
   end
 
+  # Appends +new_timings+ to +all_timings+ and emits a +Timing+ event for each
+  # one when streaming.
+  #
   #--
-  #: (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
-  def tripwire_response(agent, stream_yielder, tripwire, all_modifications)
+  #: (Enumerator::Yielder?, Array[Riffer::Timing], Array[Riffer::Timing]) -> void
+  def record_timings!(stream_yielder, all_timings, new_timings)
+    all_timings.concat(new_timings)
+    new_timings.each { |t| stream_yielder << Riffer::StreamEvents::Timing.new(t) } if stream_yielder
+  end
+
+  # Emits a +GuardrailTripwire+ event when streaming and returns the
+  # short-circuit +Response+ for a tripped guardrail.
+  #
+  #--
+  #: (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) -> Riffer::Agent::Response
+  def tripwire_response(agent, stream_yielder, tripwire, all_modifications, all_timings, started)
     stream_yielder << Riffer::StreamEvents::GuardrailTripwire.new(tripwire) if stream_yielder
-    build_response(agent, "", tripwire: tripwire, modifications: all_modifications)
+    build_response(agent, "", started: started, tripwire: tripwire, modifications: all_modifications, timings: all_timings)
   end
 
   #--
-  #: (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
-  def final_response(agent, all_modifications, **extra)
+  #: (Riffer::Agent, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float, **untyped) -> Riffer::Agent::Response
+  def final_response(agent, all_modifications, all_timings, started, **extra)
     response = agent.session.final_assistant_message
-    build_response(agent, response&.content || "", modifications: all_modifications, structured_output: validate_structured_output(agent, response), **extra)
+    build_response(agent, response&.content || "", started: started, modifications: all_modifications, timings: all_timings, structured_output: validate_structured_output(agent, response), **extra)
   end
 
   #--
@@ -149,15 +219,16 @@ module Riffer::Agent::Run
   end
 
   #--
-  #: (Riffer::Agent, Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
-  def execute_tool_calls(agent, assistant_message, tool_calls: assistant_message.tool_calls)
+  #: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Timing], ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
+  def execute_tool_calls(agent, assistant_message, stream_yielder, all_timings, tool_calls: assistant_message.tool_calls)
     return if tool_calls.empty?
 
     results = agent.tool_runtime.execute(tool_calls, tools: effective_tools(agent), context: agent.context, assistant_message: assistant_message)
 
     inject_discovered_tools(agent, results)
 
-    results.each do |tool_call, result|
+    timings = [] #: Array[Riffer::Timing]
+    results.each do |tool_call, result, timing|
       agent.session.add(Riffer::Messages::Tool.new(
         result.content,
         tool_call_id: tool_call.call_id,
@@ -165,11 +236,13 @@ module Riffer::Agent::Run
         error: result.error_message,
         error_type: result.error_type
       ))
+      timings << timing if timing
     end
+    record_timings!(stream_yielder, all_timings, timings)
   end
 
   #--
-  #: (Riffer::Agent, Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]) -> void
+  #: (Riffer::Agent, Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing?]]) -> void
   def inject_discovered_tools(agent, results)
     to_inject = results.flat_map { |_, result|
       result.is_a?(Riffer::Mcp::SearchTool::Result) ? result.discovered_tools : [] #: Array[singleton(Riffer::Tool)]
@@ -180,39 +253,41 @@ module Riffer::Agent::Run
   end
 
   #--
-  #: (Riffer::Agent) -> void
-  def execute_pending_tool_calls(agent)
+  #: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Timing]) -> void
+  def execute_pending_tool_calls(agent, stream_yielder, all_timings)
     assistant_message, pending = agent.session.pending_tool_calls
-    execute_tool_calls(agent, assistant_message, tool_calls: pending) if assistant_message
+    execute_tool_calls(agent, assistant_message, stream_yielder, all_timings, tool_calls: pending) if assistant_message
   end
 
   #--
-  #: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> void
-  def run_before_guardrails(agent, stream_yielder, all_modifications)
+  #: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> void
+  def run_before_guardrails(agent, stream_yielder, all_modifications, all_timings, started)
     guardrails = agent.config.guardrails_for(:before)
     return if guardrails.empty?
 
-    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :before, context: agent.context)
-    processed_messages, tripwire, modifications = runner.run(agent.session.messages)
+    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :before, context: agent.context, measure_timings: Riffer.config.report_timings)
+    processed_messages, tripwire, modifications, timings = runner.run(agent.session.messages)
     agent.session.set(processed_messages) unless tripwire
     record_modifications!(stream_yielder, all_modifications, modifications)
-    yield tripwire_response(agent, stream_yielder, tripwire, all_modifications) if tripwire
+    record_timings!(stream_yielder, all_timings, timings)
+    yield tripwire_response(agent, stream_yielder, tripwire, all_modifications, all_timings, started) if tripwire
   end
 
   #--
-  #: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> untyped
-  def run_after_guardrails(agent, response, stream_yielder, all_modifications)
+  #: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> untyped
+  def run_after_guardrails(agent, response, stream_yielder, all_modifications, all_timings, started)
     guardrails = agent.config.guardrails_for(:after)
     return response if guardrails.empty?
 
-    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :after, context: agent.context)
-    processed_response, tripwire, modifications = runner.run(response, messages: agent.session.messages)
+    runner = Riffer::Guardrails::Runner.new(guardrails, phase: :after, context: agent.context, measure_timings: Riffer.config.report_timings)
+    processed_response, tripwire, modifications, timings = runner.run(response, messages: agent.session.messages)
 
     response_index = agent.session.messages.length
     modifications.each { |m| m.message_indices.map! { response_index } }
 
     record_modifications!(stream_yielder, all_modifications, modifications)
-    yield tripwire_response(agent, stream_yielder, tripwire, all_modifications) if tripwire
+    record_timings!(stream_yielder, all_timings, timings)
+    yield tripwire_response(agent, stream_yielder, tripwire, all_modifications, all_timings, started) if tripwire
 
     processed_response
   end
@@ -240,11 +315,15 @@ module Riffer::Agent::Run
     opts
   end
 
+  # Builds the +Response+. When +started+ is given (always, inside the
+  # generation loop), the total run +duration+ is stamped from it with a fresh
+  # monotonic reading — independent of +Riffer.config.report_timings+.
   #--
-  #: (Riffer::Agent, String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
-  def build_response(agent, content, tripwire: nil, modifications: [], interrupted: false, interrupt_reason: nil, structured_output: nil, healed_tool_call_ids: [])
+  #: (Riffer::Agent, String, ?started: Float?, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response(agent, content, started: nil, tripwire: nil, modifications: [], timings: [], interrupted: false, interrupt_reason: nil, structured_output: nil, healed_tool_call_ids: [])
     messages = agent.session.messages
-    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: messages.frozen? ? messages : messages.dup.freeze, healed_tool_call_ids: healed_tool_call_ids)
+    duration = started && (monotonic_now - started)
+    Riffer::Agent::Response.new(content, tripwire: tripwire, modifications: modifications, timings: timings, duration: duration, interrupted: interrupted, interrupt_reason: interrupt_reason, structured_output: structured_output, messages: messages.frozen? ? messages : messages.dup.freeze, healed_tool_call_ids: healed_tool_call_ids)
   end
 
   # Raises when +files+ are supplied without a +prompt+ — the provider needs

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -131,6 +131,37 @@ class Riffer::Config
     end
   end
 
+  # When +true+, riffer measures how long each unit of work takes — guardrails,
+  # tool calls, and LLM calls — and exposes the per-unit results, in execution
+  # order, on +Riffer::Agent::Response#timings+ (and, when streaming, as
+  # +Riffer::StreamEvents::Timing+ events).
+  #
+  # Defaults to +false+, in which case no per-unit timing is collected and
+  # +timings+ is empty. This flag does not gate +Riffer::Agent::Response#duration+
+  # (the total run time), which is always measured.
+  attr_reader :report_timings #: bool
+
+  # Sets the +report_timings+ flag.
+  #
+  # Coerces common boolean representations so values pulled from
+  # environment variables behave predictably — the string +"false"+ is
+  # truthy in Ruby and would otherwise flip the flag on. Accepts
+  # +true+/+false+, +"true"+/+"false"+, +1+/+0+, +"1"+/+"0"+, and +nil+
+  # (treated as +false+, the default). Raises +Riffer::ArgumentError+ for
+  # any other value.
+  #
+  #--
+  #: (untyped) -> void
+  def report_timings=(value)
+    @report_timings = case value
+    when true, "true", 1, "1" then true
+    when false, "false", 0, "0", nil then false
+    else
+      raise Riffer::ArgumentError,
+        "report_timings must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
+    end
+  end
+
   #--
   #: () -> void
   def initialize
@@ -146,5 +177,6 @@ class Riffer::Config
     @skills = Skills.new
     @message_id_strategy = :none
     @experimental_history_healing = false
+    @report_timings = false
   end
 end

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Executes guardrails sequentially, passing each one's output to the next; if
-# any blocks, execution stops and a tripwire is returned.
+# Executes guardrails sequentially and manages the processing pipeline.
+#
+# The runner processes guardrails in order, passing the output of each
+# to the next. If any guardrail blocks, execution stops and a tripwire
+# is returned.
+#
+#   runner = Runner.new(guardrail_configs, phase: :before, context: context)
+#   data, tripwire, modifications, timings = runner.run(messages)
 class Riffer::Guardrails::Runner
   # The guardrail configs to execute.
   attr_reader :guardrail_configs #: Array[Hash[Symbol, untyped]]
@@ -13,26 +19,47 @@ class Riffer::Guardrails::Runner
   # The context passed to guardrails.
   attr_reader :context #: untyped
 
+  # Whether to record a timing for each guardrail's execution.
+  attr_reader :measure_timings #: bool
+
+  # Creates a new runner.
+  #
+  # [guardrail_configs] configs with :class and :options keys.
+  # [phase] :before or :after.
+  # [context] optional context to pass to guardrails.
+  # [measure_timings] when true, records a Timing per guardrail.
+  #
   #--
-  #: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
-  def initialize(guardrail_configs, phase:, context: nil)
+  #: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped, ?measure_timings: bool) -> void
+  def initialize(guardrail_configs, phase:, context: nil, measure_timings: false)
     @guardrail_configs = guardrail_configs
     @phase = phase
     @context = context
+    @measure_timings = measure_timings
   end
 
-  # Runs the guardrails sequentially. For the +:before+ phase +data+ is the
-  # messages array; for +:after+ it's the response (and +messages+ must be
-  # provided).
+  # Runs the guardrails sequentially.
+  #
+  # For before phase, data should be an array of messages.
+  # For after phase, data should be a response and messages must be provided.
+  #
+  # Returns a 4-tuple: the processed data, a tripwire (or +nil+), the
+  # modifications, and the per-guardrail timings. Timings are empty unless
+  # +measure_timings+ was set.
+  #
+  # [data] the data to process (messages for before, response for after).
+  # [messages] the conversation messages (required for after phase).
+  #
   #--
-  #: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
+  #: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Timing]]
   def run(data, messages: nil)
     current_data = data
     modifications = [] #: Array[Riffer::Guardrails::Modification]
+    timings = [] #: Array[Riffer::Guardrails::Timing]
 
     guardrail_configs.each do |config|
       guardrail = instantiate_guardrail(config)
-      result = execute_guardrail(guardrail, current_data, messages: messages)
+      result = run_with_timing(guardrail, current_data, messages: messages, timings: timings)
 
       if result.block?
         tripwire = Riffer::Guardrails::Tripwire.new(
@@ -41,7 +68,7 @@ class Riffer::Guardrails::Runner
           phase: phase,
           metadata: result.metadata
         )
-        return [current_data, tripwire, modifications]
+        return [current_data, tripwire, modifications, timings]
       end
 
       if result.transform?
@@ -55,10 +82,30 @@ class Riffer::Guardrails::Runner
       current_data = result.data
     end
 
-    [current_data, nil, modifications]
+    [current_data, nil, modifications, timings]
   end
 
   private
+
+  # Executes a single guardrail, recording a Timing into +timings+ when
+  # +measure_timings+ is set. The duration is captured with a monotonic
+  # clock around the +process_*+ call (guardrail instantiation is excluded).
+  #
+  #--
+  #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?, timings: Array[Riffer::Guardrails::Timing]) -> Riffer::Guardrails::Result
+  def run_with_timing(guardrail, data, messages:, timings:)
+    return execute_guardrail(guardrail, data, messages: messages) unless measure_timings
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = execute_guardrail(guardrail, data, messages: messages)
+    timings << Riffer::Guardrails::Timing.new(
+      guardrail: guardrail.class,
+      phase: phase,
+      duration: Process.clock_gettime(Process::CLOCK_MONOTONIC) - started,
+      result_type: result.type
+    )
+    result
+  end
 
   #--
   #: (Hash[Symbol, untyped]) -> Riffer::Guardrail

--- a/lib/riffer/guardrails/timing.rb
+++ b/lib/riffer/guardrails/timing.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Records how long a single guardrail took to execute.
+#
+# When +Riffer.config.report_timings+ is enabled, the runner measures each
+# guardrail's +process_input+/+process_output+ call and produces one Timing per
+# guardrail, in execution order.
+#
+#   timing = Timing.new(
+#     guardrail: ProfanityFilter,
+#     phase: :before,
+#     duration: 0.0012,
+#     result_type: :pass
+#   )
+#   timing.kind        # => :guardrail
+#   timing.duration_ms # => 1.2
+class Riffer::Guardrails::Timing < Riffer::Timing
+  # The guardrail class that was executed.
+  attr_reader :guardrail #: singleton(Riffer::Guardrail)
+
+  # The phase when the guardrail ran (:before or :after).
+  attr_reader :phase #: Symbol
+
+  # The result the guardrail returned (:pass, :transform, or :block). A
+  # guardrail that raises aborts the run before a timing is recorded, so
+  # this is always set in practice; it is nilable only as a safe default.
+  attr_reader :result_type #: Symbol?
+
+  # Creates a new timing record.
+  #
+  # [guardrail] the guardrail class that ran.
+  # [phase] :before or :after.
+  # [duration] execution time in seconds.
+  # [result_type] :pass, :transform, or :block.
+  #
+  #--
+  #: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, duration: Float, ?result_type: Symbol?) -> void
+  def initialize(guardrail:, phase:, duration:, result_type: nil)
+    super(duration: duration)
+    @guardrail = guardrail
+    @phase = phase
+    @result_type = result_type
+  end
+
+  # Identifies this as a guardrail timing.
+  #
+  #--
+  #: () -> Symbol
+  def kind = :guardrail
+
+  # Converts the timing to a hash.
+  #
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    super.merge(guardrail: guardrail.name, phase: phase, result_type: result_type)
+  end
+end

--- a/lib/riffer/providers/timing.rb
+++ b/lib/riffer/providers/timing.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Records how long a single LLM call took.
+#
+# When +Riffer.config.report_timings+ is enabled, the generation loop measures
+# each provider call — a +generate+ round-trip, or a full streamed response —
+# and produces one Timing per call, tagged with the +step+ it produced.
+#
+# For streamed calls, +ttft+ holds the time to first token: the elapsed time
+# until the first generated-content event (a text, reasoning, or tool-call
+# delta). It is +nil+ for non-streaming calls and for streams that yield no
+# content.
+#
+#   timing = Timing.new(model: "openai/gpt-4", step: 1, duration: 1.8, ttft: 0.3)
+#   timing.kind   # => :llm
+#   timing.ttft_ms # => 300.0
+class Riffer::Providers::Timing < Riffer::Timing
+  # The model that produced the response (e.g. "openai/gpt-4").
+  attr_reader :model #: String
+
+  # The step (loop iteration) this call produced.
+  attr_reader :step #: Integer
+
+  # Time to first token, in seconds (streaming only); +nil+ otherwise.
+  attr_reader :ttft #: Float?
+
+  # Creates a new timing record.
+  #
+  # [model] the model that produced the response.
+  # [step] the loop iteration this call produced.
+  # [duration] total call time in seconds.
+  # [ttft] time to first token in seconds (streaming only).
+  #
+  #--
+  #: (model: String, step: Integer, duration: Float, ?ttft: Float?) -> void
+  def initialize(model:, step:, duration:, ttft: nil)
+    super(duration: duration)
+    @model = model
+    @step = step
+    @ttft = ttft
+  end
+
+  # Identifies this as an LLM timing.
+  #
+  #--
+  #: () -> Symbol
+  def kind = :llm
+
+  # The time to first token in milliseconds, or +nil+ when not measured.
+  #
+  #--
+  #: () -> Float?
+  def ttft_ms
+    ttft && ttft * 1000.0
+  end
+
+  # Converts the timing to a hash.
+  #
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    super.merge(model: model, step: step, ttft: ttft)
+  end
+end

--- a/lib/riffer/stream_events/timing.rb
+++ b/lib/riffer/stream_events/timing.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Represents a timing event during streaming.
+#
+# Emitted after each timed unit of work — a guardrail, a tool call, or an LLM
+# call — when +Riffer.config.report_timings+ is enabled. The wrapped
+# Riffer::Timing carries the details; use +kind+ to discriminate.
+class Riffer::StreamEvents::Timing < Riffer::StreamEvents::Base
+  # The timing record.
+  attr_reader :timing #: Riffer::Timing
+
+  # Creates a new timing stream event.
+  #
+  # [timing] the timing details.
+  # [role] the message role (defaults to :assistant).
+  #
+  #--
+  #: (Riffer::Timing, ?role: Symbol) -> void
+  def initialize(timing, role: :assistant)
+    super(role: role)
+    @timing = timing
+  end
+
+  # The kind of unit this timing describes (:guardrail, :tool, or :llm).
+  #
+  #--
+  #: () -> Symbol
+  def kind = timing.kind
+
+  # The execution time in seconds.
+  #
+  #--
+  #: () -> Float
+  def duration = timing.duration
+
+  # Converts the event to a hash.
+  #
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    {role: @role, timing: timing.to_h}
+  end
+end

--- a/lib/riffer/timing.rb
+++ b/lib/riffer/timing.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for execution timings.
+#
+# When +Riffer.config.report_timings+ is enabled, the framework measures how
+# long individual units of work take and produces one Timing per unit —
+# guardrails, tool calls, and LLM calls — exposed together, in execution order,
+# on Riffer::Agent::Response#timings (and, when streaming, as
+# Riffer::StreamEvents::Timing events).
+#
+# Every timing carries a +kind+ (use it to discriminate) and a +duration+ in
+# seconds, measured with a monotonic clock. Each subclass adds the fields
+# relevant to its unit of work.
+class Riffer::Timing
+  # The wall-clock execution time, in seconds, measured with a monotonic clock.
+  attr_reader :duration #: Float
+
+  #--
+  #: (duration: Float) -> void
+  def initialize(duration:)
+    @duration = duration
+  end
+
+  # A symbol identifying the kind of unit this timing describes (e.g.
+  # +:guardrail+, +:tool+, +:llm+). Implemented by each subclass.
+  #
+  #--
+  #: () -> Symbol
+  def kind
+    raise NotImplementedError, "#{self.class} must implement #kind"
+  end
+
+  # The execution time in milliseconds.
+  #
+  #--
+  #: () -> Float
+  def duration_ms
+    duration * 1000.0
+  end
+
+  # Converts the timing to a hash. Subclasses merge their own fields onto this
+  # +kind+/+duration+ core.
+  #
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    {kind: kind, duration: duration}
+  end
+end

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -16,15 +16,29 @@ class Riffer::Tools::Runtime
     @runner = runner
   end
 
-  # Executes a batch of tool calls, returning <tt>[tool_call, response]</tt> pairs.
+  # Executes a batch of tool calls, returning
+  # <tt>[tool_call, response, timing]</tt> triples. The +timing+ is a
+  # Riffer::Tools::Timing when +Riffer.config.report_timings+ is enabled, else
+  # +nil+. The duration spans the dispatch and any +around_tool_call+ wrapper,
+  # and is captured per call (correct under any concurrency model).
   #--
-  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
+  #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing?]]
   def execute(tool_calls, tools:, context:, assistant_message: nil)
+    measure = Riffer.config.report_timings
     @runner.map(tool_calls, context: context) do |tool_call|
+      started = measure ? Process.clock_gettime(Process::CLOCK_MONOTONIC) : nil
       result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
         dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
       end
-      [tool_call, result]
+      timing = if started
+        Riffer::Tools::Timing.new(
+          tool_name: tool_call.name,
+          call_id: tool_call.call_id,
+          duration: Process.clock_gettime(Process::CLOCK_MONOTONIC) - started,
+          error_type: result.error_type
+        )
+      end
+      [tool_call, result, timing]
     end
   end
 

--- a/lib/riffer/tools/timing.rb
+++ b/lib/riffer/tools/timing.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Records how long a single tool call took to execute.
+#
+# When +Riffer.config.report_timings+ is enabled, the tool runtime measures each
+# tool call — the dispatch plus any +around_tool_call+ wrapper — and produces
+# one Timing per call.
+#
+# Unlike guardrails, a tool that errors or times out is still timed: the runtime
+# captures the failure into a Riffer::Tools::Response rather than raising, so
+# +error_type+ records the outcome and +duration+ covers the failed attempt.
+#
+#   timing = Timing.new(
+#     tool_name: "get_weather",
+#     call_id: "call_123",
+#     duration: 0.42,
+#     error_type: nil
+#   )
+#   timing.kind     # => :tool
+#   timing.success? # => true
+class Riffer::Tools::Timing < Riffer::Timing
+  # The name of the tool that was called.
+  attr_reader :tool_name #: String
+
+  # The tool call id, used to correlate parallel calls to the same tool.
+  attr_reader :call_id #: String
+
+  # The error type when the call failed (:unknown_tool, :validation_error,
+  # :execution_error, :timeout_error), or +nil+ on success.
+  attr_reader :error_type #: Symbol?
+
+  # Creates a new timing record.
+  #
+  # [tool_name] the name of the tool that ran.
+  # [call_id] the tool call id.
+  # [duration] execution time in seconds.
+  # [error_type] the error type, or +nil+ on success.
+  #
+  #--
+  #: (tool_name: String, call_id: String, duration: Float, ?error_type: Symbol?) -> void
+  def initialize(tool_name:, call_id:, duration:, error_type: nil)
+    super(duration: duration)
+    @tool_name = tool_name
+    @call_id = call_id
+    @error_type = error_type
+  end
+
+  # Identifies this as a tool timing.
+  #
+  #--
+  #: () -> Symbol
+  def kind = :tool
+
+  # Returns true if the tool call succeeded.
+  #
+  #--
+  #: () -> bool
+  def success? = error_type.nil?
+
+  # Converts the timing to a hash.
+  #
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    super.merge(tool_name: tool_name, call_id: call_id, error_type: error_type)
+  end
+end

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -21,6 +21,16 @@ class Riffer::Agent::Response
   # The modifications made by guardrails during processing.
   attr_reader modifications: Array[Riffer::Guardrails::Modification]
 
+  # The per-unit execution timings (guardrails, tool calls, and LLM calls), in
+  # execution order. Empty unless +Riffer.config.report_timings+ is enabled.
+  # Discriminate entries with +Riffer::Timing#kind+.
+  attr_reader timings: Array[Riffer::Timing]
+
+  # The total run time in seconds, measured with a monotonic clock. Always
+  # populated for +generate+ (independent of +Riffer.config.report_timings+);
+  # +nil+ for responses built outside the generation loop.
+  attr_reader duration: Float?
+
   # The reason provided with the interrupt, if any.
   attr_reader interrupt_reason: (String | Symbol)?
 
@@ -34,9 +44,24 @@ class Riffer::Agent::Response
   # turn (when an interrupt left them unanswered and history healing is on).
   attr_reader healed_tool_call_ids: Array[String]
 
+  # Creates a new response.
+  #
+  # [content] the response content.
+  # [tripwire] optional tripwire for blocked responses.
+  # [modifications] guardrail modifications applied during processing.
+  # [timings] per-unit execution timings (empty unless
+  #   +Riffer.config.report_timings+ is enabled).
+  # [duration] total run time in seconds (+nil+ outside the generation loop).
+  # [interrupted] whether the agent loop was interrupted by a callback.
+  # [interrupt_reason] optional reason passed via <tt>throw :riffer_interrupt, reason</tt>.
+  # [structured_output] parsed structured output when structured output is configured.
+  # [messages] the full message history from the agent conversation.
+  # [healed_tool_call_ids] call ids filled with placeholder tool results
+  #   when history healing is enabled.
+  #
   # --
-  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
+  # : (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?duration: Float?, ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
+  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?duration: Float?, ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String]) -> void
 
   # Returns true if the response was blocked by a guardrail.
   #

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -23,21 +23,53 @@ module Riffer::Agent::Run
   # : (Riffer::Agent, ?stream_yielder: Enumerator::Yielder?) -> Riffer::Agent::Response
   def run_loop: (Riffer::Agent, ?stream_yielder: Enumerator::Yielder?) -> Riffer::Agent::Response
 
+  # Returns the current monotonic clock reading, in seconds.
   # --
-  # : (Riffer::Agent, Enumerator::Yielder) -> Riffer::Messages::Assistant
-  def accumulate_streamed_response: (Riffer::Agent, Enumerator::Yielder) -> Riffer::Messages::Assistant
+  # : () -> Float
+  def monotonic_now: () -> Float
+
+  # Calls the LLM (streamed or not) and, when +Riffer.config.report_timings+ is
+  # enabled, records a Riffer::Providers::Timing for the call — total duration
+  # plus, for streamed calls, time-to-first-token.
+  # --
+  # : (Riffer::Agent, Integer, Enumerator::Yielder?, Array[Riffer::Timing]) -> Riffer::Messages::Assistant
+  def perform_llm_call: (Riffer::Agent, Integer, Enumerator::Yielder?, Array[Riffer::Timing]) -> Riffer::Messages::Assistant
+
+  # Consumes the provider's stream, yielding each event downstream and
+  # accumulating the assistant message. When +on_first_content+ is given, it is
+  # invoked once, on the first generated-content event (text, reasoning, or
+  # tool-call delta) — used to capture time-to-first-token.
+  # --
+  # : (Riffer::Agent, Enumerator::Yielder, ?on_first_content: (^() -> void)?) -> Riffer::Messages::Assistant
+  def accumulate_streamed_response: (Riffer::Agent, Enumerator::Yielder, ?on_first_content: (^() -> void)?) -> Riffer::Messages::Assistant
+
+  # Returns true for the first generated-content events — text, reasoning, or
+  # tool-call deltas — used to mark time-to-first-token.
+  # --
+  # : (Riffer::StreamEvents::Base) -> bool
+  def first_content_event?: (Riffer::StreamEvents::Base) -> bool
 
   # --
   # : (Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Modification]) -> void
   def record_modifications!: (Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Modification]) -> void
 
+  # Appends +new_timings+ to +all_timings+ and emits a +Timing+ event for each
+  # one when streaming.
+  #
   # --
-  # : (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
-  def tripwire_response: (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification]) -> Riffer::Agent::Response
+  # : (Enumerator::Yielder?, Array[Riffer::Timing], Array[Riffer::Timing]) -> void
+  def record_timings!: (Enumerator::Yielder?, Array[Riffer::Timing], Array[Riffer::Timing]) -> void
+
+  # Emits a +GuardrailTripwire+ event when streaming and returns the
+  # short-circuit +Response+ for a tripped guardrail.
+  #
+  # --
+  # : (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) -> Riffer::Agent::Response
+  def tripwire_response: (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) -> Riffer::Agent::Response
 
   # --
-  # : (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
-  def final_response: (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
+  # : (Riffer::Agent, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float, **untyped) -> Riffer::Agent::Response
+  def final_response: (Riffer::Agent, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float, **untyped) -> Riffer::Agent::Response
 
   # --
   # : (Riffer::Agent) -> Riffer::Messages::Assistant
@@ -48,24 +80,24 @@ module Riffer::Agent::Run
   def call_llm_stream: (Riffer::Agent) -> Enumerator[Riffer::StreamEvents::Base, void]
 
   # --
-  # : (Riffer::Agent, Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
-  def execute_tool_calls: (Riffer::Agent, Riffer::Messages::Assistant, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
+  # : (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Timing], ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
+  def execute_tool_calls: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Timing], ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall]) -> void
 
   # --
-  # : (Riffer::Agent, Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]) -> void
-  def inject_discovered_tools: (Riffer::Agent, Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]) -> void
+  # : (Riffer::Agent, Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing?]]) -> void
+  def inject_discovered_tools: (Riffer::Agent, Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing? ]]) -> void
 
   # --
-  # : (Riffer::Agent) -> void
-  def execute_pending_tool_calls: (Riffer::Agent) -> void
+  # : (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Timing]) -> void
+  def execute_pending_tool_calls: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Timing]) -> void
 
   # --
-  # : (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> void
-  def run_before_guardrails: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> void
+  # : (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> void
+  def run_before_guardrails: (Riffer::Agent, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> void
 
   # --
-  # : (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> untyped
-  def run_after_guardrails: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification]) { (Riffer::Agent::Response) -> void } -> untyped
+  # : (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> untyped
+  def run_after_guardrails: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], Array[Riffer::Timing], Float) { (Riffer::Agent::Response) -> void } -> untyped
 
   # --
   # : (Riffer::Agent, Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
@@ -79,9 +111,12 @@ module Riffer::Agent::Run
   # : (Riffer::Agent) -> Hash[Symbol, untyped]
   def merged_model_options: (Riffer::Agent) -> Hash[Symbol, untyped]
 
+  # Builds the +Response+. When +started+ is given (always, inside the
+  # generation loop), the total run +duration+ is stamped from it with a fresh
+  # monotonic reading — independent of +Riffer.config.report_timings+.
   # --
-  # : (Riffer::Agent, String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
-  def build_response: (Riffer::Agent, String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  # : (Riffer::Agent, String, ?started: Float?, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
+  def build_response: (Riffer::Agent, String, ?started: Float?, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?timings: Array[Riffer::Timing], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String]) -> Riffer::Agent::Response
 
   # Raises when +files+ are supplied without a +prompt+ — the provider needs
   # text to anchor the attachments.

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -159,6 +159,29 @@ class Riffer::Config
   # : (untyped) -> void
   def experimental_history_healing=: (untyped) -> void
 
+  # When +true+, riffer measures how long each unit of work takes — guardrails,
+  # tool calls, and LLM calls — and exposes the per-unit results, in execution
+  # order, on +Riffer::Agent::Response#timings+ (and, when streaming, as
+  # +Riffer::StreamEvents::Timing+ events).
+  #
+  # Defaults to +false+, in which case no per-unit timing is collected and
+  # +timings+ is empty. This flag does not gate +Riffer::Agent::Response#duration+
+  # (the total run time), which is always measured.
+  attr_reader report_timings: bool
+
+  # Sets the +report_timings+ flag.
+  #
+  # Coerces common boolean representations so values pulled from
+  # environment variables behave predictably — the string +"false"+ is
+  # truthy in Ruby and would otherwise flip the flag on. Accepts
+  # +true+/+false+, +"true"+/+"false"+, +1+/+0+, +"1"+/+"0"+, and +nil+
+  # (treated as +false+, the default). Raises +Riffer::ArgumentError+ for
+  # any other value.
+  #
+  # --
+  # : (untyped) -> void
+  def report_timings=: (untyped) -> void
+
   # --
   # : () -> void
   def initialize: () -> void

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -1,7 +1,13 @@
 # Generated from lib/riffer/guardrails/runner.rb with RBS::Inline
 
-# Executes guardrails sequentially, passing each one's output to the next; if
-# any blocks, execution stops and a tripwire is returned.
+# Executes guardrails sequentially and manages the processing pipeline.
+#
+# The runner processes guardrails in order, passing the output of each
+# to the next. If any guardrail blocks, execution stops and a tripwire
+# is returned.
+#
+#   runner = Runner.new(guardrail_configs, phase: :before, context: context)
+#   data, tripwire, modifications, timings = runner.run(messages)
 class Riffer::Guardrails::Runner
   # The guardrail configs to execute.
   attr_reader guardrail_configs: Array[Hash[Symbol, untyped]]
@@ -12,18 +18,45 @@ class Riffer::Guardrails::Runner
   # The context passed to guardrails.
   attr_reader context: untyped
 
-  # --
-  # : (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
-  def initialize: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped) -> void
+  # Whether to record a timing for each guardrail's execution.
+  attr_reader measure_timings: bool
 
-  # Runs the guardrails sequentially. For the +:before+ phase +data+ is the
-  # messages array; for +:after+ it's the response (and +messages+ must be
-  # provided).
+  # Creates a new runner.
+  #
+  # [guardrail_configs] configs with :class and :options keys.
+  # [phase] :before or :after.
+  # [context] optional context to pass to guardrails.
+  # [measure_timings] when true, records a Timing per guardrail.
+  #
   # --
-  # : (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification]]
-  def run: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification] ]
+  # : (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped, ?measure_timings: bool) -> void
+  def initialize: (Array[Hash[Symbol, untyped]], phase: Symbol, ?context: untyped, ?measure_timings: bool) -> void
+
+  # Runs the guardrails sequentially.
+  #
+  # For before phase, data should be an array of messages.
+  # For after phase, data should be a response and messages must be provided.
+  #
+  # Returns a 4-tuple: the processed data, a tripwire (or +nil+), the
+  # modifications, and the per-guardrail timings. Timings are empty unless
+  # +measure_timings+ was set.
+  #
+  # [data] the data to process (messages for before, response for after).
+  # [messages] the conversation messages (required for after phase).
+  #
+  # --
+  # : (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Timing]]
+  def run: (untyped, ?messages: Array[Riffer::Messages::Base]?) -> [ untyped, Riffer::Guardrails::Tripwire?, Array[Riffer::Guardrails::Modification], Array[Riffer::Guardrails::Timing] ]
 
   private
+
+  # Executes a single guardrail, recording a Timing into +timings+ when
+  # +measure_timings+ is set. The duration is captured with a monotonic
+  # clock around the +process_*+ call (guardrail instantiation is excluded).
+  #
+  # --
+  # : (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?, timings: Array[Riffer::Guardrails::Timing]) -> Riffer::Guardrails::Result
+  def run_with_timing: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?, timings: Array[Riffer::Guardrails::Timing]) -> Riffer::Guardrails::Result
 
   # --
   # : (Hash[Symbol, untyped]) -> Riffer::Guardrail

--- a/sig/generated/riffer/guardrails/timing.rbs
+++ b/sig/generated/riffer/guardrails/timing.rbs
@@ -1,0 +1,51 @@
+# Generated from lib/riffer/guardrails/timing.rb with RBS::Inline
+
+# Records how long a single guardrail took to execute.
+#
+# When +Riffer.config.report_timings+ is enabled, the runner measures each
+# guardrail's +process_input+/+process_output+ call and produces one Timing per
+# guardrail, in execution order.
+#
+#   timing = Timing.new(
+#     guardrail: ProfanityFilter,
+#     phase: :before,
+#     duration: 0.0012,
+#     result_type: :pass
+#   )
+#   timing.kind        # => :guardrail
+#   timing.duration_ms # => 1.2
+class Riffer::Guardrails::Timing < Riffer::Timing
+  # The guardrail class that was executed.
+  attr_reader guardrail: singleton(Riffer::Guardrail)
+
+  # The phase when the guardrail ran (:before or :after).
+  attr_reader phase: Symbol
+
+  # The result the guardrail returned (:pass, :transform, or :block). A
+  # guardrail that raises aborts the run before a timing is recorded, so
+  # this is always set in practice; it is nilable only as a safe default.
+  attr_reader result_type: Symbol?
+
+  # Creates a new timing record.
+  #
+  # [guardrail] the guardrail class that ran.
+  # [phase] :before or :after.
+  # [duration] execution time in seconds.
+  # [result_type] :pass, :transform, or :block.
+  #
+  # --
+  # : (guardrail: singleton(Riffer::Guardrail), phase: Symbol, duration: Float, ?result_type: Symbol?) -> void
+  def initialize: (guardrail: singleton(Riffer::Guardrail), phase: Symbol, duration: Float, ?result_type: Symbol?) -> void
+
+  # Identifies this as a guardrail timing.
+  #
+  # --
+  # : () -> Symbol
+  def kind: () -> Symbol
+
+  # Converts the timing to a hash.
+  #
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/providers/timing.rbs
+++ b/sig/generated/riffer/providers/timing.rbs
@@ -1,0 +1,55 @@
+# Generated from lib/riffer/providers/timing.rb with RBS::Inline
+
+# Records how long a single LLM call took.
+#
+# When +Riffer.config.report_timings+ is enabled, the generation loop measures
+# each provider call — a +generate+ round-trip, or a full streamed response —
+# and produces one Timing per call, tagged with the +step+ it produced.
+#
+# For streamed calls, +ttft+ holds the time to first token: the elapsed time
+# until the first generated-content event (a text, reasoning, or tool-call
+# delta). It is +nil+ for non-streaming calls and for streams that yield no
+# content.
+#
+#   timing = Timing.new(model: "openai/gpt-4", step: 1, duration: 1.8, ttft: 0.3)
+#   timing.kind   # => :llm
+#   timing.ttft_ms # => 300.0
+class Riffer::Providers::Timing < Riffer::Timing
+  # The model that produced the response (e.g. "openai/gpt-4").
+  attr_reader model: String
+
+  # The step (loop iteration) this call produced.
+  attr_reader step: Integer
+
+  # Time to first token, in seconds (streaming only); +nil+ otherwise.
+  attr_reader ttft: Float?
+
+  # Creates a new timing record.
+  #
+  # [model] the model that produced the response.
+  # [step] the loop iteration this call produced.
+  # [duration] total call time in seconds.
+  # [ttft] time to first token in seconds (streaming only).
+  #
+  # --
+  # : (model: String, step: Integer, duration: Float, ?ttft: Float?) -> void
+  def initialize: (model: String, step: Integer, duration: Float, ?ttft: Float?) -> void
+
+  # Identifies this as an LLM timing.
+  #
+  # --
+  # : () -> Symbol
+  def kind: () -> Symbol
+
+  # The time to first token in milliseconds, or +nil+ when not measured.
+  #
+  # --
+  # : () -> Float?
+  def ttft_ms: () -> Float?
+
+  # Converts the timing to a hash.
+  #
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/stream_events/timing.rbs
+++ b/sig/generated/riffer/stream_events/timing.rbs
@@ -1,0 +1,38 @@
+# Generated from lib/riffer/stream_events/timing.rb with RBS::Inline
+
+# Represents a timing event during streaming.
+#
+# Emitted after each timed unit of work — a guardrail, a tool call, or an LLM
+# call — when +Riffer.config.report_timings+ is enabled. The wrapped
+# Riffer::Timing carries the details; use +kind+ to discriminate.
+class Riffer::StreamEvents::Timing < Riffer::StreamEvents::Base
+  # The timing record.
+  attr_reader timing: Riffer::Timing
+
+  # Creates a new timing stream event.
+  #
+  # [timing] the timing details.
+  # [role] the message role (defaults to :assistant).
+  #
+  # --
+  # : (Riffer::Timing, ?role: Symbol) -> void
+  def initialize: (Riffer::Timing, ?role: Symbol) -> void
+
+  # The kind of unit this timing describes (:guardrail, :tool, or :llm).
+  #
+  # --
+  # : () -> Symbol
+  def kind: () -> Symbol
+
+  # The execution time in seconds.
+  #
+  # --
+  # : () -> Float
+  def duration: () -> Float
+
+  # Converts the event to a hash.
+  #
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/timing.rbs
+++ b/sig/generated/riffer/timing.rbs
@@ -1,0 +1,41 @@
+# Generated from lib/riffer/timing.rb with RBS::Inline
+
+# Base class for execution timings.
+#
+# When +Riffer.config.report_timings+ is enabled, the framework measures how
+# long individual units of work take and produces one Timing per unit —
+# guardrails, tool calls, and LLM calls — exposed together, in execution order,
+# on Riffer::Agent::Response#timings (and, when streaming, as
+# Riffer::StreamEvents::Timing events).
+#
+# Every timing carries a +kind+ (use it to discriminate) and a +duration+ in
+# seconds, measured with a monotonic clock. Each subclass adds the fields
+# relevant to its unit of work.
+class Riffer::Timing
+  # The wall-clock execution time, in seconds, measured with a monotonic clock.
+  attr_reader duration: Float
+
+  # --
+  # : (duration: Float) -> void
+  def initialize: (duration: Float) -> void
+
+  # A symbol identifying the kind of unit this timing describes (e.g.
+  # +:guardrail+, +:tool+, +:llm+). Implemented by each subclass.
+  #
+  # --
+  # : () -> Symbol
+  def kind: () -> Symbol
+
+  # The execution time in milliseconds.
+  #
+  # --
+  # : () -> Float
+  def duration_ms: () -> Float
+
+  # Converts the timing to a hash. Subclasses merge their own fields onto this
+  # +kind+/+duration+ core.
+  #
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -10,10 +10,14 @@ class Riffer::Tools::Runtime
   # : (runner: Riffer::Runner) -> void
   def initialize: (runner: Riffer::Runner) -> void
 
-  # Executes a batch of tool calls, returning <tt>[tool_call, response]</tt> pairs.
+  # Executes a batch of tool calls, returning
+  # <tt>[tool_call, response, timing]</tt> triples. The +timing+ is a
+  # Riffer::Tools::Timing when +Riffer.config.report_timings+ is enabled, else
+  # +nil+. The duration spans the dispatch and any +around_tool_call+ wrapper,
+  # and is captured per call (correct under any concurrency model).
   # --
-  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
-  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]]
+  # : (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing?]]
+  def execute: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response, Riffer::Tools::Timing? ]]
 
   # Hook wrapping each tool call; override in subclasses to instrument or
   # customize. Must +yield+ to continue.

--- a/sig/generated/riffer/tools/timing.rbs
+++ b/sig/generated/riffer/tools/timing.rbs
@@ -1,0 +1,60 @@
+# Generated from lib/riffer/tools/timing.rb with RBS::Inline
+
+# Records how long a single tool call took to execute.
+#
+# When +Riffer.config.report_timings+ is enabled, the tool runtime measures each
+# tool call — the dispatch plus any +around_tool_call+ wrapper — and produces
+# one Timing per call.
+#
+# Unlike guardrails, a tool that errors or times out is still timed: the runtime
+# captures the failure into a Riffer::Tools::Response rather than raising, so
+# +error_type+ records the outcome and +duration+ covers the failed attempt.
+#
+#   timing = Timing.new(
+#     tool_name: "get_weather",
+#     call_id: "call_123",
+#     duration: 0.42,
+#     error_type: nil
+#   )
+#   timing.kind     # => :tool
+#   timing.success? # => true
+class Riffer::Tools::Timing < Riffer::Timing
+  # The name of the tool that was called.
+  attr_reader tool_name: String
+
+  # The tool call id, used to correlate parallel calls to the same tool.
+  attr_reader call_id: String
+
+  # The error type when the call failed (:unknown_tool, :validation_error,
+  # :execution_error, :timeout_error), or +nil+ on success.
+  attr_reader error_type: Symbol?
+
+  # Creates a new timing record.
+  #
+  # [tool_name] the name of the tool that ran.
+  # [call_id] the tool call id.
+  # [duration] execution time in seconds.
+  # [error_type] the error type, or +nil+ on success.
+  #
+  # --
+  # : (tool_name: String, call_id: String, duration: Float, ?error_type: Symbol?) -> void
+  def initialize: (tool_name: String, call_id: String, duration: Float, ?error_type: Symbol?) -> void
+
+  # Identifies this as a tool timing.
+  #
+  # --
+  # : () -> Symbol
+  def kind: () -> Symbol
+
+  # Returns true if the tool call succeeded.
+  #
+  # --
+  # : () -> bool
+  def success?: () -> bool
+
+  # Converts the timing to a hash.
+  #
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -42,6 +42,38 @@ describe Riffer::Agent::Response do
     end
   end
 
+  describe "#timings" do
+    it "defaults to empty array" do
+      response = Riffer::Agent::Response.new("Hello!")
+      expect(response.timings).must_equal []
+    end
+
+    it "returns provided timings of any kind" do
+      guardrail_timing = Riffer::Guardrails::Timing.new(
+        guardrail: Riffer::Guardrail,
+        phase: :before,
+        duration: 0.01,
+        result_type: :pass
+      )
+      tool_timing = Riffer::Tools::Timing.new(tool_name: "t", call_id: "c1", duration: 0.02)
+      response = Riffer::Agent::Response.new("Hello!", timings: [guardrail_timing, tool_timing])
+      expect(response.timings).must_equal [guardrail_timing, tool_timing]
+      expect(response.timings.map(&:kind)).must_equal %i[guardrail tool]
+    end
+  end
+
+  describe "#duration" do
+    it "defaults to nil" do
+      response = Riffer::Agent::Response.new("Hello!")
+      expect(response.duration).must_be_nil
+    end
+
+    it "stores the total run duration" do
+      response = Riffer::Agent::Response.new("Hello!", duration: 1.5)
+      expect(response.duration).must_equal 1.5
+    end
+  end
+
   describe "#modified?" do
     it "returns false when no modifications" do
       response = Riffer::Agent::Response.new("Hello!")

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -164,6 +164,58 @@ describe Riffer::Config do
     end
   end
 
+  describe "report_timings" do
+    it "defaults to false" do
+      expect(Riffer::Config.new.report_timings).must_equal false
+    end
+
+    it "accepts true and false" do
+      config = Riffer::Config.new
+      config.report_timings = true
+      expect(config.report_timings).must_equal true
+      config.report_timings = false
+      expect(config.report_timings).must_equal false
+    end
+
+    it "coerces ENV-style truthy strings" do
+      config = Riffer::Config.new
+      config.report_timings = "true"
+      expect(config.report_timings).must_equal true
+      config.report_timings = "1"
+      expect(config.report_timings).must_equal true
+      config.report_timings = 1
+      expect(config.report_timings).must_equal true
+    end
+
+    it "coerces ENV-style falsy strings" do
+      config = Riffer::Config.new
+      config.report_timings = true
+      config.report_timings = "false"
+      expect(config.report_timings).must_equal false
+      config.report_timings = "0"
+      expect(config.report_timings).must_equal false
+      config.report_timings = 0
+      expect(config.report_timings).must_equal false
+    end
+
+    it "treats nil as false (ENV-not-set)" do
+      config = Riffer::Config.new
+      config.report_timings = true
+      config.report_timings = nil
+      expect(config.report_timings).must_equal false
+    end
+
+    it "raises for other strings" do
+      config = Riffer::Config.new
+      expect { config.report_timings = "yes" }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises for unrelated values" do
+      config = Riffer::Config.new
+      expect { config.report_timings = :on }.must_raise Riffer::ArgumentError
+    end
+  end
+
   describe "mcp namespace" do
     it "initializes credentials to nil" do
       config = Riffer::Config.new

--- a/test/riffer/guardrails/runner_test.rb
+++ b/test/riffer/guardrails/runner_test.rb
@@ -313,4 +313,62 @@ describe Riffer::Guardrails::Runner do
       expect(modifications.first.message_indices).must_equal [0]
     end
   end
+
+  describe "timings" do
+    it "returns empty timings when measure_timings is false" do
+      configs = [config_for(pass_guardrail_class), config_for(transform_guardrail_class)]
+      runner = Riffer::Guardrails::Runner.new(configs, phase: :before)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, _tripwire, _modifications, timings = runner.run(messages)
+      expect(timings).must_be_empty
+    end
+
+    it "records one timing per guardrail when enabled" do
+      configs = [config_for(pass_guardrail_class), config_for(transform_guardrail_class)]
+      runner = Riffer::Guardrails::Runner.new(configs, phase: :before, measure_timings: true)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, _tripwire, _modifications, timings = runner.run(messages)
+      expect(timings.length).must_equal 2
+    end
+
+    it "records timings in execution order" do
+      configs = [config_for(pass_guardrail_class), config_for(transform_guardrail_class)]
+      runner = Riffer::Guardrails::Runner.new(configs, phase: :before, measure_timings: true)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, _tripwire, _modifications, timings = runner.run(messages)
+      expect(timings.map(&:guardrail)).must_equal [pass_guardrail_class, transform_guardrail_class]
+    end
+
+    it "captures the guardrail's result type" do
+      configs = [config_for(pass_guardrail_class), config_for(transform_guardrail_class)]
+      runner = Riffer::Guardrails::Runner.new(configs, phase: :before, measure_timings: true)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, _tripwire, _modifications, timings = runner.run(messages)
+      expect(timings.map(&:result_type)).must_equal [:pass, :transform]
+    end
+
+    it "records a non-negative duration" do
+      runner = Riffer::Guardrails::Runner.new([config_for(pass_guardrail_class)], phase: :before, measure_timings: true)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, _tripwire, _modifications, timings = runner.run(messages)
+      expect(timings.first.duration).must_be :>=, 0.0
+    end
+
+    it "sets the phase on each timing" do
+      runner = Riffer::Guardrails::Runner.new([config_for(pass_guardrail_class)], phase: :after, measure_timings: true)
+      response = Riffer::Messages::Assistant.new("Hi!")
+      _data, _tripwire, _modifications, timings = runner.run(response, messages: [])
+      expect(timings.first.phase).must_equal :after
+    end
+
+    it "records a timing for the blocking guardrail and stops" do
+      configs = [config_for(pass_guardrail_class), config_for(block_guardrail_class), config_for(pass_guardrail_class)]
+      runner = Riffer::Guardrails::Runner.new(configs, phase: :before, measure_timings: true)
+      messages = [Riffer::Messages::User.new("Hello")]
+      _data, tripwire, _modifications, timings = runner.run(messages)
+      expect(tripwire).wont_be_nil
+      expect(timings.length).must_equal 2
+      expect(timings.last.result_type).must_equal :block
+    end
+  end
 end

--- a/test/riffer/guardrails/timing_test.rb
+++ b/test/riffer/guardrails/timing_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Guardrails::Timing do
+  def build(**overrides)
+    defaults = {guardrail: Riffer::Guardrail, phase: :before, duration: 0.5, result_type: :pass}
+    Riffer::Guardrails::Timing.new(**defaults.merge(overrides))
+  end
+
+  describe "#initialize" do
+    it "stores the guardrail" do
+      expect(build.guardrail).must_equal Riffer::Guardrail
+    end
+
+    it "stores the phase" do
+      expect(build(phase: :after).phase).must_equal :after
+    end
+
+    it "stores the duration" do
+      expect(build(duration: 1.25).duration).must_equal 1.25
+    end
+
+    it "stores the result type" do
+      expect(build(result_type: :block).result_type).must_equal :block
+    end
+
+    it "defaults result_type to nil" do
+      timing = Riffer::Guardrails::Timing.new(guardrail: Riffer::Guardrail, phase: :before, duration: 0.1)
+      expect(timing.result_type).must_be_nil
+    end
+  end
+
+  describe "#kind" do
+    it "is :guardrail" do
+      expect(build.kind).must_equal :guardrail
+    end
+
+    it "is a Riffer::Timing" do
+      expect(build).must_be_kind_of Riffer::Timing
+    end
+  end
+
+  describe "#duration_ms" do
+    it "converts seconds to milliseconds" do
+      expect(build(duration: 0.5).duration_ms).must_equal 500.0
+    end
+  end
+
+  describe "#to_h" do
+    it "includes the kind" do
+      expect(build.to_h[:kind]).must_equal :guardrail
+    end
+
+    it "includes the guardrail name" do
+      expect(build.to_h[:guardrail]).must_equal "Riffer::Guardrail"
+    end
+
+    it "includes the phase" do
+      expect(build(phase: :after).to_h[:phase]).must_equal :after
+    end
+
+    it "includes the duration" do
+      expect(build(duration: 0.75).to_h[:duration]).must_equal 0.75
+    end
+
+    it "includes the result type" do
+      expect(build(result_type: :transform).to_h[:result_type]).must_equal :transform
+    end
+  end
+end

--- a/test/riffer/providers/timing_test.rb
+++ b/test/riffer/providers/timing_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Providers::Timing do
+  def build(**overrides)
+    defaults = {model: "openai/gpt-4", step: 1, duration: 1.5, ttft: nil}
+    Riffer::Providers::Timing.new(**defaults.merge(overrides))
+  end
+
+  describe "#initialize" do
+    it "stores the model" do
+      expect(build.model).must_equal "openai/gpt-4"
+    end
+
+    it "stores the step" do
+      expect(build(step: 3).step).must_equal 3
+    end
+
+    it "stores the duration" do
+      expect(build(duration: 2.0).duration).must_equal 2.0
+    end
+
+    it "stores the ttft" do
+      expect(build(ttft: 0.3).ttft).must_equal 0.3
+    end
+
+    it "defaults ttft to nil" do
+      expect(build.ttft).must_be_nil
+    end
+  end
+
+  describe "#kind" do
+    it "is :llm" do
+      expect(build.kind).must_equal :llm
+    end
+  end
+
+  describe "#ttft_ms" do
+    it "converts ttft seconds to milliseconds" do
+      expect(build(ttft: 0.3).ttft_ms).must_equal 300.0
+    end
+
+    it "is nil when ttft is nil" do
+      expect(build(ttft: nil).ttft_ms).must_be_nil
+    end
+  end
+
+  describe "#to_h" do
+    it "includes the kind, model, step, duration, and ttft" do
+      hash = build(ttft: 0.3).to_h
+      expect(hash[:kind]).must_equal :llm
+      expect(hash[:model]).must_equal "openai/gpt-4"
+      expect(hash[:step]).must_equal 1
+      expect(hash[:duration]).must_equal 1.5
+      expect(hash[:ttft]).must_equal 0.3
+    end
+  end
+end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -476,6 +476,210 @@ describe Riffer::Agent::Run do
     end
   end
 
+  describe "timing reporting" do
+    before { @original_report_timings = Riffer.config.report_timings }
+    after { Riffer.config.report_timings = @original_report_timings }
+
+    let(:pass_guardrail_class) do
+      Class.new(Riffer::Guardrail) do
+        def process_input(messages, context:)
+          pass(messages)
+        end
+
+        def process_output(response, messages:, context:)
+          pass(response)
+        end
+      end
+    end
+
+    let(:agent_with_around_guardrail) do
+      gr = pass_guardrail_class
+      klass = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+      end
+      klass.guardrail(:around, with: gr)
+      klass
+    end
+
+    let(:weather_tool_class) do
+      Class.new(Riffer::Tool) do
+        description "Gets the weather"
+        params { required :city, String }
+        def call(context:, city:)
+          text("Weather in #{city}: 20 degrees")
+        end
+      end.tap { |t| t.identifier("timing_weather_tool") }
+    end
+
+    describe "total duration (always on)" do
+      it "is populated on #generate even when the flag is off" do
+        Riffer.config.report_timings = false
+        result = agent_class.generate("Hello")
+        expect(result.duration).must_be_kind_of Float
+        expect(result.duration).must_be :>=, 0.0
+      end
+
+      it "is populated on a blocked response" do
+        Riffer.config.report_timings = false
+        gr = Class.new(Riffer::Guardrail) do
+          def process_input(messages, context:)
+            block("nope")
+          end
+        end
+        klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+        klass.guardrail(:before, with: gr)
+        result = klass.generate("Hello")
+        expect(result.blocked?).must_equal true
+        expect(result.duration).must_be_kind_of Float
+      end
+    end
+
+    describe "guardrail timings with #generate" do
+      it "is empty when the flag is off" do
+        Riffer.config.report_timings = false
+        result = agent_with_around_guardrail.generate("Hello")
+        expect(result.timings).must_be_empty
+      end
+
+      it "records one guardrail timing per phase when the flag is on" do
+        Riffer.config.report_timings = true
+        result = agent_with_around_guardrail.generate("Hello")
+        guardrail_timings = result.timings.select { |t| t.kind == :guardrail }
+        expect(guardrail_timings.length).must_equal 2
+        expect(guardrail_timings.map(&:phase).sort).must_equal %i[after before]
+      end
+
+      it "attaches timings to a blocked response" do
+        Riffer.config.report_timings = true
+        gr = Class.new(Riffer::Guardrail) do
+          def process_input(messages, context:)
+            block("nope")
+          end
+        end
+        klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+        klass.guardrail(:before, with: gr)
+        result = klass.generate("Hello")
+        expect(result.blocked?).must_equal true
+        guardrail_timings = result.timings.select { |t| t.kind == :guardrail }
+        expect(guardrail_timings.length).must_equal 1
+        expect(guardrail_timings.first.result_type).must_equal :block
+      end
+    end
+
+    describe "llm timings with #generate" do
+      it "records one llm timing per step" do
+        Riffer.config.report_timings = true
+        tc = weather_tool_class
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          uses_tools [tc]
+        end
+        agent = klass.new
+        provider = agent.provider
+        provider.stub_response("", tool_calls: [{name: "timing_weather_tool", arguments: '{"city":"Toronto"}'}])
+        provider.stub_response("Nice and sunny!")
+
+        result = agent.generate("Weather?")
+        llm_timings = result.timings.select { |t| t.kind == :llm }
+        expect(llm_timings.length).must_equal 2
+        expect(llm_timings.map(&:step)).must_equal [1, 2]
+        expect(llm_timings.first.model).must_equal "riffer-1"
+      end
+
+      it "does not set ttft for non-streaming calls" do
+        Riffer.config.report_timings = true
+        result = agent_class.generate("Hello")
+        llm_timing = result.timings.find { |t| t.kind == :llm }
+        expect(llm_timing.ttft).must_be_nil
+      end
+    end
+
+    describe "tool timings with #generate" do
+      it "records a tool timing per tool call, including outcome" do
+        Riffer.config.report_timings = true
+        tc = weather_tool_class
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          uses_tools [tc]
+        end
+        agent = klass.new
+        provider = agent.provider
+        provider.stub_response("", tool_calls: [{name: "timing_weather_tool", arguments: '{"city":"Toronto"}'}])
+        provider.stub_response("Done!")
+
+        result = agent.generate("Weather?")
+        tool_timings = result.timings.select { |t| t.kind == :tool }
+        expect(tool_timings.length).must_equal 1
+        expect(tool_timings.first.tool_name).must_equal "timing_weather_tool"
+        expect(tool_timings.first.success?).must_equal true
+      end
+
+      it "times a failed tool call too" do
+        Riffer.config.report_timings = true
+        tc = weather_tool_class
+        klass = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          uses_tools [tc]
+        end
+        agent = klass.new
+        provider = agent.provider
+        provider.stub_response("", tool_calls: [{name: "timing_weather_tool", arguments: "{}"}])
+        provider.stub_response("Sorry.")
+
+        result = agent.generate("Weather?")
+        tool_timing = result.timings.find { |t| t.kind == :tool }
+        expect(tool_timing).wont_be_nil
+        expect(tool_timing.error_type).must_equal :validation_error
+        expect(tool_timing.success?).must_equal false
+      end
+
+      it "collects guardrail, llm, and tool timings together in execution order" do
+        Riffer.config.report_timings = true
+        tc = weather_tool_class
+        klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+        klass.uses_tools([tc])
+        klass.guardrail(:before, with: pass_guardrail_class)
+        agent = klass.new
+        provider = agent.provider
+        provider.stub_response("", tool_calls: [{name: "timing_weather_tool", arguments: '{"city":"Toronto"}'}])
+        provider.stub_response("Done!")
+
+        result = agent.generate("Weather?")
+        kinds = result.timings.map(&:kind)
+        expect(kinds.first).must_equal :guardrail
+        expect(kinds).must_include :llm
+        expect(kinds).must_include :tool
+      end
+    end
+
+    describe "with #stream" do
+      it "emits no Timing events when the flag is off" do
+        Riffer.config.report_timings = false
+        events = agent_with_around_guardrail.stream("Hello").to_a
+        timing_events = events.select { |e| e.is_a?(Riffer::StreamEvents::Timing) }
+        expect(timing_events).must_be_empty
+      end
+
+      it "emits Timing events for guardrails and the llm call when on" do
+        Riffer.config.report_timings = true
+        events = agent_with_around_guardrail.stream("Hello").to_a
+        timing_events = events.select { |e| e.is_a?(Riffer::StreamEvents::Timing) }
+        kinds = timing_events.map(&:kind)
+        expect(kinds.count(:guardrail)).must_equal 2
+        expect(kinds).must_include :llm
+      end
+
+      it "captures time-to-first-token on the streamed llm timing" do
+        Riffer.config.report_timings = true
+        events = agent_class.stream("Hello").to_a
+        llm_event = events.select { |e| e.is_a?(Riffer::StreamEvents::Timing) }.find { |e| e.kind == :llm }
+        expect(llm_event).wont_be_nil
+        expect(llm_event.timing.ttft).must_be_kind_of Float
+        expect(llm_event.timing.ttft).must_be :<=, llm_event.timing.duration
+      end
+    end
+  end
+
   describe "token usage tracking with #generate" do
     let(:token_usage) { Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50) }
 

--- a/test/riffer/stream_events/timing_test.rb
+++ b/test/riffer/stream_events/timing_test.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::StreamEvents::Timing do
+  let(:guardrail_timing) do
+    Riffer::Guardrails::Timing.new(
+      guardrail: Riffer::Guardrail,
+      phase: :before,
+      duration: 0.25,
+      result_type: :pass
+    )
+  end
+
+  let(:tool_timing) do
+    Riffer::Tools::Timing.new(tool_name: "get_weather", call_id: "call_1", duration: 0.4)
+  end
+
+  describe "#timing" do
+    it "returns the wrapped timing record" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing)
+      expect(event.timing).must_equal guardrail_timing
+    end
+  end
+
+  describe "#kind" do
+    it "delegates to the timing for a guardrail" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing)
+      expect(event.kind).must_equal :guardrail
+    end
+
+    it "delegates to the timing for a tool" do
+      event = Riffer::StreamEvents::Timing.new(tool_timing)
+      expect(event.kind).must_equal :tool
+    end
+  end
+
+  describe "#duration" do
+    it "delegates to the timing" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing)
+      expect(event.duration).must_equal 0.25
+    end
+  end
+
+  describe "#role" do
+    it "defaults to assistant" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing)
+      expect(event.role).must_equal :assistant
+    end
+
+    it "accepts custom role" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing, role: :system)
+      expect(event.role).must_equal :system
+    end
+  end
+
+  describe "#to_h" do
+    it "includes role" do
+      event = Riffer::StreamEvents::Timing.new(guardrail_timing)
+      expect(event.to_h[:role]).must_equal :assistant
+    end
+
+    it "includes the timing hash with its kind" do
+      event = Riffer::StreamEvents::Timing.new(tool_timing)
+      expect(event.to_h[:timing][:kind]).must_equal :tool
+      expect(event.to_h[:timing][:tool_name]).must_equal "get_weather"
+    end
+  end
+end

--- a/test/riffer/timing_test.rb
+++ b/test/riffer/timing_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Timing do
+  describe "#kind" do
+    it "raises NotImplementedError on the abstract base" do
+      timing = Riffer::Timing.new(duration: 0.1)
+      expect { timing.kind }.must_raise NotImplementedError
+    end
+  end
+
+  describe "#duration_ms" do
+    it "converts seconds to milliseconds" do
+      expect(Riffer::Timing.new(duration: 0.5).duration_ms).must_equal 500.0
+    end
+  end
+
+  describe "subclasses" do
+    it "are all Riffer::Timing" do
+      expect(Riffer::Guardrails::Timing.ancestors).must_include Riffer::Timing
+      expect(Riffer::Tools::Timing.ancestors).must_include Riffer::Timing
+      expect(Riffer::Providers::Timing.ancestors).must_include Riffer::Timing
+    end
+  end
+end

--- a/test/riffer/tools/timing_test.rb
+++ b/test/riffer/tools/timing_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tools::Timing do
+  def build(**overrides)
+    defaults = {tool_name: "get_weather", call_id: "call_1", duration: 0.5, error_type: nil}
+    Riffer::Tools::Timing.new(**defaults.merge(overrides))
+  end
+
+  describe "#initialize" do
+    it "stores the tool name" do
+      expect(build.tool_name).must_equal "get_weather"
+    end
+
+    it "stores the call id" do
+      expect(build(call_id: "call_9").call_id).must_equal "call_9"
+    end
+
+    it "stores the duration" do
+      expect(build(duration: 1.25).duration).must_equal 1.25
+    end
+
+    it "stores the error type" do
+      expect(build(error_type: :timeout_error).error_type).must_equal :timeout_error
+    end
+
+    it "defaults error_type to nil" do
+      expect(build.error_type).must_be_nil
+    end
+  end
+
+  describe "#kind" do
+    it "is :tool" do
+      expect(build.kind).must_equal :tool
+    end
+  end
+
+  describe "#success?" do
+    it "is true when error_type is nil" do
+      expect(build.success?).must_equal true
+    end
+
+    it "is false when error_type is set" do
+      expect(build(error_type: :execution_error).success?).must_equal false
+    end
+  end
+
+  describe "#duration_ms" do
+    it "converts seconds to milliseconds" do
+      expect(build(duration: 0.5).duration_ms).must_equal 500.0
+    end
+  end
+
+  describe "#to_h" do
+    it "includes the kind, tool name, call id, and error type" do
+      hash = build(error_type: :timeout_error).to_h
+      expect(hash[:kind]).must_equal :tool
+      expect(hash[:tool_name]).must_equal "get_weather"
+      expect(hash[:call_id]).must_equal "call_1"
+      expect(hash[:duration]).must_equal 0.5
+      expect(hash[:error_type]).must_equal :timeout_error
+    end
+  end
+end


### PR DESCRIPTION
## What

Widens the original per-guardrail duration reporting into a single, global **timing** facility that measures every unit of work in the agent loop — guardrails, tool calls, and LLM calls — behind one flag.

## Why

The original PR timed guardrails only. Timing is a cross-cutting concern: the most useful view of "where did my run spend its time?" spans guardrails, tools, and the LLM round-trips. Rather than ship a guardrail-only flag and rename it later, this generalizes it now (none of the original surface had shipped, so there's no compatibility cost).

## Design

- **One flag.** `Riffer.config.report_timings` (renamed from the unreleased `report_guardrail_durations`) gates the per-unit breakdown.
- **One model.** A `Riffer::Timing` base class (`kind`, `duration`, `duration_ms`, `to_h`) with three subclasses — `Guardrails::Timing`, `Tools::Timing`, `Providers::Timing`. Each keeps its own precisely-typed fields; no freeform metadata.
- **One ordered surface.** `Riffer::Agent::Response#timings` is a single `Array[Riffer::Timing]` in execution order — a timeline of the whole run. Discriminate with `#kind`. When streaming, a single `Riffer::StreamEvents::Timing` event is emitted per unit.
- **Total duration is always on.** `Response#duration` (total run time, `Float`) is populated for every `generate` regardless of the flag — it's two clock reads. The flag only gates the allocating per-unit breakdown.

## What's covered

| `kind`       | Fields | Notes |
| ------------ | ------ | ----- |
| `:guardrail` | `guardrail`, `phase`, `result_type` | unchanged behavior |
| `:tool`      | `tool_name`, `call_id`, `error_type`, `success?` | measured per call in the runtime → correct under sequential/threaded/fibers; failed & timed-out calls are timed; MCP tool calls covered |
| `:llm`       | `model`, `step`, `ttft`, `ttft_ms` | `ttft` = time to first token (first text/reasoning/tool-call delta), streaming only |

## Deferred

- **MCP discovery timing** (`tools_list` at registration). MCP tool *calls* are already covered via the runtime; discovery is a one-time boot cost outside the generate loop with no `Response` home, so it's left for a follow-up.

## Replaces (all unreleased)

`report_guardrail_durations` → `report_timings`; `Response#guardrail_timings` → `Response#timings`; `StreamEvents::GuardrailTiming` → `StreamEvents::Timing`.

## Tests / checks

New unit tests for each timing class and the stream event; integration tests in `run_test.rb` cover guardrail/tool/LLM timings, always-on `duration`, blocked responses, failed tool calls, mixed execution order, and streamed TTFT. `bin/rake` (test + standard + steep) is green; RBS regenerated. Docs updated per-feature (guardrails, tools, agent loop, stream events) with the shared model documented canonically in configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
