### PR TITLE
feat: record time to first chunk on streaming chat spans

### DIFF
--- a/docs/16_TRACING.md
+++ b/docs/16_TRACING.md
@@ -147,6 +147,7 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 | `riffer.cost`                              | float    | When the call's model was priced                                              |
 | `gen_ai.response.finish_reasons`           | string[] | When the provider reported a finish reason                                    |
 | `riffer.finish_reason.raw`                 | string   | When the raw value differs from the normalized one                            |
+| `gen_ai.response.time_to_first_chunk`      | float    | Streaming only — seconds from request issuance to the first stream event      |
 | `gen_ai.input.messages`                    | string   | When `capture_messages` is on (JSON; see [capture](#message-content-capture)) |
 | `gen_ai.system_instructions`               | string   | When `capture_messages` is on and a system prompt exists                      |
 | `gen_ai.output.messages`                   | string   | When `capture_messages` is on (JSON)                                          |

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -263,6 +263,8 @@ class Riffer::Providers::Base
   def record_stream_outcome(span, recorder)
     Riffer::Tracing.record_usage(span, recorder.token_usage)
     record_finish_reason(span, recorder.finish_reason, recorder.raw_finish_reason)
+    time_to_first_chunk = recorder.time_to_first_chunk
+    span.set_attribute("gen_ai.response.time_to_first_chunk", time_to_first_chunk) if time_to_first_chunk
     capture_output(span, content: recorder.content, tool_calls: recorder.tool_calls, finish_reason: recorder.finish_reason)
   end
 

--- a/lib/riffer/tracing/stream_recorder.rb
+++ b/lib/riffer/tracing/stream_recorder.rb
@@ -5,8 +5,12 @@
 # forwarding every event downstream untouched.
 class Riffer::Tracing::StreamRecorder # :nodoc: all
   # @rbs @yielder: Enumerator::Yielder
+  # @rbs @clock: ^() -> Float
+  # @rbs @started_at: Float
 
   attr_reader :token_usage #: Riffer::Providers::TokenUsage?
+
+  attr_reader :time_to_first_chunk #: Float?
 
   attr_reader :finish_reason #: Symbol?
 
@@ -17,15 +21,18 @@ class Riffer::Tracing::StreamRecorder # :nodoc: all
   attr_reader :tool_calls #: Array[Riffer::Messages::Assistant::ToolCall]
 
   #--
-  #: (Enumerator::Yielder) -> void
-  def initialize(yielder)
+  #: (Enumerator::Yielder, ?clock: ^() -> Float) -> void
+  def initialize(yielder, clock: -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) })
     @yielder = yielder
+    @clock = clock
+    @started_at = clock.call
     @tool_calls = [] #: Array[Riffer::Messages::Assistant::ToolCall]
   end
 
   #--
   #: (Riffer::StreamEvents::Base) -> self
   def <<(event)
+    @time_to_first_chunk ||= @clock.call - @started_at
     record(event)
     @yielder << event
     self

--- a/sig/generated/riffer/tracing/stream_recorder.rbs
+++ b/sig/generated/riffer/tracing/stream_recorder.rbs
@@ -5,7 +5,13 @@
 class Riffer::Tracing::StreamRecorder
   @yielder: Enumerator::Yielder
 
+  @clock: ^() -> Float
+
+  @started_at: Float
+
   attr_reader token_usage: Riffer::Providers::TokenUsage?
+
+  attr_reader time_to_first_chunk: Float?
 
   attr_reader finish_reason: Symbol?
 
@@ -16,8 +22,8 @@ class Riffer::Tracing::StreamRecorder
   attr_reader tool_calls: Array[Riffer::Messages::Assistant::ToolCall]
 
   # --
-  # : (Enumerator::Yielder) -> void
-  def initialize: (Enumerator::Yielder) -> void
+  # : (Enumerator::Yielder, ?clock: ^() -> Float) -> void
+  def initialize: (Enumerator::Yielder, ?clock: ^() -> Float) -> void
 
   # --
   # : (Riffer::StreamEvents::Base) -> self

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -19,6 +19,13 @@ class ChatTracingExplodingProvider < Riffer::Providers::Mock
   end
 end
 
+class ChatTracingSilentStreamProvider < Riffer::Providers::Mock
+  private
+
+  def execute_stream(params, yielder)
+  end
+end
+
 describe Riffer::Providers::Base do
   let(:provider) { Riffer::Providers::Base.new }
 
