### PR TITLE
feat(evals): expose token usage on evaluation results

### DIFF
--- a/docs/11_EVALS.md
+++ b/docs/11_EVALS.md
@@ -110,6 +110,7 @@ The runner returns a `Riffer::Evals::RunResult`:
 ```ruby
 result.scores             # => { EvaluatorClass => avg_score } across all scenarios
 result.scenario_results   # => Array of ScenarioResult objects
+result.token_usage        # => TokenUsage summed across all scenarios (nil if no judge ran)
 result.to_h               # => Hash representation
 ```
 
@@ -125,6 +126,7 @@ scenario.ground_truth # => "Paris"
 scenario.scores       # => { EvaluatorClass => score } for this scenario
 scenario.results      # => Array of Result objects
 scenario.messages     # => Array of Message objects (system, user, assistant, tool)
+scenario.token_usage  # => TokenUsage summed across this scenario's evaluators (nil if no judge ran)
 scenario.to_h         # => Hash representation
 ```
 
@@ -138,7 +140,10 @@ r.evaluator        # => AnswerRelevancyEvaluator
 r.score            # => 0.92
 r.reason           # => "The response directly addresses..."
 r.higher_is_better # => true
+r.token_usage      # => TokenUsage for the judge call (nil for rule-based evaluators)
 ```
+
+`token_usage` is a `Riffer::Providers::TokenUsage`, the same type the agent exposes on `Agent::Response`, so eval usage accumulates with the `+` operator just like agent usage. It's populated for LLM-as-judge evaluators and `nil` for rule-based ones that never call an LLM.
 
 ## Defining Custom Evaluators
 
@@ -190,7 +195,7 @@ Instance methods:
 
 - `evaluate(input:, output:, ground_truth:, messages:)` - Override for custom logic; default calls judge with `instructions`
 - `judge` - Returns a Judge instance for LLM-as-judge calls
-- `result(score:, reason:, metadata:)` - Helper to build Result objects
+- `result(score:, reason:, metadata:, token_usage:)` - Helper to build Result objects
 
 ### Advanced: Custom Evaluate Override
 

--- a/docs/11_EVALS.md
+++ b/docs/11_EVALS.md
@@ -108,10 +108,11 @@ Per-scenario `context` overrides the top-level value. Scenarios without their ow
 The runner returns a `Riffer::Evals::RunResult`:
 
 ```ruby
-result.scores             # => { EvaluatorClass => avg_score } across all scenarios
-result.scenario_results   # => Array of ScenarioResult objects
-result.token_usage        # => TokenUsage summed across all scenarios (nil if no judge ran)
-result.to_h               # => Hash representation
+result.scores                  # => { EvaluatorClass => avg_score } across all scenarios
+result.scenario_results        # => Array of ScenarioResult objects
+result.token_usage             # => TokenUsage the agent under test spent, summed across scenarios (nil if none reported)
+result.evaluator_token_usage   # => TokenUsage the judges spent, summed across scenarios (nil if no judge ran)
+result.to_h                    # => Hash representation
 ```
 
 ### ScenarioResult
@@ -120,14 +121,15 @@ Each scenario produces a `Riffer::Evals::ScenarioResult`:
 
 ```ruby
 scenario = result.scenario_results.first
-scenario.input        # => "What is the capital of France?"
-scenario.output       # => "The capital of France is Paris."
-scenario.ground_truth # => "Paris"
-scenario.scores       # => { EvaluatorClass => score } for this scenario
-scenario.results      # => Array of Result objects
-scenario.messages     # => Array of Message objects (system, user, assistant, tool)
-scenario.token_usage  # => TokenUsage summed across this scenario's evaluators (nil if no judge ran)
-scenario.to_h         # => Hash representation
+scenario.input                  # => "What is the capital of France?"
+scenario.output                 # => "The capital of France is Paris."
+scenario.ground_truth           # => "Paris"
+scenario.scores                 # => { EvaluatorClass => score } for this scenario
+scenario.results                # => Array of Result objects
+scenario.messages               # => Array of Message objects (system, user, assistant, tool)
+scenario.token_usage            # => TokenUsage the agent under test spent on this scenario (nil if not reported)
+scenario.evaluator_token_usage  # => TokenUsage the judges spent on this scenario (nil if no judge ran)
+scenario.to_h                   # => Hash representation
 ```
 
 ### Result
