### PR TITLE
feat!: tools are the error boundary — call_with_validation never raises

### DIFF
--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -15,15 +15,15 @@ When an agent receives a response with tool calls:
 
 ## Error Handling
 
-Tool execution errors are captured and sent back to the LLM. A tool call is a sub-program, so no failure inside one aborts the loop:
+Tool execution errors never abort the loop — each is captured and sent back to the LLM as a tool result:
 
 - `unknown_tool` - Tool not found in registered tools
-- `validation_error` - Arguments failed validation, or the provider sent malformed argument JSON
+- `validation_error` - Arguments failed validation or were malformed JSON
 - `timeout_error` - Tool exceeded its configured timeout
-- `execution_error` - Tool returned an error, or raised `Riffer::ToolExecutionError`
-- `unhandled_error` - Tool raised an unanticipated exception; the content is `Error executing tool: <ExceptionClass>: <message>`
+- `execution_error` - Tool returned an error or raised `Riffer::ToolExecutionError`
+- `unhandled_error` - Tool raised an unanticipated exception
 
-The LLM can use this information to retry or respond appropriately. See [Error Handling](TOOL_ADVANCED.md#error-handling) for the full contract.
+The LLM can use this information to retry or respond appropriately. See [Error Handling](TOOL_ADVANCED.md#error-handling) for details.
 
 ## Ways the Agent Loop Can Stop
 

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -15,13 +15,15 @@ When an agent receives a response with tool calls:
 
 ## Error Handling
 
-Tool execution errors are captured and sent back to the LLM:
+Tool execution errors are captured and sent back to the LLM. A tool call is a sub-program, so no failure inside one aborts the loop:
 
 - `unknown_tool` - Tool not found in registered tools
-- `validation_error` - Arguments failed validation
-- `execution_error` - Tool raised an exception
+- `validation_error` - Arguments failed validation, or the provider sent malformed argument JSON
+- `timeout_error` - Tool exceeded its configured timeout
+- `execution_error` - Tool returned an error, or raised `Riffer::ToolExecutionError`
+- `unhandled_error` - Tool raised an unanticipated exception; the content is `Error executing tool: <ExceptionClass>: <message>`
 
-The LLM can use this information to retry or respond appropriately.
+The LLM can use this information to retry or respond appropriately. See [Error Handling](TOOL_ADVANCED.md#error-handling) for the full contract.
 
 ## Ways the Agent Loop Can Stop
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -269,7 +269,7 @@ error("Service unavailable", type: :service_error)
 error("Rate limit exceeded", type: :rate_limit)
 ```
 
-If no type is specified, it defaults to `:execution_error`. Riffer reserves `:unhandled_error` for exceptions a tool didn't anticipate — don't use it for a deliberate failure.
+If no type is specified, it defaults to `:execution_error`. Riffer reserves `:unhandled_error` for unrescued exceptions — don't set it yourself.
 
 ### Using Riffer::Tools::Response Directly
 
@@ -300,4 +300,4 @@ error_response.error_type     # => :not_found
 error_response.exception      # => nil
 ```
 
-`exception` is set only on the `:unhandled_error` responses Riffer builds when a tool raises something it didn't anticipate. It is excluded from `to_h` and every other serialized form, so the exception never reaches the LLM — see [Error Handling](TOOL_ADVANCED.md#error-handling).
+`exception` holds the rescued exception on the `:unhandled_error` responses Riffer builds. It never appears in serialized output, so it is not visible to the LLM.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -269,7 +269,7 @@ error("Service unavailable", type: :service_error)
 error("Rate limit exceeded", type: :rate_limit)
 ```
 
-If no type is specified, it defaults to `:execution_error`.
+If no type is specified, it defaults to `:execution_error`. Riffer reserves `:unhandled_error` for exceptions a tool didn't anticipate — don't use it for a deliberate failure.
 
 ### Using Riffer::Tools::Response Directly
 
@@ -297,4 +297,7 @@ error_response.success?       # => false
 error_response.error?         # => true
 error_response.error_message  # => "failed"
 error_response.error_type     # => :not_found
+error_response.exception      # => nil
 ```
+
+`exception` is set only on the `:unhandled_error` responses Riffer builds when a tool raises something it didn't anticipate. It is excluded from `to_h` and every other serialized form, so the exception never reaches the LLM — see [Error Handling](TOOL_ADVANCED.md#error-handling).

--- a/docs/TOOL_ADVANCED.md
+++ b/docs/TOOL_ADVANCED.md
@@ -26,7 +26,7 @@ Arguments are automatically validated before `call` is invoked:
 - Types must match the schema
 - Enum values must be in the allowed list
 
-Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`, as is malformed JSON in the provider's tool-call arguments.
+Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`, as is malformed or non-object JSON in the provider's tool-call arguments.
 
 ## JSON Schema Generation
 

--- a/docs/TOOL_ADVANCED.md
+++ b/docs/TOOL_ADVANCED.md
@@ -16,7 +16,7 @@ class SlowExternalApiTool < Riffer::Tool
 end
 ```
 
-When a tool times out, the error is reported to the LLM with error type `:timeout_error`, allowing it to respond appropriately (e.g., suggest retrying or using a different approach).
+When a tool times out, `call_with_validation` returns an error response with type `:timeout_error` instead of raising, so the LLM can respond appropriately (e.g., suggest retrying or using a different approach).
 
 ## Validation
 
@@ -26,7 +26,7 @@ Arguments are automatically validated before `call` is invoked:
 - Types must match the schema
 - Enum values must be in the allowed list
 
-Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`.
+Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`. Malformed JSON in the provider's tool-call arguments is reported the same way, so a bad payload never crashes the run.
 
 ## JSON Schema Generation
 
@@ -95,7 +95,20 @@ rescue => e
 end
 ```
 
-Unhandled `RuntimeError` exceptions are caught by Riffer and converted to error responses with type `:execution_error`. For expected execution errors, raise `Riffer::ToolExecutionError` — these are also caught and returned to the LLM. Programming bugs (`NoMethodError`, `NameError`, `TypeError`, etc.) propagate to the caller. It's recommended to handle expected errors explicitly for better error messages.
+`Riffer::Tool#call_with_validation` — the framework wrapper the runtime invokes — **never raises**. Every `StandardError` that escapes your `#call` is folded into an error response, so one bad tool call can't take down the run:
+
+| Raised inside `call_with_validation`     | Error type         | Response content                              |
+| ---------------------------------------- | ------------------ | --------------------------------------------- |
+| `Riffer::ValidationError` (param schema) | `:validation_error` | the validation message                        |
+| `Timeout::Error` (tool timeout)          | `:timeout_error`   | `Tool execution timed out after N seconds`    |
+| `Riffer::ToolExecutionError`             | `:execution_error` | the exception message                         |
+| any other `StandardError`                | `:unhandled_error` | `Error executing tool: <ExceptionClass>: <message>` |
+
+`:unhandled_error` is the bug bucket — a `NoMethodError`, a `TypeError`, a tool that returned something other than a `Riffer::Tools::Response`. The content carries the exception class and message but no backtrace, and the response also carries the rescued exception object on `response.exception`, which is deliberately excluded from every serialized form so it never reaches the LLM or the message history. The `execute_tool` span records that exception and sets an `ERROR` status (see [Tracing](TRACING.md)), so unanticipated failures stay loud in telemetry while the LLM still gets a usable result.
+
+`NotImplementedError` is **not** rescued. An unimplemented `#call` crashes the run, because that's a broken deploy rather than a bad request.
+
+For expected failures, prefer returning `error(...)` yourself or raising `Riffer::ToolExecutionError` — both produce a clean message the LLM can act on, instead of the `:unhandled_error` bug bucket.
 
 The LLM receives the error message and can decide how to respond (retry, apologize, ask for different input, etc.).
 
@@ -222,13 +235,13 @@ class HttpToolRuntime < Riffer::Tools::Runtime
       arguments: tool_call.arguments
     })
     Riffer::Tools::Response.text(response.body)
-  rescue Riffer::ToolExecutionError => e
-    Riffer::Tools::Response.error(e.message, type: :execution_error)
-  rescue RuntimeError => e
-    Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+  rescue HttpClient::Error => e
+    Riffer::Tools::Response.error("Tool service unavailable: #{e.message}", type: :execution_error)
   end
 end
 ```
+
+The built-in runtime is a **router, not an error boundary** — it only handles pre-tool concerns (an unknown tool name, malformed argument JSON) and leaves the tool's own failures to `call_with_validation`. A custom `dispatch_tool_call` that bypasses `Riffer::Tool` owns that boundary itself: rescue whatever your transport can raise and return an error response, because anything that escapes `dispatch_tool_call` propagates out of the run.
 
 ### Around-Call Hook
 

--- a/docs/TOOL_ADVANCED.md
+++ b/docs/TOOL_ADVANCED.md
@@ -16,7 +16,7 @@ class SlowExternalApiTool < Riffer::Tool
 end
 ```
 
-When a tool times out, `call_with_validation` returns an error response with type `:timeout_error` instead of raising, so the LLM can respond appropriately (e.g., suggest retrying or using a different approach).
+When a tool times out, the LLM receives an error response with type `:timeout_error` and can respond appropriately (e.g., suggest retrying or using a different approach).
 
 ## Validation
 
@@ -26,7 +26,7 @@ Arguments are automatically validated before `call` is invoked:
 - Types must match the schema
 - Enum values must be in the allowed list
 
-Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`. Malformed JSON in the provider's tool-call arguments is reported the same way, so a bad payload never crashes the run.
+Validation errors are captured and sent back to the LLM as tool results with error type `:validation_error`, as is malformed JSON in the provider's tool-call arguments.
 
 ## JSON Schema Generation
 
@@ -95,20 +95,20 @@ rescue => e
 end
 ```
 
-`Riffer::Tool#call_with_validation` — the framework wrapper the runtime invokes — **never raises**. Every `StandardError` that escapes your `#call` is folded into an error response, so one bad tool call can't take down the run:
+A tool never raises into the agent loop — every `StandardError` raised during a tool call becomes an error response:
 
-| Raised inside `call_with_validation`     | Error type         | Response content                              |
-| ---------------------------------------- | ------------------ | --------------------------------------------- |
-| `Riffer::ValidationError` (param schema) | `:validation_error` | the validation message                        |
-| `Timeout::Error` (tool timeout)          | `:timeout_error`   | `Tool execution timed out after N seconds`    |
-| `Riffer::ToolExecutionError`             | `:execution_error` | the exception message                         |
-| any other `StandardError`                | `:unhandled_error` | `Error executing tool: <ExceptionClass>: <message>` |
+| Failure                      | Error type          | Response content                                     |
+| ---------------------------- | ------------------- | ---------------------------------------------------- |
+| Invalid arguments            | `:validation_error` | the validation message                               |
+| Timeout                      | `:timeout_error`    | `Tool execution timed out after N seconds`           |
+| `Riffer::ToolExecutionError` | `:execution_error`  | the exception message                                |
+| Any other `StandardError`    | `:unhandled_error`  | `Error executing tool: <ExceptionClass>: <message>` |
 
-`:unhandled_error` is the bug bucket — a `NoMethodError`, a `TypeError`, a tool that returned something other than a `Riffer::Tools::Response`. The content carries the exception class and message but no backtrace, and the response also carries the rescued exception object on `response.exception`, which is deliberately excluded from every serialized form so it never reaches the LLM or the message history. The `execute_tool` span records that exception and sets an `ERROR` status (see [Tracing](TRACING.md)), so unanticipated failures stay loud in telemetry while the LLM still gets a usable result.
+An `:unhandled_error` response also carries the rescued exception on `response.exception` — never serialized, so it stays out of the message history — and its `execute_tool` span records the exception with an `ERROR` status (see [Tracing](TRACING.md)).
 
-`NotImplementedError` is **not** rescued. An unimplemented `#call` crashes the run, because that's a broken deploy rather than a bad request.
+`NotImplementedError` is not rescued: an unimplemented `#call` raises out of the run.
 
-For expected failures, prefer returning `error(...)` yourself or raising `Riffer::ToolExecutionError` — both produce a clean message the LLM can act on, instead of the `:unhandled_error` bug bucket.
+For expected failures, return `error(...)` or raise `Riffer::ToolExecutionError` — both give the LLM a clean message rather than an `:unhandled_error`.
 
 The LLM receives the error message and can decide how to respond (retry, apologize, ask for different input, etc.).
 
@@ -241,7 +241,7 @@ class HttpToolRuntime < Riffer::Tools::Runtime
 end
 ```
 
-The built-in runtime is a **router, not an error boundary** — it only handles pre-tool concerns (an unknown tool name, malformed argument JSON) and leaves the tool's own failures to `call_with_validation`. A custom `dispatch_tool_call` that bypasses `Riffer::Tool` owns that boundary itself: rescue whatever your transport can raise and return an error response, because anything that escapes `dispatch_tool_call` propagates out of the run.
+Anything that escapes `dispatch_tool_call` propagates out of the run — rescue whatever your transport can raise and return an error response. The base class handles only an unknown tool name and malformed argument JSON.
 
 ### Around-Call Hook
 

--- a/docs/TOOL_ADVANCED.md
+++ b/docs/TOOL_ADVANCED.md
@@ -16,7 +16,7 @@ class SlowExternalApiTool < Riffer::Tool
 end
 ```
 
-When a tool times out, the LLM receives an error response with type `:timeout_error` and can respond appropriately (e.g., suggest retrying or using a different approach).
+When a tool times out, the LLM receives an error response with type `:timeout_error` and can respond appropriately (e.g., suggest retrying or using a different approach). The timeout raises `Riffer::TimeoutError` inside `call`, so a tool can rescue it to release resources before it propagates.
 
 ## Validation
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -170,10 +170,11 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 
 A tool failure comes in two shapes, distinguished by span status:
 
-- **Handled error** — the tool returned an error response. `error.type` carries the category and the **span status stays unset** (the run continues). The framework's categories are `unknown_tool`, `validation_error`, `timeout_error`, and `execution_error`; a custom tool may set its own via `Riffer::Tools::Response.error(type:)`.
-- **Unhandled exception** — the dispatch raised. `error.type` is the exception class name and the **span status is `ERROR`**, with the exception recorded.
+- **Handled error** — the tool returned a deliberate error response. `error.type` carries the category and the **span status stays unset** (the run continues). The framework's categories are `unknown_tool`, `validation_error`, `timeout_error`, and `execution_error`; a custom tool may set its own via `Riffer::Tools::Response.error(type:)`.
+- **Unhandled error** — the tool raised an unanticipated `StandardError`, which `Riffer::Tool#call_with_validation` folds into an `unhandled_error` response carrying the exception. `error.type` is `unhandled_error`, the **span status is `ERROR`**, and the exception itself is recorded on the span (its class and message are on the exception event). The run continues — the LLM receives the error response.
+- Host code raising **around** the tool call (an `around_tool_call` hook, a tracing callback) still propagates out of the run. `error.type` is the exception class name and the span status is `ERROR`.
 
-This status convention is the same on `chat` and `invoke_agent`: an unhandled exception sets `error.type` to the class name and marks the span `ERROR`; everything else leaves the status unset.
+This status convention is the same on `chat` and `invoke_agent`: an unhandled exception marks the span `ERROR` with the exception recorded; a handled outcome leaves the status unset.
 
 ## `execute_guardrail {name}` — the guardrail span
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -170,7 +170,7 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 
 A tool failure comes in three shapes, distinguished by span status:
 
-- **Handled error** — the tool returned a deliberate error response. `error.type` carries the category and the **span status stays unset** (the run continues). The framework's categories are `unknown_tool`, `validation_error`, `timeout_error`, and `execution_error`; a custom tool may set its own via `Riffer::Tools::Response.error(type:)`.
+- **Handled error** — the tool call produced a deliberate error response, from the tool itself or from the runtime (an unknown tool, malformed arguments). `error.type` carries the category and the **span status stays unset** (the run continues). The framework's categories are `unknown_tool`, `validation_error`, `timeout_error`, and `execution_error`; a custom tool may set its own via `Riffer::Tools::Response.error(type:)`.
 - **Unhandled error** — the tool raised an unanticipated `StandardError`. `error.type` is `unhandled_error`, the **span status is `ERROR`**, and the exception is recorded on the span. The run continues — the LLM receives the error response.
 - **Host code raising** around the tool call (an `around_tool_call` hook, a tracing callback) propagates out of the run. `error.type` is the exception class name and the span status is `ERROR`.
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -168,11 +168,11 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 | `gen_ai.tool.call.arguments` | string | When `capture_messages` is on (see [capture](#message-content-capture)) |
 | `gen_ai.tool.call.result`    | string | When `capture_messages` is on                                           |
 
-A tool failure comes in two shapes, distinguished by span status:
+A tool failure comes in three shapes, distinguished by span status:
 
 - **Handled error** — the tool returned a deliberate error response. `error.type` carries the category and the **span status stays unset** (the run continues). The framework's categories are `unknown_tool`, `validation_error`, `timeout_error`, and `execution_error`; a custom tool may set its own via `Riffer::Tools::Response.error(type:)`.
-- **Unhandled error** — the tool raised an unanticipated `StandardError`, which `Riffer::Tool#call_with_validation` folds into an `unhandled_error` response carrying the exception. `error.type` is `unhandled_error`, the **span status is `ERROR`**, and the exception itself is recorded on the span (its class and message are on the exception event). The run continues — the LLM receives the error response.
-- Host code raising **around** the tool call (an `around_tool_call` hook, a tracing callback) still propagates out of the run. `error.type` is the exception class name and the span status is `ERROR`.
+- **Unhandled error** — the tool raised an unanticipated `StandardError`. `error.type` is `unhandled_error`, the **span status is `ERROR`**, and the exception is recorded on the span. The run continues — the LLM receives the error response.
+- **Host code raising** around the tool call (an `around_tool_call` hook, a tracing callback) propagates out of the run. `error.type` is the exception class name and the span status is `ERROR`.
 
 This status convention is the same on `chat` and `invoke_agent`: an unhandled exception marks the span `ERROR` with the exception recorded; a handled outcome leaves the status unset.
 

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -26,6 +26,11 @@ module Riffer
   # Raised when tool parameter validation fails.
   class ValidationError < Error; end
 
+  # Raised inside a tool's +call+ when execution exceeds the configured
+  # timeout. Rescue it in the tool to clean up; otherwise it becomes a
+  # +:timeout_error+ response.
+  class TimeoutError < Error; end
+
   # Raised when a tool encounters an expected execution error.
   class ToolExecutionError < Error; end
 

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -26,9 +26,6 @@ module Riffer
   # Raised when tool parameter validation fails.
   class ValidationError < Error; end
 
-  # Raised when tool execution times out.
-  class TimeoutError < Error; end
-
   # Raised when a tool encounters an expected execution error.
   class ToolExecutionError < Error; end
 

--- a/lib/riffer/messages/tool.rb
+++ b/lib/riffer/messages/tool.rb
@@ -12,7 +12,8 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The error message if the tool execution failed.
   attr_reader :error #: String?
 
-  # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
+  # The type of error (:unknown_tool, :validation_error, :execution_error,
+  # :timeout_error, :unhandled_error).
   attr_reader :error_type #: Symbol?
 
   #--

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -56,11 +56,10 @@ class Riffer::Tool
     Riffer::Tools::Response.error(message, type: type)
   end
 
-  # Executes the tool with validation and timeout (used by Agent).
-  #
-  # Raises Riffer::ValidationError if validation fails.
-  # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
-  # Raises Riffer::Error if the tool does not return a Response object.
+  # Executes the tool with validation and timeout, folding every +StandardError+
+  # into an error Response. Anything outside +StandardError+ — an unimplemented
+  # +#call+ above all — still propagates, because a broken tool is a broken
+  # deploy rather than a bad request.
   #
   #--
   #: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
@@ -77,7 +76,20 @@ class Riffer::Tool
     end
 
     result
+  rescue Riffer::ValidationError => e
+    Riffer::Tools::Response.error(e.message, type: :validation_error)
   rescue Timeout::Error
-    raise Riffer::TimeoutError, "Tool execution timed out after #{self.class.timeout} seconds"
+    Riffer::Tools::Response.error(
+      "Tool execution timed out after #{self.class.timeout} seconds",
+      type: :timeout_error,
+    )
+  rescue Riffer::ToolExecutionError => e
+    Riffer::Tools::Response.error(e.message, type: :execution_error)
+  rescue StandardError => e
+    Riffer::Tools::Response.error(
+      "Error executing tool: #{e.class}: #{e.message}",
+      type: :unhandled_error,
+      exception: e,
+    )
   end
 end

--- a/lib/riffer/tool.rb
+++ b/lib/riffer/tool.rb
@@ -65,9 +65,14 @@ class Riffer::Tool
   #: (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response
   def call_with_validation(context:, **kwargs)
     params_builder = self.class.params
-    validated_args = params_builder ? params_builder.validate(kwargs) : kwargs
 
-    result = Timeout.timeout(self.class.timeout) do
+    begin
+      validated_args = params_builder ? params_builder.validate(kwargs) : kwargs
+    rescue Riffer::ValidationError => e
+      return Riffer::Tools::Response.error(e.message, type: :validation_error)
+    end
+
+    result = Timeout.timeout(self.class.timeout, Riffer::TimeoutError) do
       call(context: context, **validated_args) #: untyped
     end
 
@@ -76,9 +81,7 @@ class Riffer::Tool
     end
 
     result
-  rescue Riffer::ValidationError => e
-    Riffer::Tools::Response.error(e.message, type: :validation_error)
-  rescue Timeout::Error
+  rescue Riffer::TimeoutError
     Riffer::Tools::Response.error(
       "Tool execution timed out after #{self.class.timeout} seconds",
       type: :timeout_error,

--- a/lib/riffer/tools/response.rb
+++ b/lib/riffer/tools/response.rb
@@ -28,6 +28,10 @@ class Riffer::Tools::Response
   # The error type, or +nil+ on success.
   attr_reader :error_type #: Symbol?
 
+  # The exception an unhandled failure was folded from, or +nil+. Kept out of
+  # every serialized form so it never reaches an LLM or a message payload.
+  attr_reader :exception #: Exception?
+
   # Creates a success response.
   #
   # Raises Riffer::ArgumentError if format is invalid.
@@ -62,9 +66,9 @@ class Riffer::Tools::Response
   # Creates an error response.
   #
   #--
-  #: (String, ?type: Symbol) -> Riffer::Tools::Response
-  def self.error(message, type: :execution_error)
-    new(content: message, success: false, error_message: message, error_type: type)
+  #: (String, ?type: Symbol, ?exception: Exception?) -> Riffer::Tools::Response
+  def self.error(message, type: :execution_error, exception: nil)
+    new(content: message, success: false, error_message: message, error_type: type, exception: exception)
   end
 
   # Returns true if the tool execution succeeded.
@@ -88,11 +92,12 @@ class Riffer::Tools::Response
   private
 
   #--
-  #: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
-  def initialize(content:, success:, error_message: nil, error_type: nil)
+  #: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?, ?exception: Exception?) -> void
+  def initialize(content:, success:, error_message: nil, error_type: nil, exception: nil)
     @content = content
     @success = success
     @error_message = error_message
     @error_type = error_type
+    @exception = exception
   end
 end

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -89,14 +89,8 @@ class Riffer::Tools::Runtime
     arguments = parse_arguments(tool_call.arguments)
 
     tool_instance.call_with_validation(context: context, **arguments)
-  rescue Riffer::TimeoutError => e
-    Riffer::Tools::Response.error(e.message, type: :timeout_error)
-  rescue Riffer::ValidationError => e
-    Riffer::Tools::Response.error(e.message, type: :validation_error)
-  rescue Riffer::ToolExecutionError => e
-    Riffer::Tools::Response.error(e.message, type: :execution_error)
-  rescue RuntimeError => e
-    Riffer::Tools::Response.error("Error executing tool: #{e.message}", type: :execution_error)
+  rescue JSON::ParserError => e
+    Riffer::Tools::Response.error("Invalid JSON in tool arguments: #{e.message}", type: :validation_error)
   end
 
   #--
@@ -144,13 +138,21 @@ class Riffer::Tools::Runtime
     tags.transform_keys { |key| "riffer.tag.#{key}" }
   end
 
-  # A returned error Response is a handled outcome, so its status stays unset —
-  # an error span status is reserved for a raised exception.
+  # A deliberate error Response is a handled outcome, so its status stays unset.
+  # An error status is reserved for a Response carrying the exception it was
+  # folded from — the tool failed for a reason nobody anticipated.
   #--
   #: ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
   def record_tool_outcome(span, result)
     error_type = result.error_type
     span.set_attribute("error.type", error_type.to_s) if error_type
+
+    exception = result.exception
+    if exception
+      span.record_exception(exception)
+      span.error!(exception.message)
+    end
+
     capture_tool_result(span, result)
   end
 

--- a/lib/riffer/tools/runtime.rb
+++ b/lib/riffer/tools/runtime.rb
@@ -88,13 +88,20 @@ class Riffer::Tools::Runtime
     tool_instance = tool_class.new
     arguments = parse_arguments(tool_call.arguments)
 
+    unless arguments.is_a?(Hash)
+      return Riffer::Tools::Response.error(
+        "Invalid JSON in tool arguments: expected an object, got #{arguments.class}",
+        type: :validation_error,
+      )
+    end
+
     tool_instance.call_with_validation(context: context, **arguments)
   rescue JSON::ParserError => e
     Riffer::Tools::Response.error("Invalid JSON in tool arguments: #{e.message}", type: :validation_error)
   end
 
   #--
-  #: (String?) -> Hash[Symbol, untyped]
+  #: (String?) -> untyped
   def parse_arguments(arguments)
     return {} if arguments.nil? || arguments.empty?
 

--- a/sig/generated/riffer.rbs
+++ b/sig/generated/riffer.rbs
@@ -15,6 +15,12 @@ module Riffer
   class ValidationError < Error
   end
 
+  # Raised inside a tool's +call+ when execution exceeds the configured
+  # timeout. Rescue it in the tool to clean up; otherwise it becomes a
+  # +:timeout_error+ response.
+  class TimeoutError < Error
+  end
+
   # Raised when a tool encounters an expected execution error.
   class ToolExecutionError < Error
   end

--- a/sig/generated/riffer.rbs
+++ b/sig/generated/riffer.rbs
@@ -15,10 +15,6 @@ module Riffer
   class ValidationError < Error
   end
 
-  # Raised when tool execution times out.
-  class TimeoutError < Error
-  end
-
   # Raised when a tool encounters an expected execution error.
   class ToolExecutionError < Error
   end

--- a/sig/generated/riffer/messages/tool.rbs
+++ b/sig/generated/riffer/messages/tool.rbs
@@ -11,7 +11,8 @@ class Riffer::Messages::Tool < Riffer::Messages::Base
   # The error message if the tool execution failed.
   attr_reader error: String?
 
-  # The type of error (:unknown_tool, :validation_error, :execution_error, :timeout_error).
+  # The type of error (:unknown_tool, :validation_error, :execution_error,
+  # :timeout_error, :unhandled_error).
   attr_reader error_type: Symbol?
 
   # --

--- a/sig/generated/riffer/tool.rbs
+++ b/sig/generated/riffer/tool.rbs
@@ -43,11 +43,10 @@ class Riffer::Tool
   # : (String, ?type: Symbol) -> Riffer::Tools::Response
   def error: (String, ?type: Symbol) -> Riffer::Tools::Response
 
-  # Executes the tool with validation and timeout (used by Agent).
-  #
-  # Raises Riffer::ValidationError if validation fails.
-  # Raises Riffer::TimeoutError if execution exceeds the configured timeout.
-  # Raises Riffer::Error if the tool does not return a Response object.
+  # Executes the tool with validation and timeout, folding every +StandardError+
+  # into an error Response. Anything outside +StandardError+ — an unimplemented
+  # +#call+ above all — still propagates, because a broken tool is a broken
+  # deploy rather than a bad request.
   #
   # --
   # : (context: Riffer::Agent::Context?, **untyped) -> Riffer::Tools::Response

--- a/sig/generated/riffer/tools/response.rbs
+++ b/sig/generated/riffer/tools/response.rbs
@@ -24,6 +24,10 @@ class Riffer::Tools::Response
   # The error type, or +nil+ on success.
   attr_reader error_type: Symbol?
 
+  # The exception an unhandled failure was folded from, or +nil+. Kept out of
+  # every serialized form so it never reaches an LLM or a message payload.
+  attr_reader exception: Exception?
+
   # Creates a success response.
   #
   # Raises Riffer::ArgumentError if format is invalid.
@@ -47,8 +51,8 @@ class Riffer::Tools::Response
   # Creates an error response.
   #
   # --
-  # : (String, ?type: Symbol) -> Riffer::Tools::Response
-  def self.error: (String, ?type: Symbol) -> Riffer::Tools::Response
+  # : (String, ?type: Symbol, ?exception: Exception?) -> Riffer::Tools::Response
+  def self.error: (String, ?type: Symbol, ?exception: Exception?) -> Riffer::Tools::Response
 
   # Returns true if the tool execution succeeded.
   # --
@@ -69,6 +73,6 @@ class Riffer::Tools::Response
   private
 
   # --
-  # : (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
-  def initialize: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?) -> void
+  # : (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?, ?exception: Exception?) -> void
+  def initialize: (content: String, success: bool, ?error_message: String?, ?error_type: Symbol?, ?exception: Exception?) -> void
 end

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -44,8 +44,8 @@ class Riffer::Tools::Runtime
   def dispatch_tool_call: (Riffer::Messages::Assistant::ToolCall, tools: Array[singleton(Riffer::Tool)], context: Riffer::Agent::Context?, ?assistant_message: Riffer::Messages::Assistant?) -> Riffer::Tools::Response
 
   # --
-  # : (String?) -> Hash[Symbol, untyped]
-  def parse_arguments: (String?) -> Hash[Symbol, untyped]
+  # : (String?) -> untyped
+  def parse_arguments: (String?) -> untyped
 
   # Emitted outside +around_tool_call+ so host enrichment spans nest beneath it.
   # --

--- a/sig/generated/riffer/tools/runtime.rbs
+++ b/sig/generated/riffer/tools/runtime.rbs
@@ -62,8 +62,9 @@ class Riffer::Tools::Runtime
   # : (Hash[String, String]) -> Hash[String, String]
   def tag_attributes: (Hash[String, String]) -> Hash[String, String]
 
-  # A returned error Response is a handled outcome, so its status stays unset —
-  # an error span status is reserved for a raised exception.
+  # A deliberate error Response is a handled outcome, so its status stays unset.
+  # An error status is reserved for a Response carrying the exception it was
+  # folded from — the tool failed for a reason nobody anticipated.
   # --
   # : ((Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span), Riffer::Tools::Response) -> void
   def record_tool_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Tools::Response) -> void

--- a/test/riffer/mcp/search_tool_test.rb
+++ b/test/riffer/mcp/search_tool_test.rb
@@ -144,10 +144,11 @@ describe Riffer::Mcp::SearchTool do
   end
 
   describe "#call_with_validation" do
-    it "raises a validation error when query is nil" do
-      assert_raises(Riffer::ValidationError) do
-        Riffer::Mcp::SearchTool.new.call_with_validation(context: context, query: nil)
-      end
+    it "returns a validation error response when query is nil" do
+      response = Riffer::Mcp::SearchTool.new.call_with_validation(context: context, query: nil)
+
+      assert_predicate response, :error?
+      assert_equal :validation_error, response.error_type
     end
   end
 end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -2332,8 +2332,8 @@ describe Riffer::Agent::Run do
         expect(tool_message.error?).must_equal true
       end
 
-      it "emits tool message with execution_error type" do
-        expect(tool_message.error_type).must_equal :execution_error
+      it "emits tool message with unhandled_error type" do
+        expect(tool_message.error_type).must_equal :unhandled_error
       end
     end
   end

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -57,16 +57,19 @@ describe Riffer::Tool do
   end
 
   describe "#call_with_validation" do
-    it "raises ValidationError for missing required params" do
+    it "returns a validation_error response for missing required params" do
       tool = weather_tool_class.new
+      response = tool.call_with_validation(context: nil)
 
-      expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::ValidationError)
+      expect(response.error?).must_equal true
+      expect(response.error_type).must_equal :validation_error
     end
 
     it "includes param name in validation error message" do
       tool = weather_tool_class.new
-      error = expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::ValidationError)
-      expect(error.message).must_match(/city is required/)
+      response = tool.call_with_validation(context: nil)
+
+      expect(response.content).must_match(/city is required/)
     end
 
     it "applies defaults for optional params" do
