### PR TITLE
feat: Bedrock prompt caching + surface cached tokens

### DIFF
--- a/docs/providers/02_AMAZON_BEDROCK.md
+++ b/docs/providers/02_AMAZON_BEDROCK.md
@@ -83,6 +83,20 @@ model_options additional_model_request_fields: {
 }
 ```
 
+### cache_control
+
+Enable prompt caching for models that support it (Claude, Nova). Riffer appends a single Converse `cachePoint` to the stable prefix — after the system array, or after the tools when there is no system prompt — so system instructions and tool definitions are reused across the calls in an agent loop and across conversation turns. The volatile message tail is never cached.
+
+```ruby
+# 5-minute TTL (default)
+model_options cache_control: {type: "ephemeral"}
+
+# 1-hour TTL (model-dependent; Bedrock validates support)
+model_options cache_control: {type: "ephemeral", ttl: "1h"}
+```
+
+Caching is opt-in: omit `cache_control` and no cachePoint is sent. The breakpoint is only honored once the prefix clears the model's minimum token count; on models that don't support `cachePoint`, the Converse request errors. Verify hits via `response.token_usage.cache_read_tokens`.
+
 ## Example
 
 ```ruby

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -47,12 +47,13 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     partitioned_messages = partition_messages(messages)
     tools = options[:tools]
     structured_output = options[:structured_output]
+    cache_control = options[:cache_control]
 
     params = {
       model_id: model,
       system: partitioned_messages[:system],
       messages: partitioned_messages[:conversation],
-      **options.except(:tools, :structured_output)
+      **options.except(:tools, :structured_output, :cache_control)
     } #: Hash[Symbol, untyped]
 
     if tools && !tools.empty?
@@ -78,7 +79,35 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       }
     end
 
+    apply_cache_point(params, cache_control) if cache_control
+
     params
+  end
+
+  # Converse chains +tools -> system -> messages+, so a single +cachePoint+ at
+  # the end of the system array (or the tools array, when there is no system
+  # prompt) also caches the preceding sections.
+  #--
+  #: (Hash[Symbol, untyped], untyped) -> void
+  def apply_cache_point(params, cache_control)
+    cache_point = {cache_point: build_cache_point(cache_control)}
+    system = params[:system]
+    tools = params.dig(:tool_config, :tools)
+
+    if system && !system.empty?
+      system << cache_point
+    elsif tools && !tools.empty?
+      tools << cache_point
+    end
+  end
+
+  #--
+  #: (untyped) -> Hash[Symbol, untyped]
+  def build_cache_point(cache_control)
+    point = {type: "default"} #: Hash[Symbol, untyped]
+    ttl = cache_control.is_a?(Hash) ? cache_control[:ttl] : nil
+    point[:ttl] = ttl if ttl
+    point
   end
 
   #--
@@ -96,7 +125,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens,
       output_tokens: usage.output_tokens,
-      cache_creation_tokens: usage.cache_write_input_tokens,
+      cache_write_tokens: usage.cache_write_input_tokens,
       cache_read_tokens: usage.cache_read_input_tokens
     )
   end
@@ -246,7 +275,7 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
       token_usage: Riffer::Providers::TokenUsage.new(
         input_tokens: typed_event.usage.input_tokens,
         output_tokens: typed_event.usage.output_tokens,
-        cache_creation_tokens: typed_event.usage.cache_write_input_tokens,
+        cache_write_tokens: typed_event.usage.cache_write_input_tokens,
         cache_read_tokens: typed_event.usage.cache_read_input_tokens
       )
     )

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -86,7 +86,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens,
       output_tokens: usage.output_tokens,
-      cache_creation_tokens: usage.cache_creation_input_tokens,
+      cache_write_tokens: usage.cache_creation_input_tokens,
       cache_read_tokens: usage.cache_read_input_tokens
     )
   end
@@ -293,7 +293,7 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
       token_usage: Riffer::Providers::TokenUsage.new(
         input_tokens: usage.input_tokens,
         output_tokens: usage.output_tokens,
-        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_write_tokens: usage.cache_creation_input_tokens,
         cache_read_tokens: usage.cache_read_input_tokens
       )
     )

--- a/lib/riffer/providers/gemini.rb
+++ b/lib/riffer/providers/gemini.rb
@@ -105,7 +105,8 @@ class Riffer::Providers::Gemini < Riffer::Providers::Base
 
     Riffer::Providers::TokenUsage.new(
       input_tokens: usage[:promptTokenCount] || 0,
-      output_tokens: usage[:candidatesTokenCount] || 0
+      output_tokens: usage[:candidatesTokenCount] || 0,
+      cache_read_tokens: usage[:cachedContentTokenCount]
     )
   end
 
