### PR TITLE
[Riffer] designed step by step workflow following mastra

### DIFF
--- a/docs/17_WORKFLOWS.md
+++ b/docs/17_WORKFLOWS.md
@@ -1,0 +1,309 @@
+# Workflows
+
+Workflows compose multiple steps into a sequential pipeline. Each step declares its input and output contract, and data flows from one step to the next. The workflow returns a structured result that communicates success, failure, and per-step outcomes.
+
+## When to Use Workflows
+
+Use workflows when a task requires multiple deterministic steps that must run in sequence. If the task is a single LLM call, use an Agent directly. If you need to orchestrate parallel or branching logic, workflows are not the right fit (yet).
+
+## Defining a Step
+
+Create a step by subclassing `Riffer::Workflow::Step`:
+
+```ruby
+class CategorizeRequest < Riffer::Workflow::Step
+  uses ClassifierAgent
+
+  input do
+    required :message, String
+  end
+
+  output do
+    required :message, String
+    required :category, String
+    required :priority, String
+  end
+
+  def execute(message:)
+    response = ClassifierAgent.generate(message)
+    parsed = JSON.parse(response.content, symbolize_names: true)
+
+    {message: message, category: parsed[:category], priority: parsed[:priority]}
+  end
+end
+```
+
+### input / output
+
+Declare what the step expects and what it returns using the same `Riffer::Params` DSL that tools use:
+
+```ruby
+class FetchAccount < Riffer::Workflow::Step
+  uses AccountLookupTool
+
+  input do
+    required :message, String
+    required :category, String
+    required :priority, String
+  end
+
+  output do
+    required :message, String
+    required :category, String
+    required :priority, String
+    required :account_summary, String
+  end
+
+  def execute(message:, category:, priority:)
+    tool = AccountLookupTool.new
+    response = tool.call(context: nil, patient_id: context[:patient_id])
+
+    {message: message, category: category, priority: priority, account_summary: response.content}
+  end
+end
+```
+
+Both blocks are optional. Without them, the framework skips validation for that boundary.
+
+### identifier
+
+Sets a custom identifier. Defaults to the snake_case class name:
+
+```ruby
+class CategorizeRequest < Riffer::Workflow::Step
+  identifier "categorize"
+end
+
+CategorizeRequest.identifier  # => "categorize"
+```
+
+Without an explicit override, `CategorizeRequest.identifier` returns `"categorize_request"`.
+
+### uses
+
+Declares agents or tools the step depends on. Optional, used by `to_mermaid` and `describe` for visualization:
+
+```ruby
+class CategorizeRequest < Riffer::Workflow::Step
+  uses ClassifierAgent
+  # ...
+end
+```
+
+### execute
+
+The only method you must implement. It receives validated keyword arguments and must return a Hash matching the output contract:
+
+```ruby
+def execute(message:)
+  {message: message.strip, category: "general", priority: "normal"}
+end
+```
+
+### context
+
+Inside `execute`, `self.context` gives access to the workflow-level context hash for cross-cutting data that shouldn't flow through step I/O:
+
+```ruby
+def execute(category:, priority:)
+  patient_id = context[:patient_id]
+  # ...
+end
+```
+
+## Defining a Workflow
+
+Declare a workflow by subclassing `Riffer::Workflow` and registering steps with the `step` macro:
+
+```ruby
+class HelpDeskWorkflow < Riffer::Workflow
+  step CategorizeRequest
+  step FetchAccount
+  step DraftReply
+end
+```
+
+Steps run in the order they are declared. The first step receives the workflow input. Each subsequent step receives the previous step's output.
+
+## Running a Workflow
+
+```ruby
+# Class convenience
+result = HelpDeskWorkflow.execute(
+  {message: "I can't log in and my appointment is in an hour"},
+  context: {patient_id: "patient_123", clinic_id: "jane_demo"}
+)
+
+# Instance form
+workflow = HelpDeskWorkflow.new(context: {patient_id: "patient_123"})
+result = workflow.execute(message: "I can't log in...")
+```
+
+## Data Flow
+
+Each step's output becomes the next step's input:
+
+```
+{ message: "I can't log in..." }
+  → CategorizeRequest → { message: "...", category: "account_access", priority: "urgent" }
+  → FetchAccount      → { message: "...", category: "...", priority: "...", account_summary: "..." }
+  → DraftReply        → { reply: "Hi! I can see your account...", escalate: false }
+```
+
+Steps must pass through any data the next step needs.
+
+## Result
+
+`Riffer::Workflow::Result` is a value object returned by `execute`:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `status` | Symbol | `:success` or `:failed` |
+| `input` | Hash | The original input passed to the workflow |
+| `output` | Hash | Final step's output (nil on failure) |
+| `error` | StandardError | The captured exception (nil on success) |
+| `failed_step` | String | Identifier of the failed step (nil on success) |
+| `steps` | Hash | Per-step `StepResult` objects keyed by identifier |
+| `success?` | Boolean | Whether the workflow completed |
+| `failed?` | Boolean | Whether a step failed |
+
+### StepResult
+
+Each entry in `result.steps` is a `Riffer::Workflow::StepResult`:
+
+| Attribute | Type | Description |
+|---|---|---|
+| `status` | Symbol | `:success`, `:failed`, or `:pending` |
+| `payload` | Hash | The input received by this step |
+| `output` | Hash | The output produced (nil unless success) |
+| `error` | StandardError | The captured exception (nil unless failed) |
+
+Steps that didn't run because a prior step failed have `status: :pending`.
+
+### Serialization
+
+Call `to_h` on the result for a full snapshot:
+
+```ruby
+result = HelpDeskWorkflow.execute(
+  {message: "I can't log in"},
+  context: {patient_id: "patient_123"}
+)
+
+result.to_h
+# => {
+#   status: :success,
+#   input: { message: "I can't log in" },
+#   output: { reply: "Hi! I can see...", escalate: false },
+#   steps: {
+#     "categorize_request" => {
+#       status: :success,
+#       payload: { message: "I can't log in" },
+#       output: { message: "...", category: "account_access", priority: "urgent" }
+#     },
+#     "fetch_account" => {
+#       status: :success,
+#       payload: { message: "...", category: "account_access", priority: "urgent" },
+#       output: { message: "...", category: "...", priority: "...", account_summary: "..." }
+#     },
+#     "draft_reply" => {
+#       status: :success,
+#       payload: { message: "...", category: "...", priority: "...", account_summary: "..." },
+#       output: { reply: "Hi! I can see...", escalate: false }
+#     }
+#   }
+# }
+```
+
+### Per-step inspection
+
+```ruby
+result.steps.each do |step_id, step_result|
+  case step_result.status
+  when :success then puts "#{step_id}: #{step_result.output}"
+  when :failed  then puts "#{step_id}: #{step_result.error.message}"
+  when :pending then puts "#{step_id}: did not run"
+  end
+end
+```
+
+## Error Handling
+
+Workflows fail fast. When a step fails, the workflow stops and remaining steps are marked `:pending`. Errors during step execution are captured in the result, not raised to the caller.
+
+Three failure modes:
+
+1. **Input validation** - a step's input doesn't match its `input` declaration. Captured as `Riffer::ValidationError`.
+2. **Execution error** - `execute` raises an exception. The original exception is captured.
+3. **Output validation** - a step's return value doesn't match its `output` declaration. Captured as `Riffer::ValidationError`.
+
+```ruby
+result = HelpDeskWorkflow.execute({message: "I can't log in..."}, context: {patient_id: "p1"})
+
+if result.failed?
+  puts result.failed_step   # => "fetch_account"
+  puts result.error.message # => "connection refused"
+end
+```
+
+## Visualization
+
+Two class methods help you inspect a workflow's shape without running it.
+
+### describe
+
+Prints a text summary to stdout:
+
+```ruby
+HelpDeskWorkflow.describe
+# help_desk_workflow (3 steps)
+#   1. categorize_request  [message] → [message, category, priority]  · ClassifierAgent
+#   2. fetch_account       [message, category, priority] → [message, category, priority, account_summary]  · AccountLookupTool
+#   3. draft_reply         [message, category, priority, account_summary] → [reply, escalate]  · ReplyDrafterAgent
+```
+
+### to_mermaid
+
+Returns a Mermaid flowchart string. GitHub, Notion, and Obsidian render it natively in markdown:
+
+```ruby
+puts HelpDeskWorkflow.to_mermaid
+```
+
+```mermaid
+graph LR
+  subgraph help_desk_workflow
+    categorize_request["categorize_request · ClassifierAgent"] --> fetch_account["fetch_account · AccountLookupTool"]
+    fetch_account --> draft_reply["draft_reply · ReplyDrafterAgent"]
+  end
+```
+
+## Using Agents and Tools in Steps
+
+Steps call agents and tools directly. Any exception they raise is captured by the runner, the workflow stops, and the error surfaces in the result:
+
+```ruby
+class DraftReply < Riffer::Workflow::Step
+  uses ReplyDrafterAgent
+
+  input do
+    required :message, String
+    required :category, String
+    required :priority, String
+    required :account_summary, String
+  end
+
+  output do
+    required :reply, String
+    required :escalate, Riffer::Params::Boolean
+  end
+
+  def execute(message:, category:, priority:, account_summary:)
+    prompt = "Draft a #{priority} #{category} reply.\nMessage: #{message}\nAccount: #{account_summary}"
+    response = ReplyDrafterAgent.generate(prompt)
+    parsed = JSON.parse(response.content, symbolize_names: true)
+
+    {reply: parsed[:reply], escalate: parsed[:escalate]}
+  end
+end
+```

