### PR TITLE
feat(providers): first-class provider registration API

### DIFF
--- a/docs/providers/07_CUSTOM_PROVIDERS.md
+++ b/docs/providers/07_CUSTOM_PROVIDERS.md
@@ -137,30 +137,13 @@ end
 
 ## Registering Your Provider
 
-Add your provider to the repository:
+Register your provider under an identifier — from an initializer or anywhere during boot:
 
 ```ruby
-# In lib/riffer/providers/repository.rb or your own code
-
-Riffer::Providers::Repository::REPO[:my_provider] = -> { Riffer::Providers::MyProvider }
+Riffer::Providers::Repository.register(:my_provider) { Riffer::Providers::MyProvider }
 ```
 
-Or create a custom repository:
-
-```ruby
-module MyApp
-  module Providers
-    def self.find(identifier)
-      case identifier.to_sym
-      when :my_provider
-        Riffer::Providers::MyProvider
-      else
-        Riffer::Providers::Repository.find(identifier)
-      end
-    end
-  end
-end
-```
+The block resolves the provider class lazily, so it need not be loaded at registration time. Registration is idempotent — re-registering the same identifier replaces the previous factory — and a custom registration takes precedence over a built-in sharing the identifier, which lets you route an existing prefix (e.g. `openai`) through your own backend. Both `find` and `key_for` (used for pricing and observability keys) honor the registration. Remove one with `Riffer::Providers::Repository.unregister(:my_provider)`.
 
 ## Using Your Provider
 

--- a/docs/providers/07_CUSTOM_PROVIDERS.md
+++ b/docs/providers/07_CUSTOM_PROVIDERS.md
@@ -137,13 +137,15 @@ end
 
 ## Registering Your Provider
 
-Register your provider under an identifier — from an initializer or anywhere during boot:
+Register your provider under an identifier.
 
 ```ruby
 Riffer::Providers::Repository.register(:my_provider) { Riffer::Providers::MyProvider }
 ```
 
 The block resolves the provider class lazily, so it need not be loaded at registration time. Registration is idempotent — re-registering the same identifier replaces the previous factory — and a custom registration takes precedence over a built-in sharing the identifier, which lets you route an existing prefix (e.g. `openai`) through your own backend. Both `find` and `key_for` (used for pricing and observability keys) honor the registration. Remove one with `Riffer::Providers::Repository.unregister(:my_provider)`.
+
+Register during application boot — from a Rails initializer or equivalent — before you start handling requests. The registry is not synchronized for concurrent mutation, so treat registration as a one-time setup step rather than something you do from a live request path.
 
 ## Using Your Provider
 

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -2,11 +2,11 @@
 # rbs_inline: enabled
 
 # Resolves provider classes by identifier, combining the built-in REPO with
-# consumer registrations added through +register+.
+# consumer registrations added through +register+. Registration is not
+# synchronized — register during boot, before concurrent generation begins.
 module Riffer::Providers::Repository
   extend self
 
-  # @rbs @mutex: Thread::Mutex
   # @rbs @registrations: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
   # @rbs @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
 
@@ -20,13 +20,10 @@ module Riffer::Providers::Repository
     mock: -> { Riffer::Providers::Mock }
   }.freeze #: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
-  @mutex = Mutex.new
   @registrations = {} #: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
-  # Registers a custom provider under +identifier+, resolved lazily by the
-  # block so the provider class need not be loaded at registration time. Takes
-  # precedence over a built-in sharing the identifier, and is idempotent —
-  # re-registering an identifier replaces the previous factory.
+  # Registers a custom provider under +identifier+, resolved lazily by the block.
+  # Takes precedence over a built-in sharing the identifier.
   #
   #   Riffer::Providers::Repository.register(:jane) { MyApp::JaneProvider }
   #
@@ -37,10 +34,8 @@ module Riffer::Providers::Repository
   def register(identifier, &factory)
     raise Riffer::ArgumentError, "register requires a block returning a provider class" unless factory
 
-    @mutex.synchronize do
-      @registrations[identifier.to_sym] = factory
-      @key_for = nil
-    end
+    @registrations[identifier.to_sym] = factory
+    @key_for = nil
   end
 
   # Removes a custom registration by identifier, leaving any built-in of the