@@ -161,7 +162,8 @@ class Riffer::Providers::Gemini < Riffer::Providers::Base
           yielder << Riffer::StreamEvents::TokenUsageDone.new(
             token_usage: Riffer::Providers::TokenUsage.new(
               input_tokens: usage[:promptTokenCount] || 0,
-              output_tokens: usage[:candidatesTokenCount] || 0
+              output_tokens: usage[:candidatesTokenCount] || 0,
+              cache_read_tokens: usage[:cachedContentTokenCount]
             )
           )
         end

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -76,7 +76,8 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
 
     Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens,
-      output_tokens: usage.output_tokens
+      output_tokens: usage.output_tokens,
+      cache_read_tokens: usage.input_tokens_details&.cached_tokens
     )
   end
 
@@ -225,7 +226,8 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     yielder << Riffer::StreamEvents::TokenUsageDone.new(
       token_usage: Riffer::Providers::TokenUsage.new(
         input_tokens: usage.input_tokens,
-        output_tokens: usage.output_tokens
+        output_tokens: usage.output_tokens,
+        cache_read_tokens: usage.input_tokens_details&.cached_tokens
       )
     )
   end

--- a/lib/riffer/providers/token_usage.rb
+++ b/lib/riffer/providers/token_usage.rb
@@ -9,18 +9,18 @@ class Riffer::Providers::TokenUsage
   # Number of tokens in the output/response.
   attr_reader :output_tokens #: Integer
 
-  # Number of tokens written to cache (Anthropic-specific).
-  attr_reader :cache_creation_tokens #: Integer?
+  # Number of tokens written to cache, when the provider reports it.
+  attr_reader :cache_write_tokens #: Integer?
 
-  # Number of tokens read from cache (Anthropic-specific).
+  # Number of tokens read from cache, when the provider reports it.
   attr_reader :cache_read_tokens #: Integer?
 
   #--
-  #: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
-  def initialize(input_tokens:, output_tokens:, cache_creation_tokens: nil, cache_read_tokens: nil)
+  #: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
+  def initialize(input_tokens:, output_tokens:, cache_write_tokens: nil, cache_read_tokens: nil)
     @input_tokens = input_tokens
     @output_tokens = output_tokens
-    @cache_creation_tokens = cache_creation_tokens
+    @cache_write_tokens = cache_write_tokens
     @cache_read_tokens = cache_read_tokens
   end
 
@@ -40,7 +40,7 @@ class Riffer::Providers::TokenUsage
     Riffer::Providers::TokenUsage.new(
       input_tokens: input_tokens + other.input_tokens,
       output_tokens: output_tokens + other.output_tokens,
-      cache_creation_tokens: add_nullable(cache_creation_tokens, other.cache_creation_tokens),
+      cache_write_tokens: add_nullable(cache_write_tokens, other.cache_write_tokens),
       cache_read_tokens: add_nullable(cache_read_tokens, other.cache_read_tokens)
     )
   end
@@ -50,7 +50,7 @@ class Riffer::Providers::TokenUsage
   #: () -> Hash[Symbol, Integer]
   def to_h
     hash = {input_tokens: input_tokens, output_tokens: output_tokens}
-    hash[:cache_creation_tokens] = cache_creation_tokens if cache_creation_tokens
+    hash[:cache_write_tokens] = cache_write_tokens if cache_write_tokens
     hash[:cache_read_tokens] = cache_read_tokens if cache_read_tokens
     hash
   end

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -23,6 +23,17 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
+  # Converse chains +tools -> system -> messages+, so a single +cachePoint+ at
+  # the end of the system array (or the tools array, when there is no system
+  # prompt) also caches the preceding sections.
+  # --
+  # : (Hash[Symbol, untyped], untyped) -> void
+  def apply_cache_point: (Hash[Symbol, untyped], untyped) -> void
+
+  # --
+  # : (untyped) -> Hash[Symbol, untyped]
+  def build_cache_point: (untyped) -> Hash[Symbol, untyped]
+
   # --
   # : (Hash[Symbol, untyped]) -> untyped
   def execute_generate: (Hash[Symbol, untyped]) -> untyped