@@ -404,6 +411,22 @@ describe Riffer::Providers::Base do
     it "records the finish reason from the stream" do
       provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
       expect(chat_span.attributes["gen_ai.response.finish_reasons"]).must_equal ["stop"]
+    end
+
+    it "stamps the time to first chunk on the streamed span" do
+      provider.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      expect(chat_span.attributes["gen_ai.response.time_to_first_chunk"]).must_be :>, 0
+    end
+
+    it "omits the time to first chunk when the stream yields no events" do
+      silent = ChatTracingSilentStreamProvider.new
+      silent.stream_text(prompt: "Hello", model: "riffer-1").each { |_| }
+      expect(chat_span.attributes).wont_include "gen_ai.response.time_to_first_chunk"
+    end
+
+    it "keeps the time to first chunk off the generate_text span" do
+      provider.generate_text(prompt: "Hello", model: "riffer-1")
+      expect(chat_span.attributes).wont_include "gen_ai.response.time_to_first_chunk"
     end
 
     it "parents the chat span to the trace active at the call" do

--- a/test/riffer/tracing/stream_recorder_test.rb
+++ b/test/riffer/tracing/stream_recorder_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Tracing::StreamRecorder do
+  describe "#time_to_first_chunk" do
+    def build_recorder(clock_values)
+      remaining = clock_values.dup
+      Riffer::Tracing::StreamRecorder.new([], clock: -> { remaining.shift })
+    end
+
+    it "measures from construction to the first event" do
+      recorder = build_recorder([1.0, 1.5])
+      recorder << Riffer::StreamEvents::TextDelta.new("Hi")
+      expect(recorder.time_to_first_chunk).must_equal 0.5
+    end
+
+    it "counts a non-text event as the first chunk" do
+      recorder = build_recorder([1.0, 1.25])
+      recorder << Riffer::StreamEvents::ToolCallDelta.new(item_id: "call_1", name: "my_tool", arguments_delta: "{}")
+      expect(recorder.time_to_first_chunk).must_equal 0.25
+    end
+
+    it "keeps the first measurement across subsequent events" do
+      recorder = build_recorder([1.0, 1.5, 9.0])
+      recorder << Riffer::StreamEvents::TextDelta.new("Hi")
+      recorder << Riffer::StreamEvents::TextDone.new("Hi")
+      expect(recorder.time_to_first_chunk).must_equal 0.5
+    end
+
+    it "is nil when no event arrives" do
+      recorder = build_recorder([1.0])
+      expect(recorder.time_to_first_chunk).must_be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Consumers of riffer's tracing have no way to see time-to-first-token latency for streaming LLM calls — the `chat` span only exposes total duration, which conflates queueing/prefill latency with generation time. TTFT is the primary responsiveness metric for streaming UX, and observability backends can't derive it from the span data riffer emits today.

## Solution

Adds the OpenTelemetry GenAI semantic convention attribute `gen_ai.response.time_to_first_chunk` (a Float in seconds, per the convention's definition in `open-telemetry/semantic-conventions-genai`) to streaming `chat` spans. `Tracing::StreamRecorder` captures a monotonic timestamp at construction — immediately before the provider request is issued — and memoizes the elapsed time on the first stream event of any type, so tool-call-only and reasoning-only streams are measured too, matching the convention's "first chunk" (not "first text token") semantics. The value is stamped in `record_stream_outcome` alongside the other terminal attributes.

Two deliberate boundaries: the attribute is never set on the non-streaming `generate_text` path (the convention marks it streaming-only), and streams that produce no events omit the attribute rather than recording a nil or zero. The clock is injected as a constructor parameter (defaulting to `Process::CLOCK_MONOTONIC`) so tests are deterministic without sleeps.

Note the attribute is Development-stability in the semconv and postdates the schema version riffer pins (1.37.0); it lives in the newer dedicated GenAI conventions repo. `docs/16_TRACING.md` documents it in the `chat` span table.

## Proof

Covered by CI: new unit tests for `StreamRecorder` (first-event measurement, memoization across subsequent events, nil when no events arrive) and span-level tests in `base_test.rb` (streamed span gets a positive value, silent streams and `generate_text` omit the attribute). Full `bin/rake` (tests + StandardRB + Steep) is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat streaming traces now include the time from request start until the first streamed response chunk.
  * This metric is recorded only when streaming produces an event and is not added to non-streaming text generation spans.

* **Documentation**
  * Documented the new streaming-only OpenTelemetry attribute and its meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->