### PR TITLE
feat: emit gen_ai.client.token.usage metric

### DIFF
--- a/docs/17_METRICS.md
+++ b/docs/17_METRICS.md
@@ -33,6 +33,25 @@ Instruments are recorded under the instrumentation scope named `riffer`, version
 
 Histogram bucket boundaries are a **host-side** concern. The OpenTelemetry metrics API does not let an instrumenting library attach bucket boundaries at instrument creation, so Riffer does not set them — the SDK's default buckets apply unless you override them. To match the GenAI semantic conventions' recommended boundaries (or your own), register a [View](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) on the meter provider that targets the instrument by name and sets explicit bucket boundaries.
 
+The convention recommends boundaries scaled to each instrument, so register one View per histogram — the token-count buckets below are for `gen_ai.client.token.usage`; `gen_ai.client.operation.duration` wants its own latency-scaled set.
+
+```ruby
+require "opentelemetry-metrics-sdk"
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = "my-agent-host"
+end
+
+# The GenAI semconv's recommended token-count boundaries. Register the View
+# before Riffer records its first measurement.
+OpenTelemetry.meter_provider.add_view(
+  "gen_ai.client.token.usage",
+  aggregation: OpenTelemetry::SDK::Metrics::Aggregation::ExplicitBucketHistogram.new(
+    boundaries: [1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864]
+  )
+)
+```
+
 ## Instruments
 
 Each instrument is documented here as a row carrying its name, instrument type, unit, and attribute set.
@@ -52,6 +71,21 @@ Histogram, unit `s`. The latency of a single GenAI operation, recorded around th
 > **Streamed operations are consumption-paced.** A streamed `chat` or `invoke_agent` records its duration when the stream drains, so the value includes the time your consumer takes to iterate the events, not just provider latency. The matching span behaves the same way.
 
 > **`gen_ai.tool.name` cardinality.** One time series exists per distinct tool name. With a large or dynamic tool set (for example MCP-discovered tools) that can grow unbounded — drop the attribute with a [View](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) if your backend strains.