--- a/lib/riffer/workflow.rb
+++ b/lib/riffer/workflow.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for workflows. Subclass it and declare steps to build a sequential
+# pipeline.
+#
+#   class HelpDeskWorkflow < Riffer::Workflow
+#     step CategorizeRequest
+#     step FetchAccount
+#     step DraftReply
+#   end
+#
+#   result = HelpDeskWorkflow.execute(
+#     {message: "I can't log in"},
+#     context: {patient_id: "patient_123"}
+#   )
+#
+class Riffer::Workflow
+  # @rbs self.@steps: Array[singleton(Riffer::Workflow::Step)]?
+  # @rbs self.@identifier_value: String?
+  # @rbs @context: Hash[Symbol, untyped]?
+
+  # The workflow-level context.
+  attr_reader :context #: Hash[Symbol, untyped]?
+
+  # Gets or sets the workflow identifier. Defaults to the snake_case class name.
+  #--
+  #: (?String?) -> String
+  def self.identifier(value = nil)
+    if value.nil?
+      @identifier_value || Riffer::Helpers::ClassNameConverter.convert(name)
+    else
+      @identifier_value = value.to_s
+    end
+  end
+
+  # Registers a step class in the workflow pipeline.
+  #--
+  #: (singleton(Riffer::Workflow::Step)) -> void
+  def self.step(step_class)
+    unless step_class.is_a?(Class) && step_class < Riffer::Workflow::Step
+      raise Riffer::ArgumentError, "#{step_class} is not a Riffer::Workflow::Step subclass"
+    end
+
+    registered = (@steps ||= []) #: Array[singleton(Riffer::Workflow::Step)]
+    id = step_class.identifier
+
+    if id.empty?
+      raise Riffer::ArgumentError, "#{step_class} has no name; set an explicit identifier with `identifier \"my_step\"`"
+    end
+
+    if registered.any? { |s| s.identifier == id }
+      raise Riffer::ArgumentError, "duplicate step identifier: #{id.inspect}"
+    end
+
+    registered << step_class
+  end
+
+  # Returns the registered step classes.
+  #--
+  #: () -> Array[singleton(Riffer::Workflow::Step)]
+  def self.steps
+    @steps || [] #: Array[singleton(Riffer::Workflow::Step)]
+  end
+
+  # Convenience class method. Creates a new instance and runs the workflow.
+  #--
+  #: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+  def self.execute(input, context: nil)
+    new(context: context).execute(**input)
+  end
+
+  # Returns a Mermaid flowchart string of the step pipeline.
+  #--
+  #: () -> String
+  def self.to_mermaid
+    lines = ["graph LR"]
+
+    if steps.any?
+      lines << "  subgraph #{identifier}"
+      nodes = steps.map { |s| mermaid_node(s) }
+      nodes.each_cons(2) { |a, b| lines << "    #{a} --> #{b}" }
+      lines << "    #{nodes.first}" if nodes.size == 1
+      lines << "  end"
+    end
+
+    lines.join("\n")
+  end
+
+  # Prints a text summary of the workflow to +$stdout+.
+  #--
+  #: () -> void
+  def self.describe
+    puts "#{identifier} (#{steps.size} steps)"
+    steps.each_with_index do |step, i|
+      input_fields = step.input&.parameters&.map(&:name) || []
+      output_fields = step.output&.parameters&.map(&:name) || []
+      line = "  #{i + 1}. #{step.identifier}  [#{input_fields.join(", ")}] → [#{output_fields.join(", ")}]"
+      deps = step.uses
+      line += "  · #{deps.map(&:name).join(", ")}" if deps.any?
+      puts line
+    end
+  end
+
+  #--
+  #: (singleton(Riffer::Workflow::Step)) -> String
+  def self.mermaid_node(step)
+    deps = step.uses
+    if deps.any?
+      label = "#{step.identifier} · #{deps.map(&:name).join(", ")}"
+      "#{step.identifier}[\"#{label}\"]"
+    else
+      step.identifier
+    end
+  end
+  private_class_method :mermaid_node
+
+  #--
+  #: (?context: Hash[Symbol, untyped]?) -> void
+  def initialize(context: nil)
+    @context = context&.dup
+  end
+
+  # Runs the workflow pipeline with the given input.
+  #--
+  #: (**untyped) -> Riffer::Workflow::Result
+  def execute(**input)
+    Riffer::Workflow::Runner.execute(
+      steps: self.class.steps,
+      input: input,
+      context: @context
+    )
+  end
+end

