### PR TITLE
feat: emit gen_ai.client.operation.duration metric

### DIFF
--- a/docs/17_METRICS.md
+++ b/docs/17_METRICS.md
@@ -35,7 +35,23 @@ Histogram bucket boundaries are a **host-side** concern. The OpenTelemetry metri
 
 ## Instruments
 
-This release lands the metrics **port and configuration only** — Riffer records **no instruments yet**. Each instrument is documented here as it ships, as a row carrying its name, instrument type, unit, and attribute set. Until then there is nothing on the wire to query.
+Each instrument is documented here as a row carrying its name, instrument type, unit, and attribute set.
+
+### `gen_ai.client.operation.duration`
+
+Histogram, unit `s`. The latency of a single GenAI operation, recorded around the same wrap as the matching [span](16_TRACING.md) on both the success and error paths and timed with a monotonic clock. Recording is independent of tracing — the metric fires even with `config.tracing.enabled = false`. Tell the three operations apart by `gen_ai.operation.name`.
+
+| `gen_ai.operation.name` | Recorded around                                  | Attributes                                                                                                                |
+| ----------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `chat`                  | each provider call (`generate_text`/`stream_text`) | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` (when set), `error.type` (on error)               |
+| `invoke_agent`          | each agent run (`generate`/`stream`)             | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.agent.name`, `error.type` (on error)     |
+| `execute_tool`          | each tool call                                   | `gen_ai.operation.name`, `gen_ai.tool.name`, `error.type` (on error)                                                      |
+
+`error.type` carries the exception class for a raised error; for `execute_tool` it carries the handled error category (e.g. `validation_error`, `timeout_error`) when a tool returns an error result instead of raising — matching the span. `gen_ai.response.model` is not recorded yet; it will land once it is also captured on the chat span.
+
+> **Streamed operations are consumption-paced.** A streamed `chat` or `invoke_agent` records its duration when the stream drains, so the value includes the time your consumer takes to iterate the events, not just provider latency. The matching span behaves the same way.
+
+> **`gen_ai.tool.name` cardinality.** One time series exists per distinct tool name. With a large or dynamic tool set (for example MCP-discovered tools) that can grow unbounded — drop the attribute with a [View](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) if your backend strains.
 
 ## Stability
 

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -36,15 +36,26 @@ module Riffer::Agent::Run
   #--
   #: (Riffer::Agent, ?stream_yielder: Enumerator::Yielder?) -> Riffer::Agent::Response
   def run_loop(agent, stream_yielder: nil)
-    Riffer::Tracing.in_span("invoke_agent #{agent.class.identifier}", attributes: run_span_attributes(agent), kind: :internal) do |span|
-      response = execute_run(agent, stream_yielder)
-      record_run_outcome(span, response)
-      response
+    start = Riffer::Metrics.monotonic_now
+    error_type = nil #: String?
+    begin
+      Riffer::Tracing.in_span("invoke_agent #{agent.class.identifier}", attributes: run_span_attributes(agent), kind: :internal) do |span|
+        response = execute_run(agent, stream_yielder)
+        record_run_outcome(span, response)
+        response
+      rescue => error
+        # The backend records the exception and error status on the re-raise;
+        # error.type is the one semconv attribute it doesn't set.
+        span.set_attribute("error.type", error.class.name)
+        raise
+      end
     rescue => error
-      # The backend records the exception and error status on the re-raise;
-      # error.type is the one semconv attribute it doesn't set.
-      span.set_attribute("error.type", error.class.name)
+      # The inner rescue tags the span; capture error.type here too, at method
+      # scope, where the ensure can read it onto the metric.
+      error_type = error.class.name #: String?
       raise
+    ensure
+      Riffer::Metrics::Instruments::OPERATION_DURATION.record(Riffer::Metrics.monotonic_now - start, attributes: run_metric_attributes(agent, error_type))
     end
   end
 
