### PR TITLE
feat: emit an execute_guardrail span per guardrail

### DIFF
--- a/docs/16_TRACING.md
+++ b/docs/16_TRACING.md
@@ -44,13 +44,15 @@ Spans are emitted under the instrumentation scope named `riffer`, versioned with
 
 ## Spans
 
-Riffer emits three span types. A single agent run produces one `invoke_agent` span wrapping one `chat` span per model call and one `execute_tool` span per tool call, interleaved in execution order:
+Riffer emits four span types. A single agent run produces one `invoke_agent` span wrapping one `chat` span per model call, one `execute_tool` span per tool call, and one `execute_guardrail` span per guardrail execution, interleaved in execution order:
 
 ```
 invoke_agent {agent}             INTERNAL
+├─ execute_guardrail {name}      INTERNAL   (one per before-phase guardrail)
 ├─ chat {model}                  CLIENT     (one per LLM call)
 ├─ execute_tool {tool}           INTERNAL   (one per tool call)
 │   └─ (host spans nest here via around_tool_call / tool internals)
+├─ execute_guardrail {name}      INTERNAL   (one per after-phase guardrail, after each response)
 ├─ chat {model}
 └─ …
 ```
@@ -88,6 +90,8 @@ The contract promise is: **when present**, a key carries the documented meaning 
 | `riffer.tripwire.reason`                   | string | On a guardrail tripwire                              |
 | `riffer.tripwire.phase`                    | string | On a guardrail tripwire (`"before"` / `"after"`)     |
 | `error.type`                               | string | On an unhandled exception                            |