@@ -99,7 +102,7 @@ describe Riffer::Tool do
       expect(result.content).must_equal "Simple result"
     end
 
-    it "raises TimeoutError when execution exceeds timeout" do
+    it "returns a timeout_error response when execution exceeds timeout" do
       slow_tool_class = Class.new(Riffer::Tool) do
         timeout 0.01
 
@@ -109,9 +112,10 @@ describe Riffer::Tool do
         end
       end
 
-      tool = slow_tool_class.new
+      response = slow_tool_class.new.call_with_validation(context: nil)
 
-      expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::TimeoutError)
+      expect(response.error?).must_equal true
+      expect(response.error_type).must_equal :timeout_error
     end
 
     it "includes timeout duration in error message" do
@@ -124,9 +128,9 @@ describe Riffer::Tool do
         end
       end
 
-      tool = slow_tool_class.new
-      error = expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::TimeoutError)
-      expect(error.message).must_match(/0\.01 seconds/)
+      response = slow_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.content).must_match(/0\.01 seconds/)
     end
 
     it "completes successfully when within timeout" do
@@ -144,16 +148,89 @@ describe Riffer::Tool do
       expect(result.content).must_equal "fast result"
     end
 
-    it "raises Error when tool does not return Response" do
+    it "returns an execution_error response for ToolExecutionError" do
+      failing_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise Riffer::ToolExecutionError, "Expected failure"
+        end
+      end
+
+      response = failing_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error?).must_equal true
+      expect(response.error_type).must_equal :execution_error
+      expect(response.content).must_equal "Expected failure"
+    end
+
+    it "carries no exception on a deliberate error response" do
+      failing_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise Riffer::ToolExecutionError, "Expected failure"
+        end
+      end
+
+      response = failing_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.exception).must_be_nil
+    end
+
+    it "folds an arbitrary StandardError into an unhandled_error response" do
+      buggy_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise "Something went wrong"
+        end
+      end
+
+      response = buggy_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error?).must_equal true
+      expect(response.error_type).must_equal :unhandled_error
+      expect(response.content).must_equal "Error executing tool: RuntimeError: Something went wrong"
+    end
+
+    it "folds a programming bug into an unhandled_error response" do
+      buggy_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          nil.nonexistent_method
+        end
+      end
+
+      response = buggy_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error_type).must_equal :unhandled_error
+      expect(response.content).must_match(/\AError executing tool: NoMethodError: /)
+    end
+
+    it "carries the rescued exception on an unhandled_error response" do
+      buggy_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise "Something went wrong"
+        end
+      end
+
+      response = buggy_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.exception).must_be_instance_of RuntimeError
+      expect(response.exception.message).must_equal "Something went wrong"
+    end
+
+    it "returns an unhandled_error response when tool does not return Response" do
       bad_tool_class = Class.new(Riffer::Tool) do
         def call(context:)
           "raw string instead of Response"
         end
       end
 
