### PR TITLE
feat: add Provider#pricing_key override for stable pricing lookup

### DIFF
--- a/docs/10_CONFIGURATION.md
+++ b/docs/10_CONFIGURATION.md
@@ -153,6 +153,8 @@ cost = (input − cache_read − cache_write) × input_rate
 
 (all rates ÷ 1,000,000; an unset cache rate falls back to `input_rate`.) Cost is for observability, not billing — it's a `Float`, and sub-cent rounding can accumulate over a long run. See [Messages → Token Usage Semantics](08_MESSAGES.md#token-usage-semantics) for how cost surfaces and aggregates.
 
+The lookup key defaults to the declared `provider/model` id — the provider's registry name joined to the model you passed. A provider can override `Riffer::Providers::Base#pricing_key(model)` to return a different id, which is what a routing provider that delegates to different backends does: it returns one stable declared name so consumers register rates once instead of against whichever backend happened to execute.
+
 ### Message ID Strategy
 
 Opt in to stable identifiers on every message for logging, persistence, or replay:

--- a/docs/providers/07_CUSTOM_PROVIDERS.md
+++ b/docs/providers/07_CUSTOM_PROVIDERS.md
@@ -285,6 +285,16 @@ def self.semconv_provider_name
 end
 ```
 
+## Pricing Key
+
+[Pricing](../10_CONFIGURATION.md#pricing) rates are looked up by the `provider/model` id returned from `pricing_key`, which defaults to your registry name joined to the model. Override it when your provider routes to different backends, so it reports one stable declared id and consumers register rates once rather than against whichever backend executed:
+
+```ruby
+def pricing_key(model)
+  "my_provider/#{model}"
+end
+```
+
 ## Error Handling
 
 Raise appropriate Riffer errors:

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -171,10 +171,22 @@ class Riffer::Providers::Base
     pricing = Riffer.config.pricing
     return nil if pricing.empty?
 
+    key = pricing_key(model)
+    return nil unless key
+
+    pricing.rates_for(key)
+  end
+
+  # An override seam: a routing provider that delegates to different backends
+  # overrides this to return a stable declared id, so consumers register rates
+  # once rather than against whichever backend happened to execute.
+  #--
+  #: (String) -> String?
+  def pricing_key(model)
     key = Riffer::Providers::Repository.key_for(self.class)
     return nil unless key
 
-    pricing.rates_for("#{key}/#{model}")
+    "#{key}/#{model}"
   end
 
   # Defaults to nil rather than raising — finish reasons are optional, so

--- a/sig/generated/riffer/providers/base.rbs
+++ b/sig/generated/riffer/providers/base.rbs
@@ -73,6 +73,13 @@ class Riffer::Providers::Base
   # : () -> Riffer::Config::Pricing::Rates?
   def pricing_rates: () -> Riffer::Config::Pricing::Rates?
 
+  # An override seam: a routing provider that delegates to different backends
+  # overrides this to return a stable declared id, so consumers register rates
+  # once rather than against whichever backend happened to execute.
+  # --
+  # : (String) -> String?
+  def pricing_key: (String) -> String?
+
   # Defaults to nil rather than raising — finish reasons are optional, so
   # providers that don't report one stay valid.
   # --

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -19,6 +19,14 @@ class ChatTracingExplodingProvider < Riffer::Providers::Mock
   end
 end
 
+class DeclaredKeyProvider < Riffer::Providers::Mock
+  private
+
+  def pricing_key(model)
+    "jane/#{model}"
+  end
+end
+
 describe Riffer::Providers::Base do
   let(:provider) { Riffer::Providers::Base.new }
 
@@ -39,6 +47,19 @@ describe Riffer::Providers::Base do
 
     it "falls back to unknown for anonymous classes" do
       expect(Class.new(Riffer::Providers::Base).semconv_provider_name).must_equal "unknown"
+    end
+  end
+
+  describe "#pricing_key" do
+    before { Riffer.instance_variable_set(:@config, Riffer::Config.new) }
+    after { Riffer.instance_variable_set(:@config, Riffer::Config.new) }
+
+    it "resolves rates against the overridden declared id, independent of the concrete class" do
+      Riffer.config.pricing.set("jane/claude-sonnet-4-6", input: 3.0, output: 15.0)
+      provider = DeclaredKeyProvider.new
+      provider.stub_response("hi", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 1_000_000, output_tokens: 1_000_000))
+      message = provider.generate_text(prompt: "x", model: "claude-sonnet-4-6")
+      expect(message.token_usage.cost).must_equal 18.0
     end
   end
 


### PR DESCRIPTION
## Problem

Riffer computes token cost inside the concrete provider (`Base#apply_pricing` → `pricing_rates`), keying the lookup on the resolved provider class: `"#{Repository.key_for(self.class)}/#{@current_model}"`. For a plain provider this is fine, but for a routing provider that delegates to an inner Anthropic/Bedrock/etc. instance, the key becomes whichever backend actually ran — so the same logical model is priced under different keys per environment (`anthropic/claude-sonnet-4-6` in one, `amazon_bedrock/us.anthropic.claude-sonnet-4-6-v1:0` in another). Consumers had to recompute and register a separate pricing entry per environment, and could never register rates once against the stable name they declared on the agent (e.g. `jane/claude-sonnet-4-6`).

`Config::Pricing#set`/`#rates_for` already accept arbitrary `provider/model` strings; the gap was purely that the lookup key was derived from the concrete class rather than from what the agent declared.

## Solution

Extract the pricing-key derivation from `pricing_rates` into a new overridable seam, `Riffer::Providers::Base#pricing_key(model)`. The default implementation reproduces today's behavior exactly (`"#{Repository.key_for(self.class)}/#{model}"`, `nil` when the class is unregistered), so existing providers are byte-for-byte unchanged. A routing provider overrides `pricing_key` to return one stable declared id regardless of which backend executes, letting consumers register a model's rates once, environment-independently.

Includes regenerated RBS signatures and doc notes in `docs/10_CONFIGURATION.md` (Pricing) and `docs/providers/07_CUSTOM_PROVIDERS.md`.

## Proof

CI covers it: added a `#pricing_key` spec in `test/riffer/providers/base_test.rb` proving a provider whose `pricing_key` override returns a stable id (`jane/…`) resolves rates against that id even though its concrete class is not registered under `jane`. Existing default-key pricing tests in `mock_test.rb` continue to pass. `bin/rake` (test + standard + steep:check) is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)