--- a/sig/generated/riffer/providers/token_usage.rbs
+++ b/sig/generated/riffer/providers/token_usage.rbs
@@ -8,15 +8,15 @@ class Riffer::Providers::TokenUsage
   # Number of tokens in the output/response.
   attr_reader output_tokens: Integer
 
-  # Number of tokens written to cache (Anthropic-specific).
-  attr_reader cache_creation_tokens: Integer?
+  # Number of tokens written to cache, when the provider reports it.
+  attr_reader cache_write_tokens: Integer?
 
-  # Number of tokens read from cache (Anthropic-specific).
+  # Number of tokens read from cache, when the provider reports it.
   attr_reader cache_read_tokens: Integer?
 
   # --
-  # : (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
-  def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_creation_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
+  # : (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
+  def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
 
   # Returns the total number of tokens (input + output).
   #

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -711,6 +711,64 @@ describe Riffer::Providers::AmazonBedrock do
     end
   end
 
+  describe "prompt caching" do
+    let(:model) { "us.anthropic.claude-haiku-4-5-20251001-v1:0" }
+    let(:cache_tool) do
+      Class.new(Riffer::Tool) do
+        identifier "get_weather"
+        description "Get the current weather for a city"
+        params do
+          required :city, String, description: "The city name"
+        end
+      end
+    end
+
+    it "appends a cachePoint after the system array when a system prompt is present" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, model, {cache_control: {type: "ephemeral"}})
+
+      expect(params[:system].last).must_equal({cache_point: {type: "default"}})
+    end
+
+    it "appends a cachePoint after the tools when there is no system prompt" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, model, {cache_control: {type: "ephemeral"}, tools: [cache_tool]})
+
+      expect(params[:tool_config][:tools].last).must_equal({cache_point: {type: "default"}})
+    end
+
+    it "translates the ttl onto the cachePoint" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, model, {cache_control: {type: "ephemeral", ttl: "1h"}})
+
+      expect(params[:system].last[:cache_point][:ttl]).must_equal "1h"
+    end
+
+    it "does not pass cache_control through as a top-level param" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, model, {cache_control: {type: "ephemeral"}})
+
+      expect(params.key?(:cache_control)).must_equal false
+    end
+
+    it "adds no cachePoint when caching is not requested" do
+      provider = Riffer::Providers::AmazonBedrock.new(api_token: api_token, region: "us-east-1")
+      messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
+
+      params = provider.send(:build_request_params, messages, model, {})
+
+      expect(params[:system].none? { |block| block.key?(:cache_point) }).must_equal true
+    end
+  end
+
   describe "file handling" do
     let(:image_base64) { "iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAIAAACRXR/mAAAAQ0lEQVR4nO3OMQ0AMAwDsPAnvRHonxyWDMB5yaD+QEtLS0tLa0N/oKWlpaWltaE/0NLS0tLS2tAfaGlpaWlpbegPTh97K7rEaOcNTQAAAABJRU5ErkJggg==" }
 

--- a/test/riffer/providers/gemini_test.rb
+++ b/test/riffer/providers/gemini_test.rb
@@ -587,6 +587,20 @@ describe Riffer::Providers::Gemini do
         end
       end
     end
+
+    describe "cache read tokens" do
+      it "surfaces cachedContentTokenCount when present" do
+        provider = Riffer::Providers::Gemini.new(api_key: api_key)
+        usage = provider.send(:extract_token_usage, {usageMetadata: {promptTokenCount: 100, candidatesTokenCount: 20, cachedContentTokenCount: 80}})
+        expect(usage.cache_read_tokens).must_equal 80
+      end
+
+      it "leaves cache_read_tokens nil when absent" do
+        provider = Riffer::Providers::Gemini.new(api_key: api_key)
+        usage = provider.send(:extract_token_usage, {usageMetadata: {promptTokenCount: 100, candidatesTokenCount: 20}})
+        expect(usage.cache_read_tokens).must_be_nil
+      end
+    end
   end
 
   describe "file handling" do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -467,6 +467,7 @@ describe Riffer::Providers::OpenAI do
           expect(result.token_usage.input_tokens).must_equal 8
           expect(result.token_usage.output_tokens).must_equal 73
           expect(result.token_usage.total_tokens).must_equal 81
+          expect(result.token_usage.cache_read_tokens).must_equal 0
         end
       end
     end

--- a/test/riffer/providers/token_usage_test.rb
+++ b/test/riffer/providers/token_usage_test.rb
@@ -14,9 +14,9 @@ describe Riffer::Providers::TokenUsage do
       expect(usage.output_tokens).must_equal 50
     end
 