+
+### `gen_ai.client.token.usage`
+
+Histogram, unit `{token}`. Token volume for a single `chat` call, recorded from the normalized token usage after the provider responds. Each call emits **two data points** — one `input`, one `output` — distinguished by `gen_ai.token.type`. Recording is independent of tracing (it fires with `config.tracing.enabled = false`); for a streamed call it fires when the stream drains. `gen_ai.response.model` is not recorded yet, for the same reason as `operation.duration`.
+
+| `gen_ai.token.type` | Value                                                   | Attributes                                                                                       |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `input`             | total prompt tokens for the call, **cache-inclusive**   | `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, `gen_ai.token.type`, `gen_ai.request.model` (when set) |
+| `output`            | tokens generated, including reasoning/thinking tokens   | same                                                                                             |
+
+> **Per-call only.** Token usage is never recorded at the run (`invoke_agent`) level. Metrics pre-aggregate, so emitting both the per-call points and a run total would double-count — sum the per-call points in your backend if you want a run total. This is the metric-side counterpart of the span-level [double-count trap](16_TRACING.md#token-usage-and-cost).
+
+> **Cache buckets stay on spans.** The semconv `gen_ai.token.type` defines only `input` and `output`, so the prompt-cache subsets (`cache_read` / `cache_creation`) live on [spans](16_TRACING.md#token-usage-and-cost), not this metric. The `input` value is the cache-inclusive total, matching the span's `gen_ai.usage.input_tokens`.
+
+A call that reports no usage records no data points, and a failed call has nothing to count — so this metric carries no `error.type` (the semconv marks it not applicable here, unlike `operation.duration`).
 
 ## Stability
 

--- a/lib/riffer/metrics.rb
+++ b/lib/riffer/metrics.rb
@@ -53,6 +53,14 @@ module Riffer::Metrics # :nodoc: all
     backend.record_histogram(name, value, unit: unit, description: description, attributes: attributes)
   end
 
+  # Mirrors a span's +recording?+ so a caller can skip work that exists only to
+  # feed a metric.
+  #--
+  #: () -> bool
+  def recording?
+    Riffer.config.metrics.enabled && backend.is_a?(Otel)
+  end
+
   # Reads the monotonic clock in seconds — the time source for duration metrics,
   # immune to wall-clock adjustments.
   #--

--- a/lib/riffer/metrics/instruments.rb
+++ b/lib/riffer/metrics/instruments.rb
@@ -10,4 +10,10 @@ module Riffer::Metrics::Instruments # :nodoc: all
     unit: "s",
     description: "Duration of GenAI client operations"
   ) #: Riffer::Metrics::Histogram
+
+  TOKEN_USAGE = Riffer::Metrics.create_histogram(
+    "gen_ai.client.token.usage",
+    unit: "{token}",
+    description: "Number of input and output tokens used in GenAI operations"
+  ) #: Riffer::Metrics::Histogram
 end

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -57,6 +57,7 @@ class Riffer::Providers::Base
       structured_output = parse_structured_output(content) if options[:structured_output] && tool_calls.empty?
 
       Riffer::Tracing.record_usage(span, token_usage)
+      record_token_usage_metric(model, token_usage)
       record_finish_reason(span, finish_reason&.reason, finish_reason&.raw)
       capture_output(span, content: content, tool_calls: tool_calls, finish_reason: finish_reason&.reason)
 
@@ -90,9 +91,15 @@ class Riffer::Providers::Base
     Enumerator.new do |yielder|
       Riffer::Tracing.with_context(trace_context) do
         in_chat_span(model, messages, options) do |span|
-          sink = span.recording? ? Riffer::Tracing::StreamRecorder.new(yielder) : yielder
+          # The recorder feeds both the span and the token-usage metric, so build
+          # it whenever either is live — metrics fire even with tracing off.
+          observe = span.recording? || Riffer::Metrics.recording?
+          sink = observe ? Riffer::Tracing::StreamRecorder.new(yielder) : yielder
           execute_stream(params, sink)
-          record_stream_outcome(span, sink) if sink.is_a?(Riffer::Tracing::StreamRecorder)
+          if sink.is_a?(Riffer::Tracing::StreamRecorder)
+            record_stream_outcome(span, sink)
+            record_token_usage_metric(model, sink.token_usage)
+          end
         end
       end
     end
@@ -253,15 +260,33 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: (String?, String?) -> Hash[String, untyped]
-  def chat_metric_attributes(model, error_type)
+  #: (String?) -> Hash[String, untyped]
+  def chat_metric_base_attributes(model)
     attributes = {
       "gen_ai.operation.name" => "chat",
       "gen_ai.provider.name" => self.class.semconv_provider_name
     } #: Hash[String, untyped]
     attributes["gen_ai.request.model"] = model if model
+    attributes
+  end
+
+  #--
+  #: (String?, String?) -> Hash[String, untyped]
+  def chat_metric_attributes(model, error_type)
+    attributes = chat_metric_base_attributes(model)
     attributes["error.type"] = error_type if error_type
     attributes
+  end
+
+  # Per-call only — the run level would double-count an aggregate.
+  #--
+  #: (String?, Riffer::Providers::TokenUsage?) -> void
+  def record_token_usage_metric(model, usage)
+    return unless usage
+
+    base = chat_metric_base_attributes(model)
+    Riffer::Metrics::Instruments::TOKEN_USAGE.record(usage.input_tokens, attributes: base.merge("gen_ai.token.type" => "input"))
+    Riffer::Metrics::Instruments::TOKEN_USAGE.record(usage.output_tokens, attributes: base.merge("gen_ai.token.type" => "output"))
   end
 
   #--

--- a/sig/generated/riffer/metrics.rbs
+++ b/sig/generated/riffer/metrics.rbs
@@ -41,6 +41,12 @@ module Riffer::Metrics
   # : (String, Numeric, ?unit: String?, ?description: String?, ?attributes: Hash[String, untyped]?) -> void
   def record_histogram: (String, Numeric, ?unit: String?, ?description: String?, ?attributes: Hash[String, untyped]?) -> void
 
+  # Mirrors a span's +recording?+ so a caller can skip work that exists only to
+  # feed a metric.
+  # --
+  # : () -> bool
+  def recording?: () -> bool
+
   # Reads the monotonic clock in seconds — the time source for duration metrics,
   # immune to wall-clock adjustments.
   # --

--- a/sig/generated/riffer/metrics/instruments.rbs
+++ b/sig/generated/riffer/metrics/instruments.rbs
@@ -6,4 +6,6 @@
 module Riffer::Metrics::Instruments
   # :nodoc: all
   OPERATION_DURATION: Riffer::Metrics::Histogram
+
+  TOKEN_USAGE: Riffer::Metrics::Histogram
 end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -99,8 +99,17 @@ class Riffer::Providers::Base
   def chat_span_attributes: (String?, Hash[Symbol, untyped]) -> Hash[String, untyped]
 
   # --
+  # : (String?) -> Hash[String, untyped]
+  def chat_metric_base_attributes: (String?) -> Hash[String, untyped]
+
+  # --
   # : (String?, String?) -> Hash[String, untyped]
   def chat_metric_attributes: (String?, String?) -> Hash[String, untyped]
+
+  # Per-call only — the run level would double-count an aggregate.
+  # --
+  # : (String?, Riffer::Providers::TokenUsage?) -> void
+  def record_token_usage_metric: (String?, Riffer::Providers::TokenUsage?) -> void
 
   # --
   # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Symbol?, String?) -> void

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -505,5 +505,62 @@ describe Riffer::Providers::Base do
       provider.generate_text(prompt: "Hello", model: "riffer-1")
       expect(duration_attributes["gen_ai.operation.name"]).must_equal "chat"
     end
+
+    def token_usage_snapshot
+      @exporter.pull
+      @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.token.usage" }
+    end
+
+    it "records the token usage histogram in tokens" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      snapshot = token_usage_snapshot
+      expect([snapshot.name, snapshot.unit]).must_equal ["gen_ai.client.token.usage", "{token}"]
+    end
+
+    it "records one input and one output data point carrying the token counts" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      counts = token_usage_snapshot.data_points.to_h { |dp| [dp.attributes["gen_ai.token.type"], dp.sum] }
+      expect(counts).must_equal({"input" => 12, "output" => 7})
+    end
+
+    it "records the chat attributes on each data point" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      input_point = token_usage_snapshot.data_points.find { |dp| dp.attributes["gen_ai.token.type"] == "input" }
+      expect(input_point.attributes).must_equal({
+        "gen_ai.operation.name" => "chat",
+        "gen_ai.provider.name" => "mock",
+        "gen_ai.request.model" => "riffer-1",
+        "gen_ai.token.type" => "input"
+      })
+    end
+
+    it "omits the request model when none is given" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.generate_text(prompt: "Hello")
+      expect(token_usage_snapshot.data_points.first.attributes).wont_include "gen_ai.request.model"
+    end
+
+    it "records nothing when the provider reports no usage" do
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(token_usage_snapshot).must_be_nil
+    end
+
+    it "records two data points when the stream drains" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      counts = token_usage_snapshot.data_points.to_h { |dp| [dp.attributes["gen_ai.token.type"], dp.sum] }
+      expect(counts).must_equal({"input" => 12, "output" => 7})
+    end
+
+    it "records token usage from a stream even when tracing is disabled" do
+      Riffer.config.tracing.enabled = false
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      types = token_usage_snapshot.data_points.map { |dp| dp.attributes["gen_ai.token.type"] }.sort
+      expect(types).must_equal ["input", "output"]
+    end
   end
 end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -3321,5 +3321,15 @@ describe Riffer::Agent::Run do
       agent_class.new.stream("Hello").each { |_| }
       expect(invoke_agent_attributes["gen_ai.operation.name"]).must_equal "invoke_agent"
     end
+
+    it "never records token usage at the run level" do
+      agent = agent_class.new
+      agent.provider.stub_response("Hello!", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50))
+      agent.generate("Hello")
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "gen_ai.client.token.usage" }
+      operations = snapshot.data_points.map { |dp| dp.attributes["gen_ai.operation.name"] }.uniq
+      expect(operations).must_equal ["chat"]
+    end
   end
 end


### PR DESCRIPTION
## Problem

Riffer records the `gen_ai.client.operation.duration` metric but no token volume. Token usage exists only on spans today, which carries a double-count trap: a `chat` span holds per-call usage while the enclosing `invoke_agent` span holds the run total, so any collector aggregating both over-counts. The OpenTelemetry GenAI semantic conventions define `gen_ai.client.token.usage` as the canonical token metric — pre-aggregated client-side, useful on its own (token volume by model), and the natural input a cost metric is derived from. As a metric, recorded at one level only, it sidesteps that trap entirely.

## Solution

Record a `gen_ai.client.token.usage` histogram (unit `{token}`) after each `chat` call, from the normalized `Riffer::Providers::TokenUsage`. Each call emits **two data points** — one `gen_ai.token.type=input`, one `=output` — sharing the per-call attribute base `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, and `gen_ai.request.model` (when set). The attribute helper is factored out of the existing duration helper so both metrics keep a single source for the shared attributes.

