### PR TITLE
refactor(telemetry): rename Null backends to NoOp

### DIFF
--- a/docs/16_TRACING.md
+++ b/docs/16_TRACING.md
@@ -64,7 +64,7 @@ The backend is duck-typed — any object satisfying the contract works, and the 
 - `current_context` — return the active trace context (for re-attaching across fiber/thread boundaries), or `nil` when there is none.
 - `with_context(context) { … }` — run the block with the given context active; a `nil` context passes straight through, so a span re-attached while tracing was dark stays harmless.
 
-The yielded span must respond to `set_attribute(key, value)`, `add_event(name, attributes:)`, `record_exception(exception)`, `error!(description)`, and `recording?` — the same surface the OTEL span exposes. `Riffer::Tracing::Null` is the reference shape for both the backend and the span contract. The `enabled` kill switch is still honoured ahead of the backend: with `config.tracing.enabled = false`, spans short-circuit to the no-op without ever reaching a custom backend.
+The yielded span must respond to `set_attribute(key, value)`, `add_event(name, attributes:)`, `record_exception(exception)`, `error!(description)`, and `recording?` — the same surface the OTEL span exposes. `Riffer::Tracing::NoOp` is the reference shape for both the backend and the span contract. The `enabled` kill switch is still honoured ahead of the backend: with `config.tracing.enabled = false`, spans short-circuit to the no-op without ever reaching a custom backend.
 
 ## Spans
 