--- a/lib/riffer/workflow/result.rb
+++ b/lib/riffer/workflow/result.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# The structured outcome of running a workflow. Carries the overall status,
+# the final output (on success), any error (on failure), and per-step results.
+class Riffer::Workflow::Result
+  # @rbs @status: Symbol
+
+  # The workflow status: +:success+ or +:failed+.
+  attr_reader :status #: Symbol
+
+  # The original input passed to the workflow.
+  attr_reader :input #: Hash[Symbol, untyped]
+
+  # The final step's validated output hash, or +nil+ on failure.
+  attr_reader :output #: Hash[Symbol, untyped]?
+
+  # The captured exception, or +nil+ on success.
+  attr_reader :error #: StandardError?
+
+  # The identifier of the step that failed, or +nil+ on success.
+  attr_reader :failed_step #: String?
+
+  # Ordered hash of step identifier to StepResult.
+  attr_reader :steps #: Hash[String, Riffer::Workflow::StepResult]
+
+  #--
+  #: (status: Symbol, input: Hash[Symbol, untyped], ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?failed_step: String?, ?steps: Hash[String, Riffer::Workflow::StepResult]) -> void
+  def initialize(status:, input:, output: nil, error: nil, failed_step: nil, steps: {})
+    @status = status
+    @input = input
+    @output = output
+    @error = error
+    @failed_step = failed_step
+    @steps = steps
+  end
+
+  #--
+  #: () -> bool
+  def success? = @status == :success
+
+  #--
+  #: () -> bool
+  def failed? = @status == :failed
+
+  # Returns a hash representation of the workflow result.
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    h = {status: @status, input: @input} #: Hash[Symbol, untyped]
+    h[:output] = @output if @output
+    h[:error] = (err = @error) ? err.message : nil if @error
+    h[:failed_step] = @failed_step if @failed_step
+    h[:steps] = @steps.transform_values(&:to_h)
+    h
+  end
+end

--- a/lib/riffer/workflow/runner.rb
+++ b/lib/riffer/workflow/runner.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Sequentially executes a workflow's steps, validating input/output at each
+# boundary and capturing per-step results.
+module Riffer::Workflow::Runner
+  extend self
+
+  # Runs the given step classes in order, threading each step's output into the
+  # next step's input.
+  #--
+  #: (steps: Array[singleton(Riffer::Workflow::Step)], input: Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+  def execute(steps:, input:, context: nil)
+    step_results = {} #: Hash[String, Riffer::Workflow::StepResult]
+    current_input = input
+
+    steps.each do |step_class|
+      step_result = run_step(step_class, current_input, context)
+      step_id = step_class.identifier
+
+      step_results[step_id] = step_result
+
+      unless step_result.success?
+        mark_pending(steps, step_results)
+        return Riffer::Workflow::Result.new(
+          status: :failed,
+          input: input,
+          error: step_result.error,
+          failed_step: step_id,
+          steps: step_results
+        )
+      end
+
+      current_input = step_result.output || current_input
+    end
+
+    Riffer::Workflow::Result.new(
+      status: :success,
+      input: input,
+      output: current_input,
+      steps: step_results
+    )
+  end
+
+  private
+
+  #--
+  #: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped], Hash[Symbol, untyped]?) -> Riffer::Workflow::StepResult
+  def run_step(step_class, input, context)
+    step_instance = step_class.new(context: context)
+
+    validated_input = validate_input(step_class, input)
+    output = step_instance.execute(**validated_input)
+    output = validate_output(step_class, output)
+
+    Riffer::Workflow::StepResult.new(status: :success, payload: validated_input, output: output)
+  rescue => e
+    payload = defined?(validated_input) ? validated_input : input
+    Riffer::Workflow::StepResult.new(status: :failed, payload: payload, error: e)
+  end
+
+  #--
+  #: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def validate_input(step_class, data)
+    params = step_class.input
+    return data unless params
+
+    params.validate(data)
+  end
+
+  #--
+  #: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def validate_output(step_class, data)
+    unless data.is_a?(Hash)
+      raise Riffer::ValidationError, "#{step_class} must return a Hash from #execute, got #{data.class}"
+    end
+
+    params = step_class.output
+    return data unless params
+
+    params.validate(data)
+  end
+
+  # Marks remaining steps as pending after a failure.
+  #--
+  #: (Array[singleton(Riffer::Workflow::Step)], Hash[String, Riffer::Workflow::StepResult]) -> void
+  def mark_pending(steps, step_results)
+    steps.each do |step_class|
+      step_id = step_class.identifier
+      next if step_results.key?(step_id)
+
+      step_results[step_id] = Riffer::Workflow::StepResult.new(status: :pending)
+    end
+  end
+end

--- a/lib/riffer/workflow/step.rb
+++ b/lib/riffer/workflow/step.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Base class for workflow steps. Subclasses declare +input+/+output+ contracts
+# and implement +#execute+.
+#
+#   class FormatMessage < Riffer::Workflow::Step
+#     input do
+#       required :message, String
+#     end
+#
+#     output do
+#       required :formatted, String
+#     end
+#
+#     def execute(message:)
+#       {formatted: message.upcase}
+#     end
+#   end
+#
+class Riffer::Workflow::Step
+  # @rbs self.@input_params: Riffer::Params?
+  # @rbs self.@output_params: Riffer::Params?
+  # @rbs self.@identifier_value: String?
+  # @rbs self.@uses: Array[Module]?
+  # @rbs @context: Hash[Symbol, untyped]?
+
+  # The workflow-level context passed at construction time.
+  attr_reader :context #: Hash[Symbol, untyped]?
+
+  #--
+  #: (?context: Hash[Symbol, untyped]?) -> void
+  def initialize(context: nil)
+    @context = context
+  end
+
+  # Gets or sets the step identifier. Defaults to the snake_case class name.
+  #--
+  #: (?String?) -> String
+  def self.identifier(value = nil)
+    if value.nil?
+      @identifier_value || Riffer::Helpers::ClassNameConverter.convert(name)
+    else
+      @identifier_value = value.to_s
+    end
+  end
+
+  # Defines the input contract using the Params DSL.
+  #--
+  #: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def self.input(&block)
+    return @input_params if block.nil?
+    builder = Riffer::Params.new
+    builder.instance_eval(&block)
+    @input_params = builder
+  end
+
+  # Defines the output contract using the Params DSL.
+  #--
+  #: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def self.output(&block)
+    return @output_params if block.nil?
+    builder = Riffer::Params.new
+    builder.instance_eval(&block)
+    @output_params = builder
+  end
+
+  # Declares agents or tools this step depends on (for visualization).
+  #--
+  #: (*Module) -> Array[Module]
+  def self.uses(*classes)
+    return @uses || [] if classes.empty?
+
+    classes.each do |cls|
+      unless cls.is_a?(Module)
+        raise Riffer::ArgumentError, "#{cls.inspect} is not a Module"
+      end
+    end
+
+    registered = (@uses ||= []) #: Array[Module]
+    registered.concat(classes)
+  end
+
+  # Executes the step. Subclasses must override this.
+  #--
+  #: (**untyped) -> Hash[Symbol, untyped]
+  def execute(**kwargs)
+    raise NotImplementedError, "#{self.class} must implement #execute"
+  end
+end