@@ -326,6 +337,19 @@ module Riffer::Agent::Run
       "gen_ai.provider.name" => agent.provider.class.semconv_provider_name,
       "gen_ai.request.model" => agent.model_name
     }
+  end
+
+  #--
+  #: (Riffer::Agent, String?) -> Hash[String, untyped]
+  def run_metric_attributes(agent, error_type)
+    attributes = {
+      "gen_ai.operation.name" => "invoke_agent",
+      "gen_ai.provider.name" => agent.provider.class.semconv_provider_name,
+      "gen_ai.request.model" => agent.model_name,
+      "gen_ai.agent.name" => agent.class.identifier
+    } #: Hash[String, untyped]
+    attributes["error.type"] = error_type if error_type
+    attributes
   end
 
   #--

--- a/lib/riffer/metrics.rb
+++ b/lib/riffer/metrics.rb
@@ -53,6 +53,14 @@ module Riffer::Metrics # :nodoc: all
     backend.record_histogram(name, value, unit: unit, description: description, attributes: attributes)
   end
 
+  # Reads the monotonic clock in seconds — the time source for duration metrics,
+  # immune to wall-clock adjustments.
+  #--
+  #: () -> Float
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
   # Discards the resolved backend so the next record re-resolves it; cached
   # instruments live on that backend, so this clears them too.
   #--

--- a/lib/riffer/metrics/instruments.rb
+++ b/lib/riffer/metrics/instruments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# The catalog of metric instruments riffer records. Each handle is a constant
+# that resolves its backend at record time, so it survives a meter-provider swap
+# or a runtime +enabled+ flip.
+module Riffer::Metrics::Instruments # :nodoc: all
+  OPERATION_DURATION = Riffer::Metrics.create_histogram(
+    "gen_ai.client.operation.duration",
+    unit: "s",
+    description: "Duration of GenAI client operations"
+  ) #: Riffer::Metrics::Histogram
+end

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -213,14 +213,25 @@ class Riffer::Providers::Base
   #--
   #: [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
   def in_chat_span(model, messages, options)
-    Riffer::Tracing.in_span(model ? "chat #{model}" : "chat", attributes: chat_span_attributes(model, options), kind: :client) do |span|
-      capture_input(span, messages)
-      yield span
+    start = Riffer::Metrics.monotonic_now
+    error_type = nil #: String?
+    begin
+      Riffer::Tracing.in_span(model ? "chat #{model}" : "chat", attributes: chat_span_attributes(model, options), kind: :client) do |span|
+        capture_input(span, messages)
+        yield span
+      rescue => error
+        # The backend records the exception and error status on the re-raise;
+        # error.type is the one semconv attribute it doesn't set.
+        span.set_attribute("error.type", error.class.name)
+        raise
+      end
     rescue => error
-      # The backend records the exception and error status on the re-raise;
-      # error.type is the one semconv attribute it doesn't set.
-      span.set_attribute("error.type", error.class.name)
+      # The inner rescue tags the span; capture error.type here too, at method
+      # scope, where the ensure can read it onto the metric.
+      error_type = error.class.name #: String?
       raise
+    ensure
+      Riffer::Metrics::Instruments::OPERATION_DURATION.record(Riffer::Metrics.monotonic_now - start, attributes: chat_metric_attributes(model, error_type))
     end
   end
 
@@ -238,6 +249,18 @@ class Riffer::Providers::Base
       attributes[attribute] = value unless value.nil?
     end
 
+    attributes
+  end
+
+  #--
+  #: (String?, String?) -> Hash[String, untyped]
+  def chat_metric_attributes(model, error_type)
+    attributes = {
+      "gen_ai.operation.name" => "chat",
+      "gen_ai.provider.name" => self.class.semconv_provider_name
+    } #: Hash[String, untyped]
+    attributes["gen_ai.request.model"] = model if model
+    attributes["error.type"] = error_type if error_type
     attributes
   end
 

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -25,13 +25,7 @@ class Riffer::Tools::Runtime
     trace_context = Riffer::Tracing.current_context
     @runner.map(tool_calls, context: context) do |tool_call|
       Riffer::Tracing.with_context(trace_context) do