-    it "sets cache_creation_tokens when provided" do
-      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_creation_tokens: 25)
-      expect(usage.cache_creation_tokens).must_equal 25
+    it "sets cache_write_tokens when provided" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_write_tokens: 25)
+      expect(usage.cache_write_tokens).must_equal 25
     end
 
     it "sets cache_read_tokens when provided" do
@@ -24,9 +24,9 @@ describe Riffer::Providers::TokenUsage do
       expect(usage.cache_read_tokens).must_equal 10
     end
 
-    it "defaults cache_creation_tokens to nil" do
+    it "defaults cache_write_tokens to nil" do
       usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
-      expect(usage.cache_creation_tokens).must_be_nil
+      expect(usage.cache_write_tokens).must_be_nil
     end
 
     it "defaults cache_read_tokens to nil" do
@@ -62,11 +62,11 @@ describe Riffer::Providers::TokenUsage do
       expect(combined.output_tokens).must_equal 125
     end
 
-    it "combines cache_creation_tokens when both have values" do
-      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_creation_tokens: 10)
-      usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75, cache_creation_tokens: 15)
+    it "combines cache_write_tokens when both have values" do
+      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_write_tokens: 10)
+      usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75, cache_write_tokens: 15)
       combined = usage1 + usage2
-      expect(combined.cache_creation_tokens).must_equal 25
+      expect(combined.cache_write_tokens).must_equal 25
     end
 
     it "combines cache_read_tokens when both have values" do
@@ -76,11 +76,11 @@ describe Riffer::Providers::TokenUsage do
       expect(combined.cache_read_tokens).must_equal 13
     end
 
-    it "keeps cache_creation_tokens nil when both are nil" do
+    it "keeps cache_write_tokens nil when both are nil" do
       usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
       usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75)
       combined = usage1 + usage2
-      expect(combined.cache_creation_tokens).must_be_nil
+      expect(combined.cache_write_tokens).must_be_nil
     end
 
     it "keeps cache_read_tokens nil when both are nil" do
@@ -90,11 +90,11 @@ describe Riffer::Providers::TokenUsage do
       expect(combined.cache_read_tokens).must_be_nil
     end
 
-    it "handles one nil cache_creation_tokens" do
-      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_creation_tokens: 10)
+    it "handles one nil cache_write_tokens" do
+      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_write_tokens: 10)
       usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75)
       combined = usage1 + usage2
-      expect(combined.cache_creation_tokens).must_equal 10
+      expect(combined.cache_write_tokens).must_equal 10
     end
 
     it "handles other nil cache_read_tokens" do
@@ -125,9 +125,9 @@ describe Riffer::Providers::TokenUsage do
       expect(usage.to_h[:output_tokens]).must_equal 50
     end
 
-    it "excludes cache_creation_tokens when nil" do
+    it "excludes cache_write_tokens when nil" do
       usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
-      expect(usage.to_h.key?(:cache_creation_tokens)).must_equal false
+      expect(usage.to_h.key?(:cache_write_tokens)).must_equal false
     end
 
     it "excludes cache_read_tokens when nil" do
@@ -135,9 +135,9 @@ describe Riffer::Providers::TokenUsage do
       expect(usage.to_h.key?(:cache_read_tokens)).must_equal false
     end
 
-    it "includes cache_creation_tokens when present" do
-      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_creation_tokens: 25)
-      expect(usage.to_h[:cache_creation_tokens]).must_equal 25
+    it "includes cache_write_tokens when present" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_write_tokens: 25)
+      expect(usage.to_h[:cache_write_tokens]).must_equal 25
     end
 
     it "includes cache_read_tokens when present" do
@@ -149,13 +149,13 @@ describe Riffer::Providers::TokenUsage do
       usage = Riffer::Providers::TokenUsage.new(
         input_tokens: 100,
         output_tokens: 50,
-        cache_creation_tokens: 25,
+        cache_write_tokens: 25,
         cache_read_tokens: 10
       )
       expected = {
         input_tokens: 100,
         output_tokens: 50,
-        cache_creation_tokens: 25,
+        cache_write_tokens: 25,
         cache_read_tokens: 10
       }
       expect(usage.to_h).must_equal expected