--- a/lib/riffer/workflow/step_result.rb
+++ b/lib/riffer/workflow/step_result.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Captures the outcome of a single step within a workflow run.
+class Riffer::Workflow::StepResult
+  # @rbs @status: Symbol
+  # @rbs @output: Hash[Symbol, untyped]?
+  # @rbs @error: StandardError?
+  # @rbs @payload: Hash[Symbol, untyped]?
+
+  # The step status: +:success+, +:failed+, or +:pending+.
+  attr_reader :status #: Symbol
+
+  # The validated output hash, or +nil+ unless the step succeeded.
+  attr_reader :output #: Hash[Symbol, untyped]?
+
+  # The captured exception, or +nil+ unless the step failed.
+  attr_reader :error #: StandardError?
+
+  # The input received by this step, or +nil+ when pending.
+  attr_reader :payload #: Hash[Symbol, untyped]?
+
+  #--
+  #: (status: Symbol, ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?payload: Hash[Symbol, untyped]?) -> void
+  def initialize(status:, output: nil, error: nil, payload: nil)
+    @status = status
+    @output = output
+    @error = error
+    @payload = payload
+  end
+
+  #--
+  #: () -> bool
+  def success? = @status == :success
+
+  #--
+  #: () -> bool
+  def failed? = @status == :failed
+
+  #--
+  #: () -> bool
+  def pending? = @status == :pending
+
+  # Returns a hash representation of this step result.
+  #--
+  #: () -> Hash[Symbol, untyped]
+  def to_h
+    h = {status: @status} #: Hash[Symbol, untyped]
+    h[:payload] = @payload if @payload
+    h[:output] = @output if @output
+    h[:error] = (err = @error) ? err.message : nil if @error
+    h
+  end
+end

--- a/sig/generated/riffer/workflow.rbs
+++ b/sig/generated/riffer/workflow.rbs
@@ -1,0 +1,68 @@
+# Generated from lib/riffer/workflow.rb with RBS::Inline
+
+# Base class for workflows. Subclass it and declare steps to build a sequential
+# pipeline.
+#
+#   class HelpDeskWorkflow < Riffer::Workflow
+#     step CategorizeRequest
+#     step FetchAccount
+#     step DraftReply
+#   end
+#
+#   result = HelpDeskWorkflow.execute(
+#     {message: "I can't log in"},
+#     context: {patient_id: "patient_123"}
+#   )
+class Riffer::Workflow
+  self.@steps: Array[singleton(Riffer::Workflow::Step)]?
+
+  self.@identifier_value: String?
+
+  @context: Hash[Symbol, untyped]?
+
+  # The workflow-level context.
+  attr_reader context: Hash[Symbol, untyped]?
+
+  # Gets or sets the workflow identifier. Defaults to the snake_case class name.
+  # --
+  # : (?String?) -> String
+  def self.identifier: (?String?) -> String
+
+  # Registers a step class in the workflow pipeline.
+  # --
+  # : (singleton(Riffer::Workflow::Step)) -> void
+  def self.step: (singleton(Riffer::Workflow::Step)) -> void
+
+  # Returns the registered step classes.
+  # --
+  # : () -> Array[singleton(Riffer::Workflow::Step)]
+  def self.steps: () -> Array[singleton(Riffer::Workflow::Step)]
+
+  # Convenience class method. Creates a new instance and runs the workflow.
+  # --
+  # : (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+  def self.execute: (Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+
+  # Returns a Mermaid flowchart string of the step pipeline.
+  # --
+  # : () -> String
+  def self.to_mermaid: () -> String
+
+  # Prints a text summary of the workflow to +$stdout+.
+  # --
+  # : () -> void
+  def self.describe: () -> void
+
+  # --
+  # : (singleton(Riffer::Workflow::Step)) -> String
+  def self.mermaid_node: (singleton(Riffer::Workflow::Step)) -> String
+
+  # --
+  # : (?context: Hash[Symbol, untyped]?) -> void
+  def initialize: (?context: Hash[Symbol, untyped]?) -> void
+
+  # Runs the workflow pipeline with the given input.
+  # --
+  # : (**untyped) -> Riffer::Workflow::Result
+  def execute: (**untyped) -> Riffer::Workflow::Result
+end

--- a/sig/generated/riffer/workflow/result.rbs
+++ b/sig/generated/riffer/workflow/result.rbs
@@ -1,0 +1,42 @@
+# Generated from lib/riffer/workflow/result.rb with RBS::Inline
+
+# The structured outcome of running a workflow. Carries the overall status,
+# the final output (on success), any error (on failure), and per-step results.
+class Riffer::Workflow::Result
+  @status: Symbol
+
+  # The workflow status: +:success+ or +:failed+.
+  attr_reader status: Symbol
+
+  # The original input passed to the workflow.
+  attr_reader input: Hash[Symbol, untyped]
+
+  # The final step's validated output hash, or +nil+ on failure.
+  attr_reader output: Hash[Symbol, untyped]?
+
+  # The captured exception, or +nil+ on success.
+  attr_reader error: StandardError?
+
+  # The identifier of the step that failed, or +nil+ on success.
+  attr_reader failed_step: String?
+
+  # Ordered hash of step identifier to StepResult.
+  attr_reader steps: Hash[String, Riffer::Workflow::StepResult]
+
+  # --
+  # : (status: Symbol, input: Hash[Symbol, untyped], ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?failed_step: String?, ?steps: Hash[String, Riffer::Workflow::StepResult]) -> void
+  def initialize: (status: Symbol, input: Hash[Symbol, untyped], ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?failed_step: String?, ?steps: Hash[String, Riffer::Workflow::StepResult]) -> void
+
+  # --
+  # : () -> bool
+  def success?: () -> bool
+
+  # --
+  # : () -> bool
+  def failed?: () -> bool
+
+  # Returns a hash representation of the workflow result.
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/workflow/runner.rbs
+++ b/sig/generated/riffer/workflow/runner.rbs
@@ -1,0 +1,30 @@
+# Generated from lib/riffer/workflow/runner.rb with RBS::Inline
+
+# Sequentially executes a workflow's steps, validating input/output at each
+# boundary and capturing per-step results.
+module Riffer::Workflow::Runner
+  # Runs the given step classes in order, threading each step's output into the
+  # next step's input.
+  # --
+  # : (steps: Array[singleton(Riffer::Workflow::Step)], input: Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+  def execute: (steps: Array[singleton(Riffer::Workflow::Step)], input: Hash[Symbol, untyped], ?context: Hash[Symbol, untyped]?) -> Riffer::Workflow::Result
+
+  private
+
+  # --
+  # : (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped], Hash[Symbol, untyped]?) -> Riffer::Workflow::StepResult
+  def run_step: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped], Hash[Symbol, untyped]?) -> Riffer::Workflow::StepResult
+
+  # --
+  # : (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def validate_input: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+
+  # --
+  # : (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+  def validate_output: (singleton(Riffer::Workflow::Step), Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
+
+  # Marks remaining steps as pending after a failure.
+  # --
+  # : (Array[singleton(Riffer::Workflow::Step)], Hash[String, Riffer::Workflow::StepResult]) -> void
+  def mark_pending: (Array[singleton(Riffer::Workflow::Step)], Hash[String, Riffer::Workflow::StepResult]) -> void
+end

