### PR TITLE
refactor: give MCP-generated tool classes a real Riffer::Mcp::Tool base

### DIFF
--- a/docs/14_MCP.md
+++ b/docs/14_MCP.md
@@ -109,6 +109,7 @@ end
 Only use `progressive: false` when the server has a small, stable set of tools you always want available.
 
 **`mcp_search`** — Search for available tools by name or description.
+
 - `query` (required, non-empty) — filter by name or description substring.
 
 On a successful search, matching tools are injected into the agent's active tool list. The model calls them natively on the next turn — no proxy or JSON-encoded arguments.
@@ -150,7 +151,7 @@ Riffer::Mcp.registrations
 # => {"github" => #<Riffer::Mcp::Registration ...>, ...}
 
 reg = Riffer::Mcp.registrations["github"]
-reg.tools    # => [<Class:...>, ...]  (Riffer::Tool subclasses)
+reg.tools    # => [<Class:...>, ...]  (Riffer::Mcp::Tool subclasses; .mcp_server_tool_name returns the server-side name)
 ```
 
 Discovery failures raise from `register` directly, typically `Faraday::Error` for network issues or `Riffer::DependencyError` if the `mcp`/`faraday` gems are missing. Rescue `StandardError` for graceful degradation:

--- a/lib/riffer/mcp/authenticated_tool.rb
+++ b/lib/riffer/mcp/authenticated_tool.rb
@@ -2,38 +2,35 @@
 # rbs_inline: enabled
 
 # Wraps MCP-generated tool classes so +tools/call+ resolves
-# +Riffer.config.mcp.credentials+ per invocation, delegating metadata to the
-# inner class.
+# +Riffer.config.mcp.credentials+ per invocation, copying metadata from the
+# inner class at wrap time.
 module Riffer::Mcp::AuthenticatedTool
   extend self
 
   # Returns one wrapper class per inner tool, sharing +manifest+ and +matched_tags+.
   #
   #--
-  #: (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
+  #: (Array[singleton(Riffer::Mcp::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Mcp::Tool)]
   def wrap_all(tool_classes, manifest, matched_tags)
     tool_classes.map { |tc| wrap_one(tc, manifest, matched_tags) }
   end
 
   #--
-  #: (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
-  # Class.new(Riffer::Tool) is typed as ::Class by steep — it cannot verify the subtype
-  # relationship for dynamically created anonymous classes, so the ignore is required.
-  def wrap_one(inner_class, manifest, matched_tags) # steep:ignore MethodBodyTypeMismatch
+  #: (singleton(Riffer::Mcp::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Mcp::Tool)
+  def wrap_one(inner_class, manifest, matched_tags)
     inner = inner_class
     man = manifest
     tags = matched_tags
 
-    Class.new(Riffer::Tool) do
-      # steep cannot type the body of a dynamically created anonymous class:
-      # its ivars and `self` inside define_method are unresolvable.
+    # steep does not model Class.new's class_eval semantics — the block body
+    # typechecks against the enclosing module, so the ivar assignments and the
+    # define_method bodies are unresolvable.
+    Class.new(Riffer::Mcp::Tool) do
       # steep:ignore:start
       @identifier = inner.identifier
-
-      define_singleton_method(:name) { inner.name }
-      define_singleton_method(:mcp_server_tool_name) { inner.mcp_server_tool_name }
-      define_singleton_method(:description) { inner.description }
-      define_singleton_method(:parameters_schema) { |strict: false| inner.parameters_schema(strict: strict) }
+      @description = inner.description
+      @input_schema = inner.parameters_schema
+      @mcp_server_tool_name = inner.mcp_server_tool_name
 
       # Creates a fresh client per +tools/call+ so headers from the credentials
       # proc stay current.
@@ -48,9 +45,6 @@ module Riffer::Mcp::AuthenticatedTool
       define_method(:call) do |context:, **kwargs|
         cred = Riffer.config.mcp.credentials
         unless cred
-          # `next` rather than `return`: inside define_method the block IS the method
-          # body, so both exit :call identically at runtime. `next` avoids a false
-          # steep ReturnTypeMismatch that would otherwise need a steep:ignore.
           next inner.new.call(context: context, **kwargs)
         end
 
@@ -61,9 +55,9 @@ module Riffer::Mcp::AuthenticatedTool
         end
 
         client = build_call_client(man.endpoint, headers)
-        text(client.tools_call(inner.mcp_server_tool_name, kwargs))
+        text(client.tools_call(self.class.mcp_server_tool_name, kwargs))
       end
       # steep:ignore:end
-    end
+    end #: singleton(Riffer::Mcp::Tool)
   end
 end

--- a/lib/riffer/mcp/registration.rb
+++ b/lib/riffer/mcp/registration.rb
@@ -5,16 +5,16 @@
 # +tools/list+ and generates tool classes when a server is registered.
 class Riffer::Mcp::Registration
   # @rbs @cancelled: bool
-  # @rbs @tools: Array[singleton(Riffer::Tool)]
+  # @rbs @tools: Array[singleton(Riffer::Mcp::Tool)]
   # @rbs @mutex: Thread::Mutex
 
   # The manifest that describes this server.
   attr_reader :manifest #: Riffer::Mcp::Manifest
 
-  # Generated Riffer::Tool subclasses.
+  # Generated Riffer::Mcp::Tool subclasses.
   #
   #--
-  #: () -> Array[singleton(Riffer::Tool)]
+  #: () -> Array[singleton(Riffer::Mcp::Tool)]
   def tools
     @mutex.synchronize { @tools }
   end
@@ -24,7 +24,7 @@ class Riffer::Mcp::Registration
   def initialize(manifest)
     @manifest = manifest
     @cancelled = false
-    @tools = [] #: Array[singleton(Riffer::Tool)]
+    @tools = [] #: Array[singleton(Riffer::Mcp::Tool)]
     @mutex = Mutex.new
     run_discovery
   end

--- a/lib/riffer/mcp/tool.rb
+++ b/lib/riffer/mcp/tool.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for MCP-generated tools.
+class Riffer::Mcp::Tool < Riffer::Tool
+  # @rbs self.@mcp_server_tool_name: String?
+  # @rbs self.@input_schema: Hash[Symbol, untyped]?
+
+  # Returns the unprefixed tool name used for +tools/call+ on the MCP server.
+  #--
+  #: () -> String
+  def self.mcp_server_tool_name
+    @mcp_server_tool_name || raise(NotImplementedError, "#{self} must set @mcp_server_tool_name")
+  end
+
+  # Returns the server-published input schema, falling back to the params DSL.
+  # MCP schemas are server-defined, so +strict+ is not applied to them.
+  #--
+  #: (?strict: bool) -> Hash[Symbol, untyped]
+  def self.parameters_schema(strict: false)
+    @input_schema || super
+  end
+end

--- a/lib/riffer/mcp/tool_factory.rb
+++ b/lib/riffer/mcp/tool_factory.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Generates anonymous Riffer::Tool subclasses from MCP tool definitions.
+# Generates anonymous Riffer::Mcp::Tool subclasses from MCP tool definitions.
 # Generated tools delegate +#call+ to the MCP client and skip Riffer's param
 # validation — the MCP server validates inputs.
 module Riffer::Mcp::ToolFactory
   extend self
 
-  # Builds one Riffer::Tool subclass per tool definition, prefixing names with
-  # the manifest name to avoid cross-server collisions (e.g. +jira__search+);
-  # the server-side name stays on +.mcp_server_tool_name+.
+  # Builds one Riffer::Mcp::Tool subclass per tool definition, prefixing names
+  # with the manifest name to avoid cross-server collisions (e.g.
+  # +jira__search+); the server-side name stays on +.mcp_server_tool_name+.
   #--
-  #: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  #: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Mcp::Tool)]
   def build(manifest_name, client, tool_defs)
     tool_defs.map { |td| build_tool_class(manifest_name, client, td) }
   end
@@ -23,32 +23,24 @@ module Riffer::Mcp::ToolFactory
     str.gsub(/[^a-zA-Z0-9_-]/, "_")
   end
 
+  #: (String, Riffer::Mcp::Client, Hash[Symbol, untyped]) -> singleton(Riffer::Mcp::Tool)
   def build_tool_class(manifest_name, client, td)
     prefixed = "#{sanitize_name_component(manifest_name)}__#{sanitize_name_component(td[:name])}"
 
-    # steep cannot type the body of a dynamically created anonymous class:
-    # its ivars and `self` inside define_method are unresolvable, so the
-    # block is ignored wholesale (cf. AuthenticatedTool.wrap_one).
-    Class.new(Riffer::Tool) do
+    # steep does not model Class.new's class_eval semantics — the block body
+    # typechecks against the enclosing module, so the ivar assignments and the
+    # define_method body are unresolvable.
+    Class.new(Riffer::Mcp::Tool) do
       # steep:ignore:start
-      @mcp_client = client
       @mcp_server_tool_name = td[:name]
-      # Set @identifier directly so .identifier does not fall back to
-      # Riffer::Helpers::ClassNameConverter.convert(nil) on this anonymous class.
       @identifier = prefixed
-
-      define_singleton_method(:name) { prefixed }
-      define_singleton_method(:mcp_server_tool_name) { td[:name] }
-      define_singleton_method(:description) { td[:description] }
-      define_singleton_method(:parameters_schema) { |strict: false| td[:input_schema] || Riffer::Tool.send(:empty_schema) }
+      @description = td[:description]
+      @input_schema = td[:input_schema]
 
       define_method(:call) do |context:, **kwargs|
-        result = self.class.instance_variable_get(:@mcp_client).tools_call(
-          self.class.instance_variable_get(:@mcp_server_tool_name), kwargs
-        )
-        text(result)
+        text(client.tools_call(self.class.mcp_server_tool_name, kwargs))
       end
       # steep:ignore:end
-    end
+    end #: singleton(Riffer::Mcp::Tool)
   end
 end

--- a/sig/generated/riffer/mcp/authenticated_tool.rbs
+++ b/sig/generated/riffer/mcp/authenticated_tool.rbs
@@ -1,18 +1,16 @@
 # Generated from lib/riffer/mcp/authenticated_tool.rb with RBS::Inline
 
 # Wraps MCP-generated tool classes so +tools/call+ resolves
-# +Riffer.config.mcp.credentials+ per invocation, delegating metadata to the
-# inner class.
+# +Riffer.config.mcp.credentials+ per invocation, copying metadata from the
+# inner class at wrap time.
 module Riffer::Mcp::AuthenticatedTool
   # Returns one wrapper class per inner tool, sharing +manifest+ and +matched_tags+.
   #
   # --
-  # : (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
-  def wrap_all: (Array[singleton(Riffer::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Tool)]
+  # : (Array[singleton(Riffer::Mcp::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Mcp::Tool)]
+  def wrap_all: (Array[singleton(Riffer::Mcp::Tool)], Riffer::Mcp::Manifest, Array[Symbol]) -> Array[singleton(Riffer::Mcp::Tool)]
 
   # --
-  # : (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
-  #  Class.new(Riffer::Tool) is typed as ::Class by steep — it cannot verify the subtype
-  #  relationship for dynamically created anonymous classes, so the ignore is required.
-  def wrap_one: (singleton(Riffer::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Tool)
+  # : (singleton(Riffer::Mcp::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Mcp::Tool)
+  def wrap_one: (singleton(Riffer::Mcp::Tool), Riffer::Mcp::Manifest, Array[Symbol]) -> singleton(Riffer::Mcp::Tool)
 end

--- a/sig/generated/riffer/mcp/registration.rbs
+++ b/sig/generated/riffer/mcp/registration.rbs
@@ -5,18 +5,18 @@
 class Riffer::Mcp::Registration
   @cancelled: bool
 
-  @tools: Array[singleton(Riffer::Tool)]
+  @tools: Array[singleton(Riffer::Mcp::Tool)]
 
   @mutex: Thread::Mutex
 
   # The manifest that describes this server.
   attr_reader manifest: Riffer::Mcp::Manifest
 
-  # Generated Riffer::Tool subclasses.
+  # Generated Riffer::Mcp::Tool subclasses.
   #
   # --
-  # : () -> Array[singleton(Riffer::Tool)]
-  def tools: () -> Array[singleton(Riffer::Tool)]
+  # : () -> Array[singleton(Riffer::Mcp::Tool)]
+  def tools: () -> Array[singleton(Riffer::Mcp::Tool)]
 
   # --
   # : (Riffer::Mcp::Manifest) -> void

--- a/sig/generated/riffer/mcp/tool.rbs
+++ b/sig/generated/riffer/mcp/tool.rbs
@@ -1,0 +1,19 @@
+# Generated from lib/riffer/mcp/tool.rb with RBS::Inline
+
+# Base class for MCP-generated tools.
+class Riffer::Mcp::Tool < Riffer::Tool
+  self.@mcp_server_tool_name: String?
+
+  self.@input_schema: Hash[Symbol, untyped]?
+
+  # Returns the unprefixed tool name used for +tools/call+ on the MCP server.
+  # --
+  # : () -> String
+  def self.mcp_server_tool_name: () -> String
+
+  # Returns the server-published input schema, falling back to the params DSL.
+  # MCP schemas are server-defined, so +strict+ is not applied to them.
+  # --
+  # : (?strict: bool) -> Hash[Symbol, untyped]
+  def self.parameters_schema: (?strict: bool) -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/mcp/tool_factory.rbs
+++ b/sig/generated/riffer/mcp/tool_factory.rbs
@@ -1,20 +1,21 @@
 # Generated from lib/riffer/mcp/tool_factory.rb with RBS::Inline
 
-# Generates anonymous Riffer::Tool subclasses from MCP tool definitions.
+# Generates anonymous Riffer::Mcp::Tool subclasses from MCP tool definitions.
 # Generated tools delegate +#call+ to the MCP client and skip Riffer's param
 # validation — the MCP server validates inputs.
 module Riffer::Mcp::ToolFactory
-  # Builds one Riffer::Tool subclass per tool definition, prefixing names with
-  # the manifest name to avoid cross-server collisions (e.g. +jira__search+);
-  # the server-side name stays on +.mcp_server_tool_name+.
+  # Builds one Riffer::Mcp::Tool subclass per tool definition, prefixing names
+  # with the manifest name to avoid cross-server collisions (e.g.
+  # +jira__search+); the server-side name stays on +.mcp_server_tool_name+.
   # --
-  # : (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
-  def build: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Tool)]
+  # : (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Mcp::Tool)]
+  def build: (String, Riffer::Mcp::Client, Array[Hash[Symbol, untyped]]) -> Array[singleton(Riffer::Mcp::Tool)]
 
   private
 
   # : (String) -> String
   def sanitize_name_component: (String) -> String
 
-  def build_tool_class: (untyped manifest_name, untyped client, untyped td) -> untyped
+  # : (String, Riffer::Mcp::Client, Hash[Symbol, untyped]) -> singleton(Riffer::Mcp::Tool)
+  def build_tool_class: (String, Riffer::Mcp::Client, Hash[Symbol, untyped]) -> singleton(Riffer::Mcp::Tool)
 end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -636,10 +636,11 @@ describe Riffer::Agent do
     after { clear_mcp_registry! }
 
     let(:fake_tool_class) do
-      klass = Class.new(Riffer::Tool) { description "Fake MCP tool" }
-      klass.instance_variable_set(:@identifier, "srv__mcp_tool")
-      klass.define_singleton_method(:mcp_server_tool_name) { "mcp_tool" }
-      klass
+      Class.new(Riffer::Mcp::Tool) do
+        identifier "srv__mcp_tool"
+        description "Fake MCP tool"
+        @mcp_server_tool_name = "mcp_tool"
+      end
     end
 
     def inject_ready_registration(name:, tags:, tools:)
@@ -744,17 +745,19 @@ describe Riffer::Agent do
 
     describe "progressive mode" do
       let(:fake_tool_a) do
-        klass = Class.new(Riffer::Tool) { description "Tool A" }
-        klass.instance_variable_set(:@identifier, "srv__tool_a")
-        klass.define_singleton_method(:mcp_server_tool_name) { "tool_a" }
-        klass
+        Class.new(Riffer::Mcp::Tool) do
+          identifier "srv__tool_a"
+          description "Tool A"
+          @mcp_server_tool_name = "tool_a"
+        end
       end
 
       let(:fake_tool_b) do
-        klass = Class.new(Riffer::Tool) { description "Tool B" }
-        klass.instance_variable_set(:@identifier, "srv__tool_b")
-        klass.define_singleton_method(:mcp_server_tool_name) { "tool_b" }
-        klass
+        Class.new(Riffer::Mcp::Tool) do
+          identifier "srv__tool_b"
+          description "Tool B"
+          @mcp_server_tool_name = "tool_b"
+        end
       end
 
       it "returns mcp_search instead of individual tool classes" do

--- a/test/riffer/mcp/authenticated_tool_test.rb
+++ b/test/riffer/mcp/authenticated_tool_test.rb
@@ -4,13 +4,12 @@ require "test_helper"
 
 describe Riffer::Mcp::AuthenticatedTool do
   let(:inner) do
-    Class.new(Riffer::Tool) do
-      define_singleton_method(:name) { "srv__echo" }
-      define_singleton_method(:mcp_server_tool_name) { "echo" }
-      define_singleton_method(:description) { "E" }
-      define_singleton_method(:parameters_schema) { |strict: false| Riffer::Tool.send(:empty_schema) }
+    Class.new(Riffer::Mcp::Tool) do
+      @identifier = "srv__echo"
+      @mcp_server_tool_name = "echo"
+      @description = "E"
 
-      define_method(:call) do |context:, **kwargs|
+      def call(context:, **kwargs)
         text("inner-#{kwargs[:x]}")
       end
     end
@@ -18,6 +17,16 @@ describe Riffer::Mcp::AuthenticatedTool do
 
   let(:manifest) do
     Riffer::Mcp::Manifest.new(name: "srv", tags: [:t], endpoint: "https://mcp.example.com", discovery_headers: {})
+  end
+
+  it "returns a Riffer::Mcp::Tool subclass" do
+    wrapped = Riffer::Mcp::AuthenticatedTool.wrap_one(inner, manifest, [:t])
+    assert wrapped < Riffer::Mcp::Tool
+  end
+
+  it "copies the inner class's mcp_server_tool_name" do
+    wrapped = Riffer::Mcp::AuthenticatedTool.wrap_one(inner, manifest, [:t])
+    assert_equal "echo", wrapped.mcp_server_tool_name
   end
 
   it "delegates to inner when credentials proc is nil" do

--- a/test/riffer/mcp/tool_factory_test.rb
+++ b/test/riffer/mcp/tool_factory_test.rb
@@ -25,8 +25,8 @@ describe Riffer::Mcp::ToolFactory do
       assert_equal 2, tool_classes.size
     end
 
-    it "returns Riffer::Tool subclasses" do
-      tool_classes.each { |klass| assert klass < Riffer::Tool }
+    it "returns Riffer::Mcp::Tool subclasses" do
+      tool_classes.each { |klass| assert klass < Riffer::Mcp::Tool }
     end
   end
 

--- a/test/riffer/mcp/tool_test.rb
+++ b/test/riffer/mcp/tool_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Mcp::Tool do
+  describe ".mcp_server_tool_name" do
+    it "returns the value set on the subclass" do
+      klass = Class.new(Riffer::Mcp::Tool) { @mcp_server_tool_name = "search" }
+      assert_equal "search", klass.mcp_server_tool_name
+    end
+
+    it "raises NotImplementedError when unset" do
+      klass = Class.new(Riffer::Mcp::Tool)
+      assert_raises(NotImplementedError) { klass.mcp_server_tool_name }
+    end
+  end
+
+  describe ".parameters_schema" do
+    let(:schema) { {type: "object", properties: {query: {type: "string"}}, required: ["query"], additionalProperties: false} }
+
+    it "returns the input schema set on the subclass" do
+      input_schema = schema
+      klass = Class.new(Riffer::Mcp::Tool) { @input_schema = input_schema }
+      assert_equal schema, klass.parameters_schema
+    end
+
+    it "falls back to the params DSL when no input schema is set" do
+      klass = Class.new(Riffer::Mcp::Tool) do
+        params { required :city, String }
+      end
+      assert_equal ["city"], klass.parameters_schema[:required]
+    end
+
+    it "falls back to the empty schema when neither is set" do
+      klass = Class.new(Riffer::Mcp::Tool)
+      assert_empty klass.parameters_schema[:properties]
+    end
+  end
+end


### PR DESCRIPTION
## Problem

MCP tool classes are built dynamically (`Class.new(Riffer::Tool)` + `define_singleton_method`) by `ToolFactory` and `AuthenticatedTool`, with the MCP-specific `mcp_server_tool_name` bolted on at runtime. The declared type — `singleton(Riffer::Tool)` — was accurate but incomplete: it didn't capture that method, so Steep flagged every `inner.mcp_server_tool_name` call as `Ruby::NoMethod`, and both files masked it (along with the genuinely untypeable parts) under blanket `steep:ignore` blocks. Any future call site touching `.mcp_server_tool_name` on these classes would have been forced into the same workaround, and the type that ships in the gem's RBS lied to downstream consumers about what `reg.tools` returns.

## Solution

Introduce `Riffer::Mcp::Tool < Riffer::Tool`, a named base class carrying the class-level MCP contract as ivar-backed readers: `mcp_server_tool_name` (raises `NotImplementedError` when unset) and `parameters_schema` (server-published `@input_schema`, falling back to the params DSL). With the contract on a real class, the generated classes shrink to plain ivar assignments plus one `define_method(:call)` — the six `define_singleton_method`s, the redundant `:name` overrides, and the `@mcp_client`/`instance_variable_get` indirection are gone (`call` closes over the client directly). The producer pipeline (`ToolFactory.build` → `Registration#tools` → `AuthenticatedTool.wrap_all`/`wrap_one`) is typed `singleton(Riffer::Mcp::Tool)` end to end; consumer-facing collections (`Context#mcp_progressive_tools`, `SearchTool`) deliberately stay `singleton(Riffer::Tool)` since they only need the Toolable surface.

