### PR TITLE
fix: respect disable-model-invocation in skills

### DIFF
--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -36,7 +36,11 @@ Review the code for:
 - `name` — lowercase alphanumeric with hyphens, 1-64 chars (must match directory name)
 - `description` — 1-1024 chars, helps the LLM decide when to activate
 
-Additional frontmatter keys are passed through as metadata.
+**Optional frontmatter fields:**
+
+- `disable-model-invocation` — when `true`, the skill is hidden from the catalog and the LLM cannot activate it via the `skill_activate` tool. It stays reachable through the programmatic `activate` config (see [Activated Skills](#activated-skills)), so you can inject it under your own logic instead of the model's. Only the literal value `true` disables invocation; any other value (or its absence) leaves the skill model-invocable.
+
+Any other frontmatter keys are passed through as metadata.
 
 ## Configuring an Agent
 
@@ -81,7 +85,7 @@ end
 
 ### Activated Skills
 
-Load skill instructions into the system prompt at startup (no tool call needed):
+Load skill instructions into the system prompt at startup (no tool call needed). This is also the only way to surface a skill marked `disable-model-invocation: true`, which the model can never activate on its own:
 
 ```ruby
 skills do

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -343,9 +343,9 @@ class Riffer::Agent
   #--
   #: () -> Riffer::Messages::System?
   def build_skills_message
-    skills = @context.skills
-    return nil unless skills&.system_prompt
-    Riffer::Messages::System.new(skills.system_prompt)
+    content = @context.skills&.system_prompt
+    return nil if content.nil? || content.empty?
+    Riffer::Messages::System.new(content)
   end
 
   #--
@@ -415,7 +415,7 @@ class Riffer::Agent
 
     skills_config = @config.skills_config
 
-    if skills_config
+    if skills_config && @context.skills&.activatable?
       skill_activate_tool_class = skills_config.activate_tool || Riffer.config.skills.default_activate_tool
 
       if tools.any? { |t| t.name == skill_activate_tool_class.name }

--- a/lib/riffer/skills/activate_tool.rb
+++ b/lib/riffer/skills/activate_tool.rb
@@ -19,6 +19,7 @@ class Riffer::Skills::ActivateTool < Riffer::Tool
   def call(context:, name:)
     skills_context = context&.skills
     return error("Skills not configured") unless skills_context
+    return error("Unknown skill: '#{name}'") unless skills_context.model_invocable?(name)
 
     text(skills_context.activate(name))
   rescue Riffer::ArgumentError => e

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -48,6 +48,21 @@ class Riffer::Skills::Context
     @activated.key?(name)
   end
 
+  # Returns whether a skill exists and may be activated by the model.
+  #--
+  #: (String) -> bool
+  def model_invocable?(name)
+    skill = skills[name]
+    !skill.nil? && !skill.disable_model_invocation
+  end
+
+  # Returns whether any skill is available for the model to activate.
+  #--
+  #: () -> bool
+  def activatable?
+    available_skills.any?
+  end
+
   # Returns the complete skills section for the system prompt — the catalog plus
   # any pre-activated skill bodies.
   #--
@@ -65,6 +80,6 @@ class Riffer::Skills::Context
   #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def available_skills
-    skills.values.reject { |skill| @activated.key?(skill.name) }
+    skills.values.reject { |skill| @activated.key?(skill.name) || skill.disable_model_invocation }
   end
 end

--- a/lib/riffer/skills/frontmatter.rb
+++ b/lib/riffer/skills/frontmatter.rb
@@ -4,7 +4,8 @@
 require "yaml"
 
 # Immutable value object holding parsed SKILL.md YAML frontmatter. Required
-# fields: +name+ and +description+; unrecognized top-level keys are merged into
+# fields: +name+ and +description+; the optional +disable-model-invocation+
+# flag is recognized, and any other unrecognized top-level keys are merged into
 # +metadata+.
 class Riffer::Skills::Frontmatter
   NAME_PATTERN = /\A[a-z0-9]+(-[a-z0-9]+)*\z/ #: Regexp
@@ -16,6 +17,11 @@ class Riffer::Skills::Frontmatter
 
   # The skill description (1-1024 chars).
   attr_reader :description #: String
+
+  # Whether the skill opts out of model-driven activation. Hidden from the
+  # catalog and rejected at model activation; still reachable via programmatic
+  # activation.
+  attr_reader :disable_model_invocation #: bool
 
   # Metadata from the spec's +metadata+ field plus any unrecognized top-level
   # keys.
@@ -29,7 +35,7 @@ class Riffer::Skills::Frontmatter
   def self.parse(raw)
     yaml, body = split_frontmatter(raw)
     raise Riffer::ArgumentError, "missing YAML frontmatter (expected --- delimiters)" if yaml.empty?
-    [new(name: yaml.delete(:name), description: yaml.delete(:description), metadata: yaml), body]
+    [new(name: yaml.delete(:name), description: yaml.delete(:description), disable_model_invocation: yaml.delete(:"disable-model-invocation"), metadata: yaml), body]
   end
 
   # Parses only the frontmatter from a raw SKILL.md string, ignoring the body.
@@ -39,7 +45,7 @@ class Riffer::Skills::Frontmatter
   def self.parse_frontmatter(raw)
     yaml, _ = split_frontmatter(raw)
     raise Riffer::ArgumentError, "missing YAML frontmatter (expected --- delimiters)" if yaml.empty?
-    new(name: yaml.delete(:name), description: yaml.delete(:description), metadata: yaml)
+    new(name: yaml.delete(:name), description: yaml.delete(:description), disable_model_invocation: yaml.delete(:"disable-model-invocation"), metadata: yaml)
   end
 
   #--
@@ -58,13 +64,15 @@ class Riffer::Skills::Frontmatter
   private_class_method :split_frontmatter
 
   # Raises Riffer::ArgumentError if +name+ or +description+ is invalid.
+  # +disable_model_invocation+ is treated as set only when literally +true+.
   #--
-  #: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
-  def initialize(name:, description:, metadata: {})
+  #: (name: String, description: String, ?disable_model_invocation: bool, ?metadata: Hash[Symbol, untyped]) -> void
+  def initialize(name:, description:, disable_model_invocation: false, metadata: {})
     validate_name!(name)
     validate_description!(description)
     @name = name.freeze
     @description = description.freeze
+    @disable_model_invocation = (disable_model_invocation == true)
     @metadata = metadata.freeze
   end
 

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -35,6 +35,16 @@ class Riffer::Skills::Context
   # : (String) -> bool
   def activated?: (String) -> bool
 
+  # Returns whether a skill exists and may be activated by the model.
+  # --
+  # : (String) -> bool
+  def model_invocable?: (String) -> bool
+
+  # Returns whether any skill is available for the model to activate.
+  # --
+  # : () -> bool
+  def activatable?: () -> bool
+
   # Returns the complete skills section for the system prompt — the catalog plus
   # any pre-activated skill bodies.
   # --

--- a/sig/generated/riffer/skills/frontmatter.rbs
+++ b/sig/generated/riffer/skills/frontmatter.rbs
@@ -1,7 +1,8 @@
 # Generated from lib/riffer/skills/frontmatter.rb with RBS::Inline
 
 # Immutable value object holding parsed SKILL.md YAML frontmatter. Required
-# fields: +name+ and +description+; unrecognized top-level keys are merged into
+# fields: +name+ and +description+; the optional +disable-model-invocation+
+# flag is recognized, and any other unrecognized top-level keys are merged into
 # +metadata+.
 class Riffer::Skills::Frontmatter
   NAME_PATTERN: Regexp
@@ -15,6 +16,11 @@ class Riffer::Skills::Frontmatter
 
   # The skill description (1-1024 chars).
   attr_reader description: String
+
+  # Whether the skill opts out of model-driven activation. Hidden from the
+  # catalog and rejected at model activation; still reachable via programmatic
+  # activation.
+  attr_reader disable_model_invocation: bool
 
   # Metadata from the spec's +metadata+ field plus any unrecognized top-level
   # keys.
@@ -38,9 +44,10 @@ class Riffer::Skills::Frontmatter
   def self.split_frontmatter: (String) -> [ Hash[Symbol, untyped], String ]
 
   # Raises Riffer::ArgumentError if +name+ or +description+ is invalid.
+  # +disable_model_invocation+ is treated as set only when literally +true+.
   # --
-  # : (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
-  def initialize: (name: String, description: String, ?metadata: Hash[Symbol, untyped]) -> void
+  # : (name: String, description: String, ?disable_model_invocation: bool, ?metadata: Hash[Symbol, untyped]) -> void
+  def initialize: (name: String, description: String, ?disable_model_invocation: bool, ?metadata: Hash[Symbol, untyped]) -> void
 
   private
 

--- a/test/riffer/skills/activate_tool_test.rb
+++ b/test/riffer/skills/activate_tool_test.rb
@@ -36,6 +36,18 @@ describe Riffer::Skills::ActivateTool do
       assert_includes result.content, "Unknown skill"
     end
 
+    it "returns error for a skill that disables model invocation" do
+      disabled = Riffer::Skills::Frontmatter.new(name: "deploy-prod", description: "Deploys.", disable_model_invocation: true)
+      disabled_context = Riffer::Skills::Context.new(backend: backend, skills: {"deploy-prod" => disabled}, adapter: Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool))
+      ctx = Riffer::Agent::Context.new
+      ctx.skills = disabled_context
+
+      tool = Riffer::Skills::ActivateTool.new
+      result = tool.call(context: ctx, name: "deploy-prod")
+      assert result.error?
+      assert_includes result.content, "Unknown skill"
+    end
+
     it "returns error when skills not configured" do
       tool = Riffer::Skills::ActivateTool.new
       result = tool.call(context: Riffer::Agent::Context.new, name: "code-review")

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -532,4 +532,78 @@ describe "Agent skills integration" do
       assert_includes tool_msg.content, "Unknown skill"
     end
   end
+
+  describe "disable-model-invocation" do
+    def write_skill(dir, name, description, disable_model_invocation: false)
+      Dir.mkdir(File.join(dir, name))
+      lines = ["---", "name: #{name}", "description: #{description}"]
+      lines << "disable-model-invocation: true" if disable_model_invocation
+      lines << "---"
+      File.write(File.join(dir, name, "SKILL.md"), "#{lines.join("\n")}\n\nBody for #{name}.")
+    end
+
+    it "hides a disabled skill from the catalog" do
+      Dir.mktmpdir do |dir|
+        write_skill(dir, "code-review", "Reviews code.")
+        write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
+
+        agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          skills do
+            backend Riffer::Skills::FilesystemBackend.new(dir)
+          end
+        end
+
+        refute_includes agent_class.new.context.skills.system_prompt, "deploy-prod"
+      end
+    end
+
+    it "registers skill_activate when an enabled skill exists alongside a disabled one" do
+      Dir.mktmpdir do |dir|
+        write_skill(dir, "code-review", "Reviews code.")
+        write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
+
+        agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          skills do
+            backend Riffer::Skills::FilesystemBackend.new(dir)
+          end
+        end
+
+        assert_includes agent_class.new.tools.map(&:name), "skill_activate"
+      end
+    end
+
+    it "omits skill_activate when every skill disables model invocation" do
+      Dir.mktmpdir do |dir|
+        write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
+
+        agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          skills do
+            backend Riffer::Skills::FilesystemBackend.new(dir)
+          end
+        end
+
+        refute_includes agent_class.new.tools.map(&:name), "skill_activate"
+      end
+    end
+
+    it "activates a disabled skill through the programmatic activate config" do
+      Dir.mktmpdir do |dir|
+        write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
+
+        agent_class = Class.new(Riffer::Agent) do
+          model "mock/riffer-1"
+          skills do
+            backend Riffer::Skills::FilesystemBackend.new(dir)
+            activate ["deploy-prod"]
+          end
+        end
+
+        skills_message = agent_class.new.session.messages.find { |m| m.is_a?(Riffer::Messages::System) && m.content.include?("Body for deploy-prod.") }
+        refute_nil skills_message
+      end
+    end
+  end
 end

--- a/test/riffer/skills/context_test.rb
+++ b/test/riffer/skills/context_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Skills::Context do
+  let(:fake_backend) do
+    Class.new(Riffer::Skills::Backend) do
+      def list_skills
+        []
+      end
+
+      def read_skill(name)
+        "BODY:#{name}"
+      end
+    end.new
+  end
+
+  let(:adapter) { Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool) }
+  let(:enabled) { Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code.") }
+  let(:disabled) { Riffer::Skills::Frontmatter.new(name: "deploy-prod", description: "Deploys to production.", disable_model_invocation: true) }
+
+  def build_context(skills)
+    Riffer::Skills::Context.new(backend: fake_backend, skills: skills, adapter: adapter)
+  end
+
+  describe "#model_invocable?" do
+    it "returns true for an enabled skill" do
+      assert build_context({"code-review" => enabled}).model_invocable?("code-review")
+    end
+
+    it "returns false for a disabled skill" do
+      refute build_context({"deploy-prod" => disabled}).model_invocable?("deploy-prod")
+    end
+
+    it "returns false for an unknown skill" do
+      refute build_context({"code-review" => enabled}).model_invocable?("nope")
+    end
+  end
+
+  describe "#activatable?" do
+    it "returns true when an enabled skill is available" do
+      assert build_context({"code-review" => enabled, "deploy-prod" => disabled}).activatable?
+    end
+
+    it "returns false when every skill is disabled" do
+      refute build_context({"deploy-prod" => disabled}).activatable?
+    end
+  end
+
+  describe "#system_prompt" do
+    it "excludes disabled skills from the catalog" do
+      refute_includes build_context({"code-review" => enabled, "deploy-prod" => disabled}).system_prompt, "deploy-prod"
+    end
+
+    it "keeps enabled skills in the catalog" do
+      assert_includes build_context({"code-review" => enabled, "deploy-prod" => disabled}).system_prompt, "code-review"
+    end
+  end
+
+  describe "#activate" do
+    it "activates a disabled skill through the programmatic path" do
+      assert_equal "BODY:deploy-prod", build_context({"deploy-prod" => disabled}).activate("deploy-prod")
+    end
+  end
+end

--- a/test/riffer/skills/frontmatter_test.rb
+++ b/test/riffer/skills/frontmatter_test.rb
@@ -19,6 +19,36 @@ describe Riffer::Skills::Frontmatter do
       assert_equal({author: "test"}, fm.metadata)
     end
 
+    it "parses disable-model-invocation: true into the attribute" do
+      raw = "---\nname: s\ndescription: d\ndisable-model-invocation: true\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      assert fm.disable_model_invocation
+    end
+
+    it "does not leak disable-model-invocation into metadata" do
+      raw = "---\nname: s\ndescription: d\ndisable-model-invocation: true\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      assert_equal({}, fm.metadata)
+    end
+
+    it "defaults disable_model_invocation to false when absent" do
+      raw = "---\nname: s\ndescription: d\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      refute fm.disable_model_invocation
+    end
+
+    it "treats disable-model-invocation: false as false" do
+      raw = "---\nname: s\ndescription: d\ndisable-model-invocation: false\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      refute fm.disable_model_invocation
+    end
+
+    it "treats a non-boolean disable-model-invocation as false" do
+      raw = "---\nname: s\ndescription: d\ndisable-model-invocation: \"true\"\n---\nBody"
+      fm, _ = Riffer::Skills::Frontmatter.parse(raw)
+      refute fm.disable_model_invocation
+    end
+
     it "raises ArgumentError when no frontmatter delimiters are present" do
       raw = "Just plain text"
       error = assert_raises(Riffer::ArgumentError) { Riffer::Skills::Frontmatter.parse(raw) }
@@ -55,6 +85,21 @@ describe Riffer::Skills::Frontmatter do
     it "accepts metadata" do
       fm = Riffer::Skills::Frontmatter.new(name: "s", description: "desc", metadata: {author: "test"})
       assert_equal({author: "test"}, fm.metadata)
+    end
+
+    it "defaults disable_model_invocation to false" do
+      fm = Riffer::Skills::Frontmatter.new(name: "s", description: "desc")
+      refute fm.disable_model_invocation
+    end
+
+    it "accepts disable_model_invocation: true" do
+      fm = Riffer::Skills::Frontmatter.new(name: "s", description: "desc", disable_model_invocation: true)
+      assert fm.disable_model_invocation
+    end
+
+    it "coerces a non-true disable_model_invocation to false" do
+      fm = Riffer::Skills::Frontmatter.new(name: "s", description: "desc", disable_model_invocation: "true")
+      refute fm.disable_model_invocation
     end
 
     it "raises on empty name" do


### PR DESCRIPTION
## Problem

Riffer documents itself as implementing the [Agent Skills spec](https://agentskills.io/), but the `disable-model-invocation` frontmatter flag was silently swallowed into the `metadata` passthrough and ignored. A skill whose author explicitly opted out of model-driven activation was still rendered in the model-facing catalog and could be activated via the `skill_activate` tool.

The spec is explicit: such skills must be **hidden from the catalog** and kept **unreachable by the model**, remaining reachable only through explicit/non-model activation. In riffer's framework context, that explicit path is the programmatic `activate` / `activate_tool` config — letting a developer inject a skill under their own logic (tenant, route, feature flag) instead of the model's judgment.

## Solution

Promote the flag to a first-class, typed field and enforce it through the per-agent skills layer, with a clean split of responsibilities:

- **`Frontmatter`** gains a `disable_model_invocation` boolean — consumed out of `metadata` (single source of truth), strict `== true` coercion so any non-boolean or absent value leaves the skill model-invocable.
- **`Context` owns the _definition_ of invocability**: `available_skills` now rejects disabled skills (catalog hidden), plus `model_invocable?(name)` and `activatable?` predicates. `Context#activate` is left untouched — a permissive primitive, so the programmatic `activate` config still reaches disabled skills (the escape hatch).
- **`ActivateTool` enforces the gate at the model's entry point**: it returns the same `"Unknown skill"` error (no existence leak) when a skill isn't `model_invocable?`. The tool is the model's only activation surface, so the gate belongs there rather than in the shared primitive.
- **`Agent`** registers `skill_activate` only when at least one skill is `activatable?`, per the spec's "don't register a tool with no valid options"; `build_skills_message` no longer emits an empty system message when nothing is renderable.

**Deliberately out of scope:** an enum-constrained `name` param on `skill_activate`. Hiding + the activation guard already make disabled skills unreachable and spec-compliant; the enum is an orthogonal anti-hallucination improvement (it would apply to all skills) and carries real complexity, so it's left for a separate change.

While scoping this, I found that subclassing `ActivateTool` does not inherit its class-level config (`identifier`/`description`/`params`/`timeout`), breaking the documented "subclass, override only `call`" pattern. It's independent of this change and filed as **CL2-898**.

## Proof

CI is sufficient — `bin/rake` passes (1683 runs, 0 failures; Steep clean; StandardRB clean). New tests cover:

- Frontmatter parsing/coercion of `disable-model-invocation` and that it does not leak into `metadata` (`frontmatter_test.rb`).
- `Context#model_invocable?`, `#activatable?`, catalog hiding, and permissive programmatic `#activate` (new `context_test.rb`).
- `ActivateTool` rejecting a disabled skill with `"Unknown skill"` (`activate_tool_test.rb`).
- Agent-level catalog hiding, `skill_activate` suppression when all skills are disabled, and programmatic activation of a disabled skill (`agent_integration_test.rb`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skills can now be marked with `disable-model-invocation: true` in their YAML frontmatter to prevent the model from invoking them via the skill activation tool, while still allowing programmatic activation.

* **Documentation**
  * Updated documentation to specify optional frontmatter fields and clarify how the `disable-model-invocation` flag controls model access to skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->