--- a/sig/generated/riffer/workflow/step.rbs
+++ b/sig/generated/riffer/workflow/step.rbs
@@ -1,0 +1,61 @@
+# Generated from lib/riffer/workflow/step.rb with RBS::Inline
+
+# Base class for workflow steps. Subclasses declare +input+/+output+ contracts
+# and implement +#execute+.
+#
+#   class FormatMessage < Riffer::Workflow::Step
+#     input do
+#       required :message, String
+#     end
+#
+#     output do
+#       required :formatted, String
+#     end
+#
+#     def execute(message:)
+#       {formatted: message.upcase}
+#     end
+#   end
+class Riffer::Workflow::Step
+  self.@input_params: Riffer::Params?
+
+  self.@output_params: Riffer::Params?
+
+  self.@identifier_value: String?
+
+  self.@uses: Array[Module]?
+
+  @context: Hash[Symbol, untyped]?
+
+  # The workflow-level context passed at construction time.
+  attr_reader context: Hash[Symbol, untyped]?
+
+  # --
+  # : (?context: Hash[Symbol, untyped]?) -> void
+  def initialize: (?context: Hash[Symbol, untyped]?) -> void
+
+  # Gets or sets the step identifier. Defaults to the snake_case class name.
+  # --
+  # : (?String?) -> String
+  def self.identifier: (?String?) -> String
+
+  # Defines the input contract using the Params DSL.
+  # --
+  # : () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def self.input: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+
+  # Defines the output contract using the Params DSL.
+  # --
+  # : () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+  def self.output: () ?{ (Riffer::Params) [self: Riffer::Params] -> void } -> Riffer::Params?
+
+  # Declares agents or tools this step depends on (for visualization).
+  # --
+  # : (*Module) -> Array[Module]
+  def self.uses: (*Module) -> Array[Module]
+
+  # Executes the step. Subclasses must override this.
+  # --
+  # : (**untyped) -> Hash[Symbol, untyped]
+  def execute: (**untyped) -> Hash[Symbol, untyped]
+end

--- a/sig/generated/riffer/workflow/step_result.rbs
+++ b/sig/generated/riffer/workflow/step_result.rbs
@@ -1,0 +1,45 @@
+# Generated from lib/riffer/workflow/step_result.rb with RBS::Inline
+
+# Captures the outcome of a single step within a workflow run.
+class Riffer::Workflow::StepResult
+  @status: Symbol
+
+  @output: Hash[Symbol, untyped]?
+
+  @error: StandardError?
+
+  @payload: Hash[Symbol, untyped]?
+
+  # The step status: +:success+, +:failed+, or +:pending+.
+  attr_reader status: Symbol
+
+  # The validated output hash, or +nil+ unless the step succeeded.
+  attr_reader output: Hash[Symbol, untyped]?
+
+  # The captured exception, or +nil+ unless the step failed.
+  attr_reader error: StandardError?
+
+  # The input received by this step, or +nil+ when pending.
+  attr_reader payload: Hash[Symbol, untyped]?
+
+  # --
+  # : (status: Symbol, ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?payload: Hash[Symbol, untyped]?) -> void
+  def initialize: (status: Symbol, ?output: Hash[Symbol, untyped]?, ?error: StandardError?, ?payload: Hash[Symbol, untyped]?) -> void
+
+  # --
+  # : () -> bool
+  def success?: () -> bool
+
+  # --
+  # : () -> bool
+  def failed?: () -> bool
+
+  # --
+  # : () -> bool
+  def pending?: () -> bool
+
+  # Returns a hash representation of this step result.
+  # --
+  # : () -> Hash[Symbol, untyped]
+  def to_h: () -> Hash[Symbol, untyped]
+end