+
+The `riffer.tripwire.*` attributes are the run-level summary of the guardrail that halted the run; `riffer.tripwire.guardrail` carries the same name value as the blocking [`execute_guardrail`](#execute_guardrail-name--the-guardrail-span) span's `riffer.guardrail.name`, so the two join on a single key.
 
 Usage on this span is the run total, aggregated across every step. See [Token usage](#token-usage) for the trap this creates.
 
@@ -142,9 +146,25 @@ A tool failure comes in two shapes, distinguished by span status:
 
 This status convention is the same on `chat` and `invoke_agent`: an unhandled exception sets `error.type` to the class name and marks the span `ERROR`; everything else leaves the status unset.
 
+## `execute_guardrail {name}` — the guardrail span
+
+`INTERNAL`. One per guardrail execution; a guardrail registered for both phases runs — and emits a span — once in each. The span name suffix is the guardrail's name (e.g. `execute_guardrail profanity_filter`), from `Riffer::Guardrail#name` — the converted class name by default, overridable to relabel the span. This is the one Riffer span with **no `gen_ai.operation.name`**. A guardrail is not a GenAI semantic-convention operation, so the span stays entirely in Riffer's own namespace rather than squat an invented value on the standardized key.
+
+| Attribute                 | Type   | Present                                                     |
+| ------------------------- | ------ | ----------------------------------------------------------- |
+| `riffer.guardrail.name`   | string | Always — the guardrail's name                               |
+| `riffer.guardrail.phase`  | string | Always (`"before"` / `"after"`)                             |
+| `riffer.guardrail.action` | string | On a returned result (`"pass"` / `"transform"` / `"block"`) |
+| `riffer.tripwire.reason`  | string | On a block — the block reason                               |
+| `error.type`              | string | On an unhandled exception                                   |
+
+`riffer.guardrail.*` holds the facts true of any execution — name, phase, action. A reason exists only on a block, so it reuses the run-level `riffer.tripwire.reason` key: one query finds the reason on both the per-guardrail span and the enclosing `invoke_agent` summary.
+
+A block is a **handled outcome**: `riffer.guardrail.action` is `block` and the **span status stays unset** — the same convention `execute_tool` uses for a returned error response. Only a guardrail that **raises** sets `error.type` to the exception class name and marks the **span status `ERROR`** (with the exception recorded); on a raise no result is produced, so `riffer.guardrail.action` is absent.
+
 ## Example trace
 
-A `generate` run where the model calls one tool, then answers — using the OpenAI provider with `gpt-4`:
+A `generate` run where the model calls one tool, then answers — with one `before` guardrail and one `after` guardrail, using the OpenAI provider with `gpt-4`. The `after` guardrail runs once per model response, so it appears after each `chat`:
 
 ```
 invoke_agent weather-agent          INTERNAL
@@ -155,21 +175,33 @@ invoke_agent weather-agent          INTERNAL
   gen_ai.usage.input_tokens  = 1240
   gen_ai.usage.output_tokens = 86
   riffer.cost                = 0.0423
+├─ execute_guardrail input_filter   INTERNAL
+│    riffer.guardrail.name   = input_filter
+│    riffer.guardrail.phase  = before
+│    riffer.guardrail.action = pass
 ├─ chat gpt-4                       CLIENT
 │    gen_ai.request.model            = gpt-4
 │    gen_ai.response.finish_reasons  = ["tool_calls"]
 │    gen_ai.usage.input_tokens       = 612
 │    gen_ai.usage.output_tokens      = 48
 │    riffer.cost                     = 0.0212
+├─ execute_guardrail output_filter  INTERNAL
+│    riffer.guardrail.name   = output_filter
+│    riffer.guardrail.phase  = after
+│    riffer.guardrail.action = pass
 ├─ execute_tool get_weather         INTERNAL
 │    gen_ai.tool.name     = get_weather
 │    gen_ai.tool.call.id  = tc_42
-└─ chat gpt-4                       CLIENT
-     gen_ai.request.model            = gpt-4
-     gen_ai.response.finish_reasons  = ["stop"]
-     gen_ai.usage.input_tokens       = 628
-     gen_ai.usage.output_tokens      = 38
-     riffer.cost                     = 0.0211
+├─ chat gpt-4                       CLIENT
+│    gen_ai.request.model            = gpt-4
+│    gen_ai.response.finish_reasons  = ["stop"]
+│    gen_ai.usage.input_tokens       = 628
+│    gen_ai.usage.output_tokens      = 38
+│    riffer.cost                     = 0.0211
+└─ execute_guardrail output_filter  INTERNAL
+     riffer.guardrail.name   = output_filter
+     riffer.guardrail.phase  = after
+     riffer.guardrail.action = pass
 ```
 
 ## Token usage and cost
@@ -209,7 +241,7 @@ When enabled, content is serialized as GenAI-semconv JSON strings. File attachme
 The span and attribute shape is a public, versioned contract, in two tiers:
 
 - **`gen_ai.*`** tracks the OpenTelemetry GenAI semantic conventions, pinned to schema version `1.37.0`. That convention is still "Development" status upstream and its attribute names may change; Riffer absorbs such renames deliberately in a release, never silently, with a CHANGELOG entry.
-- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.cost`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
+- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.cost`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.guardrail.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
 
 The semantic-convention schema version is a documented pin rather than a span attribute — the OpenTelemetry Ruby API can't attach a schema URL to a tracer. The runtime version signal is the instrumentation scope: every span carries scope name `riffer` at the gem version that emitted it. Pin the Riffer version your dashboards depend on, and watch the CHANGELOG for tracing entries before upgrading.
 

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -339,8 +339,8 @@ module Riffer::Agent::Run
     tripwire = response.tripwire
     return unless tripwire
 
-    guardrail_name = tripwire.guardrail.name
-    span.set_attribute("riffer.tripwire.guardrail", guardrail_name) if guardrail_name
+    class_name = tripwire.guardrail.name
+    span.set_attribute("riffer.tripwire.guardrail", Riffer::Helpers::ClassNameConverter.convert(class_name)) if class_name
     span.set_attribute("riffer.tripwire.reason", tripwire.reason)
     span.set_attribute("riffer.tripwire.phase", tripwire.phase.to_s)
   end

--- a/lib/riffer/guardrail.rb
+++ b/lib/riffer/guardrail.rb
@@ -31,6 +31,14 @@ class Riffer::Guardrail
     pass(response)
   end
 
+  # Returns the guardrail's identifier, used as the tracing span suffix and the
+  # <tt>riffer.guardrail.name</tt> attribute; override to label the span.
+  #--
+  #: () -> String
+  def name
+    Riffer::Helpers::ClassNameConverter.convert(self.class.name)
+  end
+
   protected
 
   # Creates a pass result that continues with unchanged data.

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -81,6 +81,21 @@ class Riffer::Guardrails::Runner
   #--
   #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail(guardrail, data, messages:)
+    Riffer::Tracing.in_span("execute_guardrail #{guardrail.name}", attributes: guardrail_span_attributes(guardrail), kind: :internal) do |span|
+      result = run_guardrail_phase(guardrail, data, messages: messages)
+      record_guardrail_outcome(span, result)
+      result
+    rescue => error
+      # The backend records the exception and error status on the re-raise;
+      # error.type is the one semconv attribute it doesn't set.
+      span.set_attribute("error.type", error.class.name)
+      raise
+    end
+  end
+
+  #--
+  #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
+  def run_guardrail_phase(guardrail, data, messages:)
     case phase
     when :before
       guardrail.process_input(data, context: context)
@@ -89,5 +104,23 @@ class Riffer::Guardrails::Runner
     else
       raise Riffer::Error, "Unexpected guardrail phase: #{phase}. Valid phases: #{Riffer::Guardrails::PHASES.join(", ")}"
     end
+  end
+
+  #--
+  #: (Riffer::Guardrail) -> Hash[String, untyped]
+  def guardrail_span_attributes(guardrail)
+    {
+      "riffer.guardrail.name" => guardrail.name,
+      "riffer.guardrail.phase" => phase.to_s
+    }
+  end
+
+  # A block is a handled outcome, so its span status stays unset — an error
+  # span status is reserved for a raised exception.
+  #--
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Guardrails::Result) -> void
+  def record_guardrail_outcome(span, result)
+    span.set_attribute("riffer.guardrail.action", result.type.to_s)
+    span.set_attribute("riffer.tripwire.reason", result.data) if result.block?
   end
 end

--- a/sig/generated/riffer/guardrail.rbs
+++ b/sig/generated/riffer/guardrail.rbs
@@ -26,6 +26,12 @@ class Riffer::Guardrail
   # : (Riffer::Messages::Assistant, messages: Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
   def process_output: (Riffer::Messages::Assistant, messages: Array[Riffer::Messages::Base], context: untyped) -> Riffer::Guardrails::Result
 
+  # Returns the guardrail's identifier, used as the tracing span suffix and the
+  # <tt>riffer.guardrail.name</tt> attribute; override to label the span.
+  # --
+  # : () -> String
+  def name: () -> String
+
   # Creates a pass result that continues with unchanged data.
   # --
   # : (untyped) -> Riffer::Guardrails::Result

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -36,4 +36,18 @@ class Riffer::Guardrails::Runner
   # --
   # : (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
+
+  # --
+  # : (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
+  def run_guardrail_phase: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
+
+  # --
+  # : (Riffer::Guardrail) -> Hash[String, untyped]
+  def guardrail_span_attributes: (Riffer::Guardrail) -> Hash[String, untyped]
+
+  # A block is a handled outcome, so its span status stays unset — an error
+  # span status is reserved for a raised exception.
+  # --
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Guardrails::Result) -> void
+  def record_guardrail_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Guardrails::Result) -> void
 end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -14,6 +14,21 @@ class RunTracingBlockingOutputGuardrail < Riffer::Guardrail
   end
 end
 
