### PR TITLE
feat: add tracing foundation with optional OTEL backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
           bundler-cache: true
       - run: bin/test
 
+  test-no-otel:
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_WITHOUT: opentelemetry
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bin/test
+
   rbs:
     runs-on: ubuntu-latest
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,10 @@ gem "irb"
 gem "dotenv"
 gem "guard"
 gem "guard-shell"
+
+# Tracing tests assert real spans via the SDK's in-memory exporter. Lives in a
+# Gemfile group (not gemspec dev deps) so the no-OTEL CI lane can exclude it
+# with BUNDLE_WITHOUT and prove the Null fallback.
+group :opentelemetry do
+  gem "opentelemetry-sdk", "~> 1.8"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,20 @@ GEM
       base64
       cgi
       connection_pool
+    opentelemetry-api (1.10.0)
+      logger
+    opentelemetry-common (0.25.0)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-registry (0.6.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.12.0)
+      logger
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.20)
+      opentelemetry-registry (~> 0.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.41.0)
+      opentelemetry-api (~> 1.0)
     parallel (1.27.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -260,6 +274,7 @@ DEPENDENCIES
   mcp (~> 0.8)
   minitest (~> 6.0)
   openai (~> 0.66.1)
+  opentelemetry-sdk (~> 1.8)
   rake (~> 13.0)
   rbs-inline (~> 0.12)
   riffer!

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -65,11 +65,11 @@ Riffer.configure do |config|
 end
 ```
 
-| Value                          | Description                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Value                             | Description                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `Riffer::Tools::Runtime` subclass | Instantiated automatically (e.g., `Riffer::Tools::Runtime::Inline`, `Riffer::Tools::Runtime::Threaded`) |
-| `Riffer::Tools::Runtime` instance | Custom runtime with specific options                                                              |
-| `Proc`                         | Dynamic resolution                                                                                |
+| `Riffer::Tools::Runtime` instance | Custom runtime with specific options                                                                    |
+| `Proc`                            | Dynamic resolution                                                                                      |
 
 Per-agent configuration overrides this global default. See [Advanced Tool Configuration — Tool Runtime](07_TOOL_ADVANCED.md#tool-runtime-experimental) for details.
 
@@ -100,6 +100,23 @@ end
 ```
 
 Accepts a `Riffer::Skills::Backend` instance or a `Proc` that receives `context` and returns a backend. Defaults to `nil` — agents that don't set their own backend get no skills, matching pre-existing behavior. Per-agent backends override this default.
+
+### Tracing
+
+Tracing-related global configuration lives under `config.tracing`. Riffer detects the OpenTelemetry API at runtime — without it (or without a host-configured OTEL SDK) every span is a silent no-op, and riffer carries no OTEL gem dependency either way.
+
+```ruby
+Riffer.configure do |config|
+  config.tracing.enabled = ENV.fetch("RIFFER_TRACING_ENABLED", "true")
+end
+```
+
+| Option            | Description                                                                                                                                                                                                                                                                                        |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enabled`         | The kill switch, consulted on every span — flipping it at runtime takes effect immediately. Accepts booleans or `'true'`/`'false'`/`'1'`/`'0'`. Defaults to `true`.                                                                                                                                |
+| `tracer_provider` | Explicit OTEL tracer provider (e.g. the SDK's in-memory provider in tests). Defaults to `nil`, which resolves the global `OpenTelemetry.tracer_provider` lazily at first span. Raises `Riffer::ArgumentError` if the `opentelemetry-api` gem isn't available at a supported version (>= 1.1, < 2). |
+
+Hosts own SDK and exporter wiring — riffer only emits spans through whatever provider the host configures.
 
 ### Message ID Strategy
 

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -72,13 +72,7 @@ class Riffer::Config
     #--
     #: (untyped) -> void
     def enabled=(value)
-      @enabled = case value
-      when true, "true", 1, "1" then true
-      when false, "false", 0, "0", nil then false
-      else
-        raise Riffer::ArgumentError,
-          "enabled must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
-      end
+      @enabled = Riffer::Helpers::Boolean.coerce(value, attribute: "enabled")
     end
 
     # Sets an explicit tracer provider, forcing the OTEL backend. Raises
@@ -172,13 +166,7 @@ class Riffer::Config
   #--
   #: (untyped) -> void
   def experimental_history_healing=(value)
-    @experimental_history_healing = case value
-    when true, "true", 1, "1" then true
-    when false, "false", 0, "0", nil then false
-    else
-      raise Riffer::ArgumentError,
-        "experimental_history_healing must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
-    end
+    @experimental_history_healing = Riffer::Helpers::Boolean.coerce(value, attribute: "experimental_history_healing")
   end
 
   #--

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -49,6 +49,53 @@ class Riffer::Config
     end
   end
 
+  # Tracing-related global configuration.
+  class Tracing
+    # Whether riffer emits OTEL spans; defaults to +true+, a no-op until a
+    # host wires an OTEL SDK.
+    attr_reader :enabled #: bool
+
+    # Explicit OTEL tracer provider; defaults to +nil+, which resolves the
+    # global <tt>OpenTelemetry.tracer_provider</tt> at first span.
+    attr_reader :tracer_provider #: untyped
+
+    #--
+    #: () -> void
+    def initialize
+      @enabled = true
+      @tracer_provider = nil
+    end
+
+    # Sets the enabled flag, coercing boolean-ish values so an env-var
+    # +"false"+ (truthy in Ruby) doesn't silently keep tracing on. Raises
+    # Riffer::ArgumentError on an unrecognized value.
+    #--
+    #: (untyped) -> void
+    def enabled=(value)
+      @enabled = case value
+      when true, "true", 1, "1" then true
+      when false, "false", 0, "0", nil then false
+      else
+        raise Riffer::ArgumentError,
+          "enabled must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
+      end
+    end
+
+    # Sets an explicit tracer provider, forcing the OTEL backend. Raises
+    # Riffer::ArgumentError when the OpenTelemetry API gem isn't available
+    # at a supported version.
+    #--
+    #: (untyped) -> void
+    def tracer_provider=(value)
+      if !value.nil? && !Riffer::Tracing::Otel.available?
+        raise Riffer::ArgumentError,
+          "tracer_provider requires the opentelemetry-api gem (#{Riffer::Tracing::Otel::SUPPORTED_API_VERSIONS})"
+      end
+      @tracer_provider = value
+      Riffer::Tracing.reset!
+    end
+  end
+
   VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
 
   # Amazon Bedrock configuration.
@@ -93,6 +140,9 @@ class Riffer::Config
 
   # Skills-related global configuration.
   attr_reader :skills #: Riffer::Config::Skills
+
+  # Tracing-related global configuration.
+  attr_reader :tracing #: Riffer::Config::Tracing
 
   # Strategy for auto-generating message ids: +:none+ (default), +:uuid+, or
   # +:uuidv7+. When not +:none+, messages get an +id+ at construction, and
@@ -144,6 +194,7 @@ class Riffer::Config
     @mcp = Mcp.new(credentials: nil, discovery_runner: Riffer::Runner::Sequential.new)
     @tool_runtime = Riffer::Tools::Runtime::Inline.new
     @skills = Skills.new
+    @tracing = Tracing.new
     @message_id_strategy = :none
     @experimental_history_healing = false
   end

--- a/lib/riffer/helpers/boolean.rb
+++ b/lib/riffer/helpers/boolean.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Coercion for boolean-ish configuration values.
+module Riffer::Helpers::Boolean
+  extend self
+
+  # Coerces +value+ to a boolean so an env-var +"false"+ (truthy in Ruby)
+  # doesn't silently read as +true+. Raises Riffer::ArgumentError on an
+  # unrecognized value, naming +attribute+ in the message.
+  #--
+  #: (untyped, attribute: String) -> bool
+  def coerce(value, attribute:)
+    case value
+    when true, "true", 1, "1" then true
+    when false, "false", 0, "0", nil then false
+    else
+      raise Riffer::ArgumentError,
+        "#{attribute} must be a boolean (or 'true'/'false'/'1'/'0'/1/0), got #{value.inspect}"
+    end
+  end
+end

--- a/lib/riffer/tracing.rb
+++ b/lib/riffer/tracing.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Internal tracing port — emits OTEL spans when the host bundles the
+# OpenTelemetry API and no-ops otherwise, so riffer never declares an OTEL
+# dependency.
+module Riffer::Tracing # :nodoc: all
+  extend self
+
+  # @rbs @backend: (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))?
+
+  MUTEX = Mutex.new #: Mutex
+
+  # The Ruby API cannot attach a schema URL to a tracer, so the semconv pin
+  # lives here as the documented contract version.
+  SCHEMA_URL = "https://opentelemetry.io/schemas/1.37.0" #: String
+
+  # Opens a span around the block, yielding the span.
+  #--
+  #: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  def in_span(name, attributes: nil, kind: :internal, &block)
+    return Null.in_span(name, &block) unless Riffer.config.tracing.enabled
+    backend.in_span(name, attributes: attributes, kind: kind, &block)
+  end
+
+  # Returns the active trace context, for re-attachment across fiber or
+  # thread boundaries.
+  #--
+  #: () -> untyped
+  def current_context
+    return Null.current_context unless Riffer.config.tracing.enabled
+    backend.current_context
+  end
+
+  # Runs the block with the given trace context active; +nil+ passes through
+  # so captures taken while tracing was dark stay harmless.
+  #--
+  #: [R] (untyped) { () -> R } -> R
+  def with_context(context, &block)
+    return Null.with_context(context, &block) unless Riffer.config.tracing.enabled
+    backend.with_context(context, &block)
+  end
+
+  # Discards the resolved backend so the next span re-resolves it.
+  #--
+  #: () -> void
+  def reset!
+    MUTEX.synchronize { @backend = nil }
+  end
+
+  private
+
+  #--
+  #: () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+  def backend
+    @backend || MUTEX.synchronize { @backend ||= resolve_backend }
+  end
+
+  #--
+  #: () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+  def resolve_backend
+    Otel.build(provider: Riffer.config.tracing.tracer_provider) || Null
+  end
+end

--- a/lib/riffer/tracing/null.rb
+++ b/lib/riffer/tracing/null.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# No-op tracing backend, used when OTEL is unavailable or tracing is
+# disabled.
+module Riffer::Tracing::Null # :nodoc: all
+  extend self
+
+  # No-op stand-in for a span; answers <tt>recording?</tt> with +false+ so
+  # callers can skip expensive attribute serialization.
+  class Span
+    #--
+    #: (String, untyped) -> void
+    def set_attribute(key, value)
+    end
+
+    #--
+    #: (String, ?attributes: Hash[String, untyped]?) -> void
+    def add_event(name, attributes: nil)
+    end
+
+    #--
+    #: (Exception) -> void
+    def record_exception(exception)
+    end
+
+    #--
+    #: (?String) -> void
+    def error!(description = "")
+    end
+
+    #--
+    #: () -> bool
+    def recording?
+      false
+    end
+  end
+
+  SPAN = Span.new.freeze #: Riffer::Tracing::Null::Span
+
+  # Yields the no-op span, ignoring all span options.
+  #--
+  #: [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
+  def in_span(_name, **)
+    yield SPAN
+  end
+
+  # Returns +nil+; there is no trace context without OTEL.
+  #--
+  #: () -> nil
+  def current_context
+    nil
+  end
+
+  # Yields immediately; there is no context to attach.
+  #--
+  #: [R] (untyped) { () -> R } -> R
+  def with_context(_context)
+    yield
+  end
+end

--- a/lib/riffer/tracing/otel.rb
+++ b/lib/riffer/tracing/otel.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# OTEL-backed tracing backend. <tt>::OpenTelemetry</tt> constants appear only
+# inside method bodies here, so the gem loads and eager-loads cleanly when the
+# OpenTelemetry API is absent.
+class Riffer::Tracing::Otel # :nodoc: all
+  SUPPORTED_API_VERSIONS = Gem::Requirement.new(">= 1.1", "< 2") #: Gem::Requirement
+
+  # Wraps a live OTEL span behind the port's span surface, so callers never
+  # touch <tt>::OpenTelemetry</tt> constants (status objects in particular).
+  class Span
+    # @rbs @otel_span: untyped
+
+    #--
+    #: (untyped) -> void
+    def initialize(otel_span)
+      @otel_span = otel_span
+    end
+
+    #--
+    #: (String, untyped) -> void
+    def set_attribute(key, value)
+      @otel_span.set_attribute(key, value)
+    end
+
+    #--
+    #: (String, ?attributes: Hash[String, untyped]?) -> void
+    def add_event(name, attributes: nil)
+      @otel_span.add_event(name, attributes: attributes)
+    end
+
+    #--
+    #: (Exception) -> void
+    def record_exception(exception)
+      @otel_span.record_exception(exception)
+    end
+
+    # Marks the span status as error.
+    #--
+    #: (?String) -> void
+    def error!(description = "")
+      @otel_span.status = ::OpenTelemetry::Trace::Status.error(description)
+    end
+
+    #--
+    #: () -> bool
+    def recording?
+      @otel_span.recording?
+    end
+  end
+
+  class << self
+    # Builds a backend when the OpenTelemetry API is loadable at a supported
+    # version; returns +nil+ so resolution falls back to Null.
+    #--
+    #: (provider: untyped) -> Riffer::Tracing::Otel?
+    def build(provider:)
+      version = api_version
+      return nil unless version
+
+      unless supported?(version)
+        Kernel.warn "riffer: opentelemetry-api #{version} is outside the supported range (#{SUPPORTED_API_VERSIONS}); tracing is disabled"
+        return nil
+      end
+
+      new(provider: provider || ::OpenTelemetry.tracer_provider)
+    end
+
+    # Whether the OpenTelemetry API gem is loadable at a supported version.
+    #--
+    #: () -> bool
+    def available?
+      version = api_version
+      !version.nil? && supported?(version)
+    end
+
+    # Whether the given opentelemetry-api version is one riffer codes
+    # against. The gem is undeclared, so this guard is the only protection
+    # against an incompatible API.
+    #--
+    #: (Gem::Version) -> bool
+    def supported?(version)
+      SUPPORTED_API_VERSIONS.satisfied_by?(version)
+    end
+
+    private
+
+    #--
+    #: () -> Gem::Version?
+    def api_version
+      require "opentelemetry"
+      spec = Gem.loaded_specs["opentelemetry-api"] #: untyped
+      spec&.version
+    rescue ::LoadError
+      nil
+    end
+  end
+
+  # @rbs @tracer: untyped
+
+  #--
+  #: (provider: untyped) -> void
+  def initialize(provider:)
+    @tracer = provider.tracer("riffer", Riffer::VERSION)
+  end
+
+  # Opens an OTEL span around the block, yielding the wrapped span.
+  #--
+  #: [R] (String, attributes: Hash[String, untyped]?, kind: Symbol) { (Riffer::Tracing::Otel::Span) -> R } -> R
+  def in_span(name, attributes:, kind:)
+    @tracer.in_span(name, attributes: attributes, kind: kind) do |otel_span, _context|
+      yield Span.new(otel_span)
+    end
+  end
+
+  # Returns the active OTEL context.
+  #--
+  #: () -> untyped
+  def current_context
+    ::OpenTelemetry::Context.current
+  end
+
+  # Runs the block with the given OTEL context active.
+  #--
+  #: [R] (untyped) { () -> R } -> R
+  def with_context(context)
+    return yield if context.nil?
+    ::OpenTelemetry::Context.with_current(context) { yield }
+  end
+end

--- a/sig/_private/opentelemetry.rbs
+++ b/sig/_private/opentelemetry.rbs
@@ -1,0 +1,19 @@
+# Minimal signatures for the `opentelemetry-api` gem (undeclared, runtime
+# detected), which ships no RBS.
+#
+# Only the surface used by Riffer::Tracing::Otel is declared.
+module OpenTelemetry
+  def self.tracer_provider: () -> untyped
+
+  class Context
+    def self.current: () -> OpenTelemetry::Context
+
+    def self.with_current: [R] (OpenTelemetry::Context) { () -> R } -> R
+  end
+
+  module Trace
+    class Status
+      def self.error: (?String) -> OpenTelemetry::Trace::Status
+    end
+  end
+end

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -95,6 +95,35 @@ class Riffer::Config
     def default_backend=: ((Riffer::Skills::Backend | Proc)?) -> void
   end
 
+  # Tracing-related global configuration.
+  class Tracing
+    # Whether riffer emits OTEL spans; defaults to +true+, a no-op until a
+    # host wires an OTEL SDK.
+    attr_reader enabled: bool
+
+    # Explicit OTEL tracer provider; defaults to +nil+, which resolves the
+    # global <tt>OpenTelemetry.tracer_provider</tt> at first span.
+    attr_reader tracer_provider: untyped
+
+    # --
+    # : () -> void
+    def initialize: () -> void
+
+    # Sets the enabled flag, coercing boolean-ish values so an env-var
+    # +"false"+ (truthy in Ruby) doesn't silently keep tracing on. Raises
+    # Riffer::ArgumentError on an unrecognized value.
+    # --
+    # : (untyped) -> void
+    def enabled=: (untyped) -> void
+
+    # Sets an explicit tracer provider, forcing the OTEL backend. Raises
+    # Riffer::ArgumentError when the OpenTelemetry API gem isn't available
+    # at a supported version.
+    # --
+    # : (untyped) -> void
+    def tracer_provider=: (untyped) -> void
+  end
+
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
   # Amazon Bedrock configuration.
@@ -135,6 +164,9 @@ class Riffer::Config
 
   # Skills-related global configuration.
   attr_reader skills: Riffer::Config::Skills
+
+  # Tracing-related global configuration.
+  attr_reader tracing: Riffer::Config::Tracing
 
   # Strategy for auto-generating message ids: +:none+ (default), +:uuid+, or
   # +:uuidv7+. When not +:none+, messages get an +id+ at construction, and

--- a/sig/generated/riffer/helpers/boolean.rbs
+++ b/sig/generated/riffer/helpers/boolean.rbs
@@ -1,0 +1,11 @@
+# Generated from lib/riffer/helpers/boolean.rb with RBS::Inline
+
+# Coercion for boolean-ish configuration values.
+module Riffer::Helpers::Boolean
+  # Coerces +value+ to a boolean so an env-var +"false"+ (truthy in Ruby)
+  # doesn't silently read as +true+. Raises Riffer::ArgumentError on an
+  # unrecognized value, naming +attribute+ in the message.
+  # --
+  # : (untyped, attribute: String) -> bool
+  def coerce: (untyped, attribute: String) -> bool
+end

--- a/sig/generated/riffer/tracing.rbs
+++ b/sig/generated/riffer/tracing.rbs
@@ -1,0 +1,46 @@
+# Generated from lib/riffer/tracing.rb with RBS::Inline
+
+# Internal tracing port — emits OTEL spans when the host bundles the
+# OpenTelemetry API and no-ops otherwise, so riffer never declares an OTEL
+# dependency.
+module Riffer::Tracing
+  @backend: (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))?
+
+  MUTEX: Mutex
+
+  # The Ruby API cannot attach a schema URL to a tracer, so the semconv pin
+  # lives here as the documented contract version.
+  SCHEMA_URL: String
+
+  # Opens a span around the block, yielding the span.
+  # --
+  # : [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  def in_span: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+
+  # Returns the active trace context, for re-attachment across fiber or
+  # thread boundaries.
+  # --
+  # : () -> untyped
+  def current_context: () -> untyped
+
+  # Runs the block with the given trace context active; +nil+ passes through
+  # so captures taken while tracing was dark stay harmless.
+  # --
+  # : [R] (untyped) { () -> R } -> R
+  def with_context: [R] (untyped) { () -> R } -> R
+
+  # Discards the resolved backend so the next span re-resolves it.
+  # --
+  # : () -> void
+  def reset!: () -> void
+
+  private
+
+  # --
+  # : () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+  def backend: () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+
+  # --
+  # : () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+  def resolve_backend: () -> (Riffer::Tracing::Otel | singleton(Riffer::Tracing::Null))
+end

--- a/sig/generated/riffer/tracing/null.rbs
+++ b/sig/generated/riffer/tracing/null.rbs
@@ -1,0 +1,46 @@
+# Generated from lib/riffer/tracing/null.rb with RBS::Inline
+
+# No-op tracing backend, used when OTEL is unavailable or tracing is
+# disabled.
+module Riffer::Tracing::Null
+  # No-op stand-in for a span; answers <tt>recording?</tt> with +false+ so
+  # callers can skip expensive attribute serialization.
+  class Span
+    # --
+    # : (String, untyped) -> void
+    def set_attribute: (String, untyped) -> void
+
+    # --
+    # : (String, ?attributes: Hash[String, untyped]?) -> void
+    def add_event: (String, ?attributes: Hash[String, untyped]?) -> void
+
+    # --
+    # : (Exception) -> void
+    def record_exception: (Exception) -> void
+
+    # --
+    # : (?String) -> void
+    def error!: (?String) -> void
+
+    # --
+    # : () -> bool
+    def recording?: () -> bool
+  end
+
+  SPAN: Riffer::Tracing::Null::Span
+
+  # Yields the no-op span, ignoring all span options.
+  # --
+  # : [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
+  def in_span: [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
+
+  # Returns +nil+; there is no trace context without OTEL.
+  # --
+  # : () -> nil
+  def current_context: () -> nil
+
+  # Yields immediately; there is no context to attach.
+  # --
+  # : [R] (untyped) { () -> R } -> R
+  def with_context: [R] (untyped) { () -> R } -> R
+end

--- a/sig/generated/riffer/tracing/otel.rbs
+++ b/sig/generated/riffer/tracing/otel.rbs
@@ -1,0 +1,83 @@
+# Generated from lib/riffer/tracing/otel.rb with RBS::Inline
+
+# OTEL-backed tracing backend. <tt>::OpenTelemetry</tt> constants appear only
+# inside method bodies here, so the gem loads and eager-loads cleanly when the
+# OpenTelemetry API is absent.
+class Riffer::Tracing::Otel
+  # :nodoc: all
+  SUPPORTED_API_VERSIONS: Gem::Requirement
+
+  # Wraps a live OTEL span behind the port's span surface, so callers never
+  # touch <tt>::OpenTelemetry</tt> constants (status objects in particular).
+  class Span
+    @otel_span: untyped
+
+    # --
+    # : (untyped) -> void
+    def initialize: (untyped) -> void
+
+    # --
+    # : (String, untyped) -> void
+    def set_attribute: (String, untyped) -> void
+
+    # --
+    # : (String, ?attributes: Hash[String, untyped]?) -> void
+    def add_event: (String, ?attributes: Hash[String, untyped]?) -> void
+
+    # --
+    # : (Exception) -> void
+    def record_exception: (Exception) -> void
+
+    # Marks the span status as error.
+    # --
+    # : (?String) -> void
+    def error!: (?String) -> void
+
+    # --
+    # : () -> bool
+    def recording?: () -> bool
+  end
+
+  # Builds a backend when the OpenTelemetry API is loadable at a supported
+  # version; returns +nil+ so resolution falls back to Null.
+  # --
+  # : (provider: untyped) -> Riffer::Tracing::Otel?
+  def self.build: (provider: untyped) -> Riffer::Tracing::Otel?
+
+  # Whether the OpenTelemetry API gem is loadable at a supported version.
+  # --
+  # : () -> bool
+  def self.available?: () -> bool
+
+  # Whether the given opentelemetry-api version is one riffer codes
+  # against. The gem is undeclared, so this guard is the only protection
+  # against an incompatible API.
+  # --
+  # : (Gem::Version) -> bool
+  def self.supported?: (Gem::Version) -> bool
+
+  # --
+  # : () -> Gem::Version?
+  private def self.api_version: () -> Gem::Version?
+
+  @tracer: untyped
+
+  # --
+  # : (provider: untyped) -> void
+  def initialize: (provider: untyped) -> void
+
+  # Opens an OTEL span around the block, yielding the wrapped span.
+  # --
+  # : [R] (String, attributes: Hash[String, untyped]?, kind: Symbol) { (Riffer::Tracing::Otel::Span) -> R } -> R
+  def in_span: [R] (String, attributes: Hash[String, untyped]?, kind: Symbol) { (Riffer::Tracing::Otel::Span) -> R } -> R
+
+  # Returns the active OTEL context.
+  # --
+  # : () -> untyped
+  def current_context: () -> untyped
+
+  # Runs the block with the given OTEL context active.
+  # --
+  # : [R] (untyped) { () -> R } -> R
+  def with_context: [R] (untyped) { () -> R } -> R
+end

--- a/sig/manual/riffer/helpers/boolean.rbs
+++ b/sig/manual/riffer/helpers/boolean.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Helpers::Boolean` uses `extend self`; rbs-inline doesn't emit that,
+# so re-extend here to expose its instance methods as singleton methods.
+module Riffer::Helpers::Boolean
+  extend ::Riffer::Helpers::Boolean
+end

--- a/sig/manual/riffer/tracing.rbs
+++ b/sig/manual/riffer/tracing.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Tracing` uses `extend self`; rbs-inline doesn't emit that, so
+# re-extend here to expose its instance methods as singleton methods.
+module Riffer::Tracing
+  extend ::Riffer::Tracing
+end

--- a/sig/manual/riffer/tracing/null.rbs
+++ b/sig/manual/riffer/tracing/null.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Tracing::Null` uses `extend self`; rbs-inline doesn't emit that, so
+# re-extend here to expose its instance methods as singleton methods.
+module Riffer::Tracing::Null
+  extend ::Riffer::Tracing::Null
+end

--- a/test/eager_load_test.rb
+++ b/test/eager_load_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "eager loading" do
+  # Catches class-level references to optional-dependency constants
+  # (::OpenTelemetry in particular), which only fail when the gem is absent —
+  # the no-OTEL CI lane runs this without opentelemetry bundled.
+  it "eager loads every riffer constant" do
+    Zeitwerk::Loader.eager_load_all
+  end
+end

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -212,16 +212,16 @@ describe Riffer::Config do
       expect(config.tracing.tracer_provider).must_be_nil
     end
 
-    it "allows setting a tracer_provider when opentelemetry is bundled" do
-      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+    it "allows setting a tracer_provider when opentelemetry is available" do
+      skip "opentelemetry is not available" unless Riffer::Tracing::Otel.available?
       config = Riffer::Config.new
       provider = OpenTelemetry::SDK::Trace::TracerProvider.new
       config.tracing.tracer_provider = provider
       expect(config.tracing.tracer_provider).must_equal provider
     end
 
-    it "raises for a tracer_provider when opentelemetry is not bundled" do
-      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+    it "raises for a tracer_provider when opentelemetry is not available" do
+      skip "opentelemetry is available" if Riffer::Tracing::Otel.available?
       config = Riffer::Config.new
       expect { config.tracing.tracer_provider = Object.new }.must_raise Riffer::ArgumentError
     end

--- a/test/riffer/config_test.rb
+++ b/test/riffer/config_test.rb
@@ -177,4 +177,53 @@ describe Riffer::Config do
       expect(config.mcp.credentials).must_equal cred
     end
   end
+
+  describe "tracing namespace" do
+    it "initializes enabled to true" do
+      config = Riffer::Config.new
+      expect(config.tracing.enabled).must_equal true
+    end
+
+    it "initializes tracer_provider to nil" do
+      config = Riffer::Config.new
+      expect(config.tracing.tracer_provider).must_be_nil
+    end
+
+    it "coerces a 'false' string for enabled" do
+      config = Riffer::Config.new
+      config.tracing.enabled = "false"
+      expect(config.tracing.enabled).must_equal false
+    end
+
+    it "coerces a 'true' string for enabled" do
+      config = Riffer::Config.new
+      config.tracing.enabled = "true"
+      expect(config.tracing.enabled).must_equal true
+    end
+
+    it "raises for an unrecognized enabled value" do
+      config = Riffer::Config.new
+      expect { config.tracing.enabled = "yes" }.must_raise Riffer::ArgumentError
+    end
+
+    it "allows setting tracer_provider to nil" do
+      config = Riffer::Config.new
+      config.tracing.tracer_provider = nil
+      expect(config.tracing.tracer_provider).must_be_nil
+    end
+
+    it "allows setting a tracer_provider when opentelemetry is bundled" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      config = Riffer::Config.new
+      provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+      config.tracing.tracer_provider = provider
+      expect(config.tracing.tracer_provider).must_equal provider
+    end
+
+    it "raises for a tracer_provider when opentelemetry is not bundled" do
+      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+      config = Riffer::Config.new
+      expect { config.tracing.tracer_provider = Object.new }.must_raise Riffer::ArgumentError
+    end
+  end
 end

--- a/test/riffer/helpers/boolean_test.rb
+++ b/test/riffer/helpers/boolean_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Helpers::Boolean do
+  describe "#coerce" do
+    it "passes a boolean through" do
+      expect(Riffer::Helpers::Boolean.coerce(true, attribute: "flag")).must_equal true
+    end
+
+    it "coerces truthy strings and integers" do
+      coerced = ["true", "1", 1].map { |value| Riffer::Helpers::Boolean.coerce(value, attribute: "flag") }
+      expect(coerced).must_equal [true, true, true]
+    end
+
+    it "coerces falsy strings, integers, and nil" do
+      coerced = ["false", "0", 0, nil].map { |value| Riffer::Helpers::Boolean.coerce(value, attribute: "flag") }
+      expect(coerced).must_equal [false, false, false, false]
+    end
+
+    it "raises for an unrecognized value" do
+      expect { Riffer::Helpers::Boolean.coerce("yes", attribute: "flag") }.must_raise Riffer::ArgumentError
+    end
+
+    it "names the attribute in the error message" do
+      error = expect { Riffer::Helpers::Boolean.coerce("yes", attribute: "enabled") }.must_raise Riffer::ArgumentError
+      expect(error.message).must_match(/^enabled /)
+    end
+  end
+end

--- a/test/riffer/tracing/null_test.rb
+++ b/test/riffer/tracing/null_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tracing::Null do
+  describe "#in_span" do
+    it "yields the frozen null span" do
+      yielded = nil
+      Riffer::Tracing::Null.in_span("test") { |span| yielded = span }
+      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+    end
+
+    it "returns the block's value" do
+      result = Riffer::Tracing::Null.in_span("test") { :value }
+      expect(result).must_equal :value
+    end
+
+    it "ignores span options" do
+      result = Riffer::Tracing::Null.in_span("test", attributes: {"key" => "value"}, kind: :client) { :value }
+      expect(result).must_equal :value
+    end
+  end
+
+  describe "#current_context" do
+    it "returns nil" do
+      expect(Riffer::Tracing::Null.current_context).must_be_nil
+    end
+  end
+
+  describe "#with_context" do
+    it "returns the block's value" do
+      result = Riffer::Tracing::Null.with_context(nil) { :value }
+      expect(result).must_equal :value
+    end
+  end
+
+  describe "SPAN" do
+    it "is frozen" do
+      expect(Riffer::Tracing::Null::SPAN).must_be :frozen?
+    end
+
+    it "is not recording" do
+      expect(Riffer::Tracing::Null::SPAN.recording?).must_equal false
+    end
+
+    it "accepts every span operation without error" do
+      span = Riffer::Tracing::Null::SPAN
+      span.set_attribute("key", "value")
+      span.add_event("event", attributes: {"key" => "value"})
+      span.record_exception(Riffer::Error.new("boom"))
+      span.error!("boom")
+    end
+  end
+end

--- a/test/riffer/tracing/otel_test.rb
+++ b/test/riffer/tracing/otel_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tracing::Otel do
+  describe ".supported?" do
+    it "rejects versions below 1.1" do
+      expect(Riffer::Tracing::Otel.supported?(Gem::Version.new("1.0.0"))).must_equal false
+    end
+
+    it "accepts 1.1" do
+      expect(Riffer::Tracing::Otel.supported?(Gem::Version.new("1.1.0"))).must_equal true
+    end
+
+    it "accepts later 1.x versions" do
+      expect(Riffer::Tracing::Otel.supported?(Gem::Version.new("1.10.0"))).must_equal true
+    end
+
+    it "rejects 2.0" do
+      expect(Riffer::Tracing::Otel.supported?(Gem::Version.new("2.0.0"))).must_equal false
+    end
+  end
+
+  describe ".available?" do
+    it "is true when opentelemetry is bundled" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      expect(Riffer::Tracing::Otel.available?).must_equal true
+    end
+
+    it "is false when opentelemetry is not bundled" do
+      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+      expect(Riffer::Tracing::Otel.available?).must_equal false
+    end
+  end
+
+  describe ".build" do
+    it "returns a backend when opentelemetry is bundled" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      expect(Riffer::Tracing::Otel.build(provider: nil)).must_be_instance_of Riffer::Tracing::Otel
+    end
+
+    it "returns nil when opentelemetry is not bundled" do
+      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+      expect(Riffer::Tracing::Otel.build(provider: nil)).must_be_nil
+    end
+  end
+end

--- a/test/riffer/tracing_test.rb
+++ b/test/riffer/tracing_test.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tracing do
+  before do
+    Riffer.config.tracing.enabled = true
+    Riffer.config.tracing.tracer_provider = nil
+  end
+
+  after do
+    Riffer.config.tracing.enabled = true
+    Riffer.config.tracing.tracer_provider = nil
+  end
+
+  describe "#in_span" do
+    it "returns the block's value" do
+      result = Riffer::Tracing.in_span("test") { :value }
+      expect(result).must_equal :value
+    end
+
+    it "yields the null span when tracing is disabled" do
+      Riffer.config.tracing.enabled = false
+      yielded = nil
+      Riffer::Tracing.in_span("test") { |span| yielded = span }
+      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+    end
+
+    it "falls back to the null backend when opentelemetry is not bundled" do
+      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+      yielded = nil
+      Riffer::Tracing.in_span("test") { |span| yielded = span }
+      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+    end
+
+    it "exports a span with the given name" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("invoke_agent test") {}
+      expect(exporter.finished_spans.map(&:name)).must_equal ["invoke_agent test"]
+    end
+
+    it "exports the given attributes" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("test", attributes: {"gen_ai.operation.name" => "chat"}) {}
+      expect(exporter.finished_spans.first.attributes).must_equal({"gen_ai.operation.name" => "chat"})
+    end
+
+    it "exports the given span kind" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("test", kind: :client) {}
+      expect(exporter.finished_spans.first.kind).must_equal :client
+    end
+
+    it "stamps the riffer instrumentation scope" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("test") {}
+      scope = exporter.finished_spans.first.instrumentation_scope
+      expect([scope.name, scope.version]).must_equal ["riffer", Riffer::VERSION]
+    end
+
+    it "nests spans opened inside an open span" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("parent") { Riffer::Tracing.in_span("child") {} }
+      child, parent = exporter.finished_spans
+      expect(child.parent_span_id).must_equal parent.span_id
+    end
+
+    it "yields a recording span when an SDK provider is wired" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      install_in_memory_provider
+      recording = nil
+      Riffer::Tracing.in_span("test") { |span| recording = span.recording? }
+      expect(recording).must_equal true
+    end
+
+    it "re-raises errors raised in the block" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      install_in_memory_provider
+      expect { Riffer::Tracing.in_span("test") { raise Riffer::Error, "boom" } }.must_raise Riffer::Error
+    end
+
+    it "records an error status when the block raises" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      begin
+        Riffer::Tracing.in_span("test") { raise Riffer::Error, "boom" }
+      rescue Riffer::Error
+      end
+      expect(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+    end
+
+    it "records an error status from the span's error! method" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("test") { |span| span.error!("tripwire") }
+      expect(exporter.finished_spans.first.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+    end
+
+    it "skips spans opened while disabled mid-process" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("before") {}
+      Riffer.config.tracing.enabled = false
+      Riffer::Tracing.in_span("dark") {}
+      Riffer.config.tracing.enabled = true
+      Riffer::Tracing.in_span("after") {}
+      expect(exporter.finished_spans.map(&:name)).must_equal ["before", "after"]
+    end
+  end
+
+  describe "#current_context" do
+    it "returns nil when tracing is disabled" do
+      Riffer.config.tracing.enabled = false
+      expect(Riffer::Tracing.current_context).must_be_nil
+    end
+
+    it "returns nil when opentelemetry is not bundled" do
+      skip "opentelemetry is bundled" if OTEL_SDK_AVAILABLE
+      expect(Riffer::Tracing.current_context).must_be_nil
+    end
+  end
+
+  describe "#with_context" do
+    it "returns the block's value" do
+      result = Riffer::Tracing.with_context(nil) { :value }
+      expect(result).must_equal :value
+    end
+
+    it "passes a nil context through" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      install_in_memory_provider
+      result = Riffer::Tracing.with_context(nil) { :value }
+      expect(result).must_equal :value
+    end
+
+    it "parents spans across an enumerator fiber via a captured context" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      enumerator = nil
+      Riffer::Tracing.in_span("parent") do
+        context = Riffer::Tracing.current_context
+        enumerator = Enumerator.new do |yielder|
+          Riffer::Tracing.with_context(context) do
+            Riffer::Tracing.in_span("child") { yielder << :done }
+          end
+        end
+      end
+      enumerator.to_a
+      parent = exporter.finished_spans.find { |span| span.name == "parent" }
+      child = exporter.finished_spans.find { |span| span.name == "child" }
+      expect(child.parent_span_id).must_equal parent.span_id
+    end
+
+    it "parents spans across threads via a captured context" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("parent") do
+        context = Riffer::Tracing.current_context
+        Thread.new do
+          Riffer::Tracing.with_context(context) do
+            Riffer::Tracing.in_span("child") {}
+          end
+        end.join
+      end
+      parent = exporter.finished_spans.find { |span| span.name == "parent" }
+      child = exporter.finished_spans.find { |span| span.name == "child" }
+      expect(child.parent_span_id).must_equal parent.span_id
+    end
+  end
+
+  describe "#reset!" do
+    it "returns without error" do
+      Riffer::Tracing.reset!
+    end
+
+    it "re-resolves the backend when the provider changes" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      first_exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("first") {}
+      second_exporter = install_in_memory_provider
+      Riffer::Tracing.in_span("second") {}
+      expect([first_exporter, second_exporter].map { |e| e.finished_spans.map(&:name) }).must_equal [["first"], ["second"]]
+    end
+  end
+
+  private
+
+  def install_in_memory_provider
+    exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+    provider = OpenTelemetry::SDK::Trace::TracerProvider.new
+    provider.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter))
+    Riffer.config.tracing.tracer_provider = provider
+    exporter
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,15 @@ require "riffer"
 require "vcr"
 require "webmock/minitest"
 
+# Tracing tests assert real spans via the SDK's in-memory exporter; the
+# no-OTEL CI lane excludes the gem to prove riffer's null fallback.
+OTEL_SDK_AVAILABLE = begin
+  require "opentelemetry-sdk"
+  true
+rescue LoadError
+  false
+end
+
 begin
   require "dotenv"
   Dotenv.load


### PR DESCRIPTION
## Problem

Riffer has no structured tracing — when an eval score moves or an agent misbehaves in production, there's no way to see which step did it. Native OTEL instrumentation of the agent loop is the fix, but rubygems has no optional-dependency concept, so the first problem to solve is plumbing: riffer must emit OTEL spans when a host wires an SDK and behave identically (and cheaply) when it doesn't, without adding any runtime dependency to the gemspec.

## Solution

This is the foundation only — no spans are wired into the agent loop yet; follow-up PRs add the agent-run, LLM-call, and tool-execution spans on top of it.

`Riffer::Tracing` is an internal port with two duck-typed backends, resolved lazily at first span: `Otel` when a guarded `require "opentelemetry"` succeeds at a supported version (`>= 1.1, < 2` — outside that it warns once and falls back), and `Null`, a frozen no-op, otherwise. The surface is block-only `in_span` (yielding a riffer-owned span wrapper so `::OpenTelemetry` constants never leak past the backend), plus `current_context`/`with_context` for re-attaching trace context across fiber and thread boundaries — the streaming enumerator and the concurrent tool runners both need this, and the context tests pin the behavior the span work will rely on.

Config gains `config.tracing.enabled` (a kill switch consulted on every span, so a runtime flip takes effect immediately) and `config.tracing.tracer_provider` (injectable, primarily for tests; raises at assignment if OTEL isn't loadable). `capture_messages` is deliberately deferred to the LLM-span follow-up that will honor it, so no inert config knob ships.

Notable choices a reviewer might otherwise trip on:

- `opentelemetry-sdk` lives in a **Gemfile group**, not the gemspec dev deps, because gemspec dev deps can't be selectively excluded — and the no-OTEL CI lane needs to exclude it.
- `::OpenTelemetry` constants appear only inside method bodies of the `Otel` backend, so zeitwerk eager-loading can't `NameError` when the gem is absent. A new eager-load test enforces this in the lane where it can actually fail.
- The schema URL pin is a documented constant rather than tracer metadata because the Ruby OTEL API's `tracer(name, version)` accepts no schema URL.

## Proof

CI is sufficient — see `test/riffer/tracing_test.rb` (span export, attributes, kind, scope, nesting, error status, mid-process kill-switch toggle, cross-fiber and cross-thread context parenting against the real in-memory SDK), `test/riffer/tracing/null_test.rb`, `test/riffer/tracing/otel_test.rb` (version-guard predicate), and `test/eager_load_test.rb`. The new `test-no-otel` job runs the full suite with `BUNDLE_WITHOUT=opentelemetry`; five inverse-skip tests execute only there and assert the genuine absent-gem fallback. Both postures verified locally: `bin/rake` (1729 runs) and `BUNDLE_WITHOUT=opentelemetry bin/test` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global tracing controls with enable/disable and pluggable OpenTelemetry provider; new boolean coercion helper.

* **Documentation**
  * Configuration guide updated with a new tracing section and usage examples.

* **Tests**
  * Added coverage for tracing behavior, null fallback, OTEL integration, eager loading, and boolean coercion.

* **Chores**
  * CI lane added to run tests with the optional tracing dependency excluded; optional opentelemetry group declared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->