### PR TITLE
feat: emit riffer.gen_ai.cost metric from TokenUsage cost

### DIFF
--- a/docs/17_METRICS.md
+++ b/docs/17_METRICS.md
@@ -33,7 +33,7 @@ Instruments are recorded under the instrumentation scope named `riffer`, version
 
 Histogram bucket boundaries are a **host-side** concern. The OpenTelemetry metrics API does not let an instrumenting library attach bucket boundaries at instrument creation, so Riffer does not set them — the SDK's default buckets apply unless you override them. To match the GenAI semantic conventions' recommended boundaries (or your own), register a [View](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view) on the meter provider that targets the instrument by name and sets explicit bucket boundaries.
 
-The convention recommends boundaries scaled to each instrument, so register one View per histogram — the token-count buckets below are for `gen_ai.client.token.usage`; `gen_ai.client.operation.duration` wants its own latency-scaled set.
+The convention recommends boundaries scaled to each instrument, so register one View per histogram — the token-count buckets below are for `gen_ai.client.token.usage`; `gen_ai.client.operation.duration` wants its own latency-scaled set, and `riffer.gen_ai.cost` a USD-scaled one.
 
 ```ruby
 require "opentelemetry-metrics-sdk"
@@ -60,11 +60,11 @@ Each instrument is documented here as a row carrying its name, instrument type, 
 
 Histogram, unit `s`. The latency of a single GenAI operation, recorded around the same wrap as the matching [span](16_TRACING.md) on both the success and error paths and timed with a monotonic clock. Recording is independent of tracing — the metric fires even with `config.tracing.enabled = false`. Tell the three operations apart by `gen_ai.operation.name`.
 
-| `gen_ai.operation.name` | Recorded around                                  | Attributes                                                                                                                |
-| ----------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
-| `chat`                  | each provider call (`generate_text`/`stream_text`) | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` (when set), `error.type` (on error)               |
-| `invoke_agent`          | each agent run (`generate`/`stream`)             | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.agent.name`, `error.type` (on error)     |
-| `execute_tool`          | each tool call                                   | `gen_ai.operation.name`, `gen_ai.tool.name`, `error.type` (on error)                                                      |
+| `gen_ai.operation.name` | Recorded around                                    | Attributes                                                                                                            |
+| ----------------------- | -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `chat`                  | each provider call (`generate_text`/`stream_text`) | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model` (when set), `error.type` (on error)           |
+| `invoke_agent`          | each agent run (`generate`/`stream`)               | `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.agent.name`, `error.type` (on error) |
+| `execute_tool`          | each tool call                                     | `gen_ai.operation.name`, `gen_ai.tool.name`, `error.type` (on error)                                                  |
 
 `error.type` carries the exception class for a raised error; for `execute_tool` it carries the handled error category (e.g. `validation_error`, `timeout_error`) when a tool returns an error result instead of raising — matching the span. `gen_ai.response.model` is not recorded yet; it will land once it is also captured on the chat span.
 
@@ -76,16 +76,28 @@ Histogram, unit `s`. The latency of a single GenAI operation, recorded around th
 
 Histogram, unit `{token}`. Token volume for a single `chat` call, recorded from the normalized token usage after the provider responds. Each call emits **two data points** — one `input`, one `output` — distinguished by `gen_ai.token.type`. Recording is independent of tracing (it fires with `config.tracing.enabled = false`); for a streamed call it fires when the stream drains. `gen_ai.response.model` is not recorded yet, for the same reason as `operation.duration`.
 