+class RunTracingPassingGuardrail < Riffer::Guardrail
+end
+
+class RunTracingTransformInputGuardrail < Riffer::Guardrail
+  def process_input(messages, context:)
+    transform(messages)
+  end
+end
+
+class RunTracingRaisingGuardrail < Riffer::Guardrail
+  def process_input(messages, context:)
+    raise "guardrail boom"
+  end
+end
+
 describe Riffer::Agent::Run do
   let(:agent_class) do
     Class.new(Riffer::Agent) do
@@ -2956,8 +2971,39 @@ describe Riffer::Agent::Run do
       klass
     end
 
+    let(:agent_class_with_passing_guardrail) do
+      klass = Class.new(Riffer::Agent) do
+        identifier "traced-agent"
+        model "mock/riffer-1"
+      end
+      klass.guardrail(:before, with: RunTracingPassingGuardrail)
+      klass
+    end
+
+    let(:agent_class_with_transform_guardrail) do
+      klass = Class.new(Riffer::Agent) do
+        identifier "traced-agent"
+        model "mock/riffer-1"
+      end
+      klass.guardrail(:before, with: RunTracingTransformInputGuardrail)
+      klass
+    end
+
+    let(:agent_class_with_raising_guardrail) do
+      klass = Class.new(Riffer::Agent) do
+        identifier "traced-agent"
+        model "mock/riffer-1"
+      end
+      klass.guardrail(:before, with: RunTracingRaisingGuardrail)
+      klass
+    end
+
     def run_span
       @exporter.finished_spans.find { |span| span.name.start_with?("invoke_agent") }
