### PR TITLE
docs: remove maintainers section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,3 @@ All notable changes to this project are documented in `CHANGELOG.md`.
 ## License
 
 Licensed under the MIT License. See `LICENSE.txt` for details.
-
-## Maintainers
-
-- Jake Bottrall - https://github.com/bottrall


### PR DESCRIPTION
## Problem

The README lists me as the sole maintainer under a dedicated Maintainers section. This is out of date and shouldn't be attached to a single individual in the project docs.

## Solution

Removes the Maintainers section from the README entirely. No other content changes.

## Proof

Docs-only change — CI (which builds and lints as usual) is sufficient. Reviewers can confirm by reading the README diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Maintainers section and attribution from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->