### PR TITLE
feat: emit an execute_tool span per tool call

### DIFF
--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -20,11 +20,19 @@ class Riffer::Tools::Runtime
   #--
   #: (Array[Riffer::Messages::Assistant::ToolCall], tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Array[[Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]]
   def execute(tool_calls, tools:, context:, assistant_message: nil)
+    # Each Runner worker runs in its own thread/fiber, where the OTEL context
+    # starts empty — capture here so the execute_tool span parents correctly.
+    trace_context = Riffer::Tracing.current_context
     @runner.map(tool_calls, context: context) do |tool_call|
-      result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
-        dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
+      Riffer::Tracing.with_context(trace_context) do
+        in_tool_span(tool_call) do |span|
+          result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
+            dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
+          end
+          record_tool_outcome(span, result)
+          [tool_call, result]
+        end
       end
-      [tool_call, result]
     end
   end
 
@@ -82,5 +90,63 @@ class Riffer::Tools::Runtime
     return {} if arguments.nil? || arguments.empty?
 
     JSON.parse(arguments, symbolize_names: true)
+  end
+
+  # Emitted outside +around_tool_call+ so host enrichment spans nest beneath it.
+  #--
+  #: [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> R } -> R
+  def in_tool_span(tool_call)
+    Riffer::Tracing.in_span("execute_tool #{tool_call.name}", attributes: tool_span_attributes(tool_call), kind: :internal) do |span|
+      capture_tool_arguments(span, tool_call)
+      yield span
+    rescue => error
+      # The backend records the exception and error status on the re-raise;
+      # error.type is the one semconv attribute it doesn't set.
+      span.set_attribute("error.type", error.class.name)
+      raise
+    end
+  end
+
+  #--
+  #: (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
+  def tool_span_attributes(tool_call)
+    {
+      "gen_ai.operation.name" => "execute_tool",
+      "gen_ai.tool.name" => tool_call.name,
+      "gen_ai.tool.call.id" => tool_call.call_id
+    }
+  end
+
+  # A returned error Response is a handled outcome, so its status stays unset —
+  # an error span status is reserved for a raised exception.
+  #--
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  def record_tool_outcome(span, result)
+    error_type = result.error_type
+    span.set_attribute("error.type", error_type.to_s) if error_type
+    capture_tool_result(span, result)
+  end
+
+  #--
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Messages::Assistant::ToolCall) -> void
+  def capture_tool_arguments(span, tool_call)
+    return unless capture_tool_content?(span)
+
+    arguments = tool_call.arguments
+    span.set_attribute("gen_ai.tool.call.arguments", arguments) if arguments
+  end
+
+  #--
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  def capture_tool_result(span, result)
+    return unless capture_tool_content?(span)
+
+    span.set_attribute("gen_ai.tool.call.result", result.content)
+  end
+
+  #--
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
+  def capture_tool_content?(span)
+    Riffer.config.tracing.capture_messages && span.recording?
   end
 end

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -42,4 +42,31 @@ class Riffer::Tools::Runtime
   # --
   # : (String?) -> Hash[Symbol, untyped]
   def parse_arguments: (String?) -> Hash[Symbol, untyped]
+
+  # Emitted outside +around_tool_call+ so host enrichment spans nest beneath it.
+  # --
+  # : [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> R } -> R
+  def in_tool_span: [R] (Riffer::Messages::Assistant::ToolCall) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+
+  # --
+  # : (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
+  def tool_span_attributes: (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
+
+  # A returned error Response is a handled outcome, so its status stays unset —
+  # an error span status is reserved for a raised exception.
+  # --
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  def record_tool_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Tools::Response) -> void
+
+  # --
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Messages::Assistant::ToolCall) -> void
+  def capture_tool_arguments: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Messages::Assistant::ToolCall) -> void
+
+  # --
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  def capture_tool_result: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Tools::Response) -> void
+
+  # --
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
+  def capture_tool_content?: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> bool
 end