--- a/docs/17_METRICS.md
+++ b/docs/17_METRICS.md
@@ -43,7 +43,7 @@ Riffer.configure do |config|
 end
 ```
 
-The backend is duck-typed: any object that responds to `record_histogram(name, value, unit:, description:, attributes:)` works, and the setter validates only that (otherwise it raises `Riffer::ArgumentError`). `Riffer::Metrics::Null` is the reference shape. All three instruments are histograms, so the single `record_histogram` method covers the full contract; tell them apart by `name` (or by `unit`: `s` for `gen_ai.client.operation.duration`, `{token}` for `gen_ai.client.token.usage`, `USD` for `riffer.gen_ai.cost`).
+The backend is duck-typed: any object that responds to `record_histogram(name, value, unit:, description:, attributes:)` works, and the setter validates only that (otherwise it raises `Riffer::ArgumentError`). `Riffer::Metrics::NoOp` is the reference shape. All three instruments are histograms, so the single `record_histogram` method covers the full contract; tell them apart by `name` (or by `unit`: `s` for `gen_ai.client.operation.duration`, `{token}` for `gen_ai.client.token.usage`, `USD` for `riffer.gen_ai.cost`).
 
 A custom backend counts as a **live** sink, so the providers still compute the token counts and cost that feed it — the same data that, under OTEL, populates `gen_ai.client.token.usage` and `riffer.gen_ai.cost`. The `enabled` kill switch is honoured ahead of the backend: with `config.metrics.enabled = false`, measurements short-circuit to the no-op without ever reaching a custom backend.
 

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -353,7 +353,7 @@ module Riffer::Agent::Run
   end
 
   #--
-  #: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Agent::Response) -> void
+  #: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Agent::Response) -> void
   def record_run_outcome(span, response)
     span.set_attribute("riffer.steps", response.steps)
     Riffer::Tracing.record_usage(span, response.token_usage)

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -118,7 +118,7 @@ class Riffer::Guardrails::Runner
   # A block is a handled outcome, so its span status stays unset — an error
   # span status is reserved for a raised exception.
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Guardrails::Result) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Guardrails::Result) -> void
   def record_guardrail_outcome(span, result)
     span.set_attribute("riffer.guardrail.action", result.type.to_s)
     span.set_attribute("riffer.tripwire.reason", result.data) if result.block?

--- a/lib/riffer/metrics.rb
+++ b/lib/riffer/metrics.rb
@@ -59,7 +59,7 @@ module Riffer::Metrics # :nodoc: all
   #--
   #: () -> bool
   def recording?
-    Riffer.config.metrics.enabled && !backend.equal?(Null)
+    Riffer.config.metrics.enabled && !backend.equal?(NoOp)
   end
 
   # Reads the monotonic clock in seconds — the time source for duration metrics,
@@ -89,6 +89,6 @@ module Riffer::Metrics # :nodoc: all
   #--
   #: () -> untyped
   def resolve_backend
-    Riffer.config.metrics.backend || Null
+    Riffer.config.metrics.backend || NoOp
   end
 end

--- a/lib/riffer/metrics/no_op.rb
+++ b/lib/riffer/metrics/no_op.rb
@@ -3,7 +3,7 @@
 
 # No-op metrics backend, used when the OpenTelemetry metrics API is unavailable
 # or metrics are disabled.
-module Riffer::Metrics::Null # :nodoc: all
+module Riffer::Metrics::NoOp # :nodoc: all
   extend self
 
   # Ignores the measurement; there is no meter without the OTEL metrics API.

--- a/lib/riffer/metrics/otel.rb
+++ b/lib/riffer/metrics/otel.rb
@@ -9,7 +9,7 @@ class Riffer::Metrics::Otel # :nodoc: all
 
   class << self
     # Builds a backend when the OpenTelemetry metrics API is loadable at a
-    # supported version; returns +nil+ so resolution falls back to Null.
+    # supported version; returns +nil+ so resolution falls back to NoOp.
     # +provider+ defaults to the global <tt>OpenTelemetry.meter_provider</tt>.
     #--
     #: (?provider: untyped) -> Riffer::Metrics::Otel?

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -220,7 +220,7 @@ class Riffer::Providers::Base
   }.freeze #: Hash[Symbol, String]
 
   #--
-  #: [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  #: [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
   def in_chat_span(model, messages, options)
     start = Riffer::Metrics.monotonic_now
     error_type = nil #: String?
@@ -302,7 +302,7 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Symbol?, String?) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Symbol?, String?) -> void
   def record_finish_reason(span, reason, raw)
     return unless reason
 
@@ -311,7 +311,7 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tracing::StreamRecorder) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tracing::StreamRecorder) -> void
   def record_stream_outcome(span, recorder)
     Riffer::Tracing.record_usage(span, recorder.token_usage)
     record_finish_reason(span, recorder.finish_reason, recorder.raw_finish_reason)
@@ -319,7 +319,7 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Array[Riffer::Messages::Base]) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Array[Riffer::Messages::Base]) -> void
   def capture_input(span, messages)
     return unless capture_messages?(span)
 
@@ -329,7 +329,7 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
   def capture_output(span, content:, tool_calls:, finish_reason:)
     return unless capture_messages?(span)
 
@@ -337,7 +337,7 @@ class Riffer::Providers::Base
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> bool
   def capture_messages?(span)
     Riffer.config.tracing.capture_messages && span.recording?
   end

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -113,7 +113,7 @@ class Riffer::Tools::Runtime
 
   # Emitted outside +around_tool_call+ so host enrichment spans nest beneath it.
   #--
-  #: [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> R } -> R
+  #: [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> R } -> R
   def in_tool_span(tool_call)
     Riffer::Tracing.in_span("execute_tool #{tool_call.name}", attributes: tool_span_attributes(tool_call), kind: :internal) do |span|
       capture_tool_arguments(span, tool_call)
@@ -150,7 +150,7 @@ class Riffer::Tools::Runtime
   # A returned error Response is a handled outcome, so its status stays unset —
   # an error span status is reserved for a raised exception.
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
   def record_tool_outcome(span, result)
     error_type = result.error_type
     span.set_attribute("error.type", error_type.to_s) if error_type
@@ -158,7 +158,7 @@ class Riffer::Tools::Runtime
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Messages::Assistant::ToolCall) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Messages::Assistant::ToolCall) -> void
   def capture_tool_arguments(span, tool_call)
     return unless capture_tool_content?(span)
 
@@ -167,7 +167,7 @@ class Riffer::Tools::Runtime
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
   def capture_tool_result(span, result)
     return unless capture_tool_content?(span)
 
@@ -175,7 +175,7 @@ class Riffer::Tools::Runtime
   end
 
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> bool
   def capture_tool_content?(span)
     Riffer.config.tracing.capture_messages && span.recording?
   end

--- a/lib/riffer/tracing.rb
+++ b/lib/riffer/tracing.rb
@@ -17,9 +17,9 @@ module Riffer::Tracing # :nodoc: all
 
   # Opens a span around the block, yielding the span.
   #--
-  #: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  #: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
   def in_span(name, attributes: nil, kind: :internal, &block)
-    return Null.in_span(name, &block) unless Riffer.config.tracing.enabled
+    return NoOp.in_span(name, &block) unless Riffer.config.tracing.enabled
     backend.in_span(name, attributes: attributes, kind: kind, &block)
   end
 
@@ -28,7 +28,7 @@ module Riffer::Tracing # :nodoc: all
   #--
   #: () -> untyped
   def current_context
-    return Null.current_context unless Riffer.config.tracing.enabled
+    return NoOp.current_context unless Riffer.config.tracing.enabled
     backend.current_context
   end
 
@@ -37,14 +37,14 @@ module Riffer::Tracing # :nodoc: all
   #--
   #: [R] (untyped) { () -> R } -> R
   def with_context(context, &block)
-    return Null.with_context(context, &block) unless Riffer.config.tracing.enabled
+    return NoOp.with_context(context, &block) unless Riffer.config.tracing.enabled
     backend.with_context(context, &block)
   end
 
   # Stamps token usage onto the span — the <tt>gen_ai.usage.*</tt> counts and,
   # when the model was priced, <tt>riffer.cost</tt>.
   #--
-  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Providers::TokenUsage?) -> void
+  #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Providers::TokenUsage?) -> void
   def record_usage(span, usage)
     return unless usage
 
@@ -73,6 +73,6 @@ module Riffer::Tracing # :nodoc: all
   #--
   #: () -> untyped
   def resolve_backend
-    Riffer.config.tracing.backend || Null
+    Riffer.config.tracing.backend || NoOp
   end
 end

--- a/lib/riffer/tracing/no_op.rb
+++ b/lib/riffer/tracing/no_op.rb
@@ -3,7 +3,7 @@
 
 # No-op tracing backend, used when OTEL is unavailable or tracing is
 # disabled.
-module Riffer::Tracing::Null # :nodoc: all
+module Riffer::Tracing::NoOp # :nodoc: all
   extend self
 
   # No-op stand-in for a span; answers <tt>recording?</tt> with +false+ so
@@ -36,11 +36,11 @@ module Riffer::Tracing::Null # :nodoc: all
     end
   end
 
-  SPAN = Span.new.freeze #: Riffer::Tracing::Null::Span
+  SPAN = Span.new.freeze #: Riffer::Tracing::NoOp::Span
 
   # Yields the no-op span, ignoring all span options.
   #--
-  #: [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
+  #: [R] (String, **untyped) { (Riffer::Tracing::NoOp::Span) -> R } -> R
   def in_span(_name, **)
     yield SPAN
   end

--- a/lib/riffer/tracing/otel.rb
+++ b/lib/riffer/tracing/otel.rb
@@ -52,7 +52,7 @@ class Riffer::Tracing::Otel # :nodoc: all
 
   class << self
     # Builds a backend when the OpenTelemetry API is loadable at a supported
-    # version; returns +nil+ so resolution falls back to Null. +provider+
+    # version; returns +nil+ so resolution falls back to NoOp. +provider+
     # defaults to the global <tt>OpenTelemetry.tracer_provider</tt>.
     #--
     #: (?provider: untyped) -> Riffer::Tracing::Otel?

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -110,6 +110,6 @@ module Riffer::Agent::Run
   def run_metric_attributes: (Riffer::Agent, String?) -> Hash[String, untyped]
 
   # --
-  # : (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Agent::Response) -> void
-  def record_run_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Agent::Response) -> void
+  # : (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Agent::Response) -> void
+  def record_run_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Agent::Response) -> void
 end

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -48,6 +48,6 @@ class Riffer::Guardrails::Runner
   # A block is a handled outcome, so its span status stays unset — an error
   # span status is reserved for a raised exception.
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Guardrails::Result) -> void
-  def record_guardrail_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Guardrails::Result) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Guardrails::Result) -> void
+  def record_guardrail_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Guardrails::Result) -> void
 end

--- a/sig/generated/riffer/metrics/no_op.rbs
+++ b/sig/generated/riffer/metrics/no_op.rbs
@@ -1,8 +1,8 @@
-# Generated from lib/riffer/metrics/null.rb with RBS::Inline
+# Generated from lib/riffer/metrics/no_op.rb with RBS::Inline
 
 # No-op metrics backend, used when the OpenTelemetry metrics API is unavailable
 # or metrics are disabled.
-module Riffer::Metrics::Null
+module Riffer::Metrics::NoOp
   # Ignores the measurement; there is no meter without the OTEL metrics API.
   # --
   # : (String, Numeric, unit: String?, description: String?, attributes: Hash[String, untyped]?) -> void

--- a/sig/generated/riffer/metrics/otel.rbs
+++ b/sig/generated/riffer/metrics/otel.rbs
@@ -8,7 +8,7 @@ class Riffer::Metrics::Otel
   SUPPORTED_API_VERSIONS: Gem::Requirement
 
   # Builds a backend when the OpenTelemetry metrics API is loadable at a
-  # supported version; returns +nil+ so resolution falls back to Null.
+  # supported version; returns +nil+ so resolution falls back to NoOp.
   # +provider+ defaults to the global <tt>OpenTelemetry.meter_provider</tt>.
   # --
   # : (?provider: untyped) -> Riffer::Metrics::Otel?

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -91,8 +91,8 @@ class Riffer::Providers::Base
   REQUEST_PARAM_ATTRIBUTES: Hash[Symbol, String]
 
   # --
-  # : [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
-  def in_chat_span: [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  # : [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
+  def in_chat_span: [R] (String?, Array[Riffer::Messages::Base], Hash[Symbol, untyped]) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
 
   # --
   # : (String?, Hash[Symbol, untyped]) -> Hash[String, untyped]
@@ -117,24 +117,24 @@ class Riffer::Providers::Base
   def record_cost_metric: (String?, Riffer::Providers::TokenUsage?) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Symbol?, String?) -> void
-  def record_finish_reason: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Symbol?, String?) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Symbol?, String?) -> void
+  def record_finish_reason: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Symbol?, String?) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tracing::StreamRecorder) -> void
-  def record_stream_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Tracing::StreamRecorder) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tracing::StreamRecorder) -> void
+  def record_stream_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Tracing::StreamRecorder) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Array[Riffer::Messages::Base]) -> void
-  def capture_input: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Array[Riffer::Messages::Base]) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Array[Riffer::Messages::Base]) -> void
+  def capture_input: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Array[Riffer::Messages::Base]) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
-  def capture_output: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
+  def capture_output: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, content: String?, tool_calls: Array[Riffer::Messages::Assistant::ToolCall], finish_reason: Symbol?) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
-  def capture_messages?: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> bool
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> bool
+  def capture_messages?: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> bool
 
   # --
   # : (Riffer::Providers::_EventSink, Riffer::Providers::FinishReason?) -> void

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -49,8 +49,8 @@ class Riffer::Tools::Runtime
 
   # Emitted outside +around_tool_call+ so host enrichment spans nest beneath it.
   # --
-  # : [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> R } -> R
-  def in_tool_span: [R] (Riffer::Messages::Assistant::ToolCall) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  # : [R] (Riffer::Messages::Assistant::ToolCall) { ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> R } -> R
+  def in_tool_span: [R] (Riffer::Messages::Assistant::ToolCall) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
 
   # --
   # : (Riffer::Messages::Assistant::ToolCall) -> Hash[String, untyped]
@@ -63,18 +63,18 @@ class Riffer::Tools::Runtime
   # A returned error Response is a handled outcome, so its status stays unset —
   # an error span status is reserved for a raised exception.
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
-  def record_tool_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Tools::Response) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
+  def record_tool_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Tools::Response) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Messages::Assistant::ToolCall) -> void
-  def capture_tool_arguments: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Messages::Assistant::ToolCall) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Messages::Assistant::ToolCall) -> void
+  def capture_tool_arguments: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Messages::Assistant::ToolCall) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Tools::Response) -> void
-  def capture_tool_result: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Tools::Response) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
+  def capture_tool_result: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Tools::Response) -> void
 
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span)) -> bool
-  def capture_tool_content?: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> bool
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span)) -> bool
+  def capture_tool_content?: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> bool
 end

--- a/sig/generated/riffer/tracing.rbs
+++ b/sig/generated/riffer/tracing.rbs
@@ -14,8 +14,8 @@ module Riffer::Tracing
 
   # Opens a span around the block, yielding the span.
   # --
-  # : [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
-  def in_span: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span) -> R } -> R
+  # : [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
+  def in_span: [R] (String, ?attributes: Hash[String, untyped]?, ?kind: Symbol) { (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span) -> R } -> R
 
   # Returns the active trace context, for re-attachment across fiber or
   # thread boundaries.
@@ -32,8 +32,8 @@ module Riffer::Tracing
   # Stamps token usage onto the span — the <tt>gen_ai.usage.*</tt> counts and,
   # when the model was priced, <tt>riffer.cost</tt>.
   # --
-  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span), Riffer::Providers::TokenUsage?) -> void
-  def record_usage: (Riffer::Tracing::Otel::Span | Riffer::Tracing::Null::Span, Riffer::Providers::TokenUsage?) -> void
+  # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Providers::TokenUsage?) -> void
+  def record_usage: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Providers::TokenUsage?) -> void
 
   # Discards the resolved backend so the next span re-resolves it.
   # --

--- a/sig/generated/riffer/tracing/no_op.rbs
+++ b/sig/generated/riffer/tracing/no_op.rbs
@@ -1,8 +1,8 @@
-# Generated from lib/riffer/tracing/null.rb with RBS::Inline
+# Generated from lib/riffer/tracing/no_op.rb with RBS::Inline
 
 # No-op tracing backend, used when OTEL is unavailable or tracing is
 # disabled.
-module Riffer::Tracing::Null
+module Riffer::Tracing::NoOp
   # No-op stand-in for a span; answers <tt>recording?</tt> with +false+ so
   # callers can skip expensive attribute serialization.
   class Span
@@ -27,12 +27,12 @@ module Riffer::Tracing::Null
     def recording?: () -> bool
   end
 
-  SPAN: Riffer::Tracing::Null::Span
+  SPAN: Riffer::Tracing::NoOp::Span
 
   # Yields the no-op span, ignoring all span options.
   # --
-  # : [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
-  def in_span: [R] (String, **untyped) { (Riffer::Tracing::Null::Span) -> R } -> R
+  # : [R] (String, **untyped) { (Riffer::Tracing::NoOp::Span) -> R } -> R
+  def in_span: [R] (String, **untyped) { (Riffer::Tracing::NoOp::Span) -> R } -> R
 
   # Returns +nil+; there is no trace context without OTEL.
   # --

--- a/sig/generated/riffer/tracing/otel.rbs
+++ b/sig/generated/riffer/tracing/otel.rbs
@@ -39,7 +39,7 @@ class Riffer::Tracing::Otel
   end
 
   # Builds a backend when the OpenTelemetry API is loadable at a supported
-  # version; returns +nil+ so resolution falls back to Null. +provider+
+  # version; returns +nil+ so resolution falls back to NoOp. +provider+
   # defaults to the global <tt>OpenTelemetry.tracer_provider</tt>.
   # --
   # : (?provider: untyped) -> Riffer::Tracing::Otel?

--- a/sig/manual/riffer/metrics/no_op.rbs
+++ b/sig/manual/riffer/metrics/no_op.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Metrics::NoOp` uses `extend self`; rbs-inline doesn't emit that, so
+# re-extend here to expose its instance methods as singleton methods.
+module Riffer::Metrics::NoOp
+  extend ::Riffer::Metrics::NoOp
+end

--- a/sig/manual/riffer/metrics/null.rbs
+++ b/sig/manual/riffer/metrics/null.rbs
@@ -1,5 +1,0 @@
-# `Riffer::Metrics::Null` uses `extend self`; rbs-inline doesn't emit that, so
-# re-extend here to expose its instance methods as singleton methods.
-module Riffer::Metrics::Null
-  extend ::Riffer::Metrics::Null
-end

--- a/sig/manual/riffer/tracing/no_op.rbs
+++ b/sig/manual/riffer/tracing/no_op.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Tracing::NoOp` uses `extend self`; rbs-inline doesn't emit that, so
+# re-extend here to expose its instance methods as singleton methods.
+module Riffer::Tracing::NoOp
+  extend ::Riffer::Tracing::NoOp
+end

--- a/sig/manual/riffer/tracing/null.rbs
+++ b/sig/manual/riffer/tracing/null.rbs
@@ -1,5 +1,0 @@
-# `Riffer::Tracing::Null` uses `extend self`; rbs-inline doesn't emit that, so
-# re-extend here to expose its instance methods as singleton methods.
-module Riffer::Tracing::Null
-  extend ::Riffer::Tracing::Null
-end

--- a/test/riffer/metrics/no_op_test.rb
+++ b/test/riffer/metrics/no_op_test.rb
@@ -2,10 +2,10 @@
 
 require "test_helper"
 
-describe Riffer::Metrics::Null do
+describe Riffer::Metrics::NoOp do
   describe "#record_histogram" do
     it "ignores the measurement without error" do
-      result = Riffer::Metrics::Null.record_histogram("riffer.test", 0.5, unit: "s", description: "d", attributes: {"k" => "v"})
+      result = Riffer::Metrics::NoOp.record_histogram("riffer.test", 0.5, unit: "s", description: "d", attributes: {"k" => "v"})
       expect(result).must_be_nil
     end
   end

--- a/test/riffer/tracing/no_op_test.rb
+++ b/test/riffer/tracing/no_op_test.rb
@@ -2,49 +2,49 @@
 
 require "test_helper"
 
-describe Riffer::Tracing::Null do
+describe Riffer::Tracing::NoOp do
   describe "#in_span" do
-    it "yields the frozen null span" do
+    it "yields the frozen no-op span" do
       yielded = nil
-      Riffer::Tracing::Null.in_span("test") { |span| yielded = span }
-      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+      Riffer::Tracing::NoOp.in_span("test") { |span| yielded = span }
+      expect(yielded).must_be_same_as Riffer::Tracing::NoOp::SPAN
     end
 
     it "returns the block's value" do
-      result = Riffer::Tracing::Null.in_span("test") { :value }
+      result = Riffer::Tracing::NoOp.in_span("test") { :value }
       expect(result).must_equal :value
     end
 
     it "ignores span options" do
-      result = Riffer::Tracing::Null.in_span("test", attributes: {"key" => "value"}, kind: :client) { :value }
+      result = Riffer::Tracing::NoOp.in_span("test", attributes: {"key" => "value"}, kind: :client) { :value }
       expect(result).must_equal :value
     end
   end
 
   describe "#current_context" do
     it "returns nil" do
-      expect(Riffer::Tracing::Null.current_context).must_be_nil
+      expect(Riffer::Tracing::NoOp.current_context).must_be_nil
     end
   end
 
   describe "#with_context" do
     it "returns the block's value" do
-      result = Riffer::Tracing::Null.with_context(nil) { :value }
+      result = Riffer::Tracing::NoOp.with_context(nil) { :value }
       expect(result).must_equal :value
     end
   end
 
   describe "SPAN" do
     it "is frozen" do
-      expect(Riffer::Tracing::Null::SPAN).must_be :frozen?
+      expect(Riffer::Tracing::NoOp::SPAN).must_be :frozen?
     end
 
     it "is not recording" do
-      expect(Riffer::Tracing::Null::SPAN.recording?).must_equal false
+      expect(Riffer::Tracing::NoOp::SPAN.recording?).must_equal false
     end
 
     it "accepts every span operation without error" do
-      span = Riffer::Tracing::Null::SPAN
+      span = Riffer::Tracing::NoOp::SPAN
       span.set_attribute("key", "value")
       span.add_event("event", attributes: {"key" => "value"})
       span.record_exception(Riffer::Error.new("boom"))

--- a/test/riffer/tracing_test.rb
+++ b/test/riffer/tracing_test.rb
@@ -52,17 +52,17 @@ describe Riffer::Tracing do
       expect(result).must_equal :value
     end
 
-    it "yields the null span when tracing is disabled" do
+    it "yields the no-op span when tracing is disabled" do
       Riffer.config.tracing.enabled = false
       yielded = nil
       Riffer::Tracing.in_span("test") { |span| yielded = span }
-      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+      expect(yielded).must_be_same_as Riffer::Tracing::NoOp::SPAN
     end
 
-    it "yields the null span when no backend is configured" do
+    it "yields the no-op span when no backend is configured" do
       yielded = nil
       Riffer::Tracing.in_span("test") { |span| yielded = span }
-      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+      expect(yielded).must_be_same_as Riffer::Tracing::NoOp::SPAN
     end
 
     it "exports a span with the given name" do
@@ -283,13 +283,13 @@ describe Riffer::Tracing do
       expect(backend.context_calls).must_equal 1
     end
 
-    it "yields the null span when tracing is disabled, bypassing the backend" do
+    it "yields the no-op span when tracing is disabled, bypassing the backend" do
       backend = FakeTracingBackend.new
       Riffer.config.tracing.backend = backend
       Riffer.config.tracing.enabled = false
       yielded = nil
       Riffer::Tracing.in_span("custom") { |span| yielded = span }
-      expect(yielded).must_be_same_as Riffer::Tracing::Null::SPAN
+      expect(yielded).must_be_same_as Riffer::Tracing::NoOp::SPAN
     end
   end
 


### PR DESCRIPTION
## Problem

The no-op fallback telemetry backends are named `Riffer::Tracing::Null` and `Riffer::Metrics::Null` — the backends a port resolves to when no backend is configured, and the ones the docs hold up as the reference shape for the duck-typed backend/span contract. The `Null` name reads ambiguously: it can look like a built-in null/absence rather than a deliberate no-op stand-in. Worth tidying while the surface is still settling.

## Solution

Rename both to `NoOp`, which states the behaviour. Cosmetic only — no behaviour change.

The rename covers the modules, the inner `Span` class, the frozen `SPAN` constant, the resolution fallbacks in `tracing.rb`/`metrics.rb`, and the `Metrics.recording?` identity check. Because Zeitwerk requires the file path to match the constant, the source files move `null.rb` → `no_op.rb`, along with the matching `sig/generated/`, `sig/manual/`, and `test/` paths. RBS signatures were regenerated, and the docs that name these as the contract reference (`docs/16_TRACING.md`, `docs/17_METRICS.md`) are updated. `docs/10_CONFIGURATION.md` only uses descriptive "no-op" prose and never named the constant, so it needed no change.

## Proof

CI is sufficient. The full `bin/rake` gate is green:

- **Tests**: 2084 runs, 0 failures, 0 errors (4 pre-existing OTEL-not-bundled skips)
- **Steep**: no type errors
- **Standard**: clean

RBS was regenerated with `bin/rbs`, and a repo-wide grep confirms no `Tracing::Null` / `Metrics::Null` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal module naming and type signatures across tracing and metrics backends to improve consistency.
  * Revised type annotations in RBS signature files and inline documentation to reflect naming updates.
  * Updated test files to align with refactored backend modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->