### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Problem
+
+<!-- What problem does this PR solve? Why does it matter? Link the issue or ticket if one exists. -->
+
+## Solution
+
+<!-- How does it solve the problem? Note trade-offs and anything subtle a reviewer might miss. -->
+
+## Proof
+
+<!-- Evidence it works: tests, CI, screenshots/video for UX, or manual verification steps and results. -->


### PR DESCRIPTION
## Problem

The repo has no pull request template, so PR descriptions vary in structure and often omit context reviewers need — the motivation for the change, the approach taken, and evidence that it works.

## Solution

Adds `.github/pull_request_template.md` with three sections — Problem, Solution, and Proof — each with an HTML comment prompting authors on what to cover. GitHub picks this up automatically and pre-fills the description on every new PR.

## Proof

No behaviour to test — this PR's own description follows the template. Once merged, opening a new PR will show the template pre-filled in the description box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)