--- a/test/riffer/stream_events/token_usage_done_test.rb
+++ b/test/riffer/stream_events/token_usage_done_test.rb
@@ -37,14 +37,14 @@ describe Riffer::StreamEvents::TokenUsageDone do
       token_usage_with_cache = Riffer::Providers::TokenUsage.new(
         input_tokens: 100,
         output_tokens: 50,
-        cache_creation_tokens: 25,
+        cache_write_tokens: 25,
         cache_read_tokens: 10
       )
       event = Riffer::StreamEvents::TokenUsageDone.new(token_usage: token_usage_with_cache)
       expected_token_usage = {
         input_tokens: 100,
         output_tokens: 50,
-        cache_creation_tokens: 25,
+        cache_write_tokens: 25,
         cache_read_tokens: 10
       }
       expect(event.to_h[:token_usage]).must_equal expected_token_usage


### PR DESCRIPTION
## Problem

Riffer exposes no consistent way to benefit from provider prompt caching:

- **Amazon Bedrock (Converse) caching was impossible.** A `cachePoint` must be embedded *inside* the `system`/`messages`/`tools` arrays, which Riffer builds internally from `Riffer::Messages`. Converse has no top-level knob, and the `model_options` passthrough can't reach inside those arrays — so a consumer had no way to enable it at all.
- **Cache savings were invisible on the auto-caching providers.** OpenAI, Azure, and Gemini cache automatically server-side, but Riffer dropped the cached-token counts from their usage, so the savings couldn't be measured.

(Anthropic was already reachable today — `model_options cache_control: {…}` passes straight through to the SDK's top-level auto-placement — so it needs no code.)

## Solution

- **Bedrock:** when `model_options[:cache_control]` is set, inject a single `cachePoint` at the end of the **stable prefix** — the `system` array, or the `tools` array when there's no system prompt. Converse chains `tools → system → messages`, so one breakpoint after system also caches the preceding tools. This is opt-in (no top-level DSL, no global toggle — *not* setting `cache_control` is the off-switch) and places only on the static prefix, so there's no cache-write penalty on one-shot requests. `ttl` is passed through without a local model-support matrix (Bedrock validates it).
- **Observability:** map `usage.input_tokens_details.cached_tokens` (OpenAI/Azure) and `usageMetadata.cachedContentTokenCount` (Gemini) to `TokenUsage#cache_read_tokens`, in both generate and stream paths.
- **Field rename:** the cache usage fields are now a clear read/write pair — `cache_creation_tokens` → `cache_write_tokens`; `cache_read_tokens` stays. `cache_read_tokens` is the universal field (every caching provider reports reads); `cache_write_tokens` is Anthropic/Bedrock-only (the automatic providers have no write-token concept and leave it `nil`).
- **Anthropic:** intentionally no code — documented and left as SDK passthrough.

Trade-off worth flagging for review: the same `cache_control` key places at the **stable prefix** on Bedrock (Riffer-controlled) but at the **tail** on Anthropic (the SDK's auto-placement). Both are reasonable and it's opt-in, so the divergence is accepted rather than papered over.

Note `cache_write_tokens` is a **rename of an existing public field** (`cache_creation_tokens`) — a breaking change for anyone reading that attribute.

## Proof

CI covers the logic — see new/updated tests:
- `test/riffer/providers/amazon_bedrock_test.rb` — `cachePoint` placement after system, fallback to tools, `ttl` translation, no-top-level-leak, no-op when unset (via `build_request_params`).
- `test/riffer/providers/open_ai_test.rb` — `cache_read_tokens` surfaced from the usage cassette.
- `test/riffer/providers/gemini_test.rb` — `cachedContentTokenCount` mapping (present → value, absent → nil).
- `test/riffer/providers/token_usage_test.rb`, `test/riffer/stream_events/token_usage_done_test.rb` — renamed fields.

Full suite green locally: `bin/rake` → 1610 runs, 0 failures; Steep clean; `bin/lint` clean.

**Still needed from the author:** the Bedrock `cachePoint` placement is verified at the request-shaping layer, not against a live cache write/read round-trip. Please run one real Bedrock request with `model_options cache_control: {type: "ephemeral"}` against a Claude model with a ≥4,096-token prefix and confirm a second call within the TTL reports non-zero `response.token_usage.cache_read_tokens`. Paste the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt caching support for Amazon Bedrock with configurable TTL and cache-hit visibility via token usage metrics.
  * Consistent cache read/write token reporting added across providers for clearer usage accounting.

* **Documentation**
  * New Bedrock cache-control docs explaining defaults, opt-in behavior, TTL options, eligible prompt content, and how to verify cache hits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->