-        in_tool_span(tool_call) do |span|
-          result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
-            dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
-          end
-          record_tool_outcome(span, result)
-          [tool_call, result]
-        end
+        run_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
       end
     end
   end
@@ -57,6 +51,29 @@ class Riffer::Tools::Runtime
   end
 
   private
+
+  #--
+  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+  def run_tool_call(tool_call, tools:, context:, assistant_message:)
+    start = Riffer::Metrics.monotonic_now
+    error_type = nil #: String?
+    begin
+      pair = in_tool_span(tool_call) do |span|
+        result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
+          dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
+        end
+        record_tool_outcome(span, result)
+        [tool_call, result] #: [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+      end
+      error_type = pair[1].error_type&.to_s
+      pair
+    rescue => error
+      error_type = error.class.name #: String?
+      raise
+    ensure
+      Riffer::Metrics::Instruments::OPERATION_DURATION.record(Riffer::Metrics.monotonic_now - start, attributes: tool_metric_attributes(tool_call, error_type))
+    end
+  end
 
   #--
   #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
@@ -115,6 +132,17 @@ class Riffer::Tools::Runtime
       "gen_ai.tool.name" => tool_call.name,
       "gen_ai.tool.call.id" => tool_call.call_id
     }
+  end
+
+  #--
+  #: (Riffer::Messages::Assistant::ToolCall, String?) -> Hash[String, untyped]
+  def tool_metric_attributes(tool_call, error_type)
+    attributes = {
+      "gen_ai.operation.name" => "execute_tool",
+      "gen_ai.tool.name" => tool_call.name
+    } #: Hash[String, untyped]
+    attributes["error.type"] = error_type if error_type
+    attributes
   end
 
   # A returned error Response is a handled outcome, so its status stays unset —

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -25,7 +25,11 @@ class Riffer::Tools::Runtime
     trace_context = Riffer::Tracing.current_context
     @runner.map(tool_calls, context: context) do |tool_call|
       Riffer::Tracing.with_context(trace_context) do
-        run_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
+        instrument_tool_call(tool_call) do
+          around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
+            dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
+          end
+        end
       end
     end
   end
@@ -53,20 +57,18 @@ class Riffer::Tools::Runtime
   private
 
   #--
-  #: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
-  def run_tool_call(tool_call, tools:, context:, assistant_message:)
+  #: (Riffer::Messages::Assistant::ToolCall) { () -> Riffer::Tools::Response } -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+  def instrument_tool_call(tool_call)
     start = Riffer::Metrics.monotonic_now
     error_type = nil #: String?
     begin
-      pair = in_tool_span(tool_call) do |span|
-        result = around_tool_call(tool_call, context: context, assistant_message: assistant_message) do
-          dispatch_tool_call(tool_call, tools: tools, context: context, assistant_message: assistant_message)
-        end
-        record_tool_outcome(span, result)
-        [tool_call, result] #: [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+      result = in_tool_span(tool_call) do |span|
+        response = yield
+        record_tool_outcome(span, response)
+        response
       end
-      error_type = pair[1].error_type&.to_s
-      pair
+      error_type = result.error_type&.to_s
+      [tool_call, result] #: [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
     rescue => error
       error_type = error.class.name #: String?
       raise

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -106,6 +106,10 @@ module Riffer::Agent::Run
   def run_span_attributes: (Riffer::Agent) -> Hash[String, untyped]
 
   # --
+  # : (Riffer::Agent, String?) -> Hash[String, untyped]
+  def run_metric_attributes: (Riffer::Agent, String?) -> Hash[String, untyped]
+
+  # --
   # : (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Agent::Response) -> void
   def record_run_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Agent::Response) -> void
 end