@@ -48,10 +43,8 @@ module Riffer::Providers::Repository
   #--
   #: ((String | Symbol)) -> void
   def unregister(identifier)
-    @mutex.synchronize do
-      @registrations.delete(identifier.to_sym)
-      @key_for = nil
-    end
+    @registrations.delete(identifier.to_sym)
+    @key_for = nil
   end
 
   # Finds a provider class by identifier, preferring a custom registration over
@@ -61,15 +54,14 @@ module Riffer::Providers::Repository
   #: ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def find(identifier)
     key = identifier.to_sym
-    factory = @mutex.synchronize { @registrations[key] } || REPO[key]
-    factory&.call
+    (@registrations[key] || REPO[key])&.call
   end
 
   # Returns the registry identifier for a provider class, or nil when unregistered.
   #--
   #: (singleton(Riffer::Providers::Base)) -> Symbol?
   def key_for(provider_class)
-    @mutex.synchronize { @key_for ||= build_key_index }[provider_class]
+    (@key_for ||= build_key_index)[provider_class]
   end
 
   private

--- a/lib/riffer/providers/repository.rb
+++ b/lib/riffer/providers/repository.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Registry for finding provider classes by identifier.
+# Resolves provider classes by identifier, combining the built-in REPO with
+# consumer registrations added through +register+.
 module Riffer::Providers::Repository
   extend self
 
+  # @rbs @mutex: Thread::Mutex
+  # @rbs @registrations: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
   # @rbs @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
 
   REPO = {
@@ -17,18 +20,63 @@ module Riffer::Providers::Repository
     mock: -> { Riffer::Providers::Mock }
   }.freeze #: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
-  # Finds a provider class by identifier.
+  @mutex = Mutex.new
+  @registrations = {} #: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
+
+  # Registers a custom provider under +identifier+, resolved lazily by the
+  # block so the provider class need not be loaded at registration time. Takes
+  # precedence over a built-in sharing the identifier, and is idempotent —
+  # re-registering an identifier replaces the previous factory.
+  #
+  #   Riffer::Providers::Repository.register(:jane) { MyApp::JaneProvider }
+  #
+  # Raises Riffer::ArgumentError when called without a block.
+  #
+  #--
+  #: ((String | Symbol)) { () -> singleton(Riffer::Providers::Base) } -> void
+  def register(identifier, &factory)
+    raise Riffer::ArgumentError, "register requires a block returning a provider class" unless factory
+
+    @mutex.synchronize do
+      @registrations[identifier.to_sym] = factory
+      @key_for = nil
+    end
+  end
+
+  # Removes a custom registration by identifier, leaving any built-in of the
+  # same name intact.
+  #--
+  #: ((String | Symbol)) -> void
+  def unregister(identifier)
+    @mutex.synchronize do
+      @registrations.delete(identifier.to_sym)
+      @key_for = nil
+    end
+  end
+
+  # Finds a provider class by identifier, preferring a custom registration over
+  # a built-in of the same name.
   #
   #--
   #: ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
   def find(identifier)
-    REPO.fetch(identifier.to_sym, nil)&.call
+    key = identifier.to_sym
+    factory = @mutex.synchronize { @registrations[key] } || REPO[key]
+    factory&.call
   end
 
   # Returns the registry identifier for a provider class, or nil when unregistered.
   #--
   #: (singleton(Riffer::Providers::Base)) -> Symbol?
   def key_for(provider_class)
-    (@key_for ||= REPO.to_h { |key, factory| [factory.call, key] })[provider_class]
+    @mutex.synchronize { @key_for ||= build_key_index }[provider_class]
+  end
+
+  private
+
+  #--
+  #: () -> Hash[singleton(Riffer::Providers::Base), Symbol]
+  def build_key_index
+    REPO.merge(@registrations).to_h { |key, factory| [factory.call, key] }
   end
 end

--- a/sig/generated/riffer/providers/repository.rbs
+++ b/sig/generated/riffer/providers/repository.rbs
@@ -1,20 +1,17 @@
 # Generated from lib/riffer/providers/repository.rb with RBS::Inline
 
 # Resolves provider classes by identifier, combining the built-in REPO with