@@ -143,7 +145,9 @@ r.higher_is_better # => true
 r.token_usage      # => TokenUsage for the judge call (nil for rule-based evaluators)
 ```
 
-`token_usage` is a `Riffer::Providers::TokenUsage`, the same type the agent exposes on `Agent::Response`, so eval usage accumulates with the `+` operator just like agent usage. It's populated for LLM-as-judge evaluators and `nil` for rule-based ones that never call an LLM.
+`token_usage` is a `Riffer::Providers::TokenUsage`, the same type the agent exposes on `Agent::Response`, so eval usage accumulates with the `+` operator just like agent usage. On a `Result` it's populated for LLM-as-judge evaluators and `nil` for rule-based ones that never call an LLM.
+
+`ScenarioResult` and `RunResult` keep the two sources separate rather than exposing a single total: `token_usage` is what the agent under test spent generating the output, and `evaluator_token_usage` is what the judges spent scoring it. Add them yourself if you want a combined figure.
 
 ## Defining Custom Evaluators
 

--- a/lib/riffer/evals/evaluator.rb
+++ b/lib/riffer/evals/evaluator.rb
@@ -66,7 +66,7 @@ class Riffer::Evals::Evaluator
       ground_truth: ground_truth
     )
 
-    result(score: evaluation[:score], reason: evaluation[:reason])
+    result(score: evaluation[:score], reason: evaluation[:reason], token_usage: evaluation[:token_usage])
   end
 
   private
@@ -105,14 +105,15 @@ class Riffer::Evals::Evaluator
 
   # Builds a Result for this evaluator.
   #--
-  #: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
-  def result(score:, reason: nil, metadata: {})
+  #: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?token_usage: Riffer::Providers::TokenUsage?) -> Riffer::Evals::Result
+  def result(score:, reason: nil, metadata: {}, token_usage: nil)
     Riffer::Evals::Result.new(
       evaluator: self.class,
       score: score,
       reason: reason,
       metadata: metadata,
-      higher_is_better: self.class.higher_is_better
+      higher_is_better: self.class.higher_is_better,
+      token_usage: token_usage
     )
   end
 end

--- a/lib/riffer/evals/evaluator_runner.rb
+++ b/lib/riffer/evals/evaluator_runner.rb
@@ -62,6 +62,7 @@ module Riffer::Evals::EvaluatorRunner
     response = agent.generate(input, context: resolved_context)
     output = response.content
     messages = response.messages
+    token_usage = response.token_usage
 
     results = evaluators.map do |evaluator_class|
       evaluator_class.new.evaluate(input: input, output: output, ground_truth: ground_truth, messages: messages)
@@ -72,7 +73,8 @@ module Riffer::Evals::EvaluatorRunner
       output: output,
       ground_truth: ground_truth,
       results: results,
-      messages: messages
+      messages: messages,
+      token_usage: token_usage
     )
   end
 end

--- a/lib/riffer/evals/judge.rb
+++ b/lib/riffer/evals/judge.rb
@@ -121,7 +121,8 @@ class Riffer::Evals::Judge
 
     {
       score: score.to_f,
-      reason: reason
+      reason: reason,
+      token_usage: response.token_usage
     }
   rescue JSON::ParserError => e
     raise Riffer::Error, "Invalid judge response: #{e.message}"

--- a/lib/riffer/evals/result.rb
+++ b/lib/riffer/evals/result.rb
@@ -18,16 +18,21 @@ class Riffer::Evals::Result
   # Whether higher scores are better for this evaluator.
   attr_reader :higher_is_better #: bool
 
+  # Token usage for the judge call that produced this result, when the
+  # evaluator used an LLM. Nil for rule-based evaluators.
+  attr_reader :token_usage #: Riffer::Providers::TokenUsage?
+
   # Raises Riffer::ArgumentError if +score+ is not between 0.0 and 1.0.
   #--
-  #: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
-  def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true)
+  #: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool, ?token_usage: Riffer::Providers::TokenUsage?) -> void
+  def initialize(evaluator:, score:, reason: nil, metadata: {}, higher_is_better: true, token_usage: nil)
     @evaluator = evaluator
     @score = score.to_f
     validate_score!
     @reason = reason
     @metadata = metadata
     @higher_is_better = higher_is_better
+    @token_usage = token_usage
   end
 
   # Returns a hash representation of the result.
@@ -40,7 +45,8 @@ class Riffer::Evals::Result
       score: score,
       reason: reason,
       metadata: metadata,
-      higher_is_better: higher_is_better
+      higher_is_better: higher_is_better,
+      token_usage: token_usage&.to_h
     }
   end
 

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -35,6 +35,15 @@ class Riffer::Evals::RunResult
     end
   end
 
+  # Returns the summed token usage across every scenario, or nil when none
+  # reported usage.
+  #
+  #--
+  #: () -> Riffer::Providers::TokenUsage?
+  def token_usage
+    scenario_results.map(&:token_usage).compact.reduce(:+)
+  end
+
   # Returns a hash representation of the run result.
   #
   #--
@@ -42,7 +51,8 @@ class Riffer::Evals::RunResult
   def to_h
     {
       scores: scores.transform_keys(&:name),
-      scenario_results: scenario_results.map(&:to_h)
+      scenario_results: scenario_results.map(&:to_h),
+      token_usage: token_usage&.to_h
     }
   end
 end

--- a/lib/riffer/evals/run_result.rb
+++ b/lib/riffer/evals/run_result.rb
@@ -35,13 +35,22 @@ class Riffer::Evals::RunResult
     end
   end
 
-  # Returns the summed token usage across every scenario, or nil when none
-  # reported usage.
+  # Returns the summed token usage the agents under test spent across every
+  # scenario, or nil when none reported usage.
   #
   #--
   #: () -> Riffer::Providers::TokenUsage?
   def token_usage
     scenario_results.map(&:token_usage).compact.reduce(:+)
+  end
+
+  # Returns the summed token usage across every scenario's LLM-as-judge
+  # evaluators, or nil when none reported usage.
+  #
+  #--
+  #: () -> Riffer::Providers::TokenUsage?
+  def evaluator_token_usage
+    scenario_results.map(&:evaluator_token_usage).compact.reduce(:+)
   end
 
   # Returns a hash representation of the run result.
@@ -52,7 +61,8 @@ class Riffer::Evals::RunResult
     {
       scores: scores.transform_keys(&:name),
       scenario_results: scenario_results.map(&:to_h),
-      token_usage: token_usage&.to_h
+      token_usage: token_usage&.to_h,
+      evaluator_token_usage: evaluator_token_usage&.to_h
     }
   end
 end

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -39,6 +39,15 @@ class Riffer::Evals::ScenarioResult
     end
   end
 
+  # Returns the summed token usage across this scenario's LLM-as-judge
+  # evaluators, or nil when none reported usage.
+  #
+  #--
+  #: () -> Riffer::Providers::TokenUsage?
+  def token_usage
+    results.map(&:token_usage).compact.reduce(:+)
+  end
+
   # Returns a hash representation of the scenario result.
   #
   #--
@@ -50,7 +59,8 @@ class Riffer::Evals::ScenarioResult
       ground_truth: ground_truth,
       scores: scores.transform_keys(&:name),
       results: results.map(&:to_h),
-      messages: messages.map(&:to_h)
+      messages: messages.map(&:to_h),
+      token_usage: token_usage&.to_h
     }
   end
 end

--- a/lib/riffer/evals/scenario_result.rb
+++ b/lib/riffer/evals/scenario_result.rb
@@ -18,14 +18,18 @@ class Riffer::Evals::ScenarioResult
   # The full message history from the agent conversation.
   attr_reader :messages #: Array[Riffer::Messages::Base]
 
+  # Token usage the agent under test spent generating this scenario's output.
+  attr_reader :token_usage #: Riffer::Providers::TokenUsage?
+
   #--
-  #: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
-  def initialize(input:, output:, ground_truth:, results:, messages: [])
+  #: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::Providers::TokenUsage?) -> void
+  def initialize(input:, output:, ground_truth:, results:, messages: [], token_usage: nil)
     @input = input
     @output = output
     @ground_truth = ground_truth
     @results = results
     @messages = messages
+    @token_usage = token_usage
   end
 
   # Returns scores keyed by evaluator class.
@@ -44,7 +48,7 @@ class Riffer::Evals::ScenarioResult
   #
   #--
   #: () -> Riffer::Providers::TokenUsage?
-  def token_usage
+  def evaluator_token_usage
     results.map(&:token_usage).compact.reduce(:+)
   end
 
@@ -60,7 +64,8 @@ class Riffer::Evals::ScenarioResult
       scores: scores.transform_keys(&:name),
       results: results.map(&:to_h),
       messages: messages.map(&:to_h),
-      token_usage: token_usage&.to_h
+      token_usage: token_usage&.to_h,
+      evaluator_token_usage: evaluator_token_usage&.to_h
     }
   end
 end

--- a/sig/generated/riffer/evals/evaluator.rbs
+++ b/sig/generated/riffer/evals/evaluator.rbs
@@ -57,6 +57,6 @@ class Riffer::Evals::Evaluator
 
   # Builds a Result for this evaluator.
   # --
-  # : (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
-  def result: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped]) -> Riffer::Evals::Result
+  # : (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?token_usage: Riffer::Providers::TokenUsage?) -> Riffer::Evals::Result
+  def result: (score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?token_usage: Riffer::Providers::TokenUsage?) -> Riffer::Evals::Result
 end

--- a/sig/generated/riffer/evals/result.rbs
+++ b/sig/generated/riffer/evals/result.rbs
@@ -17,10 +17,14 @@ class Riffer::Evals::Result
   # Whether higher scores are better for this evaluator.
   attr_reader higher_is_better: bool
 
+  # Token usage for the judge call that produced this result, when the
+  # evaluator used an LLM. Nil for rule-based evaluators.
+  attr_reader token_usage: Riffer::Providers::TokenUsage?
+
   # Raises Riffer::ArgumentError if +score+ is not between 0.0 and 1.0.
   # --
-  # : (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
-  def initialize: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool) -> void
+  # : (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool, ?token_usage: Riffer::Providers::TokenUsage?) -> void
+  def initialize: (evaluator: singleton(Riffer::Evals::Evaluator), score: Float, ?reason: String?, ?metadata: Hash[Symbol, untyped], ?higher_is_better: bool, ?token_usage: Riffer::Providers::TokenUsage?) -> void
 
   # Returns a hash representation of the result.
   #

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -15,6 +15,13 @@ class Riffer::Evals::RunResult
   # : () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
 
+  # Returns the summed token usage across every scenario, or nil when none
+  # reported usage.
+  #
+  # --
+  # : () -> Riffer::Providers::TokenUsage?
+  def token_usage: () -> Riffer::Providers::TokenUsage?
+
   # Returns a hash representation of the run result.
   #
   # --

--- a/sig/generated/riffer/evals/run_result.rbs
+++ b/sig/generated/riffer/evals/run_result.rbs
@@ -15,12 +15,19 @@ class Riffer::Evals::RunResult
   # : () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
 
-  # Returns the summed token usage across every scenario, or nil when none
-  # reported usage.
+  # Returns the summed token usage the agents under test spent across every
+  # scenario, or nil when none reported usage.
   #
   # --
   # : () -> Riffer::Providers::TokenUsage?
   def token_usage: () -> Riffer::Providers::TokenUsage?
+
+  # Returns the summed token usage across every scenario's LLM-as-judge
+  # evaluators, or nil when none reported usage.
+  #
+  # --
+  # : () -> Riffer::Providers::TokenUsage?
+  def evaluator_token_usage: () -> Riffer::Providers::TokenUsage?
 
   # Returns a hash representation of the run result.
   #

--- a/sig/generated/riffer/evals/scenario_result.rbs
+++ b/sig/generated/riffer/evals/scenario_result.rbs
@@ -27,6 +27,13 @@ class Riffer::Evals::ScenarioResult
   # : () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
   def scores: () -> Hash[singleton(Riffer::Evals::Evaluator), Float]
 
+  # Returns the summed token usage across this scenario's LLM-as-judge
+  # evaluators, or nil when none reported usage.
+  #
+  # --
+  # : () -> Riffer::Providers::TokenUsage?
+  def token_usage: () -> Riffer::Providers::TokenUsage?
+
   # Returns a hash representation of the scenario result.
   #
   # --

--- a/sig/generated/riffer/evals/scenario_result.rbs
+++ b/sig/generated/riffer/evals/scenario_result.rbs
@@ -17,9 +17,12 @@ class Riffer::Evals::ScenarioResult
   # The full message history from the agent conversation.
   attr_reader messages: Array[Riffer::Messages::Base]
 
+  # Token usage the agent under test spent generating this scenario's output.
+  attr_reader token_usage: Riffer::Providers::TokenUsage?
+
   # --
-  # : (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
-  def initialize: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base]) -> void
+  # : (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::Providers::TokenUsage?) -> void
+  def initialize: (input: String, output: String, ground_truth: String?, results: Array[Riffer::Evals::Result], ?messages: Array[Riffer::Messages::Base], ?token_usage: Riffer::Providers::TokenUsage?) -> void
 
   # Returns scores keyed by evaluator class.
   #
@@ -32,7 +35,7 @@ class Riffer::Evals::ScenarioResult
   #
   # --
   # : () -> Riffer::Providers::TokenUsage?
-  def token_usage: () -> Riffer::Providers::TokenUsage?
+  def evaluator_token_usage: () -> Riffer::Providers::TokenUsage?
 
   # Returns a hash representation of the scenario result.
   #

--- a/test/riffer/evals/evaluator_runner_test.rb
+++ b/test/riffer/evals/evaluator_runner_test.rb
@@ -125,6 +125,24 @@ describe Riffer::Evals::EvaluatorRunner do
       expect(received_messages).wont_be_empty
     end
 
+    it "captures agent token usage on the scenario result" do
+      usage_agent = Class.new(Riffer::Agent) do
+        model "mock/mock-model"
+        instructions "You are a helpful assistant."
+        provider_options responses: [
+          {content: "Answer", token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 15, output_tokens: 6)}
+        ]
+      end
+
+      result = Riffer::Evals::EvaluatorRunner.run(
+        agent: usage_agent,
+        scenarios: [{input: "Hello"}],
+        evaluators: [evaluator_class]
+      )
+
+      expect(result.scenario_results.first.token_usage.total_tokens).must_equal 21
+    end
+
     it "returns aggregate scores" do
       result = Riffer::Evals::EvaluatorRunner.run(
         agent: agent_class,

--- a/test/riffer/evals/evaluator_test.rb
+++ b/test/riffer/evals/evaluator_test.rb
@@ -120,6 +120,26 @@ describe Riffer::Evals::Evaluator do
 
       expect(result.score).must_equal 0.95
     end
+
+    it "captures the judge's token usage on the result" do
+      klass = Class.new(Riffer::Evals::Evaluator) do
+        instructions "Evaluate quality."
+        judge_model "mock/eval-model"
+      end
+
+      evaluator = klass.new
+      judge = evaluator.send(:judge)
+      provider = judge.send(:provider_instance)
+      provider.stub_response(
+        "",
+        tool_calls: [{name: "evaluation", arguments: {score: 0.8, reason: "Good"}}],
+        token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 30, output_tokens: 12)
+      )
+
+      result = evaluator.evaluate(input: "test input", output: "test output")
+
+      expect(result.token_usage.total_tokens).must_equal 42
+    end
   end
 
   describe "#result (protected)" do

--- a/test/riffer/evals/judge_test.rb
+++ b/test/riffer/evals/judge_test.rb
@@ -30,7 +30,25 @@ describe Riffer::Evals::Judge do
         output: "Ruby is a programming language."
       )
 
-      expect(result).must_equal({score: 0.85, reason: "Good response."})
+      expect(result).must_equal({score: 0.85, reason: "Good response.", token_usage: nil})
+    end
+
+    it "returns token usage from the provider response" do
+      judge = Riffer::Evals::Judge.new(model: "mock/eval-model")
+      provider = judge.send(:provider_instance)
+      provider.stub_response(
+        "",
+        tool_calls: [{name: "evaluation", arguments: {score: 0.85, reason: "Good response."}}],
+        token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 42, output_tokens: 7)
+      )
+
+      result = judge.evaluate(
+        instructions: "Assess answer relevancy.",
+        input: "What is Ruby?",
+        output: "Ruby is a programming language."
+      )
+
+      expect(result[:token_usage].total_tokens).must_equal 49
     end
 
     it "evaluates with ground_truth" do
@@ -45,7 +63,7 @@ describe Riffer::Evals::Judge do
         ground_truth: "Paris"
       )
 
-      expect(result).must_equal({score: 0.9, reason: "Matches ground truth."})
+      expect(result).must_equal({score: 0.9, reason: "Matches ground truth.", token_usage: nil})
     end
   end
 end

--- a/test/riffer/evals/result_test.rb
+++ b/test/riffer/evals/result_test.rb
@@ -44,6 +44,17 @@ describe Riffer::Evals::Result do
       expect(result.higher_is_better).must_equal true
     end
 
+    it "sets token_usage" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 10, output_tokens: 5)
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8, token_usage: usage)
+      expect(result.token_usage).must_equal usage
+    end
+
+    it "defaults token_usage to nil" do
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.8)
+      expect(result.token_usage).must_be_nil
+    end
+
     it "raises an error if score is below 0" do
       error = expect do
         Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: -0.1)
@@ -88,6 +99,21 @@ describe Riffer::Evals::Result do
       expect(hash[:reason]).must_equal "Good"
       expect(hash[:metadata]).must_equal({key: "value"})
       expect(hash[:higher_is_better]).must_equal true
+    end
+
+    it "includes token_usage when present" do
+      result = Riffer::Evals::Result.new(
+        evaluator: Riffer::Evals::Evaluator,
+        score: 0.85,
+        token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 10, output_tokens: 5)
+      )
+
+      expect(result.to_h[:token_usage]).must_equal({input_tokens: 10, output_tokens: 5})
+    end
+
+    it "includes token_usage as nil when absent" do
+      result = Riffer::Evals::Result.new(evaluator: Riffer::Evals::Evaluator, score: 0.85)
+      expect(result.to_h[:token_usage]).must_be_nil
     end
   end
 end

--- a/test/riffer/evals/run_result_test.rb
+++ b/test/riffer/evals/run_result_test.rb
@@ -69,6 +69,37 @@ describe Riffer::Evals::RunResult do
     end
   end
 
+  describe "#token_usage" do
+    it "sums token usage across scenarios" do
+      scenario_with_usage = Riffer::Evals::ScenarioResult.new(
+        input: "What is Ruby?",
+        output: "A programming language.",
+        ground_truth: nil,
+        results: [
+          Riffer::Evals::Result.new(evaluator: evaluator_class, score: 0.9, token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 10, output_tokens: 5))
+        ]
+      )
+      other_scenario_with_usage = Riffer::Evals::ScenarioResult.new(
+        input: "What is Python?",
+        output: "A snake.",
+        ground_truth: nil,
+        results: [
+          Riffer::Evals::Result.new(evaluator: evaluator_class, score: 0.3, token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 20, output_tokens: 8))
+        ]
+      )
+
+      run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_with_usage, other_scenario_with_usage])
+
+      expect(run_result.token_usage.total_tokens).must_equal 43
+    end
+
+    it "returns nil when no scenario reports token usage" do
+      run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_a, scenario_b])
+
+      expect(run_result.token_usage).must_be_nil
+    end
+  end
+
   describe "#to_h" do
     it "returns a hash representation" do
       run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_a])

--- a/test/riffer/evals/run_result_test.rb
+++ b/test/riffer/evals/run_result_test.rb
@@ -69,8 +69,8 @@ describe Riffer::Evals::RunResult do
     end
   end
 
-  describe "#token_usage" do
-    it "sums token usage across scenarios" do
+  describe "#evaluator_token_usage" do
+    it "sums evaluator usage across scenarios" do
       scenario_with_usage = Riffer::Evals::ScenarioResult.new(
         input: "What is Ruby?",
         output: "A programming language.",
@@ -90,10 +90,39 @@ describe Riffer::Evals::RunResult do
 
       run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_with_usage, other_scenario_with_usage])
 
+      expect(run_result.evaluator_token_usage.total_tokens).must_equal 43
+    end
+
+    it "returns nil when no scenario reports evaluator usage" do
+      run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_a, scenario_b])
+
+      expect(run_result.evaluator_token_usage).must_be_nil
+    end
+  end
+
+  describe "#token_usage" do
+    it "sums agent usage across scenarios" do
+      scenario_with_usage = Riffer::Evals::ScenarioResult.new(
+        input: "What is Ruby?",
+        output: "A programming language.",
+        ground_truth: nil,
+        results: [],
+        token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 10, output_tokens: 5)
+      )
+      other_scenario_with_usage = Riffer::Evals::ScenarioResult.new(
+        input: "What is Python?",
+        output: "A snake.",
+        ground_truth: nil,
+        results: [],
+        token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 20, output_tokens: 8)
+      )
+
+      run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_with_usage, other_scenario_with_usage])
+
       expect(run_result.token_usage.total_tokens).must_equal 43
     end
 
-    it "returns nil when no scenario reports token usage" do
+    it "returns nil when no scenario reports agent usage" do
       run_result = Riffer::Evals::RunResult.new(scenario_results: [scenario_a, scenario_b])
 
       expect(run_result.token_usage).must_be_nil

--- a/test/riffer/evals/scenario_result_test.rb
+++ b/test/riffer/evals/scenario_result_test.rb
@@ -90,6 +90,33 @@ describe Riffer::Evals::ScenarioResult do
     end
   end
 
+  describe "#token_usage" do
+    it "sums token usage across results" do
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: [
+          Riffer::Evals::Result.new(evaluator: evaluator_class, score: 0.9, token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 10, output_tokens: 5)),
+          Riffer::Evals::Result.new(evaluator: other_evaluator_class, score: 0.7, token_usage: Riffer::Providers::TokenUsage.new(input_tokens: 20, output_tokens: 8))
+        ]
+      )
+
+      expect(scenario.token_usage.total_tokens).must_equal 43
+    end
+
+    it "returns nil when no result reports token usage" do
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: [result_a, result_b]
+      )
+
+      expect(scenario.token_usage).must_be_nil
+    end
+  end
+
   describe "#to_h" do
     it "returns a hash representation" do
       scenario = Riffer::Evals::ScenarioResult.new(

--- a/test/riffer/evals/scenario_result_test.rb
+++ b/test/riffer/evals/scenario_result_test.rb
@@ -90,7 +90,7 @@ describe Riffer::Evals::ScenarioResult do
     end
   end
 
-  describe "#token_usage" do
+  describe "#evaluator_token_usage" do
     it "sums token usage across results" do
       scenario = Riffer::Evals::ScenarioResult.new(
         input: "test",
@@ -102,7 +102,7 @@ describe Riffer::Evals::ScenarioResult do
         ]
       )
 
-      expect(scenario.token_usage.total_tokens).must_equal 43
+      expect(scenario.evaluator_token_usage.total_tokens).must_equal 43
     end
 
     it "returns nil when no result reports token usage" do
@@ -111,6 +111,32 @@ describe Riffer::Evals::ScenarioResult do
         output: "test",
         ground_truth: nil,
         results: [result_a, result_b]
+      )
+
+      expect(scenario.evaluator_token_usage).must_be_nil
+    end
+  end
+
+  describe "#token_usage" do
+    it "returns the agent usage it was constructed with" do
+      usage = Riffer::Providers::TokenUsage.new(input_tokens: 30, output_tokens: 12)
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: [],
+        token_usage: usage
+      )
+
+      expect(scenario.token_usage).must_equal usage
+    end
+
+    it "defaults to nil" do
+      scenario = Riffer::Evals::ScenarioResult.new(
+        input: "test",
+        output: "test",
+        ground_truth: nil,
+        results: []
       )
 
       expect(scenario.token_usage).must_be_nil


### PR DESCRIPTION
# feat(evals): expose token usage on evaluation results

## Summary

- Evaluators now report the token usage their LLM-as-judge call spent, so consumers can accumulate eval cost the same way they already do for agents via `Agent::Response#token_usage`.
- The usage rides the evaluator `Result` (the leaf), and the run-level aggregates keep the two sources separate: what the agent under test spent generating the output vs what the judges spent scoring it.
- Additive and non-breaking. Rule-based evaluators that never call an LLM report `nil`.

