### PR TITLE
fix: keep multi-line skill descriptions within their catalog list item

### DIFF
--- a/lib/riffer/skills/markdown_adapter.rb
+++ b/lib/riffer/skills/markdown_adapter.rb
@@ -14,8 +14,19 @@ class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
     lines << catalog_instructions
     lines << ""
     skills.each do |skill|
-      lines << "- **#{skill.name}**: #{skill.description}"
+      lines << "- **#{skill.name}**: #{single_line(skill.description)}"
     end
     lines.join("\n")
+  end
+
+  private
+
+  # Collapses whitespace so a multi-line (block scalar) description stays within
+  # its `-` list item instead of breaking out to column 0, where continuation
+  # lines would read as top-level prompt text or fabricated catalog entries.
+  #--
+  #: (String) -> String
+  def single_line(description)
+    description.gsub(/\s+/, " ").strip
   end
 end

--- a/sig/generated/riffer/skills/markdown_adapter.rbs
+++ b/sig/generated/riffer/skills/markdown_adapter.rbs
@@ -7,4 +7,13 @@ class Riffer::Skills::MarkdownAdapter < Riffer::Skills::Adapter
   # --
   # : (Array[Riffer::Skills::Frontmatter]) -> String
   def render_catalog: (Array[Riffer::Skills::Frontmatter]) -> String
+
+  private
+
+  # Collapses whitespace so a multi-line (block scalar) description stays within
+  # its `-` list item instead of breaking out to column 0, where continuation
+  # lines would read as top-level prompt text or fabricated catalog entries.
+  # --
+  # : (String) -> String
+  def single_line: (String) -> String
 end

--- a/test/riffer/skills/markdown_adapter_test.rb
+++ b/test/riffer/skills/markdown_adapter_test.rb
@@ -36,6 +36,11 @@ describe Riffer::Skills::MarkdownAdapter do
     it "instructs the model not to re-activate skills already in context" do
       assert_includes adapter.render_catalog(skills), "instead of activating the skill again"
     end
+
+    it "keeps a multi-line description within its list item" do
+      skill = Riffer::Skills::Frontmatter.new(name: "code-review", description: "Reviews code.\nUse for pull requests.\n")
+      assert_includes adapter.render_catalog([skill]), "- **code-review**: Reviews code. Use for pull requests."
+    end
   end
 
   describe "#render_activation" do


### PR DESCRIPTION
## Problem

Fixes #355. Pointing riffer at a Claude Code skills directory (`FilesystemBackend` + the default `MarkdownAdapter`) produced a broken catalog whenever a skill declared its `description` as a YAML block scalar (`description: |`), which is common in Claude Code skills.

A block scalar parses to a string with embedded newlines. `MarkdownAdapter#render_catalog` interpolated that string raw into a single-line `- **name**: ...` list item, so every continuation line rendered at column 0 — outside the list item. In the system prompt the model consumes, those lines read as top-level text, and a crafted description could even fabricate what looks like an additional catalog entry (`- **something-else**: ...`), giving the structural break a mild prompt-injection angle for skills loaded from shared directories.

## Solution

Collapse whitespace in the description at render time via a private `single_line` helper (`description.gsub(/\s+/, " ").strip`) before interpolating it into the list item. This keeps the whole description on one line and closes the injection angle — a `- **fake**` in the middle of a line is not a new markdown list item.

The fix lives in the adapter rather than in `Frontmatter`, mirroring the existing pattern: `XmlAdapter` sanitizes per-format at the rendering boundary (`CGI.escapeHTML`) and leaves `Frontmatter#description` a faithful copy of the source. `XmlAdapter` is left untouched — it is already structurally safe (the closing `</description>` tag delimits the value and `<`/`>` are escaped), so embedded newlines there are harmless.

No user-facing docs change: `docs/13_SKILLS.md` already documents `description` only as a 1–1024 char field, with no single-line requirement, and this adds no public config option or message attribute.

## Proof

CI is sufficient — a new test in `test/riffer/skills/markdown_adapter_test.rb` asserts a multi-line block-scalar description collapses into a single catalog line. `bin/rake` passes locally (test + standard + steep:check; 2068 runs, 0 failures) and the RBS signature was regenerated with `bin/rbs`. The original issue repro now renders the description as one self-contained list item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown catalog rendering by keeping multi-line skill descriptions on a single list item line.
  * Normalized whitespace in skill descriptions for cleaner, more consistent formatting.

* **Tests**
  * Added coverage to verify that descriptions containing line breaks render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->