### PR TITLE
feat: support user-explicit skill activation and dedupe re-activations

### DIFF
--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -1,6 +1,6 @@
 # Skills
 
-Skills are packaged AI agent capabilities per the [Agent Skills spec](https://agentskills.io/). Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. The framework discovers skills through a pluggable backend, injects a compact catalog into the system prompt (~50 tokens/skill), and provides a tool for the LLM to activate skills on demand.
+Skills are packaged AI agent capabilities per the [Agent Skills spec](https://agentskills.io/). Each skill is a directory containing a `SKILL.md` file with YAML frontmatter and Markdown instructions. The framework discovers skills through a pluggable backend, injects a compact catalog into the system prompt (~50 tokens/skill), and supports both activation channels the spec describes: the LLM activates skills on demand through a tool, and your application injects skills the user asked for as conversation content (see [User-Triggered Activation](#user-triggered-activation)).
 
 ## Creating a Skill
 
@@ -38,7 +38,7 @@ Review the code for:
 
 **Optional frontmatter fields:**
 
-- `disable-model-invocation` — when `true`, the skill is hidden from the catalog and the LLM cannot activate it via the `skill_activate` tool. It stays reachable through the programmatic `activate` config (see [Activated Skills](#activated-skills)), so you can inject it under your own logic instead of the model's. Only the literal value `true` disables invocation; any other value (or its absence) leaves the skill model-invocable.
+- `disable-model-invocation` — when `true`, the skill is hidden from the catalog and the LLM cannot activate it via the `skill_activate` tool. It stays reachable through the programmatic `activate` config (see [Activated Skills](#activated-skills)) and through `activation_prompt` (see [User-Triggered Activation](#user-triggered-activation)), so you can inject it under your own logic instead of the model's. Only the literal value `true` disables invocation; any other value (or its absence) leaves the skill model-invocable.
 
 Any other frontmatter keys are passed through as metadata.
 
@@ -85,7 +85,7 @@ end
 
 ### Activated Skills
 
-Load skill instructions into the system prompt at startup (no tool call needed). This is also the only way to surface a skill marked `disable-model-invocation: true`, which the model can never activate on its own:
+Load skill instructions into the system prompt at startup (no tool call needed). Use this for skills that should govern the whole session — for skills the user requests mid-conversation, prefer [User-Triggered Activation](#user-triggered-activation), which keeps the system prompt (and its provider-side cache) stable:
 
 ```ruby
 skills do
@@ -107,8 +107,46 @@ end
 
 1. **Discovery** — At the start of `generate`/`stream`, the backend's `list_skills` returns frontmatter for all available skills.
 2. **Catalog injection** — The adapter formats the catalog and appends it to the system prompt.
-3. **Activation** — When the LLM matches a task to a skill, it calls the `skill_activate` tool with the skill name. The tool returns the full SKILL.md body.
+3. **Activation** — When the LLM matches a task to a skill, it calls the `skill_activate` tool with the skill name. The tool returns the full SKILL.md body wrapped in `<skill_content name="...">` tags.
 4. **Execution** — The LLM follows the skill's instructions to complete the task.
+5. **Deduplication** — Re-activating an already-active skill returns a short pointer ("already active") instead of the body again, so repeated activations don't fill the context with duplicate instructions. This applies whichever channel activated the skill first — tool call, `activation_prompt`, or the `activate` config.
+
+Activation state lives in memory on the `Riffer::Skills::Context`, not in the session. When you rebuild an agent from a persisted session, the first re-activation of each skill returns the full body again (the conversation history still carries the earlier copy); deduplication resumes from there. If you prune skill content out of a session yourself, call `deactivate(name)` so the next activation returns the body instead of a pointer to content that no longer exists.
+
+## User-Triggered Activation
+
+When a user explicitly invokes a skill (a slash command, a button, a mention), don't wait for the model to discover it — inject the skill body into the conversation as a user message. `activation_prompt` returns the body wrapped for injection and records the activation, so a later model-side `skill_activate` call for the same skill gets the pointer instead of a duplicate body:
+
+```ruby
+agent = MyAgent.new
+skills = agent.context.skills
+
+# User typed: /code-review focus on security
+if skills.activated?("code-review")
+  agent.generate("The code-review skill was invoked again — its instructions are above. focus on security")
+else
+  agent.generate(skills.activation_prompt("code-review", args: "focus on security"))
+end
+```
+
+`activation_prompt("code-review", args: "focus on security")` returns:
+
+```
+<skill_content name="code-review">
+You are a code review assistant.
+...
+</skill_content>
+
+focus on security
+```
+
+How a repeat invocation behaves is your choice — re-inject the full body (`activation_prompt` always returns it), or send a short reference as above. The check via `activated?` covers both channels, so a skill the model already activated through the tool counts too.
+
+For reading a skill body **without** recording an activation — a UI preview, or delegating the skill to a subagent whose context is separate — use `read`:
+
+```ruby
+body = skills.read("code-review") # no activation recorded
+```
 
 ## Custom Backends
 
@@ -155,6 +193,28 @@ The recommended approach is to subclass `Riffer::Skills::ActivateTool` so the id
 class InstrumentedActivateTool < Riffer::Skills::ActivateTool
   def call(context:, name:)
     Telemetry.measure("skill_activate", skill: name) { super }
+  end
+end
+
+# Change what a re-activation returns (default: a short "already active" pointer)
+class CustomPointerActivateTool < Riffer::Skills::ActivateTool
+  private
+
+  def already_active_message(name)
+    "'#{name}' is loaded — scroll up for its instructions."
+  end
+end
+
+# Return the full body on every activation (no deduplication)
+class AlwaysFullBodyActivateTool < Riffer::Skills::ActivateTool
+  def call(context:, name:)
+    skills_context = context&.skills
+    return error("Skills not configured") unless skills_context
+    return error("Unknown skill: '#{name}'") unless skills_context.model_invocable?(name)
+
+    text(skills_context.activation_prompt(name))
+  rescue Riffer::ArgumentError => e
+    error(e.message)
   end
 end
 

--- a/docs/13_SKILLS.md
+++ b/docs/13_SKILLS.md
@@ -125,19 +125,17 @@ skills = agent.context.skills
 if skills.activated?("code-review")
   agent.generate("The code-review skill was invoked again — its instructions are above. focus on security")
 else
-  agent.generate(skills.activation_prompt("code-review", args: "focus on security"))
+  agent.generate("#{skills.activation_prompt("code-review")}\n\nfocus on security")
 end
 ```
 
-`activation_prompt("code-review", args: "focus on security")` returns:
+`activation_prompt("code-review")` returns:
 
 ```
 <skill_content name="code-review">
 You are a code review assistant.
 ...
 </skill_content>
-
-focus on security
 ```
 
 How a repeat invocation behaves is your choice — re-inject the full body (`activation_prompt` always returns it), or send a short reference as above. The check via `activated?` covers both channels, so a skill the model already activated through the tool counts too.

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -395,7 +395,7 @@ class Riffer::Agent
 
     if skills_config.activate
       names = Array(Riffer::Helpers::CallOrValue.resolve(skills_config.activate, context: @context))
-      names.each { |name| skills_context.activate(name) }
+      names.each { |name| skills_context.preactivate(name) }
     end
 
     skills_context

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -36,40 +36,50 @@ module Riffer::Agent::Run
     run_before_guardrails(agent, stream_yielder, all_modifications) { |tripped| return tripped }
 
     skills = agent.context.skills
+    consumer_on_activate = skills&.on_activate
 
     if stream_yielder && skills
-      skills.on_activate = ->(name) { stream_yielder << Riffer::StreamEvents::SkillActivation.new(name) }
+      skills.on_activate = ->(name) {
+        consumer_on_activate&.call(name)
+        stream_yielder << Riffer::StreamEvents::SkillActivation.new(name)
+      }
     end
 
-    step = agent.session.steps
+    begin
+      step = agent.session.steps
 
-    reason = catch(:riffer_interrupt) do
-      execute_pending_tool_calls(agent)
+      reason = catch(:riffer_interrupt) do
+        execute_pending_tool_calls(agent)
 
-      loop do
-        response = stream_yielder ? accumulate_streamed_response(agent, stream_yielder) : call_llm(agent)
-        step += 1
-        track_token_usage(agent, response.token_usage)
+        loop do
+          response = stream_yielder ? accumulate_streamed_response(agent, stream_yielder) : call_llm(agent)
+          step += 1
+          track_token_usage(agent, response.token_usage)
 
-        processed_response = run_after_guardrails(agent, response, stream_yielder, all_modifications) { |tripped| return tripped }
+          processed_response = run_after_guardrails(agent, response, stream_yielder, all_modifications) { |tripped| return tripped }
 
-        agent.session.add(processed_response)
+          agent.session.add(processed_response)
 
-        break unless processed_response.has_tool_calls?
+          break unless processed_response.has_tool_calls?
 
-        max_steps = agent.config.max_steps
-        throw :riffer_interrupt, Riffer::Agent::INTERRUPT_MAX_STEPS if max_steps && step >= max_steps
+          max_steps = agent.config.max_steps
+          throw :riffer_interrupt, Riffer::Agent::INTERRUPT_MAX_STEPS if max_steps && step >= max_steps
 
-        execute_tool_calls(agent, processed_response)
+          execute_tool_calls(agent, processed_response)
+        end
+
+        return final_response(agent, all_modifications)
       end
 
-      return final_response(agent, all_modifications)
+      new_messages, filled = Riffer::Agent::Session::Repair.fill_orphans(agent.session.messages)
+      agent.session.set(new_messages)
+      stream_yielder << Riffer::StreamEvents::Interrupt.new(reason: reason, healed_tool_call_ids: filled) if stream_yielder
+      final_response(agent, all_modifications, interrupted: true, interrupt_reason: reason, healed_tool_call_ids: filled)
+    ensure
+      # The stream wiring must not outlive the run — a leaked lambda would push
+      # later harness-side activations into a dead Enumerator::Yielder.
+      skills.on_activate = consumer_on_activate if stream_yielder && skills
     end
-
-    new_messages, filled = Riffer::Agent::Session::Repair.fill_orphans(agent.session.messages)
-    agent.session.set(new_messages)
-    stream_yielder << Riffer::StreamEvents::Interrupt.new(reason: reason, healed_tool_call_ids: filled) if stream_yielder
-    final_response(agent, all_modifications, interrupted: true, interrupt_reason: reason, healed_tool_call_ids: filled)
   end
 
   #--

--- a/lib/riffer/skills/activate_tool.rb
+++ b/lib/riffer/skills/activate_tool.rb
@@ -13,16 +13,25 @@ class Riffer::Skills::ActivateTool < Riffer::Tool
     required :name, String, description: "The skill name to activate"
   end
 
-  # Activates a skill by name and returns its body.
+  # Activates a skill by name and returns its wrapped body, or a short pointer when the skill is already active.
   #--
   #: (context: Riffer::Agent::Context?, name: String) -> Riffer::Tools::Response
   def call(context:, name:)
     skills_context = context&.skills
     return error("Skills not configured") unless skills_context
     return error("Unknown skill: '#{name}'") unless skills_context.model_invocable?(name)
+    return text(already_active_message(name)) if skills_context.activated?(name)
 
-    text(skills_context.activate(name))
+    text(skills_context.activation_prompt(name))
   rescue Riffer::ArgumentError => e
     error(e.message)
+  end
+
+  private
+
+  #--
+  #: (String) -> String
+  def already_active_message(name)
+    "Skill '#{name}' is already active. Its instructions are already available in your context."
   end
 end

--- a/lib/riffer/skills/adapter.rb
+++ b/lib/riffer/skills/adapter.rb
@@ -21,4 +21,19 @@ class Riffer::Skills::Adapter
   def render_catalog(skills)
     raise NotImplementedError, "#{self.class} must implement #render_catalog"
   end
+
+  # Renders an activated skill body wrapped in identifying tags.
+  #--
+  #: (Riffer::Skills::Frontmatter, String) -> String
+  def render_activation(skill, body)
+    %(<skill_content name="#{skill.name}">\n#{body}\n</skill_content>)
+  end
+
+  # The behavioral instructions rendered alongside the catalog.
+  #--
+  #: () -> String
+  def catalog_instructions
+    "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions. " \
+      "If a skill's instructions already appear in your context (inside <skill_content> tags), follow them instead of activating the skill again."
+  end
 end

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -2,11 +2,13 @@
 # rbs_inline: enabled
 
 # Skills context for an agent generation cycle — coordinates discovery,
-# activation, and prompt rendering, caching activations to avoid redundant
+# activation, and prompt rendering, caching skill bodies to avoid redundant
 # backend reads. Exposed to tools via <tt>context.skills</tt>.
 class Riffer::Skills::Context
   # @rbs @backend: Riffer::Skills::Backend
-  # @rbs @activated: Hash[String, String]
+  # @rbs @bodies: Hash[String, String]
+  # @rbs @activated: Array[String]
+  # @rbs @preactivated: Array[String]
 
   # Skill catalog indexed by name.
   attr_reader :skills #: Hash[String, Riffer::Skills::Frontmatter]
@@ -15,7 +17,7 @@ class Riffer::Skills::Context
   attr_reader :adapter #: Riffer::Skills::Adapter
 
   # Optional callback invoked when a skill is first activated.
-  attr_writer :on_activate #: (^(String) -> void)?
+  attr_accessor :on_activate #: (^(String) -> void)?
 
   #--
   #: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
@@ -23,7 +25,20 @@ class Riffer::Skills::Context
     @backend = backend
     @skills = skills
     @adapter = adapter
-    @activated = {} #: Hash[String, String]
+    @bodies = {} #: Hash[String, String]
+    @activated = [] #: Array[String]
+    @preactivated = [] #: Array[String]
+  end
+
+  # Returns a skill's body without recording an activation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  #--
+  #: (String) -> String
+  def read(name)
+    raise Riffer::ArgumentError, "Unknown skill: '#{name}'" unless skills.key?(name)
+    @bodies[name] ||= @backend.read_skill(name)
   end
 
   # Activates a skill by name. Returns the cached body on re-activation.
@@ -33,11 +48,50 @@ class Riffer::Skills::Context
   #--
   #: (String) -> String
   def activate(name)
+    body = read(name)
+    unless @activated.include?(name)
+      @activated << name
+      @on_activate&.call(name)
+    end
+    body
+  end
+
+  # Activates a skill and returns its body wrapped for injection as a user
+  # message.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  #--
+  #: (String, ?args: String?) -> String
+  def activation_prompt(name, args: nil)
+    body = activate(name)
+    content = @adapter.render_activation(skills.fetch(name), body)
+    return content if args.nil? || args.strip.empty?
+    "#{content}\n\n#{args}"
+  end
+
+  # Activates a skill whose body renders in the system prompt rather than the
+  # conversation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  #--
+  #: (String) -> void
+  def preactivate(name)
+    activate(name)
+    @preactivated << name unless @preactivated.include?(name)
+  end
+
+  # Clears a skill's activation so the next activation is treated as the first.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  #--
+  #: (String) -> void
+  def deactivate(name)
     raise Riffer::ArgumentError, "Unknown skill: '#{name}'" unless skills.key?(name)
-    return @activated[name] if @activated.key?(name)
-    @activated[name] = @backend.read_skill(name)
-    @on_activate&.call(name)
-    @activated[name]
+    @activated.delete(name)
+    nil
   end
 
   # Returns whether a skill has been activated.
@@ -45,7 +99,7 @@ class Riffer::Skills::Context
   #--
   #: (String) -> bool
   def activated?(name)
-    @activated.key?(name)
+    @activated.include?(name)
   end
 
   # Returns whether a skill exists and may be activated by the model.
@@ -71,7 +125,7 @@ class Riffer::Skills::Context
     available = available_skills
     parts = [] #: Array[String]
     parts << @adapter.render_catalog(available) unless available.empty?
-    @activated.each_value { |body| parts << body }
+    @preactivated.each { |name| parts << @adapter.render_activation(skills.fetch(name), @bodies.fetch(name)) }
     parts.join("\n\n")
   end
 
@@ -80,6 +134,6 @@ class Riffer::Skills::Context
   #--
   #: () -> Array[Riffer::Skills::Frontmatter]
   def available_skills
-    skills.values.reject { |skill| @activated.key?(skill.name) || skill.disable_model_invocation }
+    skills.values.reject { |skill| @preactivated.include?(skill.name) || skill.disable_model_invocation }
   end
 end

--- a/lib/riffer/skills/context.rb
+++ b/lib/riffer/skills/context.rb
@@ -62,12 +62,10 @@ class Riffer::Skills::Context
   # Raises Riffer::ArgumentError if the skill is not in the catalog.
   #
   #--
-  #: (String, ?args: String?) -> String
-  def activation_prompt(name, args: nil)
+  #: (String) -> String
+  def activation_prompt(name)
     body = activate(name)
-    content = @adapter.render_activation(skills.fetch(name), body)
-    return content if args.nil? || args.strip.empty?
-    "#{content}\n\n#{args}"
+    @adapter.render_activation(skills.fetch(name), body)
   end
 
   # Activates a skill whose body renders in the system prompt rather than the

--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -11,7 +11,7 @@ class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
     lines = [] #: Array[String]
     lines << "## Available Skills"
     lines << ""
-    lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << catalog_instructions
     lines << ""
     skills.each do |skill|
       lines << "- **#{skill.name}**: #{skill.description}"

--- a/lib/riffer/skills/xml_adapter.rb
+++ b/lib/riffer/skills/xml_adapter.rb
@@ -11,7 +11,7 @@ class Riffer::Skills::XmlAdapter < Riffer::Skills::Adapter
   #: (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog(skills)
     lines = [] #: Array[String]
-    lines << "When a user's request matches a skill description below, call the `#{skill_activate_tool.name}` tool with the skill name. After activation, follow the skill's instructions."
+    lines << catalog_instructions
     lines << ""
     lines << "<available_skills>"
     skills.each do |skill|

--- a/sig/generated/riffer/skills/activate_tool.rbs
+++ b/sig/generated/riffer/skills/activate_tool.rbs
@@ -3,8 +3,14 @@
 # Tool the LLM calls to activate a skill and receive its instructions;
 # registered automatically when an agent has skills configured.
 class Riffer::Skills::ActivateTool < Riffer::Tool
-  # Activates a skill by name and returns its body.
+  # Activates a skill by name and returns its wrapped body, or a short pointer when the skill is already active.
   # --
   # : (context: Riffer::Agent::Context?, name: String) -> Riffer::Tools::Response
   def call: (context: Riffer::Agent::Context?, name: String) -> Riffer::Tools::Response
+
+  private
+
+  # --
+  # : (String) -> String
+  def already_active_message: (String) -> String
 end

--- a/sig/generated/riffer/skills/adapter.rbs
+++ b/sig/generated/riffer/skills/adapter.rbs
@@ -16,4 +16,14 @@ class Riffer::Skills::Adapter
   # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
+
+  # Renders an activated skill body wrapped in identifying tags.
+  # --
+  # : (Riffer::Skills::Frontmatter, String) -> String
+  def render_activation: (Riffer::Skills::Frontmatter, String) -> String
+
+  # The behavioral instructions rendered alongside the catalog.
+  # --
+  # : () -> String
+  def catalog_instructions: () -> String
 end

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -1,12 +1,16 @@
 # Generated from lib/riffer/skills/context.rb with RBS::Inline
 
 # Skills context for an agent generation cycle — coordinates discovery,
-# activation, and prompt rendering, caching activations to avoid redundant
+# activation, and prompt rendering, caching skill bodies to avoid redundant
 # backend reads. Exposed to tools via <tt>context.skills</tt>.
 class Riffer::Skills::Context
-  @backend: Riffer::Skills::Backend
+  @preactivated: Array[String]
 
-  @activated: Hash[String, String]
+  @activated: Array[String]
+
+  @bodies: Hash[String, String]
+
+  @backend: Riffer::Skills::Backend
 
   # Skill catalog indexed by name.
   attr_reader skills: Hash[String, Riffer::Skills::Frontmatter]
@@ -15,11 +19,19 @@ class Riffer::Skills::Context
   attr_reader adapter: Riffer::Skills::Adapter
 
   # Optional callback invoked when a skill is first activated.
-  attr_writer on_activate: (^(String) -> void)?
+  attr_accessor on_activate: (^(String) -> void)?
 
   # --
   # : (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
   def initialize: (backend: Riffer::Skills::Backend, skills: Hash[String, Riffer::Skills::Frontmatter], adapter: Riffer::Skills::Adapter) -> void
+
+  # Returns a skill's body without recording an activation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  # --
+  # : (String) -> String
+  def read: (String) -> String
 
   # Activates a skill by name. Returns the cached body on re-activation.
   #
@@ -28,6 +40,32 @@ class Riffer::Skills::Context
   # --
   # : (String) -> String
   def activate: (String) -> String
+
+  # Activates a skill and returns its body wrapped for injection as a user
+  # message.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  # --
+  # : (String, ?args: String?) -> String
+  def activation_prompt: (String, ?args: String?) -> String
+
+  # Activates a skill whose body renders in the system prompt rather than the
+  # conversation.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  # --
+  # : (String) -> void
+  def preactivate: (String) -> void
+
+  # Clears a skill's activation so the next activation is treated as the first.
+  #
+  # Raises Riffer::ArgumentError if the skill is not in the catalog.
+  #
+  # --
+  # : (String) -> void
+  def deactivate: (String) -> void
 
   # Returns whether a skill has been activated.
   #

--- a/sig/generated/riffer/skills/context.rbs
+++ b/sig/generated/riffer/skills/context.rbs
@@ -47,8 +47,8 @@ class Riffer::Skills::Context
   # Raises Riffer::ArgumentError if the skill is not in the catalog.
   #
   # --
-  # : (String, ?args: String?) -> String
-  def activation_prompt: (String, ?args: String?) -> String
+  # : (String) -> String
+  def activation_prompt: (String) -> String
 
   # Activates a skill whose body renders in the system prompt rather than the
   # conversation.

--- a/test/riffer/skills/activate_tool_test.rb
+++ b/test/riffer/skills/activate_tool_test.rb
@@ -21,12 +21,34 @@ describe Riffer::Skills::ActivateTool do
       assert_includes result.content, "code review assistant"
     end
 
-    it "returns cached body on re-activation" do
+    it "wraps the body in skill_content tags" do
       tool = Riffer::Skills::ActivateTool.new
-      result1 = tool.call(context: context, name: "code-review")
-      result2 = tool.call(context: context, name: "code-review")
-      assert_equal result1.content, result2.content
-      assert skills_context.activated?("code-review")
+      result = tool.call(context: context, name: "code-review")
+      assert_includes result.content, %(<skill_content name="code-review">)
+    end
+
+    it "returns a pointer instead of the body on re-activation" do
+      tool = Riffer::Skills::ActivateTool.new
+      tool.call(context: context, name: "code-review")
+      result = tool.call(context: context, name: "code-review")
+      assert result.success?
+      assert_includes result.content, "already active"
+      refute_includes result.content, "code review assistant"
+    end
+
+    it "returns the full body again after deactivation" do
+      tool = Riffer::Skills::ActivateTool.new
+      tool.call(context: context, name: "code-review")
+      skills_context.deactivate("code-review")
+      result = tool.call(context: context, name: "code-review")
+      assert_includes result.content, "code review assistant"
+    end
+
+    it "returns a pointer when the skill was activated through the user channel" do
+      tool = Riffer::Skills::ActivateTool.new
+      skills_context.activation_prompt("code-review")
+      result = tool.call(context: context, name: "code-review")
+      assert_includes result.content, "already active"
     end
 
     it "returns error for unknown skill" do

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -583,7 +583,7 @@ describe "Agent skills integration" do
 
       agent = agent_class.new
       skills = agent.context.skills
-      agent.session.add(Riffer::Messages::User.new(skills.activation_prompt("code-review", args: "focus on security")), silent: true)
+      agent.session.add(Riffer::Messages::User.new("#{skills.activation_prompt("code-review")}\n\nfocus on security"), silent: true)
 
       agent.provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
       agent.provider.stub_response("Done.")

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -490,6 +490,26 @@ describe "Agent skills integration" do
 
       assert_equal 1, events.size
     end
+
+    it "composes with and restores the consumer's on_activate across a stream" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      fired = []
+      agent.context.skills.on_activate = ->(name) { fired << name }
+      agent.provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      agent.provider.stub_response("Done.")
+
+      agent.stream("Review").each { |_| }
+      agent.context.skills.activate("data-analysis")
+
+      assert_equal ["code-review", "data-analysis"], fired
+    end
   end
 
   describe "skill activation end-to-end" do
@@ -530,6 +550,47 @@ describe "Agent skills integration" do
       tool_msg = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
       refute_nil tool_msg
       assert_includes tool_msg.content, "Unknown skill"
+    end
+
+    it "answers a re-activation with a pointer instead of the body" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      agent.provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      agent.provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      agent.provider.stub_response("Done.")
+      agent.generate("Review this code")
+
+      tool_msgs = agent.session.messages.select { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      assert_includes tool_msgs.last.content, "already active"
+      refute_includes tool_msgs.last.content, "code review assistant"
+    end
+  end
+
+  describe "user-explicit activation" do
+    it "injects the wrapped body as a user message and pointers later model activations" do
+      agent_class = Class.new(Riffer::Agent) do
+        model "mock/riffer-1"
+        skills do
+          backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
+        end
+      end
+
+      agent = agent_class.new
+      skills = agent.context.skills
+      agent.session.add(Riffer::Messages::User.new(skills.activation_prompt("code-review", args: "focus on security")), silent: true)
+
+      agent.provider.stub_response("", tool_calls: [{name: "skill_activate", arguments: '{"name":"code-review"}'}])
+      agent.provider.stub_response("Done.")
+      agent.generate
+
+      tool_msg = agent.session.messages.find { |m| m.is_a?(Riffer::Messages::Tool) && m.name == "skill_activate" }
+      assert_includes tool_msg.content, "already active"
     end
   end
 

--- a/test/riffer/skills/context_test.rb
+++ b/test/riffer/skills/context_test.rb
@@ -176,16 +176,6 @@ describe Riffer::Skills::Context do
       assert context.activated?("code-review")
     end
 
-    it "appends args after the wrapped block" do
-      prompt = build_context({"code-review" => enabled}).activation_prompt("code-review", args: "focus on security")
-      assert prompt.end_with?("</skill_content>\n\nfocus on security")
-    end
-
-    it "omits blank args" do
-      prompt = build_context({"code-review" => enabled}).activation_prompt("code-review", args: "  ")
-      assert prompt.end_with?("</skill_content>")
-    end
-
     it "wraps a disabled skill for user-channel injection" do
       prompt = build_context({"deploy-prod" => disabled}).activation_prompt("deploy-prod")
       assert_includes prompt, %(<skill_content name="deploy-prod">)

--- a/test/riffer/skills/context_test.rb
+++ b/test/riffer/skills/context_test.rb
@@ -5,11 +5,18 @@ require "test_helper"
 describe Riffer::Skills::Context do
   let(:fake_backend) do
     Class.new(Riffer::Skills::Backend) do
+      attr_reader :reads
+
+      def initialize
+        @reads = []
+      end
+
       def list_skills
         []
       end
 
       def read_skill(name)
+        @reads << name
         "BODY:#{name}"
       end
     end.new
@@ -17,6 +24,7 @@ describe Riffer::Skills::Context do
 
   let(:adapter) { Riffer::Skills::MarkdownAdapter.new(skill_activate_tool: Riffer::Skills::ActivateTool) }
   let(:enabled) { Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code.") }
+  let(:other) { Riffer::Skills::Frontmatter.new(name: "data-analysis", description: "Analyzes data.") }
   let(:disabled) { Riffer::Skills::Frontmatter.new(name: "deploy-prod", description: "Deploys to production.", disable_model_invocation: true) }
 
   def build_context(skills)
@@ -47,6 +55,173 @@ describe Riffer::Skills::Context do
     end
   end
 
+  describe "#read" do
+    it "returns the skill body" do
+      assert_equal "BODY:code-review", build_context({"code-review" => enabled}).read("code-review")
+    end
+
+    it "does not record an activation" do
+      context = build_context({"code-review" => enabled})
+      context.read("code-review")
+      refute context.activated?("code-review")
+    end
+
+    it "does not fire on_activate" do
+      context = build_context({"code-review" => enabled})
+      fired = []
+      context.on_activate = ->(name) { fired << name }
+      context.read("code-review")
+      assert_empty fired
+    end
+
+    it "caches the body across reads" do
+      context = build_context({"code-review" => enabled})
+      context.read("code-review")
+      context.read("code-review")
+      assert_equal ["code-review"], fake_backend.reads
+    end
+
+    it "raises for an unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { build_context({}).read("nope") }
+      assert_match(/Unknown skill/, error.message)
+    end
+
+    it "reads a disabled skill" do
+      assert_equal "BODY:deploy-prod", build_context({"deploy-prod" => disabled}).read("deploy-prod")
+    end
+  end
+
+  describe "#activate" do
+    it "returns the skill body" do
+      assert_equal "BODY:code-review", build_context({"code-review" => enabled}).activate("code-review")
+    end
+
+    it "records the activation" do
+      context = build_context({"code-review" => enabled})
+      context.activate("code-review")
+      assert context.activated?("code-review")
+    end
+
+    it "returns the body again on re-activation" do
+      context = build_context({"code-review" => enabled})
+      context.activate("code-review")
+      assert_equal "BODY:code-review", context.activate("code-review")
+    end
+
+    it "fires on_activate only on the first activation" do
+      context = build_context({"code-review" => enabled})
+      fired = []
+      context.on_activate = ->(name) { fired << name }
+      context.activate("code-review")
+      context.activate("code-review")
+      assert_equal ["code-review"], fired
+    end
+
+    it "reads the backend once across activations" do
+      context = build_context({"code-review" => enabled})
+      context.activate("code-review")
+      context.activate("code-review")
+      assert_equal ["code-review"], fake_backend.reads
+    end
+
+    it "activates a disabled skill through the programmatic path" do
+      assert_equal "BODY:deploy-prod", build_context({"deploy-prod" => disabled}).activate("deploy-prod")
+    end
+
+    it "raises for an unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { build_context({}).activate("nope") }
+      assert_match(/Unknown skill/, error.message)
+    end
+  end
+
+  describe "#activated?" do
+    it "returns false before activation" do
+      refute build_context({"code-review" => enabled}).activated?("code-review")
+    end
+  end
+
+  describe "#deactivate" do
+    it "clears the activation" do
+      context = build_context({"code-review" => enabled})
+      context.activate("code-review")
+      context.deactivate("code-review")
+      refute context.activated?("code-review")
+    end
+
+    it "fires on_activate again on the next activation" do
+      context = build_context({"code-review" => enabled})
+      fired = []
+      context.on_activate = ->(name) { fired << name }
+      context.activate("code-review")
+      context.deactivate("code-review")
+      context.activate("code-review")
+      assert_equal ["code-review", "code-review"], fired
+    end
+
+    it "raises for an unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { build_context({}).deactivate("nope") }
+      assert_match(/Unknown skill/, error.message)
+    end
+  end
+
+  describe "#activation_prompt" do
+    it "returns the body wrapped in skill_content tags" do
+      prompt = build_context({"code-review" => enabled}).activation_prompt("code-review")
+      assert_equal %(<skill_content name="code-review">\nBODY:code-review\n</skill_content>), prompt
+    end
+
+    it "records the activation" do
+      context = build_context({"code-review" => enabled})
+      context.activation_prompt("code-review")
+      assert context.activated?("code-review")
+    end
+
+    it "appends args after the wrapped block" do
+      prompt = build_context({"code-review" => enabled}).activation_prompt("code-review", args: "focus on security")
+      assert prompt.end_with?("</skill_content>\n\nfocus on security")
+    end
+
+    it "omits blank args" do
+      prompt = build_context({"code-review" => enabled}).activation_prompt("code-review", args: "  ")
+      assert prompt.end_with?("</skill_content>")
+    end
+
+    it "wraps a disabled skill for user-channel injection" do
+      prompt = build_context({"deploy-prod" => disabled}).activation_prompt("deploy-prod")
+      assert_includes prompt, %(<skill_content name="deploy-prod">)
+    end
+
+    it "raises for an unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { build_context({}).activation_prompt("nope") }
+      assert_match(/Unknown skill/, error.message)
+    end
+  end
+
+  describe "#preactivate" do
+    it "records the activation" do
+      context = build_context({"code-review" => enabled})
+      context.preactivate("code-review")
+      assert context.activated?("code-review")
+    end
+
+    it "renders the wrapped body in the system prompt" do
+      context = build_context({"code-review" => enabled})
+      context.preactivate("code-review")
+      assert_includes context.system_prompt, %(<skill_content name="code-review">\nBODY:code-review\n</skill_content>)
+    end
+
+    it "removes the skill from the catalog" do
+      context = build_context({"code-review" => enabled, "data-analysis" => other})
+      context.preactivate("code-review")
+      refute_includes context.system_prompt, "- **code-review**"
+    end
+
+    it "raises for an unknown skill" do
+      error = assert_raises(Riffer::ArgumentError) { build_context({}).preactivate("nope") }
+      assert_match(/Unknown skill/, error.message)
+    end
+  end
+
   describe "#system_prompt" do
     it "excludes disabled skills from the catalog" do
       refute_includes build_context({"code-review" => enabled, "deploy-prod" => disabled}).system_prompt, "deploy-prod"
@@ -55,11 +230,17 @@ describe Riffer::Skills::Context do
     it "keeps enabled skills in the catalog" do
       assert_includes build_context({"code-review" => enabled, "deploy-prod" => disabled}).system_prompt, "code-review"
     end
-  end
 
-  describe "#activate" do
-    it "activates a disabled skill through the programmatic path" do
-      assert_equal "BODY:deploy-prod", build_context({"deploy-prod" => disabled}).activate("deploy-prod")
+    it "excludes runtime-activated skill bodies" do
+      context = build_context({"code-review" => enabled, "data-analysis" => other})
+      context.activate("code-review")
+      refute_includes context.system_prompt, "BODY:code-review"
+    end
+
+    it "keeps runtime-activated skills in the catalog" do
+      context = build_context({"code-review" => enabled, "data-analysis" => other})
+      context.activate("code-review")
+      assert_includes context.system_prompt, "- **code-review**"
     end
   end
 end

--- a/test/riffer/skills/markdown_adapter_test.rb
+++ b/test/riffer/skills/markdown_adapter_test.rb
@@ -32,5 +32,16 @@ describe Riffer::Skills::MarkdownAdapter do
       output = custom_adapter.render_catalog(skills)
       assert_includes output, "`custom_activate`"
     end
+
+    it "instructs the model not to re-activate skills already in context" do
+      assert_includes adapter.render_catalog(skills), "instead of activating the skill again"
+    end
+  end
+
+  describe "#render_activation" do
+    it "wraps the body in skill_content tags" do
+      output = adapter.render_activation(skills.first, "The body.")
+      assert_equal %(<skill_content name="code-review">\nThe body.\n</skill_content>), output
+    end
   end
 end

--- a/test/riffer/skills/xml_adapter_test.rb
+++ b/test/riffer/skills/xml_adapter_test.rb
@@ -40,5 +40,16 @@ describe Riffer::Skills::XmlAdapter do
       output = custom_adapter.render_catalog(skills)
       assert_includes output, "`custom_activate`"
     end
+
+    it "instructs the model not to re-activate skills already in context" do
+      assert_includes adapter.render_catalog(skills), "instead of activating the skill again"
+    end
+  end
+
+  describe "#render_activation" do
+    it "wraps the body in skill_content tags" do
+      output = adapter.render_activation(skills.first, "The body.")
+      assert_equal %(<skill_content name="code-review">\nThe body.\n</skill_content>), output
+    end
   end
 end


### PR DESCRIPTION
## Problem

Riffer implements the [Agent Skills spec](https://agentskills.io/client-implementation/adding-skills-support)'s model-driven activation channel (catalog in system prompt, `skill_activate` tool) but has no supported path for the spec's second channel: **user-explicit activation**, where the harness intercepts a slash command and injects the skill body itself. The only documented escape hatch is the config-time `activate` option, which puts runtime-requested bodies in the system prompt — wrong tier per the spec's progressive-disclosure model, and it busts the provider prompt cache on every activation.

Two adjacent defects compound this. Re-activating a skill returns the full body again every time, duplicating instructions in context (the failure mode tracked as anthropics/claude-code#21891 in Claude Code, whose spec section "Deduplicate activations" recommends skipping re-injection). And the run loop permanently overwrites `Context#on_activate` with a lambda holding the stream's `Enumerator::Yielder`, so any harness-side activation after a completed stream would push into a dead yielder.

## Solution

`Riffer::Skills::Context` gains the primitives for the user channel while staying unopinionated about injection policy — the consumer decides what to send; riffer makes the correct thing a one-liner:

- `activation_prompt(name, args:)` — returns the body wrapped in `<skill_content name="...">` (the spec's structured-wrapping recommendation) ready to pass to `generate`, and records the activation
- `read(name)` — body fetch with no activation recorded, for UI previews and subagent delegation
- `deactivate(name)` — clears activation state, for consumers who prune skill content from history
- `preactivate(name)` — the config-time tier; only these bodies render in `system_prompt`, so runtime activations can never mutate the system prompt or shrink the catalog

Both channels share one activation state, so the shipped `ActivateTool` now answers re-activations with a short overridable pointer ("already active") instead of the body — including when the user channel injected it first. Consumers who prefer the full-body-always behavior of other harnesses subclass the tool (documented in `docs/13_SKILLS.md`). The adapters' catalog instructions tell the model not to re-activate skills whose `<skill_content>` blocks are already in context, and the run loop now composes with and restores the consumer's `on_activate` callback around streaming.

Behavior changes to note when reviewing: the activate tool's success result is now wrapped in `<skill_content>` tags, re-activation returns a pointer rather than the cached body, and pre-activated system-prompt bodies are wrapped too. Activation state is in-memory by design (the transcript is the durable record, consistent with every surveyed implementation), so a rebuilt agent on a persisted session returns one full body before dedupe resumes — documented in the skills guide.

## Proof

CI is sufficient — `bin/rake` (tests + StandardRB + Steep) passes with 38 new/updated cases covering every new Context method, pointer-on-re-activation at unit and end-to-end level, cross-channel dedupe (user injection → model tool gets the pointer), deactivate restoring full-body behavior, the system-prompt/catalog split, and the on_activate compose/restore across a stream (`test/riffer/skills/context_test.rb`, `activate_tool_test.rb`, `agent_integration_test.rb`, adapter tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-activation now returns a short "already active" pointer instead of duplicating full skill content.
  * Activated skill content is wrapped and surfaced to the model in a consistent tagged format; catalog prompts include activation guidance.

* **Bug Fixes**
  * Stream handler wiring is restored/cleaned up to avoid lingering callbacks after runs.

* **Documentation**
  * Clarified activation flows, model vs app-triggered activation, preactivation/system-prompt behavior, and examples.

* **Refactor**
  * Separated skill body caching from activation state; improved preactivate/deactivate lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->