## Changes

**Leaf (`Result`)**

- `Judge#evaluate` returns the judge call's `TokenUsage` alongside `score`/`reason`.
- `Result` carries a `token_usage` attribute, and the `Evaluator#result` helper accepts a `token_usage:` keyword. The base `Evaluator#evaluate` threads the judge's usage through automatically; evaluators that override `#evaluate` pass it via `result(token_usage:)`.

**Run-level aggregates (`ScenarioResult`, `RunResult`)**

- Both expose `token_usage` (the agent under test's generation spend, threaded from `response.token_usage` in `EvaluatorRunner`) and `evaluator_token_usage` (the judges' spend), summed via `TokenUsage#+` with nil-absorbing cost.
- Naming rule: `token_usage` always means the usage of the work each object represents, one judge call for `Result`, one agent generation for `ScenarioResult`, matching `Agent::Response#token_usage`. There's no bare `token_usage` that silently mixes both sources.

**Docs + types**

- Updated `docs/11_EVALS.md` and regenerated the RBS signatures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-usage tracking across agent runs, per-scenario evaluations, and judge calls (when available).
  * Exposed aggregated agent and evaluator token totals on full run results.
  * Extended serialized evaluation outputs to include token-usage details.
* **Documentation**
  * Updated evaluation documentation to describe the new token-usage fields in results.
* **Tests**
  * Added/expanded coverage for capturing, aggregating, and serializing token usage across evaluation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->