### PR TITLE
feat: compute per-model cost on token usage

### DIFF
--- a/docs/08_MESSAGES.md
+++ b/docs/08_MESSAGES.md
@@ -77,6 +77,8 @@ end
 
 The cache buckets are subsets of `input_tokens`, never additions to it — summing `input_tokens + cache_read_tokens` double-counts. `total_tokens` (input + output) matches the totals providers report on their dashboards.
 
+- `cost` — the computed cost of the call, set when pricing is configured for the model in use (see [Configuration → Pricing](10_CONFIGURATION.md#pricing)); `nil` when the model is unpriced. It's for observability, not billing. Run-level usage sums per-call costs through `TokenUsage#+`, so `response.token_usage.cost` is the total spend across the run — but the sum is `nil` if any call in the run used an unpriced model, rather than silently under-reporting.
+
 #### Finish Reasons
 
 `finish_reason` carries the same meaning for every provider — each adapter maps its raw wire value (Anthropic's `end_turn`, OpenAI's response status, Gemini's `STOP`, …) into a normalized vocabulary:

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -128,12 +128,15 @@ Riffer.configure do |config|
   # Rates are per million tokens, keyed by the same "provider/model" id you give the agent.
   config.pricing.set("anthropic/claude-sonnet-4-6", input: 3.0, output: 15.0, cache_read: 0.30, cache_write: 3.75)
   config.pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+
+  # Pass an array to share one set of rates across a model family:
+  config.pricing.set(["openai/gpt-4", "openai/gpt-4-0613"], input: 30.0, output: 60.0)
 end
 ```
 
-| Argument       | Description                                                                                                                               |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `model`        | The exact `provider/model` id (e.g. `"openai/gpt-4"`) — the same string you pass to `model`. No alias matching; raises on a malformed id. |
+| Argument       | Description                                                                                                                                                              |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `models`       | A `provider/model` id (e.g. `"openai/gpt-4"`) — the same string you pass to `model` — or an array of ids that share one set of rates. No alias matching; raises on a malformed id. |
 | `input:`       | Price per **million** input tokens. Required. Applies to the uncached portion of `input_tokens`.                                          |
 | `output:`      | Price per **million** output tokens. Required.                                                                                            |
 | `cache_read:`  | Price per million cache-read tokens. Optional — when omitted, cache reads bill at the `input:` rate.                                      |

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -141,7 +141,7 @@ end
 
 Because the cache buckets are subsets of `input_tokens`, the cost formula subtracts them before applying the input rate:
 
-```
+```text
 cost = (input − cache_read − cache_write) × input_rate
      + cache_read  × cache_read_rate
      + cache_write × cache_write_rate

--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -119,6 +119,37 @@ end
 
 Hosts own SDK and exporter wiring — riffer only emits spans through whatever provider the host configures. See [Tracing](16_TRACING.md) for the emitted span contract — names, attributes, hierarchy, and host wiring.
 
+### Pricing
+
+Configure per-model token prices and riffer computes the cost of each LLM call onto its [`TokenUsage`](08_MESSAGES.md#token-usage-semantics). Riffer ships **no** price table — so an unconfigured model simply carries no cost (`token_usage.cost` is `nil`).
+
+```ruby
+Riffer.configure do |config|
+  # Rates are per million tokens, keyed by the same "provider/model" id you give the agent.
+  config.pricing.set("anthropic/claude-sonnet-4-6", input: 3.0, output: 15.0, cache_read: 0.30, cache_write: 3.75)
+  config.pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+end
+```
+
+| Argument       | Description                                                                                                                               |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `model`        | The exact `provider/model` id (e.g. `"openai/gpt-4"`) — the same string you pass to `model`. No alias matching; raises on a malformed id. |
+| `input:`       | Price per **million** input tokens. Required. Applies to the uncached portion of `input_tokens`.                                          |
+| `output:`      | Price per **million** output tokens. Required.                                                                                            |
+| `cache_read:`  | Price per million cache-read tokens. Optional — when omitted, cache reads bill at the `input:` rate.                                      |
+| `cache_write:` | Price per million cache-write tokens. Optional — when omitted, cache writes bill at the `input:` rate.                                    |
+
+Because the cache buckets are subsets of `input_tokens`, the cost formula subtracts them before applying the input rate:
+
+```
+cost = (input − cache_read − cache_write) × input_rate
+     + cache_read  × cache_read_rate
+     + cache_write × cache_write_rate
+     + output      × output_rate
+```
+
+(all rates ÷ 1,000,000; an unset cache rate falls back to `input_rate`.) Cost is for observability, not billing — it's a `Float`, and sub-cent rounding can accumulate over a long run. See [Messages → Token Usage Semantics](08_MESSAGES.md#token-usage-semantics) for how cost surfaces and aggregates.
+
 ### Message ID Strategy
 
 Opt in to stable identifiers on every message for logging, persistence, or replay:

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -106,6 +106,113 @@ class Riffer::Config
     end
   end
 
+  # Consumer-configured token pricing, keyed by +provider/model+ id. Riffer
+  # ships no price table, so an unconfigured model carries no cost.
+  class Pricing
+    # @rbs @rates: Hash[String, Riffer::Config::Pricing::Rates]
+
+    # Per-million-token rates for one model's four token buckets. +cache_read+
+    # and +cache_write+ fall back to the +input+ rate when unset.
+    class Rates
+      # Input rate per million tokens.
+      attr_reader :input #: Float
+
+      # Output rate per million tokens.
+      attr_reader :output #: Float
+
+      # Cache-read rate per million tokens.
+      attr_reader :cache_read #: Float?
+
+      # Cache-write rate per million tokens.
+      attr_reader :cache_write #: Float?
+
+      #--
+      #: (input: Float, output: Float, ?cache_read: Float?, ?cache_write: Float?) -> void
+      def initialize(input:, output:, cache_read: nil, cache_write: nil)
+        @input = input
+        @output = output
+        @cache_read = cache_read
+        @cache_write = cache_write
+      end
+
+      # Returns the cost for the given token counts.
+      #--
+      #: (input_tokens: Integer, output_tokens: Integer, ?cache_read_tokens: Integer?, ?cache_write_tokens: Integer?) -> Float
+      def cost_for(input_tokens:, output_tokens:, cache_read_tokens: nil, cache_write_tokens: nil)
+        read = cache_read_tokens || 0
+        write = cache_write_tokens || 0
+        uncached = input_tokens - read - write
+        uncached = 0 if uncached.negative?
+
+        per_million = uncached * input +
+          read * (cache_read || input) +
+          write * (cache_write || input) +
+          output_tokens * output
+        per_million / 1_000_000.0
+      end
+    end
+
+    #--
+    #: () -> void
+    def initialize
+      @rates = {}
+    end
+
+    # Registers per-million-token rates for a +provider/model+ id. Raises
+    # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
+    #--
+    #: (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+    def set(model, input:, output:, cache_read: nil, cache_write: nil)
+      validate_model!(model)
+      @rates[model] = Rates.new(
+        input: coerce_rate(input, "input"),
+        output: coerce_rate(output, "output"),
+        cache_read: coerce_optional_rate(cache_read, "cache_read"),
+        cache_write: coerce_optional_rate(cache_write, "cache_write")
+      )
+    end
+
+    # Returns the rates registered for a +provider/model+ id.
+    #--
+    #: (String) -> Riffer::Config::Pricing::Rates?
+    def rates_for(model)
+      @rates[model]
+    end
+
+    # Returns true when no rates are registered.
+    #--
+    #: () -> bool
+    def empty?
+      @rates.empty?
+    end
+
+    private
+
+    #--
+    #: (String) -> void
+    def validate_model!(model)
+      segments = model.to_s.split("/", 2)
+      valid = segments.length == 2 && segments.none? { |segment| segment.strip.empty? }
+      raise Riffer::ArgumentError, "pricing model id must be in \"provider/model\" form, got #{model.inspect}" unless valid
+    end
+
+    #--
+    #: (untyped, String) -> Float
+    def coerce_rate(value, attribute)
+      number = value
+      float = value.is_a?(Numeric) ? number.to_f : nil #: Float?
+      raise Riffer::ArgumentError, "#{attribute} rate must be a non-negative number, got #{value.inspect}" unless float&.finite? && float >= 0
+      float
+    end
+
+    #--
+    #: (untyped, String) -> Float?
+    def coerce_optional_rate(value, attribute)
+      return nil if value.nil?
+      coerce_rate(value, attribute)
+    end
+  end
+
   VALID_MESSAGE_ID_STRATEGIES = %i[none uuid uuidv7].freeze
 
   # Amazon Bedrock configuration.
@@ -154,6 +261,9 @@ class Riffer::Config
   # Tracing-related global configuration.
   attr_reader :tracing #: Riffer::Config::Tracing
 
+  # Consumer-configured per-model token pricing.
+  attr_reader :pricing #: Riffer::Config::Pricing
+
   # Strategy for auto-generating message ids: +:none+ (default), +:uuid+, or
   # +:uuidv7+. When not +:none+, messages get an +id+ at construction, and
   # seeded messages passed to +Riffer::Agent#generate+ must carry their own.
@@ -199,6 +309,7 @@ class Riffer::Config
     @tool_runtime = Riffer::Tools::Runtime::Inline.new
     @skills = Skills.new
     @tracing = Tracing.new
+    @pricing = Pricing.new
     @message_id_strategy = :none
     @experimental_history_healing = false
   end

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -158,18 +158,23 @@ class Riffer::Config
       @rates = {}
     end
 
-    # Registers per-million-token rates for a +provider/model+ id. Raises
+    # Registers per-million-token rates for a +provider/model+ id, or an array
+    # of ids that share one set of rates (a model family). Raises
     # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
     #--
-    #: (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
-    def set(model, input:, output:, cache_read: nil, cache_write: nil)
-      validate_model!(model)
-      @rates[model] = Rates.new(
+    #: ((String | Array[String]), input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+    def set(models, input:, output:, cache_read: nil, cache_write: nil)
+      ids = models.is_a?(Array) ? models : [models]
+      raise Riffer::ArgumentError, "at least one model id is required" if ids.empty?
+      ids.each { |id| validate_model!(id) }
+
+      rates = Rates.new(
         input: coerce_rate(input, "input"),
         output: coerce_rate(output, "output"),
         cache_read: coerce_optional_rate(cache_read, "cache_read"),
         cache_write: coerce_optional_rate(cache_write, "cache_write")
       )
+      ids.each { |id| @rates[id] = rates }
     end
 
     # Returns the rates registered for a +provider/model+ id.

--- a/lib/riffer/config.rb
+++ b/lib/riffer/config.rb
@@ -158,8 +158,7 @@ class Riffer::Config
       @rates = {}
     end
 
-    # Registers per-million-token rates for a +provider/model+ id, or an array
-    # of ids that share one set of rates (a model family). Raises
+    # Registers per-million-token rates for a +provider/model+ id/s. Raises
     # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
     #--
     #: ((String | Array[String]), input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -147,12 +147,12 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     cache_write = usage.cache_write_input_tokens
     cache_read = usage.cache_read_input_tokens
 
-    Riffer::Providers::TokenUsage.new(
+    apply_pricing(Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens + (cache_write || 0) + (cache_read || 0),
       output_tokens: usage.output_tokens,
       cache_write_tokens: cache_write,
       cache_read_tokens: cache_read
-    )
+    ))
   end
 
   #--

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -123,12 +123,12 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     cache_write = usage.cache_creation_input_tokens
     cache_read = usage.cache_read_input_tokens
 
-    Riffer::Providers::TokenUsage.new(
+    apply_pricing(Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens + (cache_write || 0) + (cache_read || 0),
       output_tokens: usage.output_tokens,
       cache_write_tokens: cache_write,
       cache_read_tokens: cache_read
-    )
+    ))
   end
 
   #--

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -9,6 +9,7 @@ require "json"
 # class orchestrates them.
 class Riffer::Providers::Base
   # @rbs @current_tools: Array[singleton(Riffer::Tool)]
+  # @rbs @current_model: String?
 
   WIRE_SEPARATOR = "__" #: String
 
@@ -40,6 +41,7 @@ class Riffer::Providers::Base
   def generate_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
     @current_tools = options[:tools] || [] #: Array[singleton(Riffer::Tool)]
+    @current_model = model
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
     messages = merge_consecutive_messages(messages)
@@ -75,6 +77,7 @@ class Riffer::Providers::Base
   def stream_text(prompt: nil, system: nil, messages: nil, model: nil, files: nil, **options)
     validate_input!(prompt: prompt, system: system, messages: messages)
     @current_tools = options[:tools] || [] #: Array[singleton(Riffer::Tool)]
+    @current_model = model
     messages = normalize_messages(prompt: prompt, system: system, messages: messages, files: files)
     validate_normalized_messages!(messages)
     messages = merge_consecutive_messages(messages)
@@ -137,6 +140,41 @@ class Riffer::Providers::Base
   #: (untyped) -> Riffer::Providers::TokenUsage?
   def extract_token_usage(response)
     raise NotImplementedError, "Subclasses must implement #extract_token_usage"
+  end
+
+  #: (Riffer::Providers::TokenUsage) -> Riffer::Providers::TokenUsage
+  def apply_pricing(usage)
+    rates = pricing_rates
+    return usage unless rates
+
+    cost = rates.cost_for(
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_read_tokens: usage.cache_read_tokens,
+      cache_write_tokens: usage.cache_write_tokens
+    )
+    Riffer::Providers::TokenUsage.new(
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_write_tokens: usage.cache_write_tokens,
+      cache_read_tokens: usage.cache_read_tokens,
+      cost: cost
+    )
+  end
+
+  #--
+  #: () -> Riffer::Config::Pricing::Rates?
+  def pricing_rates
+    model = @current_model
+    return nil unless model
+
+    pricing = Riffer.config.pricing
+    return nil if pricing.empty?
+
+    key = Riffer::Providers::Repository.key_for(self.class)
+    return nil unless key
+
+    pricing.rates_for("#{key}/#{model}")
   end
 
   # Defaults to nil rather than raising — finish reasons are optional, so

--- a/lib/riffer/providers/gemini.rb
+++ b/lib/riffer/providers/gemini.rb
@@ -151,11 +151,11 @@ class Riffer::Providers::Gemini < Riffer::Providers::Base
   #--
   #: (Hash[Symbol, untyped]) -> Riffer::Providers::TokenUsage
   def build_token_usage(usage)
-    Riffer::Providers::TokenUsage.new(
+    apply_pricing(Riffer::Providers::TokenUsage.new(
       input_tokens: usage[:promptTokenCount] || 0,
       output_tokens: (usage[:candidatesTokenCount] || 0) + (usage[:thoughtsTokenCount] || 0),
       cache_read_tokens: usage[:cachedContentTokenCount]
-    )
+    ))
   end
 
   #--

--- a/lib/riffer/providers/mock.rb
+++ b/lib/riffer/providers/mock.rb
@@ -106,7 +106,8 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
   #--
   #: (untyped) -> Riffer::Providers::TokenUsage?
   def extract_token_usage(response)
-    response[:token_usage]
+    usage = response[:token_usage]
+    usage && apply_pricing(usage)
   end
 
   #--
@@ -170,7 +171,7 @@ class Riffer::Providers::Mock < Riffer::Providers::Base
 
     yielder << Riffer::StreamEvents::TextDone.new(full_content)
     yield_finish_reason(yielder, extract_finish_reason(response))
-    yielder << Riffer::StreamEvents::TokenUsageDone.new(token_usage: token_usage) if token_usage
+    yielder << Riffer::StreamEvents::TokenUsageDone.new(token_usage: apply_pricing(token_usage)) if token_usage
   end
 
   #--

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -87,11 +87,11 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
   #--
   #: (untyped) -> Riffer::Providers::TokenUsage
   def build_token_usage(usage)
-    Riffer::Providers::TokenUsage.new(
+    apply_pricing(Riffer::Providers::TokenUsage.new(
       input_tokens: usage.input_tokens,
       output_tokens: usage.output_tokens,
       cache_read_tokens: usage.input_tokens_details&.cached_tokens
-    )
+    ))
   end
 
   #--

--- a/lib/riffer/providers/open_router.rb
+++ b/lib/riffer/providers/open_router.rb
@@ -92,11 +92,11 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
   #--
   #: (untyped) -> Riffer::Providers::TokenUsage
   def build_token_usage(usage)
-    Riffer::Providers::TokenUsage.new(
+    apply_pricing(Riffer::Providers::TokenUsage.new(
       input_tokens: usage.prompt_tokens,
       output_tokens: usage.completion_tokens,
       cache_read_tokens: usage.prompt_tokens_details&.cached_tokens
-    )
+    ))
   end
 
   #--

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -5,6 +5,8 @@
 module Riffer::Providers::Repository
   extend self
 
+  # @rbs @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
+
   REPO = {
     amazon_bedrock: -> { Riffer::Providers::AmazonBedrock },
     anthropic: -> { Riffer::Providers::Anthropic },
@@ -21,5 +23,12 @@ module Riffer::Providers::Repository
   #: ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def find(identifier)
     REPO.fetch(identifier.to_sym, nil)&.call
+  end
+
+  # Returns the registry identifier for a provider class, or nil when unregistered.
+  #--
+  #: (singleton(Riffer::Providers::Base)) -> Symbol?
+  def key_for(provider_class)
+    (@key_for ||= REPO.to_h { |key, factory| [factory.call, key] })[provider_class]
   end
 end

--- a/lib/riffer/providers/token_usage.rb
+++ b/lib/riffer/providers/token_usage.rb
@@ -16,13 +16,17 @@ class Riffer::Providers::TokenUsage
   # Subset of +input_tokens+ read from the provider's prompt cache, when the provider reports it.
   attr_reader :cache_read_tokens #: Integer?
 
+  # Cost of the call, set when the model is priced. For observability, not billing.
+  attr_reader :cost #: Float?
+
   #--
-  #: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
-  def initialize(input_tokens:, output_tokens:, cache_write_tokens: nil, cache_read_tokens: nil)
+  #: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?, ?cost: Float?) -> void
+  def initialize(input_tokens:, output_tokens:, cache_write_tokens: nil, cache_read_tokens: nil, cost: nil)
     @input_tokens = input_tokens
     @output_tokens = output_tokens
     @cache_write_tokens = cache_write_tokens
     @cache_read_tokens = cache_read_tokens
+    @cost = cost
   end
 
   # Returns the total number of tokens (input + output).
@@ -42,17 +46,19 @@ class Riffer::Providers::TokenUsage
       input_tokens: input_tokens + other.input_tokens,
       output_tokens: output_tokens + other.output_tokens,
       cache_write_tokens: add_nullable(cache_write_tokens, other.cache_write_tokens),
-      cache_read_tokens: add_nullable(cache_read_tokens, other.cache_read_tokens)
+      cache_read_tokens: add_nullable(cache_read_tokens, other.cache_read_tokens),
+      cost: add_cost(cost, other.cost)
     )
   end
 
-  # Converts the token usage to a hash; cache tokens are omitted when nil.
+  # Converts the token usage to a hash; cache tokens and cost are omitted when nil.
   #--
-  #: () -> Hash[Symbol, Integer]
+  #: () -> Hash[Symbol, (Integer | Float)]
   def to_h
-    hash = {input_tokens: input_tokens, output_tokens: output_tokens}
+    hash = {input_tokens: input_tokens, output_tokens: output_tokens} #: Hash[Symbol, (Integer | Float)]
     hash[:cache_write_tokens] = cache_write_tokens if cache_write_tokens
     hash[:cache_read_tokens] = cache_read_tokens if cache_read_tokens
+    hash[:cost] = cost if cost
     hash
   end
 
@@ -63,5 +69,14 @@ class Riffer::Providers::TokenUsage
   def add_nullable(a, b)
     return nil if a.nil? && b.nil?
     (a || 0) + (b || 0)
+  end
+
+  # nil is absorbing, not zero: one unpriced call makes the run total nil
+  # rather than silently under-reporting.
+  #--
+  #: (Float?, Float?) -> Float?
+  def add_cost(a, b)
+    return nil if a.nil? || b.nil?
+    a + b
   end
 end

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -171,11 +171,12 @@ class Riffer::Config
     # : () -> void
     def initialize: () -> void
 
-    # Registers per-million-token rates for a +provider/model+ id. Raises
+    # Registers per-million-token rates for a +provider/model+ id, or an array
+    # of ids that share one set of rates (a model family). Raises
     # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
     # --
-    # : (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
-    def set: (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+    # : ((String | Array[String]), input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+    def set: (String | Array[String], input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
 
     # Returns the rates registered for a +provider/model+ id.
     # --

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -171,8 +171,7 @@ class Riffer::Config
     # : () -> void
     def initialize: () -> void
 
-    # Registers per-million-token rates for a +provider/model+ id, or an array
-    # of ids that share one set of rates (a model family). Raises
+    # Registers per-million-token rates for a +provider/model+ id/s. Raises
     # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
     # --
     # : ((String | Array[String]), input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void

--- a/sig/generated/riffer/config.rbs
+++ b/sig/generated/riffer/config.rbs
@@ -137,6 +137,71 @@ class Riffer::Config
     def tracer_provider=: (untyped) -> void
   end
 
+  # Consumer-configured token pricing, keyed by +provider/model+ id. Riffer
+  # ships no price table, so an unconfigured model carries no cost.
+  class Pricing
+    @rates: Hash[String, Riffer::Config::Pricing::Rates]
+
+    # Per-million-token rates for one model's four token buckets. +cache_read+
+    # and +cache_write+ fall back to the +input+ rate when unset.
+    class Rates
+      # Input rate per million tokens.
+      attr_reader input: Float
+
+      # Output rate per million tokens.
+      attr_reader output: Float
+
+      # Cache-read rate per million tokens.
+      attr_reader cache_read: Float?
+
+      # Cache-write rate per million tokens.
+      attr_reader cache_write: Float?
+
+      # --
+      # : (input: Float, output: Float, ?cache_read: Float?, ?cache_write: Float?) -> void
+      def initialize: (input: Float, output: Float, ?cache_read: Float?, ?cache_write: Float?) -> void
+
+      # Returns the cost for the given token counts.
+      # --
+      # : (input_tokens: Integer, output_tokens: Integer, ?cache_read_tokens: Integer?, ?cache_write_tokens: Integer?) -> Float
+      def cost_for: (input_tokens: Integer, output_tokens: Integer, ?cache_read_tokens: Integer?, ?cache_write_tokens: Integer?) -> Float
+    end
+
+    # --
+    # : () -> void
+    def initialize: () -> void
+
+    # Registers per-million-token rates for a +provider/model+ id. Raises
+    # Riffer::ArgumentError on a malformed id or a negative/non-numeric rate.
+    # --
+    # : (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+    def set: (String, input: Numeric, output: Numeric, ?cache_read: Numeric?, ?cache_write: Numeric?) -> void
+
+    # Returns the rates registered for a +provider/model+ id.
+    # --
+    # : (String) -> Riffer::Config::Pricing::Rates?
+    def rates_for: (String) -> Riffer::Config::Pricing::Rates?
+
+    # Returns true when no rates are registered.
+    # --
+    # : () -> bool
+    def empty?: () -> bool
+
+    private
+
+    # --
+    # : (String) -> void
+    def validate_model!: (String) -> void
+
+    # --
+    # : (untyped, String) -> Float
+    def coerce_rate: (untyped, String) -> Float
+
+    # --
+    # : (untyped, String) -> Float?
+    def coerce_optional_rate: (untyped, String) -> Float?
+  end
+
   VALID_MESSAGE_ID_STRATEGIES: untyped
 
   # Amazon Bedrock configuration.
@@ -180,6 +245,9 @@ class Riffer::Config
 
   # Tracing-related global configuration.
   attr_reader tracing: Riffer::Config::Tracing
+
+  # Consumer-configured per-model token pricing.
+  attr_reader pricing: Riffer::Config::Pricing
 
   # Strategy for auto-generating message ids: +:none+ (default), +:uuid+, or
   # +:uuidv7+. When not +:none+, messages get an +id+ at construction, and

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -5,6 +5,8 @@
 # +extract_token_usage+, +extract_content+, +extract_tool_calls+) and the base
 # class orchestrates them.
 class Riffer::Providers::Base
+  @current_model: String?
+
   @current_tools: Array[singleton(Riffer::Tool)]
 
   WIRE_SEPARATOR: String
@@ -63,6 +65,13 @@ class Riffer::Providers::Base
   # --
   # : (untyped) -> Riffer::Providers::TokenUsage?
   def extract_token_usage: (untyped) -> Riffer::Providers::TokenUsage?
+
+  # : (Riffer::Providers::TokenUsage) -> Riffer::Providers::TokenUsage
+  def apply_pricing: (Riffer::Providers::TokenUsage) -> Riffer::Providers::TokenUsage
+
+  # --
+  # : () -> Riffer::Config::Pricing::Rates?
+  def pricing_rates: () -> Riffer::Config::Pricing::Rates?
 
   # Defaults to nil rather than raising — finish reasons are optional, so
   # providers that don't report one stay valid.

--- a/sig/generated/riffer/providers/repository.rbs
+++ b/sig/generated/riffer/providers/repository.rbs
@@ -2,6 +2,8 @@
 
 # Registry for finding provider classes by identifier.
 module Riffer::Providers::Repository
+  @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
+
   REPO: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
   # Finds a provider class by identifier.
@@ -9,4 +11,9 @@ module Riffer::Providers::Repository
   # --
   # : ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def find: (String | Symbol) -> singleton(Riffer::Providers::Base)?
+
+  # Returns the registry identifier for a provider class, or nil when unregistered.
+  # --
+  # : (singleton(Riffer::Providers::Base)) -> Symbol?
+  def key_for: (singleton(Riffer::Providers::Base)) -> Symbol?
 end

--- a/sig/generated/riffer/providers/token_usage.rbs
+++ b/sig/generated/riffer/providers/token_usage.rbs
@@ -15,9 +15,12 @@ class Riffer::Providers::TokenUsage
   # Subset of +input_tokens+ read from the provider's prompt cache, when the provider reports it.
   attr_reader cache_read_tokens: Integer?
 
+  # Cost of the call, set when the model is priced. For observability, not billing.
+  attr_reader cost: Float?
+
   # --
-  # : (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
-  def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?) -> void
+  # : (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?, ?cost: Float?) -> void
+  def initialize: (input_tokens: Integer, output_tokens: Integer, ?cache_write_tokens: Integer?, ?cache_read_tokens: Integer?, ?cost: Float?) -> void
 
   # Returns the total number of tokens (input + output).
   #
@@ -31,14 +34,20 @@ class Riffer::Providers::TokenUsage
   # : (Riffer::Providers::TokenUsage) -> Riffer::Providers::TokenUsage
   def +: (Riffer::Providers::TokenUsage) -> Riffer::Providers::TokenUsage
 
-  # Converts the token usage to a hash; cache tokens are omitted when nil.
+  # Converts the token usage to a hash; cache tokens and cost are omitted when nil.
   # --
-  # : () -> Hash[Symbol, Integer]
-  def to_h: () -> Hash[Symbol, Integer]
+  # : () -> Hash[Symbol, (Integer | Float)]
+  def to_h: () -> Hash[Symbol, Integer | Float]
 
   private
 
   # --
   # : (Integer?, Integer?) -> Integer?
   def add_nullable: (Integer?, Integer?) -> Integer?
+
+  # nil is absorbing, not zero: one unpriced call makes the run total nil
+  # rather than silently under-reporting.
+  # --
+  # : (Float?, Float?) -> Float?
+  def add_cost: (Float?, Float?) -> Float?
 end

--- a/test/riffer/config/pricing_test.rb
+++ b/test/riffer/config/pricing_test.rb
@@ -41,6 +41,23 @@ describe Riffer::Config::Pricing do
       expect(pricing.rates_for("openai/gpt-4").input).must_equal 10.0
     end
 
+    it "registers the same rates for every id when given an array" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set(["openai/gpt-4", "openai/gpt-4-0613"], input: 30.0, output: 60.0)
+      expect(pricing.rates_for("openai/gpt-4-0613").input).must_equal 30.0
+    end
+
+    it "raises when given an empty array of ids" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set([], input: 30.0, output: 60.0) }.must_raise Riffer::ArgumentError
+    end
+
+    it "registers nothing when any id in the array is malformed" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set(["openai/gpt-4", "bad"], input: 30.0, output: 60.0) }.must_raise Riffer::ArgumentError
+      expect(pricing.rates_for("openai/gpt-4")).must_be_nil
+    end
+
     it "raises when the model id has no provider segment" do
       pricing = Riffer::Config::Pricing.new
       expect { pricing.set("gpt-4", input: 30.0, output: 60.0) }.must_raise Riffer::ArgumentError

--- a/test/riffer/config/pricing_test.rb
+++ b/test/riffer/config/pricing_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Config::Pricing do
+  describe "#empty?" do
+    it "is true before any rates are registered" do
+      expect(Riffer::Config::Pricing.new.empty?).must_equal true
+    end
+
+    it "is false after a model is registered" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+      expect(pricing.empty?).must_equal false
+    end
+  end
+
+  describe "#set" do
+    it "registers rates retrievable by model id" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+      expect(pricing.rates_for("openai/gpt-4").input).must_equal 30.0
+    end
+
+    it "defaults cache rates to nil when omitted" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+      expect(pricing.rates_for("openai/gpt-4").cache_read).must_be_nil
+    end
+
+    it "coerces integer rates to floats" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set("openai/gpt-4", input: 30, output: 60)
+      expect(pricing.rates_for("openai/gpt-4").input).must_equal 30.0
+    end
+
+    it "overwrites an earlier registration for the same model" do
+      pricing = Riffer::Config::Pricing.new
+      pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
+      pricing.set("openai/gpt-4", input: 10.0, output: 20.0)
+      expect(pricing.rates_for("openai/gpt-4").input).must_equal 10.0
+    end
+
+    it "raises when the model id has no provider segment" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set("gpt-4", input: 30.0, output: 60.0) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises when a model id segment is empty" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set("openai/", input: 30.0, output: 60.0) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises on a negative rate" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set("openai/gpt-4", input: -1.0, output: 60.0) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises on a non-numeric rate" do
+      pricing = Riffer::Config::Pricing.new
+      expect { pricing.set("openai/gpt-4", input: "30.0", output: 60.0) }.must_raise Riffer::ArgumentError
+    end
+  end
+
+  describe "#rates_for" do
+    it "returns nil for an unregistered model" do
+      expect(Riffer::Config::Pricing.new.rates_for("openai/gpt-4")).must_be_nil
+    end
+  end
+end
+
+describe Riffer::Config::Pricing::Rates do
+  describe "#cost_for" do
+    it "prices input and output at the per-million rates" do
+      rates = Riffer::Config::Pricing::Rates.new(input: 3.0, output: 15.0)
+      cost = rates.cost_for(input_tokens: 2_000_000, output_tokens: 1_000_000)
+      expect(cost).must_equal 21.0
+    end
+
+    it "subtracts the cache subsets and prices them at their own rates" do
+      rates = Riffer::Config::Pricing::Rates.new(input: 3.0, output: 15.0, cache_read: 1.0, cache_write: 5.0)
+      cost = rates.cost_for(input_tokens: 4_000_000, output_tokens: 0, cache_read_tokens: 1_000_000, cache_write_tokens: 1_000_000)
+      expect(cost).must_equal 12.0
+    end
+
+    it "bills cache tokens at the input rate when no cache rate is set" do
+      rates = Riffer::Config::Pricing::Rates.new(input: 3.0, output: 15.0)
+      cost = rates.cost_for(input_tokens: 2_000_000, output_tokens: 0, cache_read_tokens: 1_000_000)
+      expect(cost).must_equal 6.0
+    end
+
+    it "treats nil cache buckets as zero" do
+      rates = Riffer::Config::Pricing::Rates.new(input: 3.0, output: 15.0)
+      cost = rates.cost_for(input_tokens: 1_000_000, output_tokens: 1_000_000)
+      expect(cost).must_equal 18.0
+    end
+
+    it "clamps the uncached portion at zero rather than going negative" do
+      rates = Riffer::Config::Pricing::Rates.new(input: 4.0, output: 15.0, cache_read: 1.0, cache_write: 1.0)
+      cost = rates.cost_for(input_tokens: 2_000_000, output_tokens: 0, cache_read_tokens: 1_500_000, cache_write_tokens: 1_500_000)
+      expect(cost).must_equal 3.0
+    end
+  end
+end

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -415,4 +415,33 @@ describe Riffer::Providers::Mock do
       end
     end
   end
+
+  describe "pricing" do
+    before { Riffer.instance_variable_set(:@config, Riffer::Config.new) }
+    after { Riffer.instance_variable_set(:@config, Riffer::Config.new) }
+
+    it "attaches cost to token usage when the model is priced" do
+      Riffer.config.pricing.set("mock/riffer-1", input: 3.0, output: 15.0)
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 1_000_000, output_tokens: 1_000_000))
+      message = provider.generate_text(prompt: "x", model: "riffer-1")
+      expect(message.token_usage.cost).must_equal 18.0
+    end
+
+    it "leaves cost nil when the model is unpriced" do
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 1_000_000, output_tokens: 1_000_000))
+      message = provider.generate_text(prompt: "x", model: "riffer-1")
+      expect(message.token_usage.cost).must_be_nil
+    end
+
+    it "carries cost on the streamed TokenUsageDone event" do
+      Riffer.config.pricing.set("mock/riffer-1", input: 3.0, output: 15.0)
+      provider = Riffer::Providers::Mock.new
+      provider.stub_response("hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 1_000_000, output_tokens: 1_000_000))
+      events = provider.stream_text(prompt: "x", model: "riffer-1").to_a
+      usage_done = events.find { |e| e.is_a?(Riffer::StreamEvents::TokenUsageDone) }
+      expect(usage_done.token_usage.cost).must_equal 18.0
+    end
+  end
 end

--- a/test/riffer/providers/repository_test.rb
+++ b/test/riffer/providers/repository_test.rb
@@ -48,4 +48,18 @@ describe Riffer::Providers::Repository do
       expect { Riffer::Providers::Repository.find(nil) }.must_raise(NoMethodError)
     end
   end
+
+  describe ".key_for" do
+    it "returns the registry symbol for a registered provider class" do
+      expect(Riffer::Providers::Repository.key_for(Riffer::Providers::OpenAI)).must_equal :openai
+    end
+
+    it "distinguishes providers that share a wire format" do
+      expect(Riffer::Providers::Repository.key_for(Riffer::Providers::AzureOpenAI)).must_equal :azure_openai
+    end
+
+    it "returns nil for an unregistered class" do
+      expect(Riffer::Providers::Repository.key_for(String)).must_be_nil
+    end
+  end
 end

--- a/test/riffer/providers/token_usage_test.rb
+++ b/test/riffer/providers/token_usage_test.rb
@@ -33,6 +33,16 @@ describe Riffer::Providers::TokenUsage do
       usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
       expect(usage.cache_read_tokens).must_be_nil
     end
+
+    it "sets cost when provided" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.42)
+      expect(usage.cost).must_equal 0.42
+    end
+
+    it "defaults cost to nil" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
+      expect(usage.cost).must_be_nil
+    end
   end
 
   describe "#total_tokens" do
@@ -112,6 +122,27 @@ describe Riffer::Providers::TokenUsage do
       expect(combined).wont_equal usage1
       expect(combined).wont_equal usage2
     end
+
+    it "sums cost when both are priced" do
+      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.10)
+      usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75, cost: 0.25)
+      combined = usage1 + usage2
+      expect(combined.cost).must_equal 0.35
+    end
+
+    it "keeps cost nil when both are unpriced" do
+      usage1 = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
+      usage2 = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75)
+      combined = usage1 + usage2
+      expect(combined.cost).must_be_nil
+    end
+
+    it "poisons cost to nil when either side is unpriced" do
+      priced = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.10)
+      unpriced = Riffer::Providers::TokenUsage.new(input_tokens: 200, output_tokens: 75)
+      combined = priced + unpriced
+      expect(combined.cost).must_be_nil
+    end
   end
 
   describe "#to_h" do
@@ -143,6 +174,16 @@ describe Riffer::Providers::TokenUsage do
     it "includes cache_read_tokens when present" do
       usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_read_tokens: 10)
       expect(usage.to_h[:cache_read_tokens]).must_equal 10
+    end
+
+    it "excludes cost when nil" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
+      expect(usage.to_h.key?(:cost)).must_equal false
+    end
+
+    it "includes cost when present" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.42)
+      expect(usage.to_h[:cost]).must_equal 0.42
     end
 
     it "returns correct hash with all values" do


### PR DESCRIPTION
## Problem

Riffer surfaces normalized token usage per call and per run, but no cost. Anyone wanting to track LLM spend has to maintain their own price table and join it against usage out of band. The join is also easy to get wrong: because cache-read/cache-write tokens are subsets of `input_tokens`, pricing the buckets independently double-counts cached tokens.

## Solution

Add consumer-configured per-model pricing. Via `Riffer.configure`, register per-million-token rates (`input`, `output`, optional `cache_read`/`cache_write`) keyed by the same `provider/model` id you give an agent:

```ruby
Riffer.configure do |config|
  config.pricing.set("anthropic/claude-sonnet-4-6", input: 3.0, output: 15.0, cache_read: 0.30, cache_write: 3.75)
  config.pricing.set("openai/gpt-4", input: 30.0, output: 60.0)
end
```

When a model is priced, riffer computes the call's cost and carries it on `TokenUsage#cost`. No price table ships with the gem, so an unconfigured model carries no cost (`nil`) rather than a guess.

Notable design points a reviewer might otherwise miss:

- **Computed at `TokenUsage` creation** inside each provider (resolving the `provider/model` key via a new `Repository.key_for` reverse lookup), so cost is present everywhere usage surfaces — including the streamed `TokenUsageDone` event — not just on the final aggregate.
- **Cache subsets are subtracted before the input rate applies**, so cached tokens aren't double-counted; an unset cache rate falls back to the input rate.
- **Run-level cost sums through `TokenUsage#+`**, but is poison-`nil`: if any call in the run used an unpriced model, the aggregate is `nil` rather than a partial total masquerading as complete.
- Cost is a `Float` for observability, not billing.

## Proof

CI is sufficient — `bin/rake` (test + StandardRB + Steep) is green at 1990 runs, 0 failures. New tests cover the cost formula (subset subtraction, input-rate fallback, nil buckets, negative-input clamp), pricing config validation and lookup, the provider-class reverse lookup, `TokenUsage` cost/aggregation/serialization, and an end-to-end pass through the mock provider for both the generate and stream paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token usage now includes an optional `cost` field computed from newly supported per-model pricing (input/output plus optional cache read/write tiers).
  * When pricing is configured, cost is surfaced in both returned token usage and streamed token-usage events; unpriced portions result in `cost` remaining `nil`.
* **Documentation**
  * Added a Pricing section explaining configuration, cache pricing fallback behavior, and cost aggregation semantics.
* **Tests**
  * Added/extended tests covering pricing configuration, cost computation, and `cost` serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->