--- a/sig/generated/riffer/metrics.rbs
+++ b/sig/generated/riffer/metrics.rbs
@@ -41,6 +41,12 @@ module Riffer::Metrics
   # : (String, Numeric, ?unit: String?, ?description: String?, ?attributes: Hash[String, untyped]?) -> void
   def record_histogram: (String, Numeric, ?unit: String?, ?description: String?, ?attributes: Hash[String, untyped]?) -> void
 
+  # Reads the monotonic clock in seconds — the time source for duration metrics,
+  # immune to wall-clock adjustments.
+  # --
+  # : () -> Float
+  def monotonic_now: () -> Float
+
   # Discards the resolved backend so the next record re-resolves it; cached
   # instruments live on that backend, so this clears them too.
   # --

--- a/sig/generated/riffer/metrics/instruments.rbs
+++ b/sig/generated/riffer/metrics/instruments.rbs
@@ -1,0 +1,9 @@
+# Generated from lib/riffer/metrics/instruments.rb with RBS::Inline
+
+# The catalog of metric instruments riffer records. Each handle is a constant
+# that resolves its backend at record time, so it survives a meter-provider swap
+# or a runtime +enabled+ flip.
+module Riffer::Metrics::Instruments
+  # :nodoc: all
+  OPERATION_DURATION: Riffer::Metrics::Histogram
+end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -99,6 +99,10 @@ class Riffer::Providers::Base
   def chat_span_attributes: (String?, Hash[Symbol, untyped]) -> Hash[String, untyped]
 
   # --
+  # : (String?, String?) -> Hash[String, untyped]
+  def chat_metric_attributes: (String?, String?) -> Hash[String, untyped]
+
+  # --
   # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Symbol?, String?) -> void
   def record_finish_reason: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Symbol?, String?) -> void
 

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -36,6 +36,10 @@ class Riffer::Tools::Runtime
   private
 
   # --
+  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+  def run_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]
+
+  # --
   # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
   def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
 
@@ -51,6 +55,10 @@ class Riffer::Tools::Runtime
   # --
   # : (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
   def tool_span_attributes: (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
+
+  # --
+  # : (Riffer::Messages::Assistant::ToolCall, String?) -> Hash[String, untyped]
+  def tool_metric_attributes: (Riffer::Messages::Assistant::ToolCall, String?) -> Hash[String, untyped]
 
   # A returned error Response is a handled outcome, so its status stays unset —
   # an error span status is reserved for a raised exception.

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -36,8 +36,8 @@ class Riffer::Tools::Runtime
   private
 
   # --
-  # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
-  def run_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, assistant_message: Riffer::Messages::Assistant?) -> [ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]
+  # : (Riffer::Messages::Assistant::ToolCall) { () -> Riffer::Tools::Response } -> [Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response]
+  def instrument_tool_call: (Riffer::Messages::Assistant::ToolCall) { () -> Riffer::Tools::Response } -> [ Riffer::Messages::Assistant::ToolCall, Riffer::Tools::Response ]
 
   # --
   # : (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -446,4 +446,64 @@ describe Riffer::Providers::Base do
       expect(@exporter.finished_spans).must_be_empty
     end
   end