-| `gen_ai.token.type` | Value                                                   | Attributes                                                                                       |
-| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `input`             | total prompt tokens for the call, **cache-inclusive**   | `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, `gen_ai.token.type`, `gen_ai.request.model` (when set) |
-| `output`            | tokens generated, including reasoning/thinking tokens   | same                                                                                             |
+| `gen_ai.token.type` | Value                                                 | Attributes                                                                                                              |
+| ------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `input`             | total prompt tokens for the call, **cache-inclusive** | `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, `gen_ai.token.type`, `gen_ai.request.model` (when set) |
+| `output`            | tokens generated, including reasoning/thinking tokens | same                                                                                                                    |
 
 > **Per-call only.** Token usage is never recorded at the run (`invoke_agent`) level. Metrics pre-aggregate, so emitting both the per-call points and a run total would double-count — sum the per-call points in your backend if you want a run total. This is the metric-side counterpart of the span-level [double-count trap](16_TRACING.md#token-usage-and-cost).
 
 > **Cache buckets stay on spans.** The semconv `gen_ai.token.type` defines only `input` and `output`, so the prompt-cache subsets (`cache_read` / `cache_creation`) live on [spans](16_TRACING.md#token-usage-and-cost), not this metric. The `input` value is the cache-inclusive total, matching the span's `gen_ai.usage.input_tokens`.
 
 A call that reports no usage records no data points, and a failed call has nothing to count — so this metric carries no `error.type` (the semconv marks it not applicable here, unlike `operation.duration`).
+
+### `riffer.gen_ai.cost`
+
+Histogram, unit `USD`. The cost of a single `chat` call, recorded from the [cost](16_TRACING.md#token-usage-and-cost) on the normalized token usage after the provider responds — the same source as the cost span attribute, a different sink. This instrument is Riffer-owned (`riffer.*`, not `gen_ai.*`) so it won't collide if the semantic conventions later define a cost instrument; see [Stability](#stability). Recording is independent of tracing (it fires with `config.tracing.enabled = false`); for a streamed call it fires when the stream drains.
+
+| Value            | Attributes                                                                                         |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| cost of the call | `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, `gen_ai.request.model` (when set) |
+
+Pricing is **consumer-configured** — no price table ships with the gem (see [Configuration — Pricing](10_CONFIGURATION.md#pricing)). A call whose model has no configured price records **no** data point, so this metric covers only priced calls; `operation.duration` and `token.usage` still record. A priced call that computes to `0.0` does record a zero data point — only an absent price means there is nothing to measure.
+
+> **Per-call only.** Cost is never recorded at the run (`invoke_agent`) level, for the same reason as token usage: metrics pre-aggregate, so emitting both per-call points and a run total would double-count. Sum the per-call points in your backend for a run total.
 
 ## Stability
 

--- a/lib/riffer/metrics/instruments.rb
+++ b/lib/riffer/metrics/instruments.rb
@@ -16,4 +16,10 @@ module Riffer::Metrics::Instruments # :nodoc: all
     unit: "{token}",
     description: "Number of input and output tokens used in GenAI operations"
   ) #: Riffer::Metrics::Histogram
+
+  COST = Riffer::Metrics.create_histogram(
+    "riffer.gen_ai.cost",
+    unit: "USD",
+    description: "Cost of GenAI client operations in USD"
+  ) #: Riffer::Metrics::Histogram
 end

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -58,6 +58,7 @@ class Riffer::Providers::Base
 
       Riffer::Tracing.record_usage(span, token_usage)
       record_token_usage_metric(model, token_usage)
+      record_cost_metric(model, token_usage)
       record_finish_reason(span, finish_reason&.reason, finish_reason&.raw)
       capture_output(span, content: content, tool_calls: tool_calls, finish_reason: finish_reason&.reason)
 
@@ -99,6 +100,7 @@ class Riffer::Providers::Base
           if sink.is_a?(Riffer::Tracing::StreamRecorder)
             record_stream_outcome(span, sink)
             record_token_usage_metric(model, sink.token_usage)
+            record_cost_metric(model, sink.token_usage)
           end
         end
       end
@@ -287,6 +289,16 @@ class Riffer::Providers::Base
     base = chat_metric_base_attributes(model)
     Riffer::Metrics::Instruments::TOKEN_USAGE.record(usage.input_tokens, attributes: base.merge("gen_ai.token.type" => "input"))
     Riffer::Metrics::Instruments::TOKEN_USAGE.record(usage.output_tokens, attributes: base.merge("gen_ai.token.type" => "output"))
+  end
+
+  # Per-call only — the run level would double-count an aggregate.
+  #--
+  #: (String?, Riffer::Providers::TokenUsage?) -> void
+  def record_cost_metric(model, usage)
+    cost = usage&.cost
+    return unless cost
+
+    Riffer::Metrics::Instruments::COST.record(cost, attributes: chat_metric_base_attributes(model))
   end
 
   #--

--- a/sig/generated/riffer/metrics/instruments.rbs
+++ b/sig/generated/riffer/metrics/instruments.rbs
@@ -8,4 +8,6 @@ module Riffer::Metrics::Instruments
   OPERATION_DURATION: Riffer::Metrics::Histogram
 
   TOKEN_USAGE: Riffer::Metrics::Histogram
+
+  COST: Riffer::Metrics::Histogram
 end

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -111,6 +111,11 @@ class Riffer::Providers::Base
   # : (String?, Riffer::Providers::TokenUsage?) -> void
   def record_token_usage_metric: (String?, Riffer::Providers::TokenUsage?) -> void
 
+  # Per-call only — the run level would double-count an aggregate.
+  # --
+  # : (String?, Riffer::Providers::TokenUsage?) -> void
+  def record_cost_metric: (String?, Riffer::Providers::TokenUsage?) -> void
+
   # --
   # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Symbol?, String?) -> void
   def record_finish_reason: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Symbol?, String?) -> void

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -562,5 +562,52 @@ describe Riffer::Providers::Base do
       types = token_usage_snapshot.data_points.map { |dp| dp.attributes["gen_ai.token.type"] }.sort
       expect(types).must_equal ["input", "output"]
     end
+
+    def cost_snapshot
+      @exporter.pull
+      @exporter.metric_snapshots.find { |s| s.name == "riffer.gen_ai.cost" }
+    end
+
+    it "records the cost histogram in USD" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7, cost: 0.0021))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      snapshot = cost_snapshot
+      expect([snapshot.name, snapshot.unit]).must_equal ["riffer.gen_ai.cost", "USD"]
+    end
+
+    it "records one data point carrying the call cost" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7, cost: 0.0021))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(cost_snapshot.data_points.map(&:sum)).must_equal [0.0021]
+    end
+
+    it "records the chat attributes on the data point" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7, cost: 0.0021))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(cost_snapshot.data_points.first.attributes).must_equal({
+        "gen_ai.operation.name" => "chat",
+        "gen_ai.provider.name" => "mock",
+        "gen_ai.request.model" => "riffer-1"
+      })
+    end
+
+    it "records nothing when the call carries no cost" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(cost_snapshot).must_be_nil
+    end
+
+    it "records the cost when the stream drains" do
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7, cost: 0.0021))
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      expect(cost_snapshot.data_points.map(&:sum)).must_equal [0.0021]
+    end
+
+    it "records cost even when tracing is disabled" do
+      Riffer.config.tracing.enabled = false
+      provider.stub_response("Hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 12, output_tokens: 7, cost: 0.0021))
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(cost_snapshot.data_points.map(&:sum)).must_equal [0.0021]
+    end
   end
 end


### PR DESCRIPTION
## Problem

Spend is observable today only as a span attribute (`riffer.cost`). That makes it inspectable per call but not queryable as an aggregate — there's no way to get total spend or a per-request cost distribution (p95, etc.) the way latency (`gen_ai.client.operation.duration`) and token volume (`gen_ai.client.token.usage`) already expose as metric histograms. This adds the metric-side counterpart to the cost already surfaced on spans.

## Solution

Add a `riffer.gen_ai.cost` histogram (unit `USD`), recorded once per `chat` call from the cost already attached to the normalized `TokenUsage`. No pricing is computed here — the value is read straight off `TokenUsage#cost`, the same source as the cost span attribute, just a different sink.

Notable behaviors a reviewer might otherwise miss:

- **Owned namespace.** It lives under `riffer.*`, not `gen_ai.*`, so it won't collide if the GenAI semantic conventions later define a cost instrument.
- **Skip-when-unpriced.** Pricing is consumer-configured and no price table ships with the gem, so an unpriced model yields `nil` cost and records no data point — `operation.duration` and `token.usage` still record. A priced call that computes to `0.0` does record a zero point; only an absent price means there's nothing to measure (`return unless cost`, relying on `0.0` being truthy in Ruby).
- **Per-call only**, never run-level, to avoid double-counting under metric pre-aggregation — matching how token usage is handled.
- Recorded on both the `generate_text` and stream-drain paths, and independent of tracing (fires with `config.tracing.enabled = false`).
- Attributes match the sibling chat metrics by reusing the shared base: `gen_ai.operation.name` (always `chat`), `gen_ai.provider.name`, and `gen_ai.request.model` (when set). Bucket boundaries stay host-side, like the other histograms.

## Proof

CI is sufficient — see the new contract tests in `test/riffer/providers/base_test.rb` under `describe "metrics"`. They assert the metric name + unit (`["riffer.gen_ai.cost", "USD"]`), the recorded value, the full attribute set, that nothing is emitted when the call carries no cost, and that it records on both the stream-drain and tracing-disabled paths. `bin/rake` (test + StandardRB + Steep) is green, and `sig/generated/` is regenerated from the rbs-inline annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost tracking metric for GenAI operations, recording USD-denominated cost per call with operation-level attributes.

* **Documentation**
  * Updated metrics reference with expanded histogram configuration guidance and new cost metric specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->