--- a/test/riffer/tools/runtime_tracing_test.rb
+++ b/test/riffer/tools/runtime_tracing_test.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "Riffer::Tools::Runtime tracing" do
+  before do
+    skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+    Riffer.config.tracing.enabled = true
+    @exporter = install_in_memory_tracer_provider
+  end
+
+  after do
+    Riffer.config.tracing.enabled = true
+    Riffer.config.tracing.capture_messages = false
+    Riffer.config.tracing.tracer_provider = nil
+  end
+
+  let(:weather_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "weather_tool"
+      description "Gets the weather"
+
+      params do
+        required :city, String
+      end
+
+      def call(context:, city:)
+        text("Weather in #{city}: 20 degrees")
+      end
+    end
+  end
+
+  let(:buggy_tool_class) do
+    Class.new(Riffer::Tool) do
+      identifier "buggy_tool"
+      description "Has a bug"
+
+      def call(context:, **)
+        nil.nonexistent_method
+      end
+    end
+  end
+
+  def make_tool_call(name:, arguments: "{}", call_id: "call_1")
+    Riffer::Messages::Assistant::ToolCall.new(call_id: call_id, name: name, arguments: arguments)
+  end
+
+  def tool_spans
+    @exporter.finished_spans.select { |span| span.name.start_with?("execute_tool") }
+  end
+
+  def tool_span
+    tool_spans.first
+  end
+
+  describe "span shape" do
+    before do
+      runtime = Riffer::Tools::Runtime::Inline.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', call_id: "tc_42")
+      runtime.execute([tool_call], tools: [weather_tool_class], context: nil)
+    end
+
+    it "names the span after the tool" do
+      expect(tool_span.name).must_equal "execute_tool weather_tool"
+    end
+
+    it "marks the span as internal" do
+      expect(tool_span.kind).must_equal :internal
+    end
+
+    it "sets the tool attributes" do
+      attributes = tool_span.attributes.slice("gen_ai.operation.name", "gen_ai.tool.name", "gen_ai.tool.call.id")
+      expect(attributes).must_equal({
+        "gen_ai.operation.name" => "execute_tool",
+        "gen_ai.tool.name" => "weather_tool",
+        "gen_ai.tool.call.id" => "tc_42"
+      })
+    end
+
+    it "leaves the span status unset on success" do
+      expect(tool_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
+    end
+  end
+
+  describe "returned error responses" do
+    before do
+      runtime = Riffer::Tools::Runtime::Inline.new
+      # Empty args fail validation, which dispatch turns into an error Response.
+      tool_call = make_tool_call(name: "weather_tool", arguments: "{}")
+      runtime.execute([tool_call], tools: [weather_tool_class], context: nil)
+    end
+
+    it "records error.type from the response error type" do
+      expect(tool_span.attributes["error.type"]).must_equal "validation_error"
+    end
+
+    it "keeps the span status unset (handled outcome)" do
+      expect(tool_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
+    end
+  end
+
+  describe "raised exceptions" do
+    before do
+      runtime = Riffer::Tools::Runtime::Inline.new
+      tool_call = make_tool_call(name: "buggy_tool")
+      begin
+        runtime.execute([tool_call], tools: [buggy_tool_class], context: nil)
+      rescue NoMethodError
+      end
+    end
+
+    it "records error.type from the exception class" do
+      expect(tool_span.attributes["error.type"]).must_equal "NoMethodError"
+    end
+
+    it "marks the span status as error" do
+      expect(tool_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+    end
+  end
+
+  describe "content capture" do
+    let(:tool_call) { make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}') }
+
+    it "omits arguments and result by default" do
+      Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+      expect(tool_span.attributes).wont_include "gen_ai.tool.call.arguments"
+      expect(tool_span.attributes).wont_include "gen_ai.tool.call.result"
+    end
+
+    it "captures the raw arguments and result when enabled" do
+      Riffer.config.tracing.capture_messages = true
+      Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+      expect(tool_span.attributes["gen_ai.tool.call.arguments"]).must_equal '{"city":"Toronto"}'
+      expect(tool_span.attributes["gen_ai.tool.call.result"]).must_equal "Weather in Toronto: 20 degrees"
+    end
+  end
+
+  describe "when tracing is disabled" do
+    it "emits no span and still runs the tool" do
+      Riffer.config.tracing.enabled = false
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      results = Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+
+      expect(@exporter.finished_spans).must_be_empty
+      expect(results[0][1].content).must_equal "Weather in Toronto: 20 degrees"
+    end
+  end
+
+  describe "parenting across runners" do
+    def assert_parents_under_host(runtime)
+      tool_calls = 3.times.map { |i| make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}', call_id: "cid_#{i}") }
+
+      Riffer::Tracing.in_span("host") do
+        runtime.execute(tool_calls, tools: [weather_tool_class], context: nil)
+      end
+
+      host = @exporter.finished_spans.find { |span| span.name == "host" }
+      spans = tool_spans
+      expect(spans.length).must_equal 3
+      spans.each do |span|
+        expect(span.parent_span_id).must_equal host.span_id
+        expect(span.trace_id).must_equal host.trace_id
+      end
+    end
+
+    it "parents to the active span under the Inline runtime" do
+      assert_parents_under_host(Riffer::Tools::Runtime::Inline.new)
+    end
+
+    it "parents to the active span across the Threaded runtime's thread boundary" do
+      assert_parents_under_host(Riffer::Tools::Runtime::Threaded.new(max_concurrency: 3))
+    end
+
+    it "parents to the active span across the Fibers runtime's fiber boundary" do
+      assert_parents_under_host(Riffer::Tools::Runtime::Fibers.new)
+    end
+  end
+
+  describe "host enrichment nesting" do
+    let(:enriching_runtime_class) do
+      Class.new(Riffer::Tools::Runtime::Inline) do
+        define_method(:around_tool_call) do |_tool_call, **, &block|
+          Riffer::Tracing.in_span("host_tool_work") { block.call }
+        end
+      end
+    end
+
+    it "nests host spans under execute_tool, which nests under the active span" do
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+
+      Riffer::Tracing.in_span("invoke_agent_stub") do
+        enriching_runtime_class.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+      end
+
+      agent = @exporter.finished_spans.find { |span| span.name == "invoke_agent_stub" }
+      host = @exporter.finished_spans.find { |span| span.name == "host_tool_work" }
+
+      expect(tool_span.parent_span_id).must_equal agent.span_id
+      expect(host.parent_span_id).must_equal tool_span.span_id
+      expect([tool_span.trace_id, host.trace_id].uniq).must_equal [agent.trace_id]
+    end
+  end
+
+  describe "agent integration" do
+    let(:tool_class) do
+      Class.new(Riffer::Tool) do
+        description "Traced tool"
+        def call(context:)
+          text("done")
+        end
+      end.tap { |t| t.identifier("integration_tool") }
+    end
+
+    let(:agent_class_with_tools) do
+      tc = tool_class
+      Class.new(Riffer::Agent) do
+        identifier "traced-agent"
+        model "mock/riffer-1"
+        uses_tools [tc]
+      end
+    end
+
+    it "parents the execute_tool span to the invoke_agent span" do
+      agent = agent_class_with_tools.new
+      agent.provider.stub_response("", tool_calls: [{name: "integration_tool", arguments: "{}"}])
+      agent.provider.stub_response("Done!")
+      agent.generate("Call the tool")
+
+      run_span = @exporter.finished_spans.find { |span| span.name.start_with?("invoke_agent") }
+      expect(tool_span.name).must_equal "execute_tool integration_tool"
+      expect(tool_span.parent_span_id).must_equal run_span.span_id
+    end
+  end
+end


### PR DESCRIPTION
## Problem

riffer's agent loop emits `invoke_agent` and `chat` spans, but tool execution is an unobserved gap — there's no span covering the dispatch boundary between the model requesting a tool and the result returning. Tool calls also run inside the concurrent runners (thread/fiber pools), where OTEL's context is fiber-local and starts empty in each worker, so naive instrumentation would orphan the spans rather than nesting them under the run.

## Solution

Emit an `execute_tool {tool_name}` span (kind `internal`) in `Tools::Runtime`, completing the `invoke_agent → chat / execute_tool` hierarchy.

- **Placement.** The span wraps `around_tool_call` from the *outside*, so a host's enrichment spans opened in that hook nest beneath `execute_tool`.
- **Parenting across runners.** The parent context is captured once before `@runner.map` fans out and re-attached via `Tracing.with_context` inside each worker — mirroring how the streaming paths already bridge the fiber boundary. The `Runner` classes are left untouched: they're a generic concurrency primitive (MCP discovery uses them too), so the tracing concern stays in the runtime layer.
- **Attributes.** `gen_ai.tool.name` and `gen_ai.tool.call.id` always; `error.type` from a returned error `Response` (span status left **unset** — a handled outcome, consistent with how tripwires/interrupts are recorded) or from a raised exception (status **error**, re-raised).
- **Content capture.** `gen_ai.tool.call.arguments` / `.result` are opt-in behind the existing `capture_messages` flag (off by default) and `span.recording?`.

A follow-up is tracked to consolidate the tracing test files into their unit test files under a scoped `describe` block; the standalone file here matches the existing `run_tracing_test.rb` / `chat_tracing_test.rb` convention for now.

## Proof

CI is sufficient. New `test/riffer/tools/runtime_tracing_test.rb` covers span shape, error semantics (returned error → unset status; raised → error status), opt-in content capture, the tracing-disabled path, parenting across the Inline/Threaded/Fibers runtimes with a multi-call batch (every span shares the run's trace and parents to it), and host-enrichment nesting. `bin/rake` (test + StandardRB + Steep) is green, and the no-OTEL CI lane exercises the null/​constant-safety path automatically since no `OpenTelemetry` constants appear in the runtime layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool execution now emits OpenTelemetry spans (`execute_tool <tool>`) with tool metadata (name, call id) to improve observability.
  * Tracing can optionally capture tool call arguments and results using `Riffer.config.tracing.capture_messages`.
  * Span hierarchy is maintained consistently across inline, threaded, and fiber execution paths, including agent integration.

* **Bug Fixes**
  * Span status and error details are reported appropriately for both response-based errors and raised exceptions.

* **Tests**
  * Added a comprehensive tracing test suite covering span naming, attributes, error handling, and nesting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->