### PR TITLE
feat: forward session: through Agent.from_h/from_json for history seeding

### DIFF
--- a/docs/15_SERIALIZATION.md
+++ b/docs/15_SERIALIZATION.md
@@ -22,6 +22,17 @@ The hash forms (`to_h` / `from_h`) are public too, if you want to embed the dict
 
 `from_h` / `from_json` accept an optional `context:` — the rebuilt agent's **runtime** context, exactly the value you'd pass to `Agent.new(context:)`. It is **not** used to re-resolve the serialized definition (that's already resolved); it's threaded into tool dispatch and read by tools/runtimes at call time. Pass it when a tool or a remote runtime needs per-call data — e.g. `context: { tenant: "acme" }` for multi-tenant dispatch, or Maestro passing `context: { agent: self }` so its runtime can call back. Omit it (defaults to empty) when nothing downstream reads context.
 
+### Seeding conversation history
+
+The dict carries the agent **definition**, not its conversation history (see [What does not transfer](#what-does-not-transfer)). To resume a persisted conversation, pass a `session:` — exactly the value you'd pass to `Agent.new(session:)`:
+
+```ruby
+rebuilt = Riffer::Agent.from_h(dict, session: persisted_session)
+rebuilt.generate # continues from the seeded history
+```
+
+The session is used **as-is**: the rebuilt agent does not prepend anything to it, so the caller owns its full contents — **including the system instruction message**. When you omit `session:`, behavior is unchanged: a fresh session is built and seeded with the dict's `instructions` (and an empty history). Because a supplied session is authoritative, the dict's `instructions` are not re-injected into it — make sure your persisted session already contains the system message.
+
 ## What the dict carries
 
 ```ruby

--- a/docs/15_SERIALIZATION.md
+++ b/docs/15_SERIALIZATION.md
@@ -1,22 +1,22 @@
 # Serialization
 
-`Riffer::Agent::Serializer` turns a **resolved agent** into a self-contained, provider-neutral data dict (`to_h`) and reconstructs a **runnable agent** from that dict (`from_h`). Use it to persist agent definitions outside of code, or to transfer them across a process/service boundary.
+`Riffer::Agent::Serializer` turns a **resolved agent** into a self-contained, provider-neutral data hash (`to_h`) and reconstructs a **runnable agent** from that hash (`from_h`). Use it to persist agent definitions outside of code, or to transfer them across a process/service boundary.
 
 You normally reach it through the delegators on `Riffer::Agent`:
 
 ```ruby
-dict    = agent.to_h          # snapshot
-rebuilt = Riffer::Agent.from_h(dict) # reconstruct
+data    = agent.to_h          # snapshot
+rebuilt = Riffer::Agent.from_h(data) # reconstruct
 ```
 
-The dict is plain data — symbol-keyed, JSON-safe. For the wire, use the JSON helpers, which handle generating and parsing for you:
+The hash is plain data — symbol-keyed, JSON-safe. For the wire, use the JSON helpers, which handle generating and parsing for you:
 
 ```ruby
 json    = agent.to_json       # or Riffer::Agent::Serializer.to_json(agent:)
 rebuilt = Riffer::Agent.from_json(json)
 ```
 
-The hash forms (`to_h` / `from_h`) are public too, if you want to embed the dict in a larger payload. `from_h` expects symbol keys, so parse with `JSON.parse(str, symbolize_names: true)` — or just use `from_json`, which does that for you.
+The hash forms (`to_h` / `from_h`) are public too, if you want to embed the hash in a larger payload. `from_h` expects symbol keys, so parse with `JSON.parse(str, symbolize_names: true)` — or just use `from_json`, which does that for you.
 
 ### Runtime context
 
@@ -24,16 +24,16 @@ The hash forms (`to_h` / `from_h`) are public too, if you want to embed the dict
 
 ### Seeding conversation history
 
-The dict carries the agent **definition**, not its conversation history (see [What does not transfer](#what-does-not-transfer)). To resume a persisted conversation, pass a `session:` — exactly the value you'd pass to `Agent.new(session:)`:
+The hash carries the agent **definition**, not its conversation history (see [What does not transfer](#what-does-not-transfer)). To resume a persisted conversation, pass a `session:` — exactly the value you'd pass to `Agent.new(session:)`:
 
 ```ruby
-rebuilt = Riffer::Agent.from_h(dict, session: persisted_session)
+rebuilt = Riffer::Agent.from_h(data, session: persisted_session)
 rebuilt.generate # continues from the seeded history
 ```
 
-The session is used **as-is**: the rebuilt agent does not prepend anything to it, so the caller owns its full contents — **including the system instruction message**. When you omit `session:`, behavior is unchanged: a fresh session is built and seeded with the dict's `instructions` (and an empty history). Because a supplied session is authoritative, the dict's `instructions` are not re-injected into it — make sure your persisted session already contains the system message.
+The session is used **as-is**: the rebuilt agent does not prepend anything to it, so the caller owns its full contents — **including the system instruction message**. Omit `session:` and the rebuilt agent builds a fresh session, seeded with the hash's `instructions` and an empty history. Because a supplied session is authoritative, the hash's `instructions` are not re-injected into it — make sure your persisted session already contains the system message.
 
-## What the dict carries
+## What the hash carries
 
 ```ruby
 {
@@ -52,7 +52,7 @@ The session is used **as-is**: the rebuilt agent does not prepend anything to it
 
 ### Resolved snapshot
 
-`to_h` reads the agent's **resolved** state, not its raw configuration. By the time you call it, `Agent.new` has already evaluated any `Proc`-based `model`, `instructions`, or `uses_tools` against the agent's own context — so the dict carries plain strings and data, never Procs. The receiver's `context:` drives runtime behavior (tool dispatch); it does **not** re-evaluate baked-in fields.
+`to_h` reads the agent's **resolved** state, not its raw configuration. By the time you call it, `Agent.new` has already evaluated any `Proc`-based `model`, `instructions`, or `uses_tools` against the agent's own context — so the hash carries plain strings and data, never Procs. The receiver's `context:` drives runtime behavior (tool dispatch); it does **not** re-evaluate baked-in fields.
 
 ### Structured output
 
@@ -67,7 +67,7 @@ Tools cross as `{name, description, parameters_schema, timeout}` descriptors —
 When the rebuilt agent runs in the **same** codebase that defined the tools (e.g. persisting an agent definition and rehydrating it later), resolve each descriptor back to its real class:
 
 ```ruby
-rebuilt = Riffer::Agent.from_h(dict,
+rebuilt = Riffer::Agent.from_h(data,
   tool_resolver: ->(descriptor) { MyToolRegistry.fetch(descriptor[:name]) })
 ```
 
@@ -78,7 +78,7 @@ The real classes carry their `#call` bodies, so the agent runs on the default `I
 When the receiver holds **only the Riffer gem**, the default `tool_resolver` synthesizes body-less **tool shells**. A shell advertises the tool's schema to the LLM but has no `#call` — invoking it in-process raises. Pair the default resolver with a remote `Riffer::Tools::Runtime` that forwards each call back to the origin:
 
 ```ruby
-rebuilt = Riffer::Agent.from_h(dict,
+rebuilt = Riffer::Agent.from_h(data,
   tool_runtime: MyRemoteToolRuntime.new(client: rpc_client))
 ```
 
@@ -88,12 +88,12 @@ You own what a resolved tool does: a resolver may return real in-process classes
 
 ## `max_steps`
 
-Unlimited steps are `nil` at the agent level — set it with `max_steps nil`. On the wire, the serializer encodes that as **`-1`** (and decodes `-1` back to `nil`), so the dict stays portable across transports where JSON `null` is awkward — proto3, for one, can't distinguish `null` from an absent field. The `-1` is purely a wire detail: the DSL and your code only ever see `nil`, and the encode/decode handles the translation at the boundary.
+Unlimited steps are `nil` at the agent level — set it with `max_steps nil`. On the wire, the serializer encodes that as **`-1`** (and decodes `-1` back to `nil`), so the hash stays portable across transports where JSON `null` is awkward — proto3, for one, can't distinguish `null` from an absent field. The `-1` is purely a wire detail: the DSL and your code only ever see `nil`, and the encode/decode handles the translation at the boundary.
 
 - **DSL** — integer = bounded, `nil` = unlimited, omitted = `Config`'s default (16).
 - **Wire** — integer = bounded, `-1` = unlimited, omitted = default (16).
 
-A finite integer round-trips as-is; a dict missing the key falls back to the default rather than running unbounded.
+A finite integer round-trips as-is; a hash missing the key falls back to the default rather than running unbounded.
 
 ## Versioning
 
@@ -101,7 +101,7 @@ A finite integer round-trips as-is; a dict missing the key falls back to the def
 
 ## Secrets
 
-`provider_options` and `model_options` **ride on the wire as plain data** — they are part of the dict and _will_ transfer. Prefer configuring API keys via environment/global provider configuration rather than `provider_options`. **Never serialize an agent whose options carry sensitive values** — and if a serialized definition ever does, handle it as a secret (encrypt it, keep it out of logs).
+`provider_options` and `model_options` **ride on the wire as plain data** — they are part of the hash and _will_ transfer. Prefer configuring API keys via environment/global provider configuration rather than `provider_options`. **Never serialize an agent whose options carry sensitive values** — and if a serialized definition ever does, handle it as a secret (encrypt it, keep it out of logs).
 
 ## What does **not** transfer
 

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -212,7 +212,7 @@ class Riffer::Agent
     new(context: context).stream(prompt, files: files)
   end
 
-  # Reconstructs a runnable agent from a wire dict produced by +#to_h+.
+  # Reconstructs a runnable agent from a wire hash produced by +#to_h+.
   #
   # Delegates to Riffer::Agent::Serializer.from_h. See it for the +session+
   # seed, the +tool_resolver+ / +tool_runtime+ injection points, and what does
@@ -412,7 +412,7 @@ class Riffer::Agent
   end
 
   # Snapshots this resolved agent into a self-contained, provider-neutral
-  # wire dict. Delegates to Riffer::Agent::Serializer.to_h.
+  # wire hash. Delegates to Riffer::Agent::Serializer.to_h.
   #
   #--
   #: () -> Hash[Symbol, untyped]

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -214,26 +214,26 @@ class Riffer::Agent
 
   # Reconstructs a runnable agent from a wire dict produced by +#to_h+.
   #
-  # Delegates to Riffer::Agent::Serializer.from_h. See it for the
-  # +tool_resolver+ / +tool_runtime+ injection points and what does not
-  # transfer.
+  # Delegates to Riffer::Agent::Serializer.from_h. See it for the +session+
+  # seed, the +tool_resolver+ / +tool_runtime+ injection points, and what does
+  # not transfer.
   #
   #--
-  #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def self.from_h(hash, context: nil, tool_resolver: Riffer::Agent::Serializer::DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
-    Riffer::Agent::Serializer.from_h(hash, context: context, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
+  #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def self.from_h(hash, context: nil, session: nil, tool_resolver: Riffer::Agent::Serializer::DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
+    Riffer::Agent::Serializer.from_h(hash, context: context, session: session, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
   end
 
   # Reconstructs a runnable agent from a JSON string produced by +#to_json+.
   #
   # Delegates to Riffer::Agent::Serializer.from_json, which parses the JSON
   # (with symbol keys) for you. See Riffer::Agent::Serializer.from_h for the
-  # +tool_resolver+ / +tool_runtime+ injection points.
+  # +session+ seed and the +tool_resolver+ / +tool_runtime+ injection points.
   #
   #--
-  #: (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def self.from_json(json, context: nil, tool_resolver: Riffer::Agent::Serializer::DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
-    Riffer::Agent::Serializer.from_json(json, context: context, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
+  #: (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def self.from_json(json, context: nil, session: nil, tool_resolver: Riffer::Agent::Serializer::DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
+    Riffer::Agent::Serializer.from_json(json, context: context, session: session, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
   end
 
   # Registers a guardrail for input, output, or both phases.

--- a/lib/riffer/agent/serializer.rb
+++ b/lib/riffer/agent/serializer.rb
@@ -4,12 +4,12 @@
 require "json"
 
 # Riffer::Agent::Serializer turns a resolved agent into a self-contained,
-# provider-neutral data dict and back into a runnable agent. A pure module
+# provider-neutral data hash and back into a runnable agent. A pure module
 # (sibling to Riffer::Agent::Run), reached most often through the
 # +Riffer::Agent#to_h+ / +Riffer::Agent.from_h+ delegators.
 #
-# The dict carries only data — no Procs, no class references, no tool
-# runtime. The same dict serves two rehydration targets:
+# The hash carries only data — no Procs, no class references, no tool
+# runtime. The same hash serves two rehydration targets:
 #
 # - <b>In-process</b> (a monolith persisting agent definitions): pass a
 #   +tool_resolver+ that looks tool descriptors up in a local registry and
@@ -18,8 +18,8 @@ require "json"
 #   resolver synthesizes body-less tool shells; inject a remote
 #   +Riffer::Tools::Runtime+ to forward each call back to the origin.
 #
-#   dict  = Riffer::Agent::Serializer.to_h(agent: agent)
-#   rebuilt = Riffer::Agent::Serializer.from_h(dict, context: {tenant: "acme"})
+#   data  = Riffer::Agent::Serializer.to_h(agent: agent)
+#   rebuilt = Riffer::Agent::Serializer.from_h(data, context: {tenant: "acme"})
 #
 # == What does not transfer
 #
@@ -32,21 +32,21 @@ module Riffer::Agent::Serializer
   extend self
 
   # The wire format version. Bumped only on an incompatible change to the
-  # dict shape; +from_h+ refuses any other version. See +from_h+ for the
+  # hash shape; +from_h+ refuses any other version. See +from_h+ for the
   # dispatch seam that carries back-compat decoders.
   SCHEMA_VERSION = 1 #: Integer
 
-  # Raised by +from_h+ when the dict's +schema_version+ is unsupported.
+  # Raised by +from_h+ when the hash's +schema_version+ is unsupported.
   class VersionError < Riffer::ArgumentError; end
 
   # The default +tool_resolver+: synthesizes a body-less tool shell from a
   # descriptor. Its +#call+ raises — route shells through a remote runtime.
   DEFAULT_TOOL_RESOLVER = ->(descriptor) { build_tool_shell(descriptor) } #: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool)
 
-  # Snapshots a resolved agent into a self-contained wire dict.
+  # Snapshots a resolved agent into a self-contained wire hash.
   #
   # Reads the agent's resolved instance state — Proc-based settings have
-  # already been evaluated against the agent's own context, so the dict
+  # already been evaluated against the agent's own context, so the hash
   # carries plain strings/data, never Procs. Tools are emitted as
   # +{name, description, parameters_schema, timeout}+ descriptors (the
   # resolved +agent.tools+, including MCP tools and +skill_activate+).
@@ -71,20 +71,20 @@ module Riffer::Agent::Serializer
     }
   end
 
-  # Reconstructs a runnable agent from a wire dict.
+  # Reconstructs a runnable agent from a wire hash.
   #
-  # [hash] a Symbol-keyed wire dict (parse JSON with +symbolize_names: true+).
+  # [hash] a Symbol-keyed wire hash (parse JSON with +symbolize_names: true+).
   # [context] the rebuilt agent's runtime context — the same value you'd pass
   #   to +Agent.new(context:)+. It is *not* used to re-resolve serialized
-  #   config (the dict is already resolved); it is threaded into tool dispatch
+  #   config (the hash is already resolved); it is threaded into tool dispatch
   #   and read by tools/runtimes at call time (e.g. a remote runtime keying off
   #   <tt>context[:tenant]</tt>). Defaults to an empty context.
   # [session] an optional Riffer::Agent::Session to seed conversation history,
-  #   forwarded verbatim to +Agent.new(session:)+. The dict carries the agent
+  #   forwarded verbatim to +Agent.new(session:)+. The hash carries the agent
   #   *definition*, not its history (see "What does not transfer"); pass a
   #   session here to resume a persisted conversation. Used as-is — the caller
   #   owns its contents, including the system instruction message. When omitted,
-  #   a fresh session seeded with the dict's instructions is built, as before.
+  #   a fresh session seeded with the hash's instructions is built.
   # [tool_resolver] maps a tool descriptor to a Riffer::Tool class. Defaults
   #   to DEFAULT_TOOL_RESOLVER (body-less shells). Pass a registry lookup to
   #   rebuild real, in-process tools.
@@ -93,7 +93,7 @@ module Riffer::Agent::Serializer
   #   default (+Riffer.config.tool_runtime+).
   #
   # Raises Riffer::Agent::Serializer::VersionError on an unsupported
-  # +schema_version+, and Riffer::ArgumentError on a malformed dict.
+  # +schema_version+, and Riffer::ArgumentError on a malformed hash.
   #
   #--
   #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
@@ -150,7 +150,7 @@ module Riffer::Agent::Serializer
 
     # +session+ is forwarded verbatim: when nil, Agent.new seeds a fresh session
     # from the decoded instructions; when supplied, Agent.new uses it as-is to
-    # resume persisted history. The dict never carries history (see "What does
+    # resume persisted history. The hash never carries history (see "What does
     # not transfer"), so this is the only seam for rehydrating a conversation.
     Riffer::Agent.new(config: Riffer::Agent::Config.new(**config_args), context: context, session: session)
   end
@@ -163,7 +163,7 @@ module Riffer::Agent::Serializer
   end
 
   # The DSL represents unlimited steps as +nil+, but the wire encodes it as
-  # +-1+ so the dict stays portable across transports where JSON +null+ is
+  # +-1+ so the hash stays portable across transports where JSON +null+ is
   # awkward (e.g. proto3, which can't tell null from an absent field). The
   # magic value lives only on the wire — +encode_max_steps+/+decode_max_steps+
   # translate at the boundary so neither the DSL nor consumers see it.
@@ -174,7 +174,7 @@ module Riffer::Agent::Serializer
   end
 
   # Reverses +encode_max_steps+: +-1+ (or a literal +null+) means unlimited.
-  # An absent key falls back to the default — a partial dict must not silently
+  # An absent key falls back to the default — a partial hash must not silently
   # become an unbounded loop.
   #--
   #: (Hash[Symbol, untyped]) -> Numeric?

--- a/lib/riffer/agent/serializer.rb
+++ b/lib/riffer/agent/serializer.rb
@@ -79,6 +79,12 @@ module Riffer::Agent::Serializer
   #   config (the dict is already resolved); it is threaded into tool dispatch
   #   and read by tools/runtimes at call time (e.g. a remote runtime keying off
   #   <tt>context[:tenant]</tt>). Defaults to an empty context.
+  # [session] an optional Riffer::Agent::Session to seed conversation history,
+  #   forwarded verbatim to +Agent.new(session:)+. The dict carries the agent
+  #   *definition*, not its history (see "What does not transfer"); pass a
+  #   session here to resume a persisted conversation. Used as-is — the caller
+  #   owns its contents, including the system instruction message. When omitted,
+  #   a fresh session seeded with the dict's instructions is built, as before.
   # [tool_resolver] maps a tool descriptor to a Riffer::Tool class. Defaults
   #   to DEFAULT_TOOL_RESOLVER (body-less shells). Pass a registry lookup to
   #   rebuild real, in-process tools.
@@ -90,13 +96,13 @@ module Riffer::Agent::Serializer
   # +schema_version+, and Riffer::ArgumentError on a malformed dict.
   #
   #--
-  #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def from_h(hash, context: nil, tool_resolver: DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
+  #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def from_h(hash, context: nil, session: nil, tool_resolver: DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
     # Version -> decoder dispatch. Adding a +when 2+ arm (a backwards-compatible
     # decoder) is how a future breaking change keeps older dicts readable.
     case hash[:schema_version]
     when SCHEMA_VERSION
-      decode_v1(hash, context: context, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
+      decode_v1(hash, context: context, session: session, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
     else
       raise VersionError, "Unsupported schema_version: #{hash[:schema_version].inspect} (this Riffer supports #{SCHEMA_VERSION})"
     end
@@ -116,16 +122,16 @@ module Riffer::Agent::Serializer
   # +from_h+ for the arguments.
   #
   #--
-  #: (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def from_json(json, context: nil, tool_resolver: DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
-    from_h(JSON.parse(json, symbolize_names: true), context: context, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
+  #: (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def from_json(json, context: nil, session: nil, tool_resolver: DEFAULT_TOOL_RESOLVER, tool_runtime: nil)
+    from_h(JSON.parse(json, symbolize_names: true), context: context, session: session, tool_resolver: tool_resolver, tool_runtime: tool_runtime)
   end
 
   private
 
   #--
-  #: (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def decode_v1(hash, context:, tool_resolver:, tool_runtime:)
+  #: (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, session: Riffer::Agent::Session?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def decode_v1(hash, context:, session:, tool_resolver:, tool_runtime:)
     tools = Array(hash[:tools]).map { |descriptor| tool_resolver.call(descriptor) }
 
     config_args = {
@@ -142,7 +148,11 @@ module Riffer::Agent::Serializer
     # Config default (Riffer.config.tool_runtime) applies.
     config_args[:tool_runtime] = tool_runtime if tool_runtime
 
-    Riffer::Agent.new(config: Riffer::Agent::Config.new(**config_args), context: context)
+    # +session+ is forwarded verbatim: when nil, Agent.new seeds a fresh session
+    # from the decoded instructions; when supplied, Agent.new uses it as-is to
+    # resume persisted history. The dict never carries history (see "What does
+    # not transfer"), so this is the only seam for rehydrating a conversation.
+    Riffer::Agent.new(config: Riffer::Agent::Config.new(**config_args), context: context, session: session)
   end
 
   #--

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -164,7 +164,7 @@ class Riffer::Agent
   # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
   def self.stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?) -> Enumerator[Riffer::StreamEvents::Base, void]
 
-  # Reconstructs a runnable agent from a wire dict produced by +#to_h+.
+  # Reconstructs a runnable agent from a wire hash produced by +#to_h+.
   #
   # Delegates to Riffer::Agent::Serializer.from_h. See it for the +session+
   # seed, the +tool_resolver+ / +tool_runtime+ injection points, and what does
@@ -331,7 +331,7 @@ class Riffer::Agent
   def interrupt!: (?(String | Symbol)?) -> void
 
   # Snapshots this resolved agent into a self-contained, provider-neutral
-  # wire dict. Delegates to Riffer::Agent::Serializer.to_h.
+  # wire hash. Delegates to Riffer::Agent::Serializer.to_h.
   #
   # --
   # : () -> Hash[Symbol, untyped]

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -166,23 +166,23 @@ class Riffer::Agent
 
   # Reconstructs a runnable agent from a wire dict produced by +#to_h+.
   #
-  # Delegates to Riffer::Agent::Serializer.from_h. See it for the
-  # +tool_resolver+ / +tool_runtime+ injection points and what does not
-  # transfer.
+  # Delegates to Riffer::Agent::Serializer.from_h. See it for the +session+
+  # seed, the +tool_resolver+ / +tool_runtime+ injection points, and what does
+  # not transfer.
   #
   # --
-  # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def self.from_h: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def self.from_h: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
 
   # Reconstructs a runnable agent from a JSON string produced by +#to_json+.
   #
   # Delegates to Riffer::Agent::Serializer.from_json, which parses the JSON
   # (with symbol keys) for you. See Riffer::Agent::Serializer.from_h for the
-  # +tool_resolver+ / +tool_runtime+ injection points.
+  # +session+ seed and the +tool_resolver+ / +tool_runtime+ injection points.
   #
   # --
-  # : (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def self.from_json: (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  # : (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def self.from_json: (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
 
   # Registers a guardrail for input, output, or both phases.
   #

--- a/sig/generated/riffer/agent/serializer.rbs
+++ b/sig/generated/riffer/agent/serializer.rbs
@@ -61,6 +61,12 @@ module Riffer::Agent::Serializer
   #   config (the dict is already resolved); it is threaded into tool dispatch
   #   and read by tools/runtimes at call time (e.g. a remote runtime keying off
   #   <tt>context[:tenant]</tt>). Defaults to an empty context.
+  # [session] an optional Riffer::Agent::Session to seed conversation history,
+  #   forwarded verbatim to +Agent.new(session:)+. The dict carries the agent
+  #   *definition*, not its history (see "What does not transfer"); pass a
+  #   session here to resume a persisted conversation. Used as-is — the caller
+  #   owns its contents, including the system instruction message. When omitted,
+  #   a fresh session seeded with the dict's instructions is built, as before.
   # [tool_resolver] maps a tool descriptor to a Riffer::Tool class. Defaults
   #   to DEFAULT_TOOL_RESOLVER (body-less shells). Pass a registry lookup to
   #   rebuild real, in-process tools.
@@ -72,8 +78,8 @@ module Riffer::Agent::Serializer
   # +schema_version+, and Riffer::ArgumentError on a malformed dict.
   #
   # --
-  # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def from_h: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def from_h: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
 
   # Snapshots a resolved agent to a JSON string. Convenience over
   # <tt>JSON.generate(to_h(agent:))</tt>.
@@ -87,14 +93,14 @@ module Riffer::Agent::Serializer
   # +from_h+ for the arguments.
   #
   # --
-  # : (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def from_json: (String, ?context: Hash[Symbol, untyped]?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  # : (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def from_json: (String, ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
 
   private
 
   # --
-  # : (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
-  def decode_v1: (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  # : (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, session: Riffer::Agent::Session?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
+  def decode_v1: (Hash[Symbol, untyped], context: Hash[Symbol, untyped]?, session: Riffer::Agent::Session?, tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
 
   # --
   # : (Hash[Symbol, untyped]?) -> Riffer::Params?

--- a/sig/generated/riffer/agent/serializer.rbs
+++ b/sig/generated/riffer/agent/serializer.rbs
@@ -1,12 +1,12 @@
 # Generated from lib/riffer/agent/serializer.rb with RBS::Inline
 
 # Riffer::Agent::Serializer turns a resolved agent into a self-contained,
-# provider-neutral data dict and back into a runnable agent. A pure module
+# provider-neutral data hash and back into a runnable agent. A pure module
 # (sibling to Riffer::Agent::Run), reached most often through the
 # +Riffer::Agent#to_h+ / +Riffer::Agent.from_h+ delegators.
 #
-# The dict carries only data — no Procs, no class references, no tool
-# runtime. The same dict serves two rehydration targets:
+# The hash carries only data — no Procs, no class references, no tool
+# runtime. The same hash serves two rehydration targets:
 #
 # - <b>In-process</b> (a monolith persisting agent definitions): pass a
 #   +tool_resolver+ that looks tool descriptors up in a local registry and
@@ -15,8 +15,8 @@
 #   resolver synthesizes body-less tool shells; inject a remote
 #   +Riffer::Tools::Runtime+ to forward each call back to the origin.
 #
-#   dict  = Riffer::Agent::Serializer.to_h(agent: agent)
-#   rebuilt = Riffer::Agent::Serializer.from_h(dict, context: {tenant: "acme"})
+#   data  = Riffer::Agent::Serializer.to_h(agent: agent)
+#   rebuilt = Riffer::Agent::Serializer.from_h(data, context: {tenant: "acme"})
 #
 # == What does not transfer
 #
@@ -27,11 +27,11 @@
 # both ride on the wire as plain data.
 module Riffer::Agent::Serializer
   # The wire format version. Bumped only on an incompatible change to the
-  # dict shape; +from_h+ refuses any other version. See +from_h+ for the
+  # hash shape; +from_h+ refuses any other version. See +from_h+ for the
   # dispatch seam that carries back-compat decoders.
   SCHEMA_VERSION: Integer
 
-  # Raised by +from_h+ when the dict's +schema_version+ is unsupported.
+  # Raised by +from_h+ when the hash's +schema_version+ is unsupported.
   class VersionError < Riffer::ArgumentError
   end
 
@@ -39,10 +39,10 @@ module Riffer::Agent::Serializer
   # descriptor. Its +#call+ raises — route shells through a remote runtime.
   DEFAULT_TOOL_RESOLVER: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool)
 
-  # Snapshots a resolved agent into a self-contained wire dict.
+  # Snapshots a resolved agent into a self-contained wire hash.
   #
   # Reads the agent's resolved instance state — Proc-based settings have
-  # already been evaluated against the agent's own context, so the dict
+  # already been evaluated against the agent's own context, so the hash
   # carries plain strings/data, never Procs. Tools are emitted as
   # +{name, description, parameters_schema, timeout}+ descriptors (the
   # resolved +agent.tools+, including MCP tools and +skill_activate+).
@@ -53,20 +53,20 @@ module Riffer::Agent::Serializer
   # : (agent: Riffer::Agent) -> Hash[Symbol, untyped]
   def to_h: (agent: Riffer::Agent) -> Hash[Symbol, untyped]
 
-  # Reconstructs a runnable agent from a wire dict.
+  # Reconstructs a runnable agent from a wire hash.
   #
-  # [hash] a Symbol-keyed wire dict (parse JSON with +symbolize_names: true+).
+  # [hash] a Symbol-keyed wire hash (parse JSON with +symbolize_names: true+).
   # [context] the rebuilt agent's runtime context — the same value you'd pass
   #   to +Agent.new(context:)+. It is *not* used to re-resolve serialized
-  #   config (the dict is already resolved); it is threaded into tool dispatch
+  #   config (the hash is already resolved); it is threaded into tool dispatch
   #   and read by tools/runtimes at call time (e.g. a remote runtime keying off
   #   <tt>context[:tenant]</tt>). Defaults to an empty context.
   # [session] an optional Riffer::Agent::Session to seed conversation history,
-  #   forwarded verbatim to +Agent.new(session:)+. The dict carries the agent
+  #   forwarded verbatim to +Agent.new(session:)+. The hash carries the agent
   #   *definition*, not its history (see "What does not transfer"); pass a
   #   session here to resume a persisted conversation. Used as-is — the caller
   #   owns its contents, including the system instruction message. When omitted,
-  #   a fresh session seeded with the dict's instructions is built, as before.
+  #   a fresh session seeded with the hash's instructions is built.
   # [tool_resolver] maps a tool descriptor to a Riffer::Tool class. Defaults
   #   to DEFAULT_TOOL_RESOLVER (body-less shells). Pass a registry lookup to
   #   rebuild real, in-process tools.
@@ -75,7 +75,7 @@ module Riffer::Agent::Serializer
   #   default (+Riffer.config.tool_runtime+).
   #
   # Raises Riffer::Agent::Serializer::VersionError on an unsupported
-  # +schema_version+, and Riffer::ArgumentError on a malformed dict.
+  # +schema_version+, and Riffer::ArgumentError on a malformed hash.
   #
   # --
   # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?, ?session: Riffer::Agent::Session?, ?tool_resolver: ^(Hash[Symbol, untyped]) -> singleton(Riffer::Tool), ?tool_runtime: (singleton(Riffer::Tools::Runtime) | Riffer::Tools::Runtime | Proc)?) -> Riffer::Agent
@@ -107,7 +107,7 @@ module Riffer::Agent::Serializer
   def decode_structured_output: (Hash[Symbol, untyped]?) -> Riffer::Params?
 
   # The DSL represents unlimited steps as +nil+, but the wire encodes it as
-  # +-1+ so the dict stays portable across transports where JSON +null+ is
+  # +-1+ so the hash stays portable across transports where JSON +null+ is
   # awkward (e.g. proto3, which can't tell null from an absent field). The
   # magic value lives only on the wire — +encode_max_steps+/+decode_max_steps+
   # translate at the boundary so neither the DSL nor consumers see it.
@@ -116,7 +116,7 @@ module Riffer::Agent::Serializer
   def encode_max_steps: (Numeric?) -> Numeric
 
   # Reverses +encode_max_steps+: +-1+ (or a literal +null+) means unlimited.
-  # An absent key falls back to the default — a partial dict must not silently
+  # An absent key falls back to the default — a partial hash must not silently
   # become an unbounded loop.
   # --
   # : (Hash[Symbol, untyped]) -> Numeric?

--- a/test/riffer/agent/serializer_test.rb
+++ b/test/riffer/agent/serializer_test.rb
@@ -176,6 +176,50 @@ describe Riffer::Agent::Serializer do
       end
     end
 
+    describe "session" do
+      it "seeds a fresh session with the dict's instructions when omitted" do
+        dict = build_agent_class.new.to_h
+        agent = Riffer::Agent.from_h(dict, context: nil)
+
+        expect(agent.session.messages.map(&:role)).must_equal [:system]
+        expect(agent.session.messages.first.content).must_equal "You are helpful."
+      end
+
+      it "uses a provided session verbatim to seed conversation history" do
+        dict = build_agent_class.new.to_h
+        history = [
+          Riffer::Messages::System.new("You are helpful."),
+          Riffer::Messages::User.new("Hello"),
+          Riffer::Messages::Assistant.new("Hi there!")
+        ]
+        session = Riffer::Agent::Session.new(messages: history)
+
+        agent = Riffer::Agent.from_h(dict, context: nil, session: session)
+
+        expect(agent.session).must_be_same_as session
+        expect(agent.session.messages.map(&:content)).must_equal ["You are helpful.", "Hello", "Hi there!"]
+      end
+
+      it "forwards the session through from_json too" do
+        json = build_agent_class.new.to_json
+        history = [Riffer::Messages::System.new("You are helpful."), Riffer::Messages::User.new("Resume me")]
+        session = Riffer::Agent::Session.new(messages: history)
+
+        agent = Riffer::Agent.from_json(json, context: nil, session: session)
+
+        expect(agent.session.messages.last.content).must_equal "Resume me"
+      end
+
+      it "does not re-inject the dict's instructions into a provided session" do
+        dict = build_agent_class.new.to_h
+        session = Riffer::Agent::Session.new(messages: [Riffer::Messages::User.new("No system message here")])
+
+        agent = Riffer::Agent.from_h(dict, context: nil, session: session)
+
+        expect(agent.session.messages.map(&:role)).must_equal [:user]
+      end
+    end
+
     it "raises VersionError on an unsupported schema_version" do
       dict = build_agent_class.new.to_h.merge(schema_version: 999)
 


### PR DESCRIPTION
## Why

`Riffer::Agent::Serializer.from_h` built `Agent.new(config:, context:)` with **no `session:`**, so a rehydrated agent seeded only the instruction message — there was no seam to restore conversation history. `Agent.new` already uses a provided session verbatim; the serializer just never offered the forward. Consumers that persist history separately (e.g. Maestro) need to seed it on rebuild.

## What

- **`lib/riffer/agent/serializer.rb`** — add a backward-compatible `session:` keyword to `from_h` / `from_json`, threaded through `decode_v1` into `Agent.new(..., session: session)`.
- **`lib/riffer/agent.rb`** — add `session:` to the `Agent.from_h` / `Agent.from_json` delegators.
- **`sig/generated/…`** — regenerated via `bin/rbs`.
- **`test/riffer/agent/serializer_test.rb`** — new `session` describe: omitted → instruction-seeded (unchanged); provided → used verbatim (same object, history preserved); forwarded through `from_json`; and the deliberate "instructions are *not* re-injected into a provided session" contract.
- **`docs/15_SERIALIZATION.md`** — new "Seeding conversation history" section.

## Semantics

When `session:` is omitted, behavior is **identical** to before (fresh session seeded from the dict's `instructions`). When supplied, the session is used **as-is** — the caller owns its full contents, **including the system instruction message** — so the dict's `instructions` are not re-injected. The dict still carries only the agent *definition*, not history; this is purely the rebuild-side seam for callers that persist history separately.

## Release

Additive + backward-compatible. As a `feat:`, release-please should cut **0.31.0**, which the downstream pin (Maestro Slice 2) targets.

## Checks

`bin/rake` (test + standard + steep:check): **1604 runs, 2469 assertions, 0 failures, 0 errors**; StandardRB clean; Steep reports no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deserializing an agent can now accept an existing session to resume persisted conversations; a provided session is used as-is (history and system instruction preserved).

* **Behavior**
  * Omitting a session seeds a fresh session from the agent's instructions; serialized agent data does not contain prior conversation history.

* **Documentation**
  * Expanded docs explaining session seeding/resumption semantics and portability/versioning notes.

* **Tests**
  * Added tests for session seeding, JSON session forwarding, and prevention of system-instruction reinjection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->