The `steep:ignore` blocks narrow accordingly: the `MethodBodyTypeMismatch` ignores become `#:` type assertions on the `Class.new` expressions, and in the authenticated wrapper the credentials error path (config access, nil check, `CredentialsDeniedError` raise) is now genuinely type-checked. What remains ignored is the structurally untypeable residue — Steep typechecks a `Class.new` block body against the enclosing module, so ivar assignments and `define_method` bodies stay unresolvable. Removing those entirely would mean replacing anonymous-class construction with named classes carrying instance state, which ripples through the Toolable DSL and agent tool resolution — deferred as follow-up work.

The `AuthenticatedTool` wrapper now copies inner metadata eagerly at wrap time rather than delegating lazily; the values are static after build, and `strict:` was already a no-op for server-defined schemas, so behavior is unchanged.

## Proof

CI is sufficient — `bin/rake` (1777 tests, StandardRB, Steep) is green. New coverage: `test/riffer/mcp/tool_test.rb` specs the base class contract (both readers, all three schema fallback tiers); `tool_factory_test.rb` and `authenticated_tool_test.rb` pin the ancestry (`< Riffer::Mcp::Tool`) so a regression to bare `Riffer::Tool` subclasses can't slip through; test fakes in `agent_test.rb` and `authenticated_tool_test.rb` now subclass the real base instead of hand-rolling the contract. No VCR re-records — the change is construction-only, with no network behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an MCP-specific `Mcp::Tool` base class for standardized tool metadata and input schema handling.

* **Documentation**
  * Clarified MCP progressive discovery and introspection examples, including `mcp_search` parameter details and registration introspection.

* **Refactor**
  * Updated MCP tool generation and wrapping to preserve and consistently use the server-side tool name, aligning generated tool and wrapping types.

* **Tests**
  * Updated fixtures and added unit tests covering `Mcp::Tool`, wrapping behavior, and tool type inheritance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->