-      tool = bad_tool_class.new
-      error = expect { tool.call_with_validation(context: nil) }.must_raise(Riffer::Error)
-      expect(error.message).must_match(/must return a Riffer::Tools::Response/)
+      response = bad_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error_type).must_equal :unhandled_error
+      expect(response.content).must_match(/must return a Riffer::Tools::Response/)
+    end
+
+    it "raises NotImplementedError when call is not implemented" do
+      tool_class = Class.new(Riffer::Tool)
+
+      expect { tool_class.new.call_with_validation(context: nil) }.must_raise(NotImplementedError)
     end
   end
 

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -133,6 +133,44 @@ describe Riffer::Tool do
       expect(response.content).must_match(/0\.01 seconds/)
     end
 
+    it "returns an unhandled_error response for a Timeout::Error raised by the tool body" do
+      external_timeout_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise Timeout::Error, "external service timed out"
+        end
+      end
+
+      response = external_timeout_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error_type).must_equal :unhandled_error
+      expect(response.content).must_equal "Error executing tool: Timeout::Error: external service timed out"
+    end
+
+    it "returns a timeout_error response for a Riffer::TimeoutError raised by the tool body" do
+      timeout_raising_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise Riffer::TimeoutError
+        end
+      end
+
+      response = timeout_raising_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error_type).must_equal :timeout_error
+    end
+
+    it "returns an unhandled_error response for a Riffer::ValidationError raised by the tool body" do
+      validation_raising_tool_class = Class.new(Riffer::Tool) do
+        def call(context:)
+          raise Riffer::ValidationError, "nested validation failed"
+        end
+      end
+
+      response = validation_raising_tool_class.new.call_with_validation(context: nil)
+
+      expect(response.error_type).must_equal :unhandled_error
+      expect(response.content).must_equal "Error executing tool: Riffer::ValidationError: nested validation failed"
+    end
+
     it "completes successfully when within timeout" do
       fast_tool_class = Class.new(Riffer::Tool) do
         timeout 1

