### PR TITLE
chore: group dependabot updates to reduce weekly PR volume

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,36 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # Provider SDKs and their transport stack — these can break the
+      # adapters, so they get their own PR separate from dev tooling.
+      providers:
+        patterns:
+          - anthropic
+          - openai
+          - aws-sdk-bedrockruntime
+          - mcp
+          - faraday
+          - async
+          - io-event
+          - opentelemetry-*
+        update-types:
+          - minor
+          - patch
+      # Everything else (linting, typing, testing, docs, misc dev tools).
+      dev-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    # Major bumps stay as individual PRs (not matched by any group above).
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

Dependabot opens a separate PR for every gem and GitHub Action bump, so each week brings a pile of near-identical PRs that all need individual review, CI runs, and merges. Most of them are routine minor/patch bumps to dev tooling.

## Solution

Add Dependabot `groups` so weekly updates arrive as at most three batched PRs instead of one per dependency:

- **providers** — the LLM SDKs and their transport stack (`anthropic`, `openai`, `aws-sdk-bedrockruntime`, `mcp`, `faraday`, `async`, `io-event`, `opentelemetry-*`). These are the gems whose bumps can actually break the adapters, so they're batched separately from tooling to keep review focused.
- **dev-dependencies** — everything else (rubocop, steep, minitest, vcr, docs gems, etc.) as a catch-all.
- **github-actions** — all action bumps in one PR.

Both bundler groups only match minor and patch updates, so a major bump (e.g. a new `openai` 1.x) still opens its own PR rather than hiding in a batch. The github-actions group has no such filter since action major bumps are usually trivial. Existing Gemfile version pins are unaffected — grouping only changes PR batching, not what versions Dependabot proposes.

## Proof

The file parses as valid YAML (verified locally with `YAML.load_file`). GitHub validates `dependabot.yml` on push — check the repo's Dependabot tab (Insights → Dependency graph → Dependabot) after merge to confirm the config is accepted. The real proof arrives with the next weekly run: updates should land as grouped PRs titled `bump the providers group`, `bump the dev-dependencies group`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update organization by grouping related minor and patch updates.
  * Kept major updates separate for easier review.
  * Consolidated GitHub Actions updates into a single group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->