+
+  describe "metrics" do
+    before do
+      skip "opentelemetry metrics is not bundled" unless METRICS_SDK_AVAILABLE
+      Riffer.config.metrics.enabled = true
+      @exporter = install_in_memory_meter_provider
+    end
+
+    after do
+      Riffer.config.metrics.enabled = true
+      Riffer.config.metrics.meter_provider = nil
+      Riffer.config.tracing.enabled = true
+    end
+
+    let(:provider) { Riffer::Providers::Mock.new }
+
+    def duration_attributes
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.operation.duration" }
+      snapshot.data_points.first.attributes
+    end
+
+    it "records the operation duration histogram in seconds" do
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.operation.duration" }
+      expect([snapshot.name, snapshot.unit]).must_equal ["gen_ai.client.operation.duration", "s"]
+    end
+
+    it "records the chat operation attributes" do
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(duration_attributes).must_equal({
+        "gen_ai.operation.name" => "chat",
+        "gen_ai.provider.name" => "mock",
+        "gen_ai.request.model" => "riffer-1"
+      })
+    end
+
+    it "omits the request model when none is given" do
+      provider.generate_text(prompt: "Hello")
+      expect(duration_attributes).wont_include "gen_ai.request.model"
+    end
+
+    it "records error.type when the provider raises" do
+      exploding = ChatTracingExplodingProvider.new
+      expect { exploding.generate_text(prompt: "Hello", model: "riffer-1") }.must_raise(Riffer::Error)
+      expect(duration_attributes["error.type"]).must_equal "Riffer::Error"
+    end
+
+    it "records the duration when the stream drains" do
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      expect(duration_attributes["gen_ai.operation.name"]).must_equal "chat"
+    end
+
+    it "records even when tracing is disabled" do
+      Riffer.config.tracing.enabled = false
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(duration_attributes["gen_ai.operation.name"]).must_equal "chat"
+    end
+  end
 end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -3272,4 +3272,54 @@ describe Riffer::Agent::Run do
       expect(guardrail_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
     end
   end
+
+  describe "metrics" do
+    before do
+      skip "opentelemetry metrics is not bundled" unless METRICS_SDK_AVAILABLE
+      Riffer.config.metrics.enabled = true
+      @exporter = install_in_memory_meter_provider
+    end
+
+    after do
+      Riffer.config.metrics.enabled = true
+      Riffer.config.metrics.meter_provider = nil
+    end
+
+    let(:agent_class) do
+      Class.new(Riffer::Agent) do
+        identifier "metered-agent"
+        model "mock/riffer-1"
+      end
+    end
+
+    # The agent records both a chat and an invoke_agent data point on the shared
+    # histogram, so select the invoke_agent point by operation name.
+    def invoke_agent_attributes
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.operation.duration" }
+      snapshot.data_points.find { |dp| dp.attributes["gen_ai.operation.name"] == "invoke_agent" }.attributes
+    end
+
+    it "records the invoke_agent operation attributes" do
+      agent_class.new.generate("Hello")
+      expect(invoke_agent_attributes).must_equal({
+        "gen_ai.operation.name" => "invoke_agent",
+        "gen_ai.provider.name" => "mock",
+        "gen_ai.request.model" => "riffer-1",
+        "gen_ai.agent.name" => "metered-agent"
+      })
+    end
+
+    it "records error.type when the run raises" do
+      agent = agent_class.new
+      agent.session.on_message { raise "boom" }
+      expect { agent.generate("Hello") }.must_raise(RuntimeError)
+      expect(invoke_agent_attributes["error.type"]).must_equal "RuntimeError"
+    end
+
+    it "records the duration when the stream drains" do
+      agent_class.new.stream("Hello").each { |_| }
+      expect(invoke_agent_attributes["gen_ai.operation.name"]).must_equal "invoke_agent"
+    end
+  end
 end

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -488,6 +488,60 @@ describe Riffer::Tools::Runtime do
       expect(tool_span.parent_span_id).must_equal run_span.span_id
     end
   end
+
+  describe "metrics" do
+    before do
+      skip "opentelemetry metrics is not bundled" unless METRICS_SDK_AVAILABLE
+      Riffer.config.metrics.enabled = true
+      @exporter = install_in_memory_meter_provider
+    end
+
+    after do
+      Riffer.config.metrics.enabled = true
+      Riffer.config.metrics.meter_provider = nil
+    end
+
+    let(:buggy_tool_class) do
+      Class.new(Riffer::Tool) do
+        identifier "buggy_tool"
+        description "Has a bug"
+
+        def call(context:, **)
+          nil.nonexistent_method
+        end
+      end
+    end
+
+    def duration_attributes
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.operation.duration" }
+      snapshot.data_points.first.attributes
+    end
+
+    it "records the execute_tool operation attributes" do
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":"Toronto"}')
+      Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+      expect(duration_attributes).must_equal({
+        "gen_ai.operation.name" => "execute_tool",
+        "gen_ai.tool.name" => "weather_tool"
+      })
+    end
+
+    it "records error.type from a handled-error response" do
+      tool_call = make_tool_call(name: "weather_tool", arguments: "{}")
+      Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+      expect(duration_attributes["error.type"]).must_equal "validation_error"
+    end
+
+    it "records error.type from a raised exception" do
+      tool_call = make_tool_call(name: "buggy_tool")
+      begin
+        Riffer::Tools::Runtime::Inline.new.execute([tool_call], tools: [buggy_tool_class], context: nil)
+      rescue NoMethodError
+      end
+      expect(duration_attributes["error.type"]).must_equal "NoMethodError"
+    end
+  end
 end
 
 describe Riffer::Tools::Runtime::Inline do


### PR DESCRIPTION
## Problem

Riffer records GenAI spans but no metrics. Operation latency could only be derived from span duration in a collector, which is sampling-dependent and post-processed. The OpenTelemetry GenAI semantic conventions define `gen_ai.client.operation.duration` as the canonical latency metric — sampling-independent, pre-aggregated client-side, and the key off-the-shelf GenAI dashboards build on. Riffer landed the metrics port foundation but recorded no instruments yet; this ships the first one.

## Solution

Record a `gen_ai.client.operation.duration` histogram (unit `s`) around all three GenAI operations — `chat`, `invoke_agent`, and `execute_tool` — reusing each operation's existing span wrap so the metric and span stay consistent, and distinguishing them by `gen_ai.operation.name`. A single shared instrument handle lives in a new `Riffer::Metrics::Instruments` catalog.

Timing uses a monotonic clock and records once on both the success and error paths via an `ensure`, independent of whether tracing is enabled, and no-ops when the host bundles no metrics SDK (no OTel dependency is added).

Attributes are scoped per operation rather than a uniform set, mirroring what each span already carries:

- `chat` → `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` (when set), `error.type` (on error)
- `invoke_agent` → the above plus `gen_ai.agent.name`
- `execute_tool` → `gen_ai.operation.name`, `gen_ai.tool.name`, `error.type` (on error) — the tool runtime has no provider/model reference, and `gen_ai.tool.call.id` is deliberately kept span-only to avoid unbounded metric cardinality

`error.type` mirrors the span: the raised exception class for `chat`/`invoke_agent`, and a tool's returned handled-error category (e.g. `validation_error`, `timeout_error`) or raised class for `execute_tool`.

Notable trade-offs, all documented in `docs/17_METRICS.md`:

- **`gen_ai.response.model` is deferred** — it isn't captured on any span today, so adding it is left to a follow-up that puts it on the chat span and this metric together, keeping them consistent.
- **Streamed `chat`/`invoke_agent` durations are consumption-paced** — reusing the span's lazy-enumerator wrap means the duration spans first-pull-to-drain, so a slow consumer inflates it (same as the span behaves).
- **`gen_ai.tool.name` cardinality** can grow with dynamic/MCP tool sets; the docs note hosts can drop it via a View.
- **Bucket boundaries stay host-side** — the metrics API can't attach them at instrument creation; the docs point at a View for the semconv-recommended boundaries.

## Proof

CI is sufficient. Contract tests are folded into the operation unit tests (`base_test.rb`, `run_test.rb`, `runtime_test.rb`), asserting the metric name, unit, and per-operation attributes on success and `error.type` on error — including both tool error modes (handled Response and raised exception), the stream-drain path, and recording while tracing is disabled. `bin/rake` (test + standard + steep:check) is green; RBS signatures are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operation-duration metrics for AI client actions—chat, agent invocation, and tool execution—with consistent timing and `error.type` attribution when failures occur.
  * Metrics are emitted reliably even when tracing is disabled, including after streaming completes.

* **Documentation**
  * Updated the metrics specification to define `gen_ai.client.operation.duration`, units, and expected attributes by operation type.

* **Tests**
  * Added/extended OpenTelemetry metrics tests to validate datapoints, attribute sets, error recording, and stream-drain behavior across operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->