--- a/test/riffer/tools/response_test.rb
+++ b/test/riffer/tools/response_test.rb
@@ -138,6 +138,19 @@ describe Riffer::Tools::Response do
 
       expect(response.error_type).must_equal :custom_error
     end
+
+    it "defaults exception to nil" do
+      response = Riffer::Tools::Response.error("failed")
+
+      expect(response.exception).must_be_nil
+    end
+
+    it "carries a supplied exception" do
+      boom = RuntimeError.new("boom")
+      response = Riffer::Tools::Response.error("failed", exception: boom)
+
+      expect(response.exception).must_be_same_as boom
+    end
   end
 
   describe "#to_h" do
@@ -175,6 +188,12 @@ describe Riffer::Tools::Response do
       response = Riffer::Tools::Response.error("failed", type: :validation_error)
 
       expect(response.to_h[:error_type]).must_equal :validation_error
+    end
+
+    it "omits the exception" do
+      response = Riffer::Tools::Response.error("failed", exception: RuntimeError.new("boom"))
+
+      expect(response.to_h.keys).must_equal %i[content error error_type]
     end
   end
 

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -109,6 +109,17 @@ describe Riffer::Tools::Runtime do
       expect(result.content).must_match(/Invalid JSON in tool arguments/)
     end
 
+    it "returns error response for validation failure on non-object JSON arguments" do
+      runtime = Riffer::Tools::Runtime::Inline.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: "[1,2]")
+
+      result = execute_single(runtime, tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :validation_error
+      expect(result.content).must_equal "Invalid JSON in tool arguments: expected an object, got Array"
+    end
+
     it "returns unhandled_error response for RuntimeError" do
       error_tool = Class.new(Riffer::Tool) do
         identifier "error_tool"

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -98,7 +98,18 @@ describe Riffer::Tools::Runtime do
       expect(result.error_type).must_equal :timeout_error
     end
 
-    it "returns error response for RuntimeError" do
+    it "returns error response for validation failure on malformed JSON arguments" do
+      runtime = Riffer::Tools::Runtime::Inline.new
+      tool_call = make_tool_call(name: "weather_tool", arguments: '{"city":')
+
+      result = execute_single(runtime, tool_call, tools: tools, context: context)
+
+      expect(result.error?).must_equal true
+      expect(result.error_type).must_equal :validation_error
+      expect(result.content).must_match(/Invalid JSON in tool arguments/)
+    end
+
+    it "returns unhandled_error response for RuntimeError" do
       error_tool = Class.new(Riffer::Tool) do
         identifier "error_tool"
         description "Raises an error"
@@ -114,8 +125,8 @@ describe Riffer::Tools::Runtime do
       result = execute_single(runtime, tool_call, tools: [error_tool], context: context)
 
       expect(result.error?).must_equal true
-      expect(result.error_type).must_equal :execution_error
-      expect(result.content).must_match(/Something went wrong/)
+      expect(result.error_type).must_equal :unhandled_error
+      expect(result.content).must_equal "Error executing tool: RuntimeError: Something went wrong"
     end
 
     it "returns error response for ToolExecutionError" do
@@ -138,7 +149,7 @@ describe Riffer::Tools::Runtime do
       expect(result.content).must_equal "Expected failure"
     end
 
-    it "propagates NoMethodError (programming bugs are not swallowed)" do
+    it "returns unhandled_error response for NoMethodError, carrying the exception" do
       buggy_tool = Class.new(Riffer::Tool) do
         identifier "buggy_tool"
         description "Has a bug"
@@ -151,9 +162,10 @@ describe Riffer::Tools::Runtime do
       runtime = Riffer::Tools::Runtime::Inline.new
       tool_call = make_tool_call(name: "buggy_tool", arguments: "{}")
 
-      expect do
-        runtime.execute([tool_call], tools: [buggy_tool], context: context)
-      end.must_raise NoMethodError
+      result = execute_single(runtime, tool_call, tools: [buggy_tool], context: context)
+
+      expect(result.error_type).must_equal :unhandled_error
+      expect(result.exception).must_be_instance_of NoMethodError
     end
 
     it "returns [tool_call, response] pairs in order" do
@@ -415,19 +427,42 @@ describe Riffer::Tools::Runtime do
       end
     end
 
-    describe "raised exceptions" do
+    describe "unhandled error responses" do
       before do
         runtime = Riffer::Tools::Runtime::Inline.new
-        tool_call = make_tool_call(name: "buggy_tool")
+        runtime.execute([make_tool_call(name: "buggy_tool")], tools: [buggy_tool_class], context: nil)
+      end
+
+      it "records error.type from the response error type" do
+        expect(tool_span.attributes["error.type"]).must_equal "unhandled_error"
+      end
+
+      it "marks the span status as error" do
+        expect(tool_span.status.code).must_equal OpenTelemetry::Trace::Status::ERROR
+      end
+
+      it "records the exception on the span" do
+        event = tool_span.events.find { |e| e.name == "exception" }
+
+        expect(event.attributes["exception.type"]).must_equal "NoMethodError"
+      end
+    end
+
+    describe "host code raising around the tool call" do
+      before do
+        runtime_class = Class.new(Riffer::Tools::Runtime::Inline) do
+          define_method(:around_tool_call) { |_tool_call, **| raise IOError, "hook exploded" }
+        end
+
         begin
-          runtime.execute([tool_call], tools: [buggy_tool_class], context: nil)
-        rescue NoMethodError
-          # swallow the raise — the recorded span is the subject under test
+          runtime_class.new.execute([tool_call], tools: [weather_tool_class], context: nil)
+        rescue IOError
+          # swallow the re-raise — the recorded span is the subject under test
         end
       end
 
       it "records error.type from the exception class" do
-        expect(tool_span.attributes["error.type"]).must_equal "NoMethodError"
+        expect(tool_span.attributes["error.type"]).must_equal "IOError"
       end
 
       it "marks the span status as error" do


### PR DESCRIPTION
## Problem

A tool that raised anything outside the narrow set the runtime rescued (`Riffer::ValidationError`, `Riffer::TimeoutError`, `Riffer::ToolExecutionError`, `RuntimeError`) crashed the entire agent run — a `NoMethodError` in one tool killed the batch and discarded every sibling tool call's result, and malformed argument JSON from a provider (`JSON::ParserError`) did the same. The handling also lived inside `Runtime#dispatch_tool_call`, so any custom runtime overriding that method silently lost all error handling.

The underlying framing: a tool call is a sub-program, not a method call. Like a Rails controller action, its failures should become an error *response* at the framework wrapper, not an exception that takes down the host loop.

## Solution

The error boundary moves from the runtime into the tool. `Riffer::Tool#call_with_validation` now never raises: validation failures → `:validation_error`, timeouts → `:timeout_error`, `Riffer::ToolExecutionError` → `:execution_error`, and any other `StandardError` → a new `:unhandled_error` type with `Error executing tool: <Class>: <message>` content. Because the rescue travels with the tool, every dispatch path (inline, or a custom HTTP/gRPC runtime's server side) gets identical semantics for free.

Subtleties a reviewer might miss:

- The unhandled exception rides on the Response (`Response#exception`, deliberately excluded from `to_h` so it never reaches the LLM); the runtime uses it to call `span.record_exception` and set error status, preserving the loud telemetry the old raise gave us. Deliberate error Responses keep an unset span status — the 4xx/5xx distinction survives in traces.
- `NotImplementedError` still propagates: an unimplemented `#call` is a broken deploy, not a bad request (it's a `ScriptError`, deliberately outside `StandardError`).
- The runtime keeps only pre-tool concerns: unknown tools, and malformed argument JSON, which now returns `:validation_error` instead of crashing the run.
- `Riffer::TimeoutError` is now the sentinel `Timeout.timeout` raises, and only it maps to `:timeout_error` — an external library timeout inside a tool (`Net::ReadTimeout < Timeout::Error`) lands in `:unhandled_error` instead of masquerading as the tool's own budget. It's raised *inside* `call`, so tools can rescue it for cleanup. The validation rescue is likewise scoped to param validation only.
- **Breaking (telemetry):** on an unhandled tool failure, the `execute_tool` span's `error.type` is now always `unhandled_error` rather than the exception class name; the class still appears as `exception.type` on the recorded exception event. Dashboards or alerts grouping on exception class names in `error.type` need updating.

Docs updated: `TOOLS.md`, `TOOL_ADVANCED.md`, `AGENT_LOOP.md`, `TRACING.md`.

## Proof

CI covers it: `bin/rake` (2163 runs, 3246 assertions, 0 failures; RuboCop clean; Steep clean). New tests cover the full rescue table at the tool layer, the folded non-Response return, `NotImplementedError` still raising, malformed-JSON arguments at the runtime layer, and span assertions that `:unhandled_error` records the exception with error status while host-code raises still propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool failures now return structured responses for validation, timeout, execution, and unhandled errors.
  * Unhandled exceptions are preserved for diagnostics but excluded from serialized responses.
  * Tool tracing records unhandled exceptions and marks affected operations as errors.

* **Bug Fixes**
  * Agent runs continue after tool errors, allowing the LLM to handle returned error information.
  * Malformed or non-object tool-call JSON is reported as a validation error.

* **Documentation**
  * Expanded guidance for tool errors, timeouts, malformed input, custom runtimes, and tracing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