Deliberate contract decisions, all documented in `docs/17_METRICS.md`:

- **`gen_ai.operation.name` is included.** The semconv marks it Required for this metric; for a per-call-only metric its value is constant (`chat`), but emitting it keeps Riffer compliant and consistent with `operation.duration`.
- **Per-call only.** Never recorded at the run (`invoke_agent`) level — metrics pre-aggregate, so emitting both the per-call points and a run total would double-count. Sum the per-call points in a backend for a run total.
- **Cache buckets stay on spans.** The semconv `gen_ai.token.type` defines only `input`/`output`, so prompt-cache subsets remain span-only. The `input` value is the cache-inclusive total, matching the span's `gen_ai.usage.input_tokens`.
- **No `error.type`** — the semconv marks it not applicable here, and a failed call has no usage to count (the recorder no-ops on absent usage).
- **`gen_ai.response.model` deferred** — same reason as `operation.duration`: it isn't on any span yet.

To keep metrics independent of tracing for the streaming path, usage was previously captured only by the span recorder (gated on the span recording). This adds `Riffer::Metrics.recording?` and builds the recorder when tracing **or** metrics is live, so a streamed `chat` still records token usage with `config.tracing.enabled = false` — matching how `operation.duration` already behaves, and with no recorder overhead when neither is active. No OTel dependency is added; everything no-ops without a host metrics SDK.

The docs also gain a copy-pasteable host-side View example carrying the semconv-recommended token-count bucket boundaries, since the API can't attach them at instrument creation.

## Proof

CI is sufficient. Contract tests are folded into the operation unit tests:

- `test/riffer/providers/base_test.rb` — name + unit; one `input` and one `output` point with the correct counts; the full attribute set per point; `gen_ai.request.model` omitted when unset; **no data points when the provider reports no usage**; two points on stream drain; and **token usage recorded from a stream while tracing is disabled** (the regression guard for the recorder gate).
- `test/riffer/run_test.rb` — an agent run records only `chat`-level points, never a run-level point.

`bin/rake` (test + standard + steep:check) is green; RBS signatures are regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token usage metrics tracking to monitor input and output tokens consumed in GenAI operations, improving observability.
  
* **Documentation**
  * Enhanced metrics documentation with OpenTelemetry configuration examples and token usage metric specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->