### PR TITLE
feat: surface cost on LLM-call and run spans

### DIFF
--- a/docs/16_TRACING.md
+++ b/docs/16_TRACING.md
@@ -82,6 +82,7 @@ The contract promise is: **when present**, a key carries the documented meaning 
 | `gen_ai.usage.output_tokens`               | int    | When the run made an LLM call that reported usage    |
 | `gen_ai.usage.cache_read.input_tokens`     | int    | When the provider reported cache reads               |
 | `gen_ai.usage.cache_creation.input_tokens` | int    | When the provider reported cache writes              |
+| `riffer.cost`                              | float  | When every call in the run was priced                |
 | `riffer.interrupt.reason`                  | string | On interrupt (e.g. approval needed, max steps)       |
 | `riffer.tripwire.guardrail`                | string | On a guardrail tripwire, when the guardrail is named |
 | `riffer.tripwire.reason`                   | string | On a guardrail tripwire                              |
@@ -111,6 +112,7 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 | `gen_ai.usage.output_tokens`               | int      | When the provider reported usage                                              |
 | `gen_ai.usage.cache_read.input_tokens`     | int      | When the provider reported cache reads                                        |
 | `gen_ai.usage.cache_creation.input_tokens` | int      | When the provider reported cache writes                                       |
+| `riffer.cost`                              | float    | When the call's model was priced                                              |
 | `gen_ai.response.finish_reasons`           | string[] | When the provider reported a finish reason                                    |
 | `riffer.finish_reason.raw`                 | string   | When the raw value differs from the normalized one                            |
 | `gen_ai.input.messages`                    | string   | When `capture_messages` is on (JSON; see [capture](#message-content-capture)) |
@@ -152,11 +154,13 @@ invoke_agent weather-agent          INTERNAL
   riffer.steps           = 2
   gen_ai.usage.input_tokens  = 1240
   gen_ai.usage.output_tokens = 86
+  riffer.cost                = 0.0423
 ├─ chat gpt-4                       CLIENT
 │    gen_ai.request.model            = gpt-4
 │    gen_ai.response.finish_reasons  = ["tool_calls"]
 │    gen_ai.usage.input_tokens       = 612
 │    gen_ai.usage.output_tokens      = 48
+│    riffer.cost                     = 0.0212
 ├─ execute_tool get_weather         INTERNAL
 │    gen_ai.tool.name     = get_weather
 │    gen_ai.tool.call.id  = tc_42
@@ -165,9 +169,10 @@ invoke_agent weather-agent          INTERNAL
      gen_ai.response.finish_reasons  = ["stop"]
      gen_ai.usage.input_tokens       = 628
      gen_ai.usage.output_tokens      = 38
+     riffer.cost                     = 0.0211
 ```
 
-## Token usage
+## Token usage and cost
 
 `gen_ai.usage.input_tokens` is the **total** prompt tokens for the call, **cache-inclusive**, per the GenAI semantic conventions. `gen_ai.usage.cache_read.input_tokens` and `gen_ai.usage.cache_creation.input_tokens` are **subsets of that total** — the portion served from, or written to, the provider's prompt cache. They are _not_ additional tokens; do not add them on top of `input_tokens`.
 
@@ -180,6 +185,14 @@ cache_read.input_tokens      =  800   → 800 of the 1000 were cache hits
 Riffer normalizes this across providers, so the number may differ from a provider's native API field. Anthropic's raw `input_tokens` _excludes_ the cache buckets — Riffer folds them in. OpenAI's already includes them. Either way the span value means the same thing.
 
 **Don't double-count across spans.** Usage on a `chat` span is per-call; usage on the enclosing `invoke_agent` span is the run total already summed across every `chat`. Aggregate one level or the other, never both.
+
+### Cost
+
+`riffer.cost` is the modeled cost of one call (on a `chat` span) or a whole run (on the `invoke_agent` span). It lives in Riffer's own namespace because the GenAI semantic conventions define no cost attribute by design — Riffer never squats `gen_ai.*` for it. The attribute appears only when you have configured pricing for the model in use: Riffer ships no price table and never guesses, so an unpriced model simply carries no `riffer.cost`. See [Configuration — Pricing](10_CONFIGURATION.md#pricing) for the rates.
+
+The value is **unitless on the wire** — Riffer attaches no currency. It is the sum of the per-token rates you configured, in whatever currency you expressed them, so a `riffer.cost` of `0.0123` means 0.0123 of that unit. The raw float is emitted unrounded; round for display in your backend, not before.
+
+**Run cost is all-or-nothing.** The `riffer.cost` on an `invoke_agent` span is the sum of its per-call costs, present only when **every** call in the run was priced. A single unpriced call makes the run-level `riffer.cost` absent — costs sum with nil as absorbing, so Riffer reports no run total rather than a partial one that silently under-reports spend. The priced `chat` spans still each carry their own `riffer.cost`; sum those yourself if a partial is what you want.
 
 ## Message content capture
 
@@ -196,7 +209,7 @@ When enabled, content is serialized as GenAI-semconv JSON strings. File attachme
 The span and attribute shape is a public, versioned contract, in two tiers:
 
 - **`gen_ai.*`** tracks the OpenTelemetry GenAI semantic conventions, pinned to schema version `1.37.0`. That convention is still "Development" status upstream and its attribute names may change; Riffer absorbs such renames deliberately in a release, never silently, with a CHANGELOG entry.
-- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
+- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.cost`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
 
 The semantic-convention schema version is a documented pin rather than a span attribute — the OpenTelemetry Ruby API can't attach a schema URL to a tracer. The runtime version signal is the instrumentation scope: every span carries scope name `riffer` at the gem version that emitted it. Pin the Riffer version your dashboards depend on, and watch the CHANGELOG for tracing entries before upgrading.
 

--- a/lib/riffer/tracing.rb
+++ b/lib/riffer/tracing.rb
@@ -41,8 +41,8 @@ module Riffer::Tracing # :nodoc: all
     backend.with_context(context, &block)
   end
 
-  # Stamps the <tt>gen_ai.usage.*</tt> attributes from a TokenUsage onto the
-  # span.
+  # Stamps token usage onto the span — the <tt>gen_ai.usage.*</tt> counts and,
+  # when the model was priced, <tt>riffer.cost</tt>.
   #--
   #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Providers::TokenUsage?) -> void
   def record_usage(span, usage)
@@ -52,6 +52,7 @@ module Riffer::Tracing # :nodoc: all
     span.set_attribute("gen_ai.usage.output_tokens", usage.output_tokens)
     span.set_attribute("gen_ai.usage.cache_read.input_tokens", usage.cache_read_tokens) if usage.cache_read_tokens
     span.set_attribute("gen_ai.usage.cache_creation.input_tokens", usage.cache_write_tokens) if usage.cache_write_tokens
+    span.set_attribute("riffer.cost", usage.cost) if usage.cost
   end
 
   # Discards the resolved backend so the next span re-resolves it.

--- a/sig/generated/riffer/tracing.rbs
+++ b/sig/generated/riffer/tracing.rbs
@@ -29,8 +29,8 @@ module Riffer::Tracing
   # : [R] (untyped) { () -> R } -> R
   def with_context: [R] (untyped) { () -> R } -> R
 
-  # Stamps the <tt>gen_ai.usage.*</tt> attributes from a TokenUsage onto the
-  # span.
+  # Stamps token usage onto the span — the <tt>gen_ai.usage.*</tt> counts and,
+  # when the model was priced, <tt>riffer.cost</tt>.
   # --
   # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Providers::TokenUsage?) -> void
   def record_usage: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Providers::TokenUsage?) -> void

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -300,6 +300,12 @@ describe Riffer::Providers::Base do
       expect(chat_span.attributes).wont_include "gen_ai.usage.input_tokens"
     end
 
+    it "stamps the cost when the call carries one" do
+      provider.stub_response("Hi!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.0021))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(chat_span.attributes["riffer.cost"]).must_equal 0.0021
+    end
+
     it "records the normalized finish reason" do
       provider.generate_text(prompt: "Hello", model: "riffer-1")
       expect(chat_span.attributes["gen_ai.response.finish_reasons"]).must_equal ["stop"]
@@ -387,6 +393,12 @@ describe Riffer::Providers::Base do
       provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
       usage = chat_span.attributes.slice("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens")
       expect(usage).must_equal({"gen_ai.usage.input_tokens" => 100, "gen_ai.usage.output_tokens" => 50})
+    end
+
+    it "stamps the cost from the stream" do
+      provider.stub_response("Hi!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.0021))
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      expect(chat_span.attributes["riffer.cost"]).must_equal 0.0021
     end
 
     it "records the finish reason from the stream" do

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -3012,6 +3012,22 @@ describe Riffer::Agent::Run do
       expect(run_span.attributes).wont_include "gen_ai.usage.input_tokens"
     end
 
+    it "sums per-call cost onto the run span" do
+      agent = agent_class_with_tools.new
+      agent.provider.stub_response("", tool_calls: [{name: "run_tracing_tool", arguments: "{}"}], token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.5))
+      agent.provider.stub_response("Done!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 150, output_tokens: 75, cost: 0.25))
+      agent.generate("Call the tool")
+      expect(run_span.attributes["riffer.cost"]).must_equal 0.75
+    end
+
+    it "omits run cost when any call carries no cost" do
+      agent = agent_class_with_tools.new
+      agent.provider.stub_response("", tool_calls: [{name: "run_tracing_tool", arguments: "{}"}], token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.5))
+      agent.provider.stub_response("Done!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 150, output_tokens: 75))
+      agent.generate("Call the tool")
+      expect(run_span.attributes).wont_include "riffer.cost"
+    end
+
     it "records cache token attributes when reported" do
       agent = agent_class.new
       agent.provider.stub_response("Hello!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cache_read_tokens: 30, cache_write_tokens: 10))

--- a/test/riffer/tracing_test.rb
+++ b/test/riffer/tracing_test.rb
@@ -133,6 +133,30 @@ describe Riffer::Tracing do
       Riffer::Tracing.in_span("test") { |span| Riffer::Tracing.record_usage(span, nil) }
       expect(exporter.finished_spans.first.attributes).must_equal({})
     end
+
+    it "stamps riffer.cost when the usage carries a cost" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_tracer_provider
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.0123)
+      Riffer::Tracing.in_span("test") { |span| Riffer::Tracing.record_usage(span, usage) }
+      expect(exporter.finished_spans.first.attributes["riffer.cost"]).must_equal 0.0123
+    end
+
+    it "stamps a zero cost rather than treating it as absent" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_tracer_provider
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50, cost: 0.0)
+      Riffer::Tracing.in_span("test") { |span| Riffer::Tracing.record_usage(span, usage) }
+      expect(exporter.finished_spans.first.attributes["riffer.cost"]).must_equal 0.0
+    end
+
+    it "omits riffer.cost when the usage carries no cost" do
+      skip "opentelemetry is not bundled" unless OTEL_SDK_AVAILABLE
+      exporter = install_in_memory_tracer_provider
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
+      Riffer::Tracing.in_span("test") { |span| Riffer::Tracing.record_usage(span, usage) }
+      expect(exporter.finished_spans.first.attributes).wont_include "riffer.cost"
+    end
   end
 
   describe "#current_context" do


### PR DESCRIPTION
## Problem

Riffer already traces LLM calls and computes per-model cost on `TokenUsage`, but that cost was never surfaced on the spans themselves. The trace contract bills itself as something you "build dashboards, alerts, and cost reporting against" — yet cost reporting was the one thing you couldn't do, because the number stopped at the message and never reached a span attribute. This PR is the trace-surfacing step of that cost-attribution work; its dependencies (LLM-call tracing and per-model pricing on `TokenUsage`) already landed.

## Solution

Stamp the cost carried on `TokenUsage` as `riffer.cost` on both the `chat` (per-call) and `invoke_agent` (run total) spans. The stamping is a single conditional folded into `Tracing.record_usage`, so all three call sites — generate, stream, and run-level aggregation — inherit it for free, mirroring how cache-token attributes are already handled.

A few deliberate decisions, all documented in the trace contract:

- **`riffer.cost`, not `gen_ai.*`.** The GenAI semantic conventions define no cost attribute by design, so squatting `gen_ai.*` would be wrong; cost lives in Riffer's own namespace.
- **Unitless on the wire.** The value is the sum of the consumer's configured per-token rates in whatever currency they chose — Riffer attaches no currency and emits the raw, unrounded float.
- **Nil-only guard.** Unpriced calls (cost `nil`) carry no attribute; a genuine `0.0` is still stamped.
- **Run cost is all-or-nothing.** Because cost sums with `nil` as absorbing, a single unpriced call leaves the run-level `riffer.cost` absent rather than reporting a partial that silently under-reports spend. The per-call `chat` costs are still present individually. This trap is called out in the docs.

No manual CHANGELOG edit — the `feat:` commit drives release-please.

## Proof

CI is sufficient — covered by new tests, and `bin/rake` (test + Standard + Steep) is green locally:

- `test/riffer/tracing_test.rb` — `record_usage` stamps `riffer.cost` when present, stamps a `0.0` (locks the nil-only guard), and omits it when absent.
- `test/riffer/providers/base_test.rb` — the `chat` span carries `riffer.cost` in both the generate and stream paths.
- `test/riffer/run_test.rb` — the `invoke_agent` span sums per-call cost, and omits `riffer.cost` on a genuinely mixed run (one priced call, one unpriced) — the all-or-nothing trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracing now captures a `riffer.cost` span attribute derived from provider token usage.
  * Run spans aggregate costs across tool-loop calls when every call is priced; otherwise the run cost is omitted.
  * Chat/model spans include per-call costs when available (including `0.0` when the provider reports zero).
* **Documentation**
  * Updated tracing docs to define `riffer.cost`, its wire behavior, and stability expectations.
* **Tests**
  * Added coverage for cost stamping in both non-streaming and streaming provider flows, plus run-span aggregation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->