### PR TITLE
fix: Revert "chore(deps): bump JamesIves/github-pages-deploy-action from 4.5.0 to 4.9.0 in the github-actions group"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           bundler-cache: true
       - run: bin/docs
-      - uses: JamesIves/github-pages-deploy-action@fa24774553152dd7873cd16ebd8d959b010c5445
+      - uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
         with:
           branch: gh-pages
           folder: ./_site


### PR DESCRIPTION
Reverts janeapp/riffer#397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation deployment workflow to use a newer pinned action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->