--- a/sig/manual/riffer/workflow/runner.rbs
+++ b/sig/manual/riffer/workflow/runner.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Workflow::Runner` uses `extend self`; rbs-inline doesn't emit that,
+# so re-extend here to expose its instance methods as singleton methods.
+module Riffer::Workflow::Runner
+  extend ::Riffer::Workflow::Runner
+end

--- a/test/riffer/workflow/result_test.rb
+++ b/test/riffer/workflow/result_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Workflow::Result do
+  describe "success" do
+    let(:result) do
+      Riffer::Workflow::Result.new(
+        status: :success,
+        input: {message: "hello"},
+        output: {reply: "Done"},
+        steps: {
+          "step_a" => Riffer::Workflow::StepResult.new(status: :success, payload: {message: "hello"}, output: {reply: "Done"})
+        }
+      )
+    end
+
+    it "is success" do
+      expect(result.success?).must_equal true
+    end
+
+    it "is not failed" do
+      expect(result.failed?).must_equal false
+    end
+
+    it "carries the input" do
+      expect(result.input).must_equal({message: "hello"})
+    end
+
+    it "carries the output" do
+      expect(result.output).must_equal({reply: "Done"})
+    end
+
+    it "has no error" do
+      expect(result.error).must_be_nil
+    end
+
+    it "has no failed_step" do
+      expect(result.failed_step).must_be_nil
+    end
+
+    it "includes step results" do
+      expect(result.steps["step_a"].success?).must_equal true
+    end
+  end
+
+  describe "failed" do
+    let(:error) { RuntimeError.new("boom") }
+    let(:result) do
+      Riffer::Workflow::Result.new(
+        status: :failed,
+        input: {message: "hello"},
+        error: error,
+        failed_step: "step_b",
+        steps: {
+          "step_a" => Riffer::Workflow::StepResult.new(status: :success, payload: {message: "hello"}, output: {x: 1}),
+          "step_b" => Riffer::Workflow::StepResult.new(status: :failed, payload: {x: 1}, error: error)
+        }
+      )
+    end
+
+    it "is failed" do
+      expect(result.failed?).must_equal true
+    end
+
+    it "carries the input" do
+      expect(result.input).must_equal({message: "hello"})
+    end
+
+    it "carries the error" do
+      expect(result.error).must_equal error
+    end
+
+    it "identifies the failed step" do
+      expect(result.failed_step).must_equal "step_b"
+    end
+
+    it "has nil output" do
+      expect(result.output).must_be_nil
+    end
+  end
+
+  describe "#to_h" do
+    it "serializes a successful result" do
+      result = Riffer::Workflow::Result.new(
+        status: :success,
+        input: {text: "hi"},
+        output: {text: "HI"},
+        steps: {
+          "upcase" => Riffer::Workflow::StepResult.new(status: :success, payload: {text: "hi"}, output: {text: "HI"})
+        }
+      )
+
+      expect(result.to_h).must_equal({
+        status: :success,
+        input: {text: "hi"},
+        output: {text: "HI"},
+        steps: {
+          "upcase" => {status: :success, payload: {text: "hi"}, output: {text: "HI"}}
+        }
+      })
+    end
+
+    it "serializes a pending step result" do
+      step_result = Riffer::Workflow::StepResult.new(status: :pending)
+      expect(step_result.to_h).must_equal({status: :pending})
+    end
+
+    it "serializes a failed result" do
+      result = Riffer::Workflow::Result.new(
+        status: :failed,
+        input: {text: "hi"},
+        error: RuntimeError.new("boom"),
+        failed_step: "bad_step",
+        steps: {
+          "bad_step" => Riffer::Workflow::StepResult.new(status: :failed, payload: {text: "hi"}, error: RuntimeError.new("boom"))
+        }
+      )
+
+      expect(result.to_h).must_equal({
+        status: :failed,
+        input: {text: "hi"},
+        error: "boom",
+        failed_step: "bad_step",
+        steps: {
+          "bad_step" => {status: :failed, payload: {text: "hi"}, error: "boom"}
+        }
+      })
+    end
+  end
+end

--- a/test/riffer/workflow/step_result_test.rb
+++ b/test/riffer/workflow/step_result_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Workflow::StepResult do
+  describe "success" do
+    let(:result) do
+      Riffer::Workflow::StepResult.new(
+        status: :success,
+        payload: {message: "hello"},
+        output: {reply: "Hi"}
+      )
+    end
+
+    it "is success" do
+      expect(result.success?).must_equal true
+    end
+
+    it "is not failed" do
+      expect(result.failed?).must_equal false
+    end
+
+    it "is not pending" do
+      expect(result.pending?).must_equal false
+    end
+
+    it "carries the output" do
+      expect(result.output).must_equal({reply: "Hi"})
+    end
+
+    it "carries the payload" do
+      expect(result.payload).must_equal({message: "hello"})
+    end
+
+    it "has no error" do
+      expect(result.error).must_be_nil
+    end
+  end
+
+  describe "failed" do
+    let(:error) { RuntimeError.new("connection lost") }
+    let(:result) do
+      Riffer::Workflow::StepResult.new(
+        status: :failed,
+        payload: {message: "hello"},
+        error: error
+      )
+    end
+
+    it "is failed" do
+      expect(result.failed?).must_equal true
+    end
+
+    it "is not success" do
+      expect(result.success?).must_equal false
+    end
+
+    it "carries the error" do
+      expect(result.error).must_equal error
+    end
+
+    it "carries the payload" do
+      expect(result.payload).must_equal({message: "hello"})
+    end
+
+    it "has no output" do
+      expect(result.output).must_be_nil
+    end
+  end
+
+  describe "pending" do
+    let(:result) { Riffer::Workflow::StepResult.new(status: :pending) }
+
+    it "is pending" do
+      expect(result.pending?).must_equal true
+    end
+
+    it "has no payload" do
+      expect(result.payload).must_be_nil
+    end
+  end
+
+  describe "#to_h" do
+    it "serializes a successful step" do
+      result = Riffer::Workflow::StepResult.new(
+        status: :success,
+        payload: {text: "hi"},
+        output: {text: "HI"}
+      )
+      expect(result.to_h).must_equal({status: :success, payload: {text: "hi"}, output: {text: "HI"}})
+    end
+
+    it "serializes a failed step" do
+      result = Riffer::Workflow::StepResult.new(
+        status: :failed,
+        payload: {text: "hi"},
+        error: RuntimeError.new("boom")
+      )
+      expect(result.to_h).must_equal({status: :failed, payload: {text: "hi"}, error: "boom"})
+    end
+
+    it "serializes a pending step" do
+      result = Riffer::Workflow::StepResult.new(status: :pending)
+      expect(result.to_h).must_equal({status: :pending})
+    end
+  end
+end

--- a/test/riffer/workflow/step_test.rb
+++ b/test/riffer/workflow/step_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Workflow::Step do
+  let(:step_class) do
+    Class.new(Riffer::Workflow::Step) do
+      input do
+        required :message, String
+      end
+
+      output do
+        required :formatted, String
+      end
+
+      def execute(message:)
+        {formatted: message.upcase}
+      end
+    end
+  end
+
+  describe ".identifier" do
+    it "derives from class name by default" do
+      stub_const = Class.new(Riffer::Workflow::Step)
+      def stub_const.name = "CategorizeRequest"
+
+      expect(stub_const.identifier).must_equal "categorize_request"
+    end
+
+    it "accepts an explicit override" do
+      klass = Class.new(Riffer::Workflow::Step)
+      klass.identifier "custom_step"
+      expect(klass.identifier).must_equal "custom_step"
+    end
+  end
+
+  describe ".input" do
+    it "returns the params builder" do
+      expect(step_class.input).must_be_instance_of Riffer::Params
+    end
+
+    it "returns nil when not defined" do
+      bare = Class.new(Riffer::Workflow::Step)
+      expect(bare.input).must_be_nil
+    end
+  end
+
+  describe ".output" do
+    it "returns the params builder" do
+      expect(step_class.output).must_be_instance_of Riffer::Params
+    end
+
+    it "returns nil when not defined" do
+      bare = Class.new(Riffer::Workflow::Step)
+      expect(bare.output).must_be_nil
+    end
+  end
+
+  describe "#execute" do
+    it "raises NotImplementedError when not overridden" do
+      bare = Class.new(Riffer::Workflow::Step).new
+      expect { bare.execute }.must_raise(NotImplementedError)
+    end
+
+    it "runs the implemented logic" do
+      step = step_class.new
+      result = step.execute(message: "hello")
+      expect(result).must_equal({formatted: "HELLO"})
+    end
+  end
+
+  describe "#context" do
+    it "defaults to nil" do
+      step = step_class.new
+      expect(step.context).must_be_nil
+    end
+
+    it "is set at construction" do
+      step = step_class.new(context: {patient_id: "p1"})
+      expect(step.context[:patient_id]).must_equal "p1"
+    end
+  end
+
+  describe ".uses" do
+    it "returns an empty array by default" do
+      bare = Class.new(Riffer::Workflow::Step)
+      expect(bare.uses).must_equal []
+    end
+
+    it "stores declared dependencies" do
+      dummy_agent = Class.new
+      klass = Class.new(Riffer::Workflow::Step) { uses dummy_agent }
+      expect(klass.uses).must_equal [dummy_agent]
+    end
+
+    it "accumulates across multiple calls" do
+      agent_a = Class.new
+      agent_b = Class.new
+      klass = Class.new(Riffer::Workflow::Step) do
+        uses agent_a
+        uses agent_b
+      end
+      expect(klass.uses).must_equal [agent_a, agent_b]
+    end
+
+    it "rejects non-Module arguments" do
+      expect {
+        Class.new(Riffer::Workflow::Step) { uses "not_a_module" }
+      }.must_raise Riffer::ArgumentError
+    end
+  end
+end

--- a/test/riffer/workflow/workflow_test.rb
+++ b/test/riffer/workflow/workflow_test.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Workflow do
+  # -- Reusable step classes --------------------------------------------------
+
+  let(:upcase_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "UpcaseStep"
+
+      input do
+        required :text, String
+      end
+
+      output do
+        required :text, String
+      end
+
+      def execute(text:)
+        {text: text.upcase}
+      end
+    end
+  end
+
+  let(:append_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "AppendStep"
+
+      input do
+        required :text, String
+      end
+
+      output do
+        required :text, String
+      end
+
+      def execute(text:)
+        {text: "#{text}!"}
+      end
+    end
+  end
+
+  let(:context_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "ContextStep"
+
+      input do
+        required :text, String
+      end
+
+      output do
+        required :text, String
+        required :clinic, String
+      end
+
+      def execute(text:)
+        {text: text, clinic: context[:clinic_id]}
+      end
+    end
+  end
+
+  let(:failing_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "FailingStep"
+
+      input do
+        required :text, String
+      end
+
+      output do
+        required :text, String
+      end
+
+      def execute(text:)
+        raise "something went wrong"
+      end
+    end
+  end
+
+  let(:bad_output_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "BadOutputStep"
+
+      input do
+        required :text, String
+      end
+
+      output do
+        required :result, String
+      end
+
+      def execute(text:)
+        {wrong_key: text}
+      end
+    end
+  end
+
+  let(:no_schema_step) do
+    Class.new(Riffer::Workflow::Step) do
+      def self.name = "NoSchemaStep"
+
+      def execute(text:)
+        {text: text.reverse}
+      end
+    end
+  end
+
+  # -- Helpers ----------------------------------------------------------------
+
+  def build_workflow(*step_classes)
+    Class.new(Riffer::Workflow) do
+      step_classes.each { |s| step s }
+    end
+  end
+
+  # -- Tests ------------------------------------------------------------------
+
+  describe ".identifier" do
+    it "derives from class name" do
+      klass = Class.new(Riffer::Workflow)
+      def klass.name = "HelpDeskWorkflow"
+
+      expect(klass.identifier).must_equal "help_desk_workflow"
+    end
+
+    it "accepts an explicit override" do
+      klass = Class.new(Riffer::Workflow)
+      klass.identifier "help_desk"
+      expect(klass.identifier).must_equal "help_desk"
+    end
+  end
+
+  describe ".step" do
+    it "registers step classes in order" do
+      wf = build_workflow(upcase_step, append_step)
+      expect(wf.steps).must_equal [upcase_step, append_step]
+    end
+
+    it "rejects non-Step classes" do
+      expect { build_workflow(String) }.must_raise Riffer::ArgumentError
+    end
+
+    it "rejects duplicate step identifiers" do
+      expect {
+        Class.new(Riffer::Workflow) do
+          step_class = Class.new(Riffer::Workflow::Step) { def self.name = "DupStep" }
+          step step_class
+          step step_class
+        end
+      }.must_raise Riffer::ArgumentError
+    end
+  end
+
+  describe "happy path" do
+    it "runs steps sequentially and returns the final output" do
+      wf = build_workflow(upcase_step, append_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "HELLO!"})
+    end
+
+    it "captures the original input" do
+      wf = build_workflow(upcase_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.input).must_equal({text: "hello"})
+    end
+
+    it "records per-step results with payload and output" do
+      wf = build_workflow(upcase_step, append_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.steps.size).must_equal 2
+
+      expect(result.steps["upcase_step"].payload).must_equal({text: "hello"})
+      expect(result.steps["upcase_step"].output).must_equal({text: "HELLO"})
+
+      expect(result.steps["append_step"].payload).must_equal({text: "HELLO"})
+      expect(result.steps["append_step"].output).must_equal({text: "HELLO!"})
+    end
+
+    it "works via the instance form" do
+      wf_class = build_workflow(upcase_step)
+      wf = wf_class.new
+      result = wf.execute(text: "hello")
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "HELLO"})
+    end
+
+    it "serializes the full result via to_h" do
+      wf = build_workflow(upcase_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.to_h).must_equal({
+        status: :success,
+        input: {text: "hello"},
+        output: {text: "HELLO"},
+        steps: {
+          "upcase_step" => {status: :success, payload: {text: "hello"}, output: {text: "HELLO"}}
+        }
+      })
+    end
+  end
+
+  describe "context passing" do
+    it "makes context available inside steps" do
+      wf = build_workflow(context_step)
+      result = wf.execute({text: "hi"}, context: {clinic_id: "jane_demo"})
+
+      expect(result.success?).must_equal true
+      expect(result.output[:clinic]).must_equal "jane_demo"
+    end
+
+    it "passes context via instance form" do
+      wf_class = build_workflow(context_step)
+      wf = wf_class.new(context: {clinic_id: "west_clinic"})
+      result = wf.execute(text: "hi")
+
+      expect(result.output[:clinic]).must_equal "west_clinic"
+    end
+
+    it "does not mutate the caller's context hash" do
+      original = {clinic_id: "jane_demo"}
+      wf_class = build_workflow(context_step)
+      wf_class.new(context: original).execute(text: "hi")
+
+      expect(original).must_equal({clinic_id: "jane_demo"})
+    end
+  end
+
+  describe "input validation errors" do
+    it "fails when required input is missing" do
+      wf = build_workflow(upcase_step)
+      result = wf.execute({})
+
+      expect(result.failed?).must_equal true
+      expect(result.error).must_be_instance_of Riffer::ValidationError
+      expect(result.error.message).must_match(/text is required/)
+      expect(result.failed_step).must_equal "upcase_step"
+    end
+
+    it "fails when input type is wrong" do
+      wf = build_workflow(upcase_step)
+      result = wf.execute({text: 123})
+
+      expect(result.failed?).must_equal true
+      expect(result.error).must_be_instance_of Riffer::ValidationError
+    end
+
+    it "fails at the second step when output doesn't match next input" do
+      mismatched_step = Class.new(Riffer::Workflow::Step) do
+        def self.name = "MismatchedStep"
+
+        input do
+          required :text, String
+        end
+
+        output do
+          required :number, Integer
+        end
+
+        def execute(text:)
+          {number: text.length}
+        end
+      end
+
+      wf = build_workflow(mismatched_step, upcase_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.failed?).must_equal true
+      expect(result.failed_step).must_equal "upcase_step"
+      expect(result.steps["mismatched_step"].success?).must_equal true
+      expect(result.steps["upcase_step"].failed?).must_equal true
+    end
+  end
+
+  describe "output validation errors" do
+    it "fails when output is missing a required key" do
+      wf = build_workflow(bad_output_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.failed?).must_equal true
+      expect(result.error).must_be_instance_of Riffer::ValidationError
+      expect(result.error.message).must_match(/result is required/)
+      expect(result.failed_step).must_equal "bad_output_step"
+    end
+
+    it "fails when execute returns a non-Hash" do
+      non_hash_step = Class.new(Riffer::Workflow::Step) do
+        def self.name = "NonHashStep"
+
+        input do
+          required :text, String
+        end
+
+        def execute(text:)
+          "not a hash"
+        end
+      end
+
+      wf = build_workflow(non_hash_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.failed?).must_equal true
+      expect(result.error).must_be_instance_of Riffer::ValidationError
+      expect(result.error.message).must_match(/must return a Hash/)
+    end
+  end
+
+  describe "execution errors" do
+    it "captures the error and stops" do
+      wf = build_workflow(upcase_step, failing_step, append_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.failed?).must_equal true
+      expect(result.error).must_be_instance_of RuntimeError
+      expect(result.error.message).must_equal "something went wrong"
+      expect(result.failed_step).must_equal "failing_step"
+    end
+
+    it "marks later steps as pending" do
+      wf = build_workflow(upcase_step, failing_step, append_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.steps["upcase_step"].success?).must_equal true
+      expect(result.steps["failing_step"].failed?).must_equal true
+      expect(result.steps["append_step"].pending?).must_equal true
+    end
+
+    it "preserves completed step output before the failure" do
+      wf = build_workflow(upcase_step, failing_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.steps["upcase_step"].output).must_equal({text: "HELLO"})
+    end
+  end
+
+  describe "steps without schemas" do
+    it "skips validation when input/output are not declared" do
+      wf = build_workflow(no_schema_step)
+      result = wf.execute({text: "hello"})
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "olleh"})
+    end
+  end
+
+  describe "single-step workflow" do
+    it "works with just one step" do
+      wf = build_workflow(upcase_step)
+      result = wf.execute({text: "hi"})
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "HI"})
+      expect(result.steps.size).must_equal 1
+    end
+  end
+
+  describe "empty workflow" do
+    it "returns success with the input as output" do
+      wf = build_workflow
+      result = wf.execute({text: "hi"})
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "hi"})
+    end
+
+    it "works with context" do
+      wf = build_workflow
+      result = wf.execute({text: "hi"}, context: {user_id: "u1"})
+
+      expect(result.success?).must_equal true
+      expect(result.output).must_equal({text: "hi"})
+    end
+  end
+
+  describe ".to_mermaid" do
+    it "renders a multi-step pipeline in a subgraph" do
+      wf = build_workflow(upcase_step, append_step)
+      def wf.name = "TextWorkflow"
+
+      expected = [
+        "graph LR",
+        "  subgraph text_workflow",
+        "    upcase_step --> append_step",
+        "  end"
+      ].join("\n")
+
+      expect(wf.to_mermaid).must_equal expected
+    end
+
+    it "renders a single-step workflow" do
+      wf = build_workflow(upcase_step)
+      def wf.name = "SingleWorkflow"
+
+      expected = [
+        "graph LR",
+        "  subgraph single_workflow",
+        "    upcase_step",
+        "  end"
+      ].join("\n")
+
+      expect(wf.to_mermaid).must_equal expected
+    end
+
+    it "renders an empty workflow" do
+      wf = build_workflow
+      expect(wf.to_mermaid).must_equal "graph LR"
+    end
+
+    it "annotates steps that declare uses" do
+      dummy_agent = Class.new do
+        define_singleton_method(:name) { "ClassifierAgent" }
+      end
+      annotated_step = Class.new(Riffer::Workflow::Step) do
+        define_singleton_method(:name) { "AnnotatedStep" }
+        uses dummy_agent
+
+        def execute(**) = {}
+      end
+
+      wf = build_workflow(annotated_step, upcase_step)
+      def wf.name = "MixedWorkflow"
+
+      mermaid = wf.to_mermaid
+      expect(mermaid).must_include 'annotated_step["annotated_step · ClassifierAgent"]'
+      expect(mermaid).must_include "--> upcase_step"
+    end
+  end
+
+  describe ".describe" do
+    it "prints the workflow summary" do
+      wf = build_workflow(upcase_step, append_step)
+      def wf.name = "TestWorkflow"
+
+      output = capture_io { wf.describe }.first
+
+      expect(output).must_include "test_workflow (2 steps)"
+      expect(output).must_include "1. upcase_step  [text] → [text]"
+      expect(output).must_include "2. append_step  [text] → [text]"
+    end
+
+    it "handles steps without schemas" do
+      wf = build_workflow(no_schema_step)
+      def wf.name = "NoSchemaWorkflow"
+
+      output = capture_io { wf.describe }.first
+
+      expect(output).must_include "1. no_schema_step  [] → []"
+    end
+
+    it "handles empty workflows" do
+      wf = build_workflow
+      def wf.name = "EmptyWorkflow"
+
+      output = capture_io { wf.describe }.first
+      expect(output).must_include "empty_workflow (0 steps)"
+    end
+
+    it "shows uses declarations" do
+      dummy_tool = Class.new do
+        define_singleton_method(:name) { "LookupTool" }
+      end
+      annotated_step = Class.new(Riffer::Workflow::Step) do
+        define_singleton_method(:name) { "AnnotatedStep" }
+        uses dummy_tool
+
+        input { required :text, String }
+        output { required :text, String }
+        def execute(text:) = {text: text}
+      end
+
+      wf = build_workflow(annotated_step)
+      def wf.name = "AnnotatedWorkflow"
+
+      output = capture_io { wf.describe }.first
+
+      expect(output).must_include "· LookupTool"
+    end
+  end
+end


### PR DESCRIPTION
# What did we do

Added `Riffer::Workflow`, it composes complex, multi-step tasks as sequential pipelines instead of putting everything in a single agent call. Inspired by [Mastra's workflow design](https://mastra.ai/docs/workflows/overview), but in Ruby and strongly following riffer's existing patterns.

# How 

| Component | What it does |
|---|---|
| `Riffer::Workflow::Step` | Base class for step. It declares `input`/`output`, `identifier`, `uses`, and `execute` |
| `Riffer::Workflow` | Base class for workflow, `step` macro, runs via `execute` |
| `Riffer::Workflow::Runner` | To execute steps sequentially, and validate input/output |
| `Riffer::Workflow::Result` | `status`, `input`, `output`, `error`, `failed_step`, per-step results |
| `Riffer::Workflow::StepResult` | `status`, `payload`, `output`, `error` |
| `to_h` | Turns full result into a hash |
| `describe` | Prints step order, fields, and dependencies to stdout |
| `to_mermaid` | For Mermaid flowchart, paste returned string on [mermaid.live](https://mermaid.live/) for workflow visualization |
| `docs/WORKFLOWS.md` | Full documentation with examples for workflow users| 

### Walkthrough Video

https://github.com/user-attachments/assets/d7fa148b-18ae-4fdb-ba86-857910455f4f


### Trade-offs made

* Steps are classes, not blocks. Each step is testable on its own and matches existing Agent and Tool patterns in riffer.
* No workflow-level schema. The first step's input gates the entry, and the last step's output is what you get back.
* You can't rescue specific errors at the call site. You check result.failed? instead.
* No `Agent::Context`. Context is a plain duped Hash.
* `uses` is cosmetic. Added it later for `describe` and `to_mermaid` visualizations.


### What's next (additional features)

* Retry at step level on failure.
* Let a step read a prior step's result by identifier.
* Parallel, branching, looping.
* Streaming.

### Assumptions / Open questions

* Step identifiers must be unique per workflow. Enforced at registration.
* Now that `uses` exists, it could validate that classes are loaded at definition time.

### Tests 
<img width="681" height="208" alt="Screenshot 2026-07-15 at 5 28 31 AM" src="https://github.com/user-attachments/assets/561249e6-2389-4d2c-9f4a-a967dd74ec69" />