+    end
+
+    def guardrail_span
+      @exporter.finished_spans.find { |span| span.name.start_with?("execute_guardrail") }
     end
 
     def generate_with_tool_loop(agent)
@@ -3069,7 +3115,7 @@ describe Riffer::Agent::Run do
 
     it "records the tripwire guardrail" do
       agent_class_with_blocking_input.new.generate("Hello")
-      expect(run_span.attributes["riffer.tripwire.guardrail"]).must_equal "RunTracingBlockingInputGuardrail"
+      expect(run_span.attributes["riffer.tripwire.guardrail"]).must_equal "run_tracing_blocking_input_guardrail"
     end
 
     it "records the tripwire reason" do
@@ -3148,6 +3194,82 @@ describe Riffer::Agent::Run do
       agent.stream("Hello").each { |_| }
       usage = run_span.attributes.slice("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens")
       expect(usage).must_equal({"gen_ai.usage.input_tokens" => 100, "gen_ai.usage.output_tokens" => 50})
+    end
+
+    it "names the guardrail span after the guardrail" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.name).must_equal "execute_guardrail run_tracing_passing_guardrail"
+    end
+
+    it "marks the guardrail span as internal" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.kind).must_equal :internal
+    end
+
+    it "records the guardrail name attribute" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.name"]).must_equal "run_tracing_passing_guardrail"
+    end
+
+    it "records the guardrail phase" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.phase"]).must_equal "before"
+    end
+
+    it "records a pass action" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.action"]).must_equal "pass"
+    end
+
+    it "records a transform action" do
+      agent_class_with_transform_guardrail.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.action"]).must_equal "transform"
+    end
+
+    it "records a block action" do
+      agent_class_with_blocking_input.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.action"]).must_equal "block"
+    end
+
+    it "records the tripwire reason on a block" do
+      agent_class_with_blocking_input.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.tripwire.reason"]).must_equal "Input blocked"
+    end
+
+    it "omits the tripwire reason when not blocked" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.attributes).wont_include "riffer.tripwire.reason"
+    end
+
+    it "leaves the guardrail span status unset on a block" do
+      agent_class_with_blocking_input.new.generate("Hello")
+      expect(guardrail_span.status.code).must_equal OpenTelemetry::Trace::Status::UNSET
+    end
+
+    it "records the after phase on an after guardrail span" do
+      agent_class_with_blocking_output.new.generate("Hello")
+      expect(guardrail_span.attributes["riffer.guardrail.phase"]).must_equal "after"
+    end
+
+    it "nests the guardrail span under the run span" do
+      agent_class_with_passing_guardrail.new.generate("Hello")
+      expect(guardrail_span.parent_span_id).must_equal run_span.span_id
+    end
+
+    it "records the error type when a guardrail raises" do
+      begin
+        agent_class_with_raising_guardrail.new.generate("Hello")
+      rescue RuntimeError
+      end
+      expect(guardrail_span.attributes["error.type"]).must_equal "RuntimeError"
+    end
+
+    it "marks the guardrail span status as error when a guardrail raises" do
+      begin
+        agent_class_with_raising_guardrail.new.generate("Hello")
+      rescue RuntimeError
+      end
+      expect(guardrail_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
     end
   end
 end


### PR DESCRIPTION
## Problem

Guardrail execution is invisible in traces today. The only guardrail signal is the run-level `riffer.tripwire.*` attributes on the `invoke_agent` span, and those are emitted **only when a guardrail blocks** — there is no per-guardrail span, no duration, and nothing on the happy path. You can't see that a guardrail ran, how long it took, or whether it passed/transformed.

## Solution

Wrap the per-guardrail call in `Riffer::Guardrails::Runner` (the `execute_guardrail` seam) in `Riffer::Tracing.in_span("execute_guardrail {name}", kind: :internal)`, nested under the active `invoke_agent` context — mirroring how `Tools::Runtime#in_tool_span` emits `execute_tool`. The span carries `riffer.guardrail.name` / `.phase` / `.action` (`pass`/`transform`/`block`), `riffer.tripwire.reason` on a block, and `error.type` + status `ERROR` on a raised exception.

A few deliberate decisions worth a reviewer's eye:

- **A block is a handled outcome** — status stays `unset` (captured by `action=block` + `riffer.tripwire.reason`); only a *raised* guardrail marks the span `ERROR`. Same convention as `execute_tool`'s returned-error vs raise split.
- **No `gen_ai.operation.name`** — "guardrail" isn't a GenAI semconv operation, so the span lives purely in `riffer.*` rather than squat an invented value on the standardized key. This is the one Riffer span without it.
- **New overridable `Riffer::Guardrail#name`**, defaulting to `ClassNameConverter.convert(self.class.name)` — same derivation as `Agent`/`Tool` identifiers — used for the span suffix and `riffer.guardrail.name`.
- **Run-level realignment:** `riffer.tripwire.guardrail` now emits the converted form too, so it joins the per-span `riffer.guardrail.name` on one key. This is free because the whole tracing contract is still unreleased (no breaking footer). Trade-off: that run-level value is derived from the guardrail *class*, so a guardrail that *overrides* `#name` is reflected on its own span but not on the run-level summary — honoring overrides there would mean threading the resolved name through `Tripwire`, deferred as out of scope.

The `capture_messages`-gated message-content capture is intentionally **out of scope**, deferred to a follow-up.

## Proof

CI is sufficient. New contract tests in `test/riffer/run_test.rb` (the `describe "tracing"` block) exercise the span through full agent runs — proving it actually nests under `invoke_agent` — covering pass / transform / block / raised-exception, span name/kind, every attribute, the unset-on-block and ERROR-on-raise status, and the after-phase. The existing `riffer.tripwire.guardrail` assertion is updated to the converted form. `bin/rake` is green (test + standard + steep:check): 2014 runs, 0 failures. The span is a no-op when the host OTel SDK is absent, via the existing `Riffer::Tracing` port (`Null` backend).

`docs/16_TRACING.md` is updated in this PR: new span section + attribute table, augmented worked example, `riffer.guardrail.*` added to the `riffer.*` stability tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracing for guardrail execution with detailed span attributes capturing guardrail name, execution phase, and action outcome, enabling better observability into guardrail behavior during agent runs.

* **Documentation**
  * Updated tracing documentation with comprehensive details about guardrail execution spans, including updated trace topology examples and span attribute specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->