### PR TITLE
feat: emit a riffer.guardrail.duration metric for guardrail execution

### DIFF
--- a/docs/17_METRICS.md
+++ b/docs/17_METRICS.md
@@ -43,7 +43,7 @@ Riffer.configure do |config|
 end
 ```
 
-The backend is duck-typed: any object that responds to `record_histogram(name, value, unit:, description:, attributes:)` works, and the setter validates only that (otherwise it raises `Riffer::ArgumentError`). `Riffer::Metrics::NoOp` is the reference shape. All three instruments are histograms, so the single `record_histogram` method covers the full contract; tell them apart by `name` (or by `unit`: `s` for `gen_ai.client.operation.duration`, `{token}` for `gen_ai.client.token.usage`, `USD` for `riffer.gen_ai.cost`).
+The backend is duck-typed: any object that responds to `record_histogram(name, value, unit:, description:, attributes:)` works, and the setter validates only that (otherwise it raises `Riffer::ArgumentError`). `Riffer::Metrics::NoOp` is the reference shape. All four instruments are histograms, so the single `record_histogram` method covers the full contract; tell them apart by `name`. Two carry unit `s` — `gen_ai.client.operation.duration` and `riffer.guardrail.duration` — so `name` is the reliable discriminator; `{token}` is `gen_ai.client.token.usage` and `USD` is `riffer.gen_ai.cost`.
 
 A custom backend counts as a **live** sink, so the providers still compute the token counts and cost that feed it — the same data that, under OTEL, populates `gen_ai.client.token.usage` and `riffer.gen_ai.cost`. The `enabled` kill switch is honoured ahead of the backend: with `config.metrics.enabled = false`, measurements short-circuit to the no-op without ever reaching a custom backend.
 
@@ -116,6 +116,18 @@ Histogram, unit `USD`. The cost of a single `chat` call, recorded from the [cost
 Pricing is **consumer-configured** — no price table ships with the gem (see [Configuration — Pricing](10_CONFIGURATION.md#pricing)). A call whose model has no configured price records **no** data point, so this metric covers only priced calls; `operation.duration` and `token.usage` still record. A priced call that computes to `0.0` does record a zero data point — only an absent price means there is nothing to measure.
 
 > **Per-call only.** Cost is never recorded at the run (`invoke_agent`) level, for the same reason as token usage: metrics pre-aggregate, so emitting both per-call points and a run total would double-count. Sum the per-call points in your backend for a run total.
+
+### `riffer.guardrail.duration`
+
+Histogram, unit `s`. The latency of a single guardrail execution, recorded around the same wrap as the [`execute_guardrail` span](16_TRACING.md) on both the success and raise paths and timed with a monotonic clock. Guardrails run on the request hot path — before every model turn and after every response — so this is the guardrail counterpart to `gen_ai.client.operation.duration`. Recording is independent of tracing — the metric fires even with `config.tracing.enabled = false`.
+
+This instrument is Riffer-owned (`riffer.*`, not `gen_ai.*`) by the same reasoning as its span: a guardrail is not a GenAI semantic-convention operation, so the `execute_guardrail` span deliberately carries no `gen_ai.operation.name` and lives in riffer's own `riffer.guardrail.*` namespace (see [Tracing](16_TRACING.md)). Folding the metric into `gen_ai.client.operation.duration` would contradict that, so the duration is its own riffer-owned histogram instead; see [Stability](#stability).
+
+| Value                                | Attributes                                                            |
+| ------------------------------------ | --------------------------------------------------------------------- |
+| duration of the guardrail execution  | `riffer.guardrail.name`, `riffer.guardrail.phase`, `error.type` (on raise) |
+
+`riffer.guardrail.phase` is `before` or `after`. A pass, transform, or block is a **handled** outcome and records no `error.type` — that attribute carries the exception class only when a guardrail raises, mirroring the span. One time series exists per `riffer.guardrail.name` × `riffer.guardrail.phase`; guardrail names are bounded by the guardrails you configure, so cardinality is safe — unlike the dynamic tool names on `gen_ai.client.operation.duration`.
 
 ## Stability
 

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -81,9 +81,7 @@ class Riffer::Guardrails::Runner
   #--
   #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail(guardrail, data, messages:)
-    start = Riffer::Metrics.monotonic_now
-    error_type = nil #: String?
-    begin
+    instrument_guardrail(guardrail) do
       Riffer::Tracing.in_span("execute_guardrail #{guardrail.name}", attributes: guardrail_span_attributes(guardrail), kind: :internal) do |span|
         result = run_guardrail_phase(guardrail, data, messages: messages)
         record_guardrail_outcome(span, result)
@@ -94,9 +92,17 @@ class Riffer::Guardrails::Runner
         span.set_attribute("error.type", error.class.name)
         raise
       end
+    end
+  end
+
+  #--
+  #: (Riffer::Guardrail) { () -> Riffer::Guardrails::Result } -> Riffer::Guardrails::Result
+  def instrument_guardrail(guardrail)
+    start = Riffer::Metrics.monotonic_now
+    error_type = nil #: String?
+    begin
+      yield
     rescue => error
-      # The inner rescue tags the span; capture error.type here too, at method
-      # scope, where the ensure can read it onto the metric.
       error_type = error.class.name #: String?
       raise
     ensure

--- a/lib/riffer/guardrails/runner.rb
+++ b/lib/riffer/guardrails/runner.rb
@@ -81,15 +81,26 @@ class Riffer::Guardrails::Runner
   #--
   #: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def execute_guardrail(guardrail, data, messages:)
-    Riffer::Tracing.in_span("execute_guardrail #{guardrail.name}", attributes: guardrail_span_attributes(guardrail), kind: :internal) do |span|
-      result = run_guardrail_phase(guardrail, data, messages: messages)
-      record_guardrail_outcome(span, result)
-      result
+    start = Riffer::Metrics.monotonic_now
+    error_type = nil #: String?
+    begin
+      Riffer::Tracing.in_span("execute_guardrail #{guardrail.name}", attributes: guardrail_span_attributes(guardrail), kind: :internal) do |span|
+        result = run_guardrail_phase(guardrail, data, messages: messages)
+        record_guardrail_outcome(span, result)
+        result
+      rescue => error
+        # The backend records the exception and error status on the re-raise;
+        # error.type is the one semconv attribute it doesn't set.
+        span.set_attribute("error.type", error.class.name)
+        raise
+      end
     rescue => error
-      # The backend records the exception and error status on the re-raise;
-      # error.type is the one semconv attribute it doesn't set.
-      span.set_attribute("error.type", error.class.name)
+      # The inner rescue tags the span; capture error.type here too, at method
+      # scope, where the ensure can read it onto the metric.
+      error_type = error.class.name #: String?
       raise
+    ensure
+      Riffer::Metrics::Instruments::GUARDRAIL_DURATION.record(Riffer::Metrics.monotonic_now - start, attributes: guardrail_metric_attributes(guardrail, error_type))
     end
   end
 
@@ -113,6 +124,14 @@ class Riffer::Guardrails::Runner
       "riffer.guardrail.name" => guardrail.name,
       "riffer.guardrail.phase" => phase.to_s
     }
+  end
+
+  #--
+  #: (Riffer::Guardrail, String?) -> Hash[String, untyped]
+  def guardrail_metric_attributes(guardrail, error_type)
+    attributes = guardrail_span_attributes(guardrail)
+    attributes["error.type"] = error_type if error_type
+    attributes
   end
 
   # A block is a handled outcome, so its span status stays unset — an error

--- a/lib/riffer/metrics/instruments.rb
+++ b/lib/riffer/metrics/instruments.rb
@@ -22,4 +22,10 @@ module Riffer::Metrics::Instruments # :nodoc: all
     unit: "USD",
     description: "Cost of GenAI client operations in USD"
   ) #: Riffer::Metrics::Histogram
+
+  GUARDRAIL_DURATION = Riffer::Metrics.create_histogram(
+    "riffer.guardrail.duration",
+    unit: "s",
+    description: "Duration of guardrail execution"
+  ) #: Riffer::Metrics::Histogram
 end

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -45,6 +45,10 @@ class Riffer::Guardrails::Runner
   # : (Riffer::Guardrail) -> Hash[String, untyped]
   def guardrail_span_attributes: (Riffer::Guardrail) -> Hash[String, untyped]
 
+  # --
+  # : (Riffer::Guardrail, String?) -> Hash[String, untyped]
+  def guardrail_metric_attributes: (Riffer::Guardrail, String?) -> Hash[String, untyped]
+
   # A block is a handled outcome, so its span status stays unset — an error
   # span status is reserved for a raised exception.
   # --

--- a/sig/generated/riffer/guardrails/runner.rbs
+++ b/sig/generated/riffer/guardrails/runner.rbs
@@ -38,6 +38,10 @@ class Riffer::Guardrails::Runner
   def execute_guardrail: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
 
   # --
+  # : (Riffer::Guardrail) { () -> Riffer::Guardrails::Result } -> Riffer::Guardrails::Result
+  def instrument_guardrail: (Riffer::Guardrail) { () -> Riffer::Guardrails::Result } -> Riffer::Guardrails::Result
+
+  # --
   # : (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
   def run_guardrail_phase: (Riffer::Guardrail, untyped, messages: Array[Riffer::Messages::Base]?) -> Riffer::Guardrails::Result
 

--- a/sig/generated/riffer/metrics/instruments.rbs
+++ b/sig/generated/riffer/metrics/instruments.rbs
@@ -10,4 +10,6 @@ module Riffer::Metrics::Instruments
   TOKEN_USAGE: Riffer::Metrics::Histogram
 
   COST: Riffer::Metrics::Histogram
+
+  GUARDRAIL_DURATION: Riffer::Metrics::Histogram
 end

--- a/test/riffer/guardrails/runner_test.rb
+++ b/test/riffer/guardrails/runner_test.rb
@@ -313,4 +313,85 @@ describe Riffer::Guardrails::Runner do
       expect(modifications.first.message_indices).must_equal [0]
     end
   end
+
+  describe "metrics" do
+    before do
+      skip "opentelemetry metrics is not bundled" unless METRICS_SDK_AVAILABLE
+      Riffer.config.metrics.enabled = true
+      @exporter = install_in_memory_meter_provider
+    end
+
+    after do
+      Riffer.config.metrics.enabled = true
+      Riffer.config.metrics.backend = nil
+    end
+
+    let(:named_pass_guardrail_class) do
+      Class.new(Riffer::Guardrail) do
+        def name
+          "metrics_guardrail"
+        end
+
+        def process_input(messages, context:)
+          pass(messages)
+        end
+      end
+    end
+
+    let(:raising_guardrail_class) do
+      Class.new(Riffer::Guardrail) do
+        def process_input(messages, context:)
+          raise "guardrail boom"
+        end
+      end
+    end
+
+    def duration_data_points
+      @exporter.pull
+      snapshot = @exporter.metric_snapshots.find { |s| s.name == "riffer.guardrail.duration" }
+      snapshot ? snapshot.data_points : []
+    end
+
+    it "records a duration data point when a guardrail passes" do
+      runner = Riffer::Guardrails::Runner.new([config_for(pass_guardrail_class)], phase: :before)
+      runner.run([Riffer::Messages::User.new("Hello")])
+      expect(duration_data_points.length).must_equal 1
+    end
+
+    it "records the guardrail name and phase attributes" do
+      runner = Riffer::Guardrails::Runner.new([config_for(named_pass_guardrail_class)], phase: :before)
+      runner.run([Riffer::Messages::User.new("Hello")])
+      expect(duration_data_points.first.attributes).must_equal({
+        "riffer.guardrail.name" => "metrics_guardrail",
+        "riffer.guardrail.phase" => "before"
+      })
+    end
+
+    it "records a data point when a guardrail transforms" do
+      runner = Riffer::Guardrails::Runner.new([config_for(transform_guardrail_class)], phase: :before)
+      runner.run([Riffer::Messages::User.new("Hello")])
+      expect(duration_data_points.length).must_equal 1
+    end
+
+    it "records a data point when a guardrail blocks" do
+      runner = Riffer::Guardrails::Runner.new([config_for(block_guardrail_class)], phase: :before)
+      runner.run([Riffer::Messages::User.new("Hello")])
+      expect(duration_data_points.length).must_equal 1
+    end
+
+    it "omits error.type on a handled outcome" do
+      runner = Riffer::Guardrails::Runner.new([config_for(block_guardrail_class)], phase: :before)
+      runner.run([Riffer::Messages::User.new("Hello")])
+      expect(duration_data_points.first.attributes).wont_include "error.type"
+    end
+
+    it "records error.type when a guardrail raises" do
+      runner = Riffer::Guardrails::Runner.new([config_for(raising_guardrail_class)], phase: :before)
+      begin
+        runner.run([Riffer::Messages::User.new("Hello")])
+      rescue RuntimeError
+      end
+      expect(duration_data_points.first.attributes["error.type"]).must_equal "RuntimeError"
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The metrics port records `gen_ai.client.operation.duration` for three operations — `chat`, `invoke_agent`, and `execute_tool` — but not for guardrails. `Riffer::Guardrails::Runner#execute_guardrail` already opens an `execute_guardrail` span, yet records no metric, so guardrail latency is invisible to any metrics backend (OTEL or a custom non-OTEL sink). Guardrails run on the request hot path — before every model turn and after every response — so their cost is worth measuring. This adds the metrics-side counterpart to the existing `execute_guardrail` span.

## Solution

Add a new histogram `riffer.guardrail.duration` (unit `s`) to `Riffer::Metrics::Instruments` and record it around `execute_guardrail`, timed with `Riffer::Metrics.monotonic_now`, on both the success and raise paths — the same `begin/rescue/ensure` wrap used by the `chat` and `execute_tool` duration metrics.

The instrument is deliberately **riffer-owned** (`riffer.*`) rather than folded into `gen_ai.client.operation.duration`. A guardrail is not a GenAI semantic-convention operation, so the `execute_guardrail` span carries no `gen_ai.operation.name` and lives in riffer's own `riffer.guardrail.*` namespace; reusing the GenAI duration instrument with a squatted operation name would contradict that. Keeping it riffer-owned also means it won't collide if the semantic conventions later define an equivalent.

Attributes mirror the span: `riffer.guardrail.name`, `riffer.guardrail.phase`, and `error.type` on a raise. A pass, transform, or block is a handled outcome and records no `error.type`. Guardrail names are bounded by the configured guardrails, so cardinality is safe — unlike dynamic tool names. Recording stays independent of tracing, firing even with `config.tracing.enabled = false`.

One judgment call: `guardrail_metric_attributes` reuses `guardrail_span_attributes` as its base rather than duplicating the keys (unlike `providers/base.rb`, which keeps a separate base because its chat span carries extra request params the metric must not have). For guardrails the span and metric attribute sets are identical, so reuse is correct; if a span-only attribute is ever added, that would need revisiting.

## Proof

CI is sufficient. New Minitest coverage in `test/riffer/guardrails/runner_test.rb` asserts a duration data point is recorded on pass, transform, and block (with no `error.type`), and that `error.type` is recorded on a raise, plus the name/phase attributes — using the same in-memory meter-provider pull exporter as the existing `execute_tool` metric tests. RBS signatures were regenerated (`bin/rbs`) and the full gate (`bin/rake`: test + standard + steep:check) is green: 2090 runs, 0 failures, 0 errors. The instrument and its attributes are documented in `docs/17_METRICS.md` with the `riffer.*` stability tier noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `riffer.guardrail.duration` histogram to measure guardrail execution latency (seconds) across outcomes.
  * Duration metrics include guardrail name and phase (`before`/`after`).
* **Bug Fixes**
  * Guardrail duration metric attributes now include `error.type` when a guardrail raises (absent when errors are handled).
* **Documentation**
  * Updated the non-OpenTelemetry metrics contract to describe the new instrument, attributes, and expected units.
* **Tests**
  * Added tests validating duration recording for pass/transform/block and correct `error.type` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->