-# consumer registrations added through +register+.
+# consumer registrations added through +register+. Registration is not
+# synchronized — register during boot, before concurrent generation begins.
 module Riffer::Providers::Repository
-  @mutex: Thread::Mutex
-
   @registrations: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
   @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
 
   REPO: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
-  # Registers a custom provider under +identifier+, resolved lazily by the
-  # block so the provider class need not be loaded at registration time. Takes
-  # precedence over a built-in sharing the identifier, and is idempotent —
-  # re-registering an identifier replaces the previous factory.
+  # Registers a custom provider under +identifier+, resolved lazily by the block.
+  # Takes precedence over a built-in sharing the identifier.
   #
   #   Riffer::Providers::Repository.register(:jane) { MyApp::JaneProvider }
   #

--- a/sig/generated/riffer/providers/repository.rbs
+++ b/sig/generated/riffer/providers/repository.rbs
@@ -1,12 +1,37 @@
 # Generated from lib/riffer/providers/repository.rb with RBS::Inline
 
-# Registry for finding provider classes by identifier.
+# Resolves provider classes by identifier, combining the built-in REPO with
+# consumer registrations added through +register+.
 module Riffer::Providers::Repository
+  @mutex: Thread::Mutex
+
+  @registrations: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
+
   @key_for: Hash[singleton(Riffer::Providers::Base), Symbol]?
 
   REPO: Hash[Symbol, ^() -> singleton(Riffer::Providers::Base)]
 
-  # Finds a provider class by identifier.
+  # Registers a custom provider under +identifier+, resolved lazily by the
+  # block so the provider class need not be loaded at registration time. Takes
+  # precedence over a built-in sharing the identifier, and is idempotent —
+  # re-registering an identifier replaces the previous factory.
+  #
+  #   Riffer::Providers::Repository.register(:jane) { MyApp::JaneProvider }
+  #
+  # Raises Riffer::ArgumentError when called without a block.
+  #
+  # --
+  # : ((String | Symbol)) { () -> singleton(Riffer::Providers::Base) } -> void
+  def register: (String | Symbol) { () -> singleton(Riffer::Providers::Base) } -> void
+
+  # Removes a custom registration by identifier, leaving any built-in of the
+  # same name intact.
+  # --
+  # : ((String | Symbol)) -> void
+  def unregister: (String | Symbol) -> void
+
+  # Finds a provider class by identifier, preferring a custom registration over
+  # a built-in of the same name.
   #
   # --
   # : ((String | Symbol)) -> singleton(Riffer::Providers::Base)?
@@ -16,4 +41,10 @@ module Riffer::Providers::Repository
   # --
   # : (singleton(Riffer::Providers::Base)) -> Symbol?
   def key_for: (singleton(Riffer::Providers::Base)) -> Symbol?
+
+  private
+
+  # --
+  # : () -> Hash[singleton(Riffer::Providers::Base), Symbol]
+  def build_key_index: () -> Hash[singleton(Riffer::Providers::Base), Symbol]
 end

--- a/test/riffer/providers/repository_test.rb
+++ b/test/riffer/providers/repository_test.rb
@@ -62,4 +62,72 @@ describe Riffer::Providers::Repository do
       expect(Riffer::Providers::Repository.key_for(String)).must_be_nil
     end
   end
+
+  describe ".register" do
+    after do
+      %i[jane openai].each { |id| Riffer::Providers::Repository.unregister(id) }
+    end
+
+    it "resolves a registered custom provider via find" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { custom }
+      expect(Riffer::Providers::Repository.find(:jane)).must_equal custom
+    end
+
+    it "resolves a registered custom provider from a string identifier" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { custom }
+      expect(Riffer::Providers::Repository.find("jane")).must_equal custom
+    end
+
+    it "takes precedence over a built-in sharing the identifier" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:openai) { custom }
+      expect(Riffer::Providers::Repository.find(:openai)).must_equal custom
+    end
+
+    it "replaces the previous factory when re-registering the same identifier" do
+      first = Class.new(Riffer::Providers::Base)
+      second = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { first }
+      Riffer::Providers::Repository.register(:jane) { second }
+      expect(Riffer::Providers::Repository.find(:jane)).must_equal second
+    end
+
+    it "makes key_for return the registered identifier" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { custom }
+      expect(Riffer::Providers::Repository.key_for(custom)).must_equal :jane
+    end
+
+    it "does not add custom registrations to the built-in REPO" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { custom }
+      expect(Riffer::Providers::Repository::REPO).wont_include(:jane)
+    end
+
+    it "raises Riffer::ArgumentError without a block" do
+      expect { Riffer::Providers::Repository.register(:jane) }.must_raise(Riffer::ArgumentError)
+    end
+  end
+
+  describe ".unregister" do
+    it "removes a custom registration" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:jane) { custom }
+      Riffer::Providers::Repository.unregister(:jane)
+      expect(Riffer::Providers::Repository.find(:jane)).must_be_nil
+    end
+
+    it "restores the built-in shadowed by a custom registration" do
+      custom = Class.new(Riffer::Providers::Base)
+      Riffer::Providers::Repository.register(:openai) { custom }
+      Riffer::Providers::Repository.unregister(:openai)
+      expect(Riffer::Providers::Repository.find(:openai)).must_equal Riffer::Providers::OpenAI
+    end
+
+    it "does not raise when the identifier is not registered" do
+      expect(Riffer::Providers::Repository.unregister(:never_registered)).must_be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Resolving a model string splits `provider/model` and looks the provider up in `Riffer::Providers::Repository`, whose `REPO` is a hardcoded, frozen Hash with no public way to add an entry. A consumer integrating a custom provider — a new vendor, a mock, or a routing provider that dispatches one prefix to different backends — therefore had to reach into gem internals. The working pattern was prepending a module onto `Repository.singleton_class` to override `find`: a monkey-patch that's easy to get wrong (boot ordering, idempotency across framework reloads), isn't discoverable, and that every consumer reinvents. `key_for` (used for pricing/observability keys) only knew the built-in classes, so a monkey-patched provider had no registry identity.

## Solution

Add a first-class registration API:

```ruby
Riffer::Providers::Repository.register(:jane) { MyApp::JaneProvider }
```

honored by both `find` and `key_for`, plus a symmetric `unregister`. The built-in `REPO` stays immutable — custom registrations live in a separate store. Notable behaviours:

- **Lazy** — the block resolves the provider class on lookup, so it need not be loaded at registration time (sidesteps boot-ordering issues).
- **Precedence** — a custom registration shadows a built-in sharing the identifier, enabling a router to reroute an existing prefix like `openai`. `find` and `key_for` agree on this precedence.
- **Idempotent** — re-registering an identifier replaces the prior factory; safe to call from a consumer's initializer.

Provider registration is a **boot** concern: consumers register from an initializer, before the app serves requests. The registry is deliberately kept as plain, unsynchronized state rather than mutex-guarded — a lock bought safety for concurrent *runtime* registration that isn't a requirement, and would have meant either resolving consumer-supplied factory blocks under the lock (reentrancy-deadlock risk, provider autoload inside the critical section) or a generation-guarded cache to stay correct. The boot-time contract is documented on the module and in the custom-providers guide.

Also updates `docs/providers/07_CUSTOM_PROVIDERS.md`, whose previous "Registering Your Provider" example mutated the now-frozen `REPO` (which would raise `FrozenError`).

## Proof

CI is sufficient — see `test/riffer/providers/repository_test.rb`, which covers custom resolution via `find` (symbol + string), precedence over a built-in, idempotent re-registration, `key_for` returning the registered identifier, `REPO` remaining unmutated, the no-block `ArgumentError` guard, and `unregister` (removal + built-in restoration). Full suite green locally (2067 runs, 0 failures), with `bin/lint` and `bin/typecheck` (Steep) clean and RBS regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added APIs to register and unregister custom providers via a factory.
  - Custom providers are resolved by symbol or string identifiers.
  - Custom registrations take precedence over built-in providers, can be replaced, and are removed cleanly.
  - Reverse lookup (`key_for`) reflects the active custom registration.
  - Registration without a factory now raises an argument error.

- **Documentation**
  - Updated the custom provider guide with the new registration, precedence, replacement, removal, and boot-time instructions.

- **Tests**
  - Expanded repository coverage for register/unregister, precedence, replacement, and reverse lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->