### PR TITLE
feat: registry liveness, explicit registration, and Riffer::Testing stub factories

### DIFF
--- a/docs-site/manifest.yml
+++ b/docs-site/manifest.yml
@@ -48,6 +48,9 @@ groups:
       - source: EVALS.md
         slug: evals
         description: Evaluating agent quality
+      - source: TESTING.md
+        slug: testing
+        description: Stubbing agents and tools in tests
       - source: GUARDRAILS.md
         slug: guardrails
         description: Input/output validation

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -326,6 +326,37 @@ Only **named direct subclasses** are found:
 - Grandchildren are not visible to a grandparent's `find` or `all`. If your app defines an intermediate base class (`class ApplicationAgent < Riffer::Agent`), call `find`/`all` on the intermediate class to look up its subclasses.
 - Anonymous classes (`Class.new(Riffer::Agent)`) are never findable, even when they set an explicit `identifier`.
 - Two subclasses sharing an identifier raise `Riffer::DuplicateIdentifierError` at the first lookup.
+- A subclass whose constant no longer points at it — after a Zeitwerk reload or an RSpec `stub_const` — drops out of `find` and `all`. The check runs when the registry is rebuilt, which defining, registering, or unregistering a subclass triggers; removing or restoring a constant on its own does not, so lookups keep returning the old class until the next rebuild.
+
+### Registering an agent explicitly
+
+`register` adds an agent to its parent's registry by hand, `unregister` removes it, and `with_registered` scopes the pair to a block. This exists for test suites: an anonymous agent class is never found implicitly, so registering it is the way to make the code under test resolve it by identifier.
+
+```ruby
+stub_agent = Class.new(Riffer::Agent) do
+  identifier 'support_agent'
+  model 'mock/gpt-5-mini'
+end
+
+Riffer::Agent.with_registered(stub_agent) do
+  TriageWorkflow.new.run('What are your hours?')
+end
+# => stub_agent is unregistered again, even if the block raises
+```
+
+```ruby
+Riffer::Agent.register(stub_agent)   # findable until unregistered
+Riffer::Agent.unregister(stub_agent) # no-op if it was never registered
+```
+
+Explicit registration differs from implicit in a few ways:
+
+- Anonymous classes are allowed, as long as they declare an `identifier`. A blank identifier raises `Riffer::ArgumentError`.
+- The class must be a **direct** subclass of the receiver, mirroring implicit registration. `Riffer::Agent.register(SomeAppAgent)` raises `Riffer::ArgumentError` when `SomeAppAgent` descends from an intermediate base — call `register` on that base instead.
+- Taking an identifier already held by another agent, implicit or explicit, raises `Riffer::DuplicateIdentifierError`. Re-registering the same class raises too; there is no idempotent path.
+- The registration survives until you remove it — it is never dropped for a stale constant.
+
+Registration is not synchronized. Register during boot or from a single-threaded test, before concurrent lookups begin.
 
 ## Per-Call Tags
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -321,10 +321,10 @@ Riffer::Agent.find('missing')         # => nil
 Riffer::Agent.all                     # => [SupportAgent, ...]
 ```
 
-Only **named direct subclasses** are found:
+Only **named direct subclasses** are found implicitly:
 
 - Grandchildren are not visible to a grandparent's `find` or `all`. If your app defines an intermediate base class (`class ApplicationAgent < Riffer::Agent`), call `find`/`all` on the intermediate class to look up its subclasses.
-- Anonymous classes (`Class.new(Riffer::Agent)`) are never findable, even when they set an explicit `identifier`.
+- Anonymous classes (`Class.new(Riffer::Agent)`) are never findable implicitly, even when they set an explicit `identifier` — see [Registering an agent explicitly](#registering-an-agent-explicitly).
 - Two subclasses sharing an identifier raise `Riffer::DuplicateIdentifierError` at the first lookup.
 - A subclass whose constant no longer points at it — after a Zeitwerk reload or an RSpec `stub_const` — drops out of `find` and `all`. The check runs when the registry is rebuilt, which defining, registering, or unregistering a subclass triggers; removing or restoring a constant on its own does not, so lookups keep returning the old class until the next rebuild.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -330,23 +330,13 @@ Only **named direct subclasses** are found:
 
 ### Registering an agent explicitly
 
-`register` adds an agent to its parent's registry by hand, `unregister` removes it, and `with_registered` scopes the pair to a block. This exists for test suites: an anonymous agent class is never found implicitly, so registering it is the way to make the code under test resolve it by identifier.
+**Testing an agent that gets resolved by identifier? Use [`Riffer::Testing`](TESTING.md)** — `stub_agent` builds and registers a throwaway agent and cleans it up for you. The API below is the manual alternative, for production wiring and anything outside the stub lifecycle.
+
+`register` adds an agent to its parent's registry by hand and `unregister` removes it:
 
 ```ruby
-stub_agent = Class.new(Riffer::Agent) do
-  identifier 'support_agent'
-  model 'mock/gpt-5-mini'
-end
-
-Riffer::Agent.with_registered(stub_agent) do
-  TriageWorkflow.new.run('What are your hours?')
-end
-# => stub_agent is unregistered again, even if the block raises
-```
-
-```ruby
-Riffer::Agent.register(stub_agent)   # findable until unregistered
-Riffer::Agent.unregister(stub_agent) # no-op if it was never registered
+Riffer::Agent.register(agent)   # findable until unregistered
+Riffer::Agent.unregister(agent) # no-op if it was never registered
 ```
 
 Explicit registration differs from implicit in a few ways:

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -133,6 +133,7 @@ Response
 - [Configuration](CONFIGURATION.md) - Global configuration
 - [Tracing](TRACING.md) - OpenTelemetry span contract and host wiring
 - [Evals](EVALS.md) - Evaluating agent quality
+- [Testing](TESTING.md) - Stubbing agents and tools in tests
 - [Guardrails](GUARDRAILS.md) - Input/output validation
 - [Skills](SKILLS.md) - Packaged agent capabilities
 - [Serialization](SERIALIZATION.md) - Persisting and transferring agent definitions

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,105 @@
+# Testing
+
+`Riffer::Testing` builds throwaway agents and tools your suite can resolve by identifier, and removes them again when the test ends. It exists because agents and tools are looked up by identifier at runtime (see [Looking Up Tools](TOOLS.md#looking-up-tools)) and only **named** classes are found implicitly — an anonymous `Class.new(Riffer::Tool)` never is.
+
+## Setup
+
+Require the adapter for your framework once, in your spec/test helper:
+
+```ruby
+# spec/spec_helper.rb
+require 'riffer/testing/rspec'
+```
+
+```ruby
+# test/test_helper.rb
+require 'riffer/testing/minitest'
+```
+
+Either one adds `stub_agent` and `stub_tool` to every example and cleans up after each one. Neither RSpec nor minitest is a riffer dependency; the adapter files are only loaded when you require them yourself.
+
+## Stubbing a tool
+
+```ruby
+it 'answers from the knowledge base' do
+  stub_tool(identifier: 'kb_search') do
+    def call(context:, **)
+      text('We are open 9-5.')
+    end
+  end
+
+  response = SupportAgent.generate('What are your hours?')
+
+  expect(response.content).to include('9-5')
+end
+```
+
+`stub_tool` returns the class, so you can assert against it or pass it to `uses_tools`:
+
+```ruby
+tool = stub_tool(identifier: 'kb_search')
+
+stub_agent(identifier: 'support_agent') { uses_tools [tool] }
+```
+
+The block is evaluated in the new class, so the whole [tool DSL](TOOLS.md) is available inside it — `description`, `params`, `timeout`, `call`.
+
+## Stubbing an agent
+
+```ruby
+it 'routes to the support agent' do
+  stub_agent(identifier: 'support_agent') do
+    model 'mock/gpt-5-mini'
+    instructions 'You are a stub.'
+  end
+
+  TriageWorkflow.new.run('What are your hours?')
+end
+```
+
+Pair it with the [Mock provider](providers/MOCK_PROVIDER.md) to queue deterministic responses.
+
+## Stubbing under an intermediate base class
+
+Both helpers take a `base:` — pass your app's intermediate class so the stub lands in the registry the code under test reads:
+
+```ruby
+stub_tool(identifier: 'kb_search', base: ApplicationTool)
+```
+
+The stub is always a **direct** subclass of `base`, mirroring how implicit registration works.
+
+## Cleanup
+
+`Riffer::Testing.reset!` removes every stub built since the last reset, newest first, and forgets them. The adapters call it after each example; a no-op when nothing was stubbed.
+
+Without an adapter — a framework riffer ships no wiring for, or a suite that configures its own hooks — include the module and call `reset!` from your own teardown:
+
+```ruby
+class MyTestCase < WhateverBase
+  include Riffer::Testing
+
+  def teardown
+    Riffer::Testing.reset!
+    super
+  end
+end
+```
+
+Tracking lives on `Riffer::Testing` itself, so `Riffer::Testing.stub_tool(...)` outside an example and `stub_tool(...)` inside one share one list. Tracking is not synchronized — stub from a single-threaded test, before concurrent lookups begin.
+
+## When a stub leaks
+
+Stubbing an identifier that is already taken raises `Riffer::DuplicateIdentifierError`:
+
+```ruby
+stub_tool(identifier: 'kb_search')
+stub_tool(identifier: 'kb_search')
+# => Riffer::DuplicateIdentifierError: Duplicate identifier "kb_search" for ...
+```
+
+Seeing this on the **first** stub in a test means an earlier stub was never removed — usually a missing adapter require in the helper, or a teardown that skips `Riffer::Testing.reset!`. The same error fires when a stub collides with a real class in your app that already claims the identifier; rename the stub or stub under an intermediate `base:`.
+
+## Registering without a stub
+
+For production wiring, or a test that needs a class registered outside the stub lifecycle, `Riffer::Tool.register` / `unregister` (and the `Riffer::Agent` equivalents) manage the registry by hand. See [Registering a tool explicitly](TOOLS.md#registering-a-tool-explicitly).

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,7 +22,9 @@ Either one adds `stub_agent` and `stub_tool` to every example and cleans up afte
 
 ```ruby
 it 'answers from the knowledge base' do
-  stub_tool(identifier: 'kb_search') do
+  stub_tool('KbSearch') do
+    description 'Searches the knowledge base.'
+
     def call(context:, **)
       text('We are open 9-5.')
     end
@@ -37,9 +39,9 @@ end
 `stub_tool` returns the class, so you can assert against it or pass it to `uses_tools`:
 
 ```ruby
-tool = stub_tool(identifier: 'kb_search')
+tool = stub_tool('KbSearch') { description 'Searches the knowledge base.' }
 
-stub_agent(identifier: 'faq_agent') { uses_tools [tool] }
+stub_agent('FaqAgent') { uses_tools [tool] }
 ```
 
 The block is evaluated in the new class, so the whole [tool DSL](TOOLS.md) is available inside it — `description`, `params`, `timeout`, `call`.
@@ -69,13 +71,13 @@ stub_agent('FaqAgent')
 Object.const_get('FaqAgent').identifier # => 'faq_agent'
 ```
 
-The identifier is derived from the name exactly as it is for a regular agent or tool, so `identifier` only earns its keep when you want a different one. Pass `identifier:` on its own when nothing under test needs a constant:
+The identifier is derived from the name exactly as it is for a regular agent or tool, and the block can override it like any other config. Skip the name and set the identifier in the block when nothing under test needs a constant, or when the identifier can't derive from one:
 
 ```ruby
-stub_tool(identifier: 'kb_search')
+stub_tool { identifier 'kb-search' }
 ```
 
-At least one of the two is required; `stub_tool` with neither raises `Riffer::ArgumentError`. So does a name that isn't a simple top-level constant name (`'Legacy::Agent'` and `'legacy_agent'` are both rejected — namespaced stubs aren't supported), and so does a name that is **already defined**: riffer adds constants, it never replaces them. Use your framework's `stub_const` when you need a real class swapped out for the duration of a test.
+A stub needs a name, an identifier set in its block, or both; `stub_tool` with neither raises `Riffer::ArgumentError`. So does a name that isn't a simple top-level constant name (`'Legacy::Agent'` and `'legacy_agent'` are both rejected — namespaced stubs aren't supported), and so does a name that is **already defined**: riffer adds constants, it never replaces them. Use your framework's `stub_const` when you need a real class swapped out for the duration of a test.
 
 `reset!`, and the adapters that call it, remove the constants the stubs created along with their registrations.
 
@@ -84,7 +86,7 @@ At least one of the two is required; `stub_tool` with neither raises `Riffer::Ar
 Both helpers take a `base:` — pass your app's intermediate class so the stub lands in the registry the code under test reads:
 
 ```ruby
-stub_tool(identifier: 'kb_search', base: ApplicationTool)
+stub_tool('KbSearch', base: ApplicationTool)
 ```
 
 The stub is always a **direct** subclass of `base`, mirroring how implicit registration works.
@@ -113,8 +115,8 @@ Tracking lives on `Riffer::Testing` itself, so `Riffer::Testing.stub_tool(...)` 
 Stubbing an identifier that is already taken raises `Riffer::DuplicateIdentifierError`:
 
 ```ruby
-stub_tool(identifier: 'kb_search')
-stub_tool(identifier: 'kb_search')
+stub_tool { identifier 'kb_search' }
+stub_tool { identifier 'kb_search' }
 # => Riffer::DuplicateIdentifierError: Duplicate identifier "kb_search" for ...
 ```
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing
 
-`Riffer::Testing` builds throwaway agents and tools your suite can resolve by identifier, and removes them again when the test ends. It exists because agents and tools are looked up by identifier at runtime (see [Looking Up Tools](TOOLS.md#looking-up-tools)) and only **named** classes are found implicitly — an anonymous `Class.new(Riffer::Tool)` never is.
+`Riffer::Testing` builds throwaway agents and tools your suite can resolve by identifier or by constant name, and removes them again when the test ends. It exists because agents and tools are looked up by identifier at runtime (see [Looking Up Tools](TOOLS.md#looking-up-tools)) and only **named** classes are found implicitly — an anonymous `Class.new(Riffer::Tool)` never is.
 
 ## Setup
 
@@ -39,7 +39,7 @@ end
 ```ruby
 tool = stub_tool(identifier: 'kb_search')
 
-stub_agent(identifier: 'support_agent') { uses_tools [tool] }
+stub_agent(identifier: 'faq_agent') { uses_tools [tool] }
 ```
 
 The block is evaluated in the new class, so the whole [tool DSL](TOOLS.md) is available inside it — `description`, `params`, `timeout`, `call`.
@@ -47,8 +47,8 @@ The block is evaluated in the new class, so the whole [tool DSL](TOOLS.md) is av
 ## Stubbing an agent
 
 ```ruby
-it 'routes to the support agent' do
-  stub_agent(identifier: 'support_agent') do
+it 'routes to the FAQ agent' do
+  stub_agent('FaqAgent') do # identifier defaults to 'faq_agent', as for a regular agent
     model 'mock/gpt-5-mini'
     instructions 'You are a stub.'
   end
@@ -58,6 +58,26 @@ end
 ```
 
 Pair it with the [Mock provider](providers/MOCK_PROVIDER.md) to queue deterministic responses.
+
+## Naming a stub
+
+The first argument assigns a top-level constant, so the stub resolves the way a production class does — `Object.const_get('FaqAgent')`, a workflow runner that instantiates agents by class name, a class name stored in a row of data:
+
+```ruby
+stub_agent('FaqAgent')
+
+Object.const_get('FaqAgent').identifier # => 'faq_agent'
+```
+
+The identifier is derived from the name exactly as it is for a regular agent or tool, so `identifier` only earns its keep when you want a different one. Pass `identifier:` on its own when nothing under test needs a constant:
+
+```ruby
+stub_tool(identifier: 'kb_search')
+```
+
+At least one of the two is required; `stub_tool` with neither raises `Riffer::ArgumentError`. So does a name that isn't a simple top-level constant name (`'Legacy::Agent'` and `'legacy_agent'` are both rejected — namespaced stubs aren't supported), and so does a name that is **already defined**: riffer adds constants, it never replaces them. Use your framework's `stub_const` when you need a real class swapped out for the duration of a test.
+
+`reset!`, and the adapters that call it, remove the constants the stubs created along with their registrations.
 
 ## Stubbing under an intermediate base class
 
@@ -99,6 +119,8 @@ stub_tool(identifier: 'kb_search')
 ```
 
 Seeing this on the **first** stub in a test means an earlier stub was never removed — usually a missing adapter require in the helper, or a teardown that skips `Riffer::Testing.reset!`. The same error fires when a stub collides with a real class in your app that already claims the identifier; rename the stub or stub under an intermediate `base:`.
+
+A leaked **named** stub leaves its constant behind on top of its registration, and only `reset!` takes a constant back down — so the second test to name it gets a `Riffer::ArgumentError` about the constant rather than a fresh class.
 
 ## Registering without a stub
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -163,24 +163,13 @@ Only **named direct subclasses** are found:
 
 ### Registering a tool explicitly
 
-`register` adds a tool to its parent's registry by hand, `unregister` removes it, and `with_registered` scopes the pair to a block. This exists for test suites: an anonymous tool class is never found implicitly, so registering it is the way to make the code under test resolve it by identifier.
+**Testing a tool that gets resolved by identifier? Use [`Riffer::Testing`](TESTING.md)** — `stub_tool` builds and registers a throwaway tool and cleans it up for you. The API below is the manual alternative, for production wiring and anything outside the stub lifecycle.
+
+`register` adds a tool to its parent's registry by hand and `unregister` removes it:
 
 ```ruby
-stub_tool = Class.new(Riffer::Tool) do
-  identifier 'kb_search'
-
-  def call(context:, **) = text('stubbed')
-end
-
-Riffer::Tool.with_registered(stub_tool) do
-  SupportAgent.new.generate('What are your hours?')
-end
-# => stub_tool is unregistered again, even if the block raises
-```
-
-```ruby
-Riffer::Tool.register(stub_tool)   # findable until unregistered
-Riffer::Tool.unregister(stub_tool) # no-op if it was never registered
+Riffer::Tool.register(tool)   # findable until unregistered
+Riffer::Tool.unregister(tool) # no-op if it was never registered
 ```
 
 Explicit registration differs from implicit in a few ways:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -154,10 +154,10 @@ Riffer::Tool.find('missing')     # => nil
 Riffer::Tool.all                 # => [SearchTool, ...]
 ```
 
-Only **named direct subclasses** are found:
+Only **named direct subclasses** are found implicitly:
 
 - Grandchildren are not visible to a grandparent's `find` or `all`. If your app defines an intermediate base class (`class ApplicationTool < Riffer::Tool`), call `find`/`all` on the intermediate class to look up its subclasses.
-- Anonymous classes (`Class.new(Riffer::Tool)`) are never findable, even when they set an explicit `identifier`.
+- Anonymous classes (`Class.new(Riffer::Tool)`) are never findable implicitly, even when they set an explicit `identifier` — see [Registering a tool explicitly](#registering-a-tool-explicitly).
 - Two subclasses sharing an identifier raise `Riffer::DuplicateIdentifierError` at the first lookup.
 - A subclass whose constant no longer points at it — after a Zeitwerk reload or an RSpec `stub_const` — drops out of `find` and `all`. The check runs when the registry is rebuilt, which defining, registering, or unregistering a subclass triggers; removing or restoring a constant on its own does not, so lookups keep returning the old class until the next rebuild.
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -159,6 +159,38 @@ Only **named direct subclasses** are found:
 - Grandchildren are not visible to a grandparent's `find` or `all`. If your app defines an intermediate base class (`class ApplicationTool < Riffer::Tool`), call `find`/`all` on the intermediate class to look up its subclasses.
 - Anonymous classes (`Class.new(Riffer::Tool)`) are never findable, even when they set an explicit `identifier`.
 - Two subclasses sharing an identifier raise `Riffer::DuplicateIdentifierError` at the first lookup.
+- A subclass whose constant no longer points at it — after a Zeitwerk reload or an RSpec `stub_const` — drops out of `find` and `all`. The check runs when the registry is rebuilt, which defining, registering, or unregistering a subclass triggers; removing or restoring a constant on its own does not, so lookups keep returning the old class until the next rebuild.
+
+### Registering a tool explicitly
+
+`register` adds a tool to its parent's registry by hand, `unregister` removes it, and `with_registered` scopes the pair to a block. This exists for test suites: an anonymous tool class is never found implicitly, so registering it is the way to make the code under test resolve it by identifier.
+
+```ruby
+stub_tool = Class.new(Riffer::Tool) do
+  identifier 'kb_search'
+
+  def call(context:, **) = text('stubbed')
+end
+
+Riffer::Tool.with_registered(stub_tool) do
+  SupportAgent.new.generate('What are your hours?')
+end
+# => stub_tool is unregistered again, even if the block raises
+```
+
+```ruby
+Riffer::Tool.register(stub_tool)   # findable until unregistered
+Riffer::Tool.unregister(stub_tool) # no-op if it was never registered
+```
+
+Explicit registration differs from implicit in a few ways:
+
+- Anonymous classes are allowed, as long as they declare an `identifier`. A blank identifier raises `Riffer::ArgumentError`.
+- The class must be a **direct** subclass of the receiver, mirroring implicit registration. `Riffer::Tool.register(SomeAppTool)` raises `Riffer::ArgumentError` when `SomeAppTool` descends from an intermediate base — call `register` on that base instead.
+- Taking an identifier already held by another tool, implicit or explicit, raises `Riffer::DuplicateIdentifierError`. Re-registering the same class raises too; there is no idempotent path.
+- The registration survives until you remove it — it is never dropped for a stale constant.
+
+Registration is not synchronized. Register during boot or from a single-threaded test, before concurrent lookups begin.
 
 ## The call Method
 

--- a/lib/riffer.rb
+++ b/lib/riffer.rb
@@ -10,6 +10,13 @@ loader.inflector.inflect(
   "azure_open_ai" => "AzureOpenAI",
   "open_router" => "OpenRouter",
 )
+# Test-framework wiring a consumer requires by hand; neither file defines the
+# constant its path implies, and both reference framework constants riffer
+# never loads itself.
+loader.ignore(
+  "#{__dir__}/riffer/testing/rspec.rb",
+  "#{__dir__}/riffer/testing/minitest.rb",
+)
 loader.setup
 
 module Riffer

--- a/lib/riffer/helpers/identifier.rb
+++ b/lib/riffer/helpers/identifier.rb
@@ -29,13 +29,21 @@ module Riffer::Helpers::Identifier
     cached = klass.instance_variable_get(:@derived_identifier) #: String?
     return cached if cached
 
-    # Tool classes shadow Module#name with the identifier DSL, so the real
-    # class-path name must come from Module's own implementation.
-    real_name = Module.instance_method(:name).bind_call(klass) #: String?
+    real_name = real_name(klass)
     return "" if real_name.nil?
 
     derived = derive(real_name)
     klass.instance_variable_set(:@derived_identifier, derived)
     derived
+  end
+
+  # Returns the class-path name of a class or module, or +nil+ when anonymous.
+  # Tool classes shadow Module#name with the identifier DSL, so the real name
+  # must come from Module's own implementation.
+  #
+  #--
+  #: (Module) -> String?
+  def real_name(klass)
+    Module.instance_method(:name).bind_call(klass) #: String?
   end
 end

--- a/lib/riffer/registrable.rb
+++ b/lib/riffer/registrable.rb
@@ -44,10 +44,9 @@ module Riffer::Registrable
 
   # Registers a direct subclass under its +identifier+, whether or not it is
   # named. Unlike implicit registration it survives a name that no longer
-  # resolves, so an ephemeral class stays findable until +unregister+.
-  #
-  #   klass = Class.new(Riffer::Tool) { identifier "stub_tool" }
-  #   Riffer::Tool.register(klass)
+  # resolves, so an ephemeral class stays findable until +unregister+. Test
+  # suites are better served by Riffer::Testing, which stubs and cleans up for
+  # them.
   #
   # Raises Riffer::ArgumentError when the identifier is blank or the class is
   # not a direct subclass, and Riffer::DuplicateIdentifierError when the
@@ -79,45 +78,7 @@ module Riffer::Registrable
     @identifier_registry = nil
   end
 
-  # Registers each class for the duration of the block and returns the block's
-  # value.
-  #
-  #   Riffer::Tool.with_registered(stub_tool) do
-  #     agent.generate("...")
-  #   end
-  #
-  # Raises whatever +register+ raises, having first unregistered the classes it
-  # already registered.
-  #
-  #--
-  #: [T] (*Class) { () -> T } -> T
-  def with_registered(*klasses)
-    registered = [] #: Array[Class]
-
-    begin
-      klasses.each do |klass|
-        register(klass)
-        registered << klass
-      end
-    rescue StandardError
-      unregister_all(registered)
-      raise
-    end
-
-    begin
-      yield
-    ensure
-      unregister_all(registered)
-    end
-  end
-
   private
-
-  #--
-  #: (Array[Class]) -> void
-  def unregister_all(klasses)
-    klasses.reverse_each { |klass| unregister(klass) }
-  end
 
   # Ruby invokes +inherited+ with +self+ bound to the direct superclass — the
   # only registry the new subclass joins — so busting self's memo is exactly

--- a/lib/riffer/registrable.rb
+++ b/lib/riffer/registrable.rb
@@ -43,10 +43,10 @@ module Riffer::Registrable
   end
 
   # Registers a direct subclass under its +identifier+, whether or not it is
-  # named. Unlike implicit registration it survives a name that no longer
-  # resolves, so an ephemeral class stays findable until +unregister+. Test
-  # suites are better served by Riffer::Testing, which stubs and cleans up for
-  # them.
+  # named — unlike implicit registration, it survives a name that no longer
+  # resolves, so an ephemeral class stays findable until +unregister+. Prefer
+  # Riffer::Testing for ordinary test setup, which stubs and cleans up
+  # automatically.
   #
   # Raises Riffer::ArgumentError when the identifier is blank or the class is
   # not a direct subclass, and Riffer::DuplicateIdentifierError when the

--- a/lib/riffer/registrable.rb
+++ b/lib/riffer/registrable.rb
@@ -65,7 +65,7 @@ module Riffer::Registrable
     existing = identifier_registry[key]
     raise_duplicate_identifier!(key, existing, klass) if existing
 
-    @explicit_registrations = explicit_registrations.merge(key => klass)
+    explicit_registrations[key] = klass
     @identifier_registry = nil
   end
 
@@ -74,7 +74,10 @@ module Riffer::Registrable
   #--
   #: (Class) -> void
   def unregister(klass)
-    @explicit_registrations = explicit_registrations.reject { |_key, registered| registered.equal?(klass) }
+    key, = explicit_registrations.find { |_key, registered| registered.equal?(klass) }
+    return if key.nil?
+
+    explicit_registrations.delete(key)
     @identifier_registry = nil
   end
 

--- a/lib/riffer/registrable.rb
+++ b/lib/riffer/registrable.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Registry of a class's named direct subclasses, keyed by identifier. Extend it
+# Registry of a class's direct subclasses, keyed by identifier. Extend it
 # onto a base class to look up subclasses in constant time via +find+ and +all+.
+# Subclasses join implicitly by inheriting; +register+ adds one explicitly, for
+# ephemeral classes a test suite builds and tears down. Registration is not
+# synchronized — register during boot or from a single-threaded test, before
+# concurrent lookups begin.
 #
 #   class Riffer::Tool
 #     extend Riffer::Registrable
@@ -13,12 +17,15 @@
 # @rbs module-self Class
 module Riffer::Registrable
   # @rbs @identifier_registry: Hash[String, Class]?
+  # @rbs @explicit_registrations: Hash[String, Class]?
 
   # Finds a registered subclass by identifier, or +nil+ when none matches.
-  # Only *named direct* subclasses are registered: grandchildren are not
-  # visible to a grandparent's +find+ (call +find+ on their direct parent
-  # instead), anonymous classes are never registered, and duplicate identifiers
-  # raise Riffer::DuplicateIdentifierError at first lookup.
+  # Implicit registration covers only *named direct* subclasses: grandchildren
+  # are not visible to a grandparent's +find+ (call +find+ on their direct
+  # parent instead), anonymous classes are never registered implicitly, and a
+  # subclass whose name no longer resolves back to it is dropped at the next
+  # registry rebuild. Duplicate identifiers raise
+  # Riffer::DuplicateIdentifierError at first lookup.
   #
   #--
   #: (String | Symbol) -> Class?
@@ -26,10 +33,8 @@ module Riffer::Registrable
     identifier_registry[identifier.to_s]
   end
 
-  # Returns all registered subclasses. Only *named direct* subclasses are
-  # registered: grandchildren are not included (call +all+ on their direct
-  # parent instead), anonymous classes are never registered, and duplicate
-  # identifiers raise Riffer::DuplicateIdentifierError at first lookup.
+  # Returns all registered subclasses, implicit and explicit. Carries the same
+  # registration rules as +find+.
   #
   #--
   #: () -> Array[Class]
@@ -37,7 +42,82 @@ module Riffer::Registrable
     identifier_registry.values
   end
 
+  # Registers a direct subclass under its +identifier+, whether or not it is
+  # named. Unlike implicit registration it survives a name that no longer
+  # resolves, so an ephemeral class stays findable until +unregister+.
+  #
+  #   klass = Class.new(Riffer::Tool) { identifier "stub_tool" }
+  #   Riffer::Tool.register(klass)
+  #
+  # Raises Riffer::ArgumentError when the identifier is blank or the class is
+  # not a direct subclass, and Riffer::DuplicateIdentifierError when the
+  # identifier is already taken — including by this same class.
+  #
+  #--
+  #: (Class) -> void
+  def register(klass)
+    unless klass.superclass.equal?(self)
+      raise Riffer::ArgumentError, "#{klass} must be a direct subclass of #{self} to register"
+    end
+
+    key = identifier_key(klass)
+    raise Riffer::ArgumentError, "#{klass} must declare a non-blank identifier to register" if key.strip.empty?
+
+    existing = identifier_registry[key]
+    raise_duplicate_identifier!(key, existing, klass) if existing
+
+    @explicit_registrations = explicit_registrations.merge(key => klass)
+    @identifier_registry = nil
+  end
+
+  # Removes an explicit registration of +klass+, leaving implicit registrations
+  # untouched.
+  #--
+  #: (Class) -> void
+  def unregister(klass)
+    @explicit_registrations = explicit_registrations.reject { |_key, registered| registered.equal?(klass) }
+    @identifier_registry = nil
+  end
+
+  # Registers each class for the duration of the block and returns the block's
+  # value.
+  #
+  #   Riffer::Tool.with_registered(stub_tool) do
+  #     agent.generate("...")
+  #   end
+  #
+  # Raises whatever +register+ raises, having first unregistered the classes it
+  # already registered.
+  #
+  #--
+  #: [T] (*Class) { () -> T } -> T
+  def with_registered(*klasses)
+    registered = [] #: Array[Class]
+
+    begin
+      klasses.each do |klass|
+        register(klass)
+        registered << klass
+      end
+    rescue StandardError
+      unregister_all(registered)
+      raise
+    end
+
+    begin
+      yield
+    ensure
+      unregister_all(registered)
+    end
+  end
+
   private
+
+  #--
+  #: (Array[Class]) -> void
+  def unregister_all(klasses)
+    klasses.reverse_each { |klass| unregister(klass) }
+  end
 
   # Ruby invokes +inherited+ with +self+ bound to the direct superclass — the
   # only registry the new subclass joins — so busting self's memo is exactly
@@ -57,25 +137,64 @@ module Riffer::Registrable
 
   #--
   #: () -> Hash[String, Class]
-  def build_identifier_registry
-    registry = {} #: Hash[String, Class]
-    subclasses.each_with_object(registry) do |subclass, acc|
-      # Anonymous classes are skipped even with an explicit identifier — the
-      # MCP factory and serializer shells synthesize short-lived anonymous
-      # classes whose registration would flake with GC timing.
-      next if Riffer::Helpers::Identifier.for(subclass).empty?
+  def explicit_registrations
+    @explicit_registrations ||= {}
+  end
 
-      candidate = subclass #: untyped
-      key = candidate.identifier.to_s
+  #--
+  #: () -> Hash[String, Class]
+  def build_identifier_registry
+    subclasses.each_with_object(explicit_registrations.dup) do |subclass, acc|
+      next unless live?(subclass)
+
+      key = identifier_key(subclass)
       next if key.strip.empty?
 
       existing = acc[key]
-      if existing
-        raise Riffer::DuplicateIdentifierError,
-              "Duplicate identifier #{key.inspect} for #{existing} and #{subclass}"
-      end
+      raise_duplicate_identifier!(key, existing, subclass) if existing && !existing.equal?(subclass)
 
       acc[key] = subclass
     end.freeze
+  end
+
+  # Class#subclasses keeps returning superseded generations of a reloaded or
+  # stubbed class, so a subclass counts only while its own name still resolves
+  # back to it. An anonymous class has no name to resolve and is skipped even
+  # with an explicit identifier — the MCP factory and serializer shells
+  # synthesize short-lived anonymous classes whose registration would flake
+  # with GC timing.
+  #--
+  #: (Class) -> bool
+  def live?(subclass)
+    real_name = Riffer::Helpers::Identifier.real_name(subclass)
+    return false if real_name.nil?
+
+    # Module#autoload? does not traverse a qualified path, so each segment is
+    # resolved against its own owner: probing a pending autoload would trigger
+    # the load, whose +inherited+ hook busts the memo this build is populating.
+    root = Object #: Module
+    resolved = real_name.split("::").reduce(root) do |owner, segment|
+      return false if owner.autoload?(segment, false)
+
+      owner.const_get(segment, false) #: Module
+    end
+
+    resolved.equal?(subclass)
+  rescue NameError
+    false
+  end
+
+  #--
+  #: (Class) -> String
+  def identifier_key(klass)
+    candidate = klass #: untyped
+    candidate.identifier.to_s
+  end
+
+  #--
+  #: (String, Class, Class) -> void
+  def raise_duplicate_identifier!(key, existing, klass)
+    raise Riffer::DuplicateIdentifierError,
+          "Duplicate identifier #{key.inspect} for #{existing} and #{klass}"
   end
 end

--- a/lib/riffer/testing.rb
+++ b/lib/riffer/testing.rb
@@ -19,34 +19,36 @@ module Riffer::Testing
 
   # Builds an agent class, evaluates the optional body in it, and makes it
   # resolvable until the next +reset!+. A +name+ assigns a top-level constant
-  # and derives the identifier unless +identifier+ overrides it.
+  # and derives the identifier; the body may set +identifier+ like any other
+  # agent config.
   #
   #   agent = stub_agent("SupportAgent") { model "mock/gpt-5-mini" }
   #
-  # Raises Riffer::ArgumentError when the constant is already defined, and
-  # Riffer::DuplicateIdentifierError when another agent already holds the
-  # identifier.
+  # Raises Riffer::ArgumentError when the constant is already defined or the
+  # stub ends up with no identifier, and Riffer::DuplicateIdentifierError when
+  # another agent already holds the identifier.
   #
   #--
-  #: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
-  def stub_agent(name = nil, identifier: nil, base: Riffer::Agent, &body)
-    build_stub(name, identifier: identifier, base: base, &body) #: singleton(Riffer::Agent)
+  #: (?(String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent(name = nil, base: Riffer::Agent, &body)
+    build_stub(name, base: base, &body) #: singleton(Riffer::Agent)
   end
 
   # Builds a tool class, evaluates the optional body in it, and makes it
   # resolvable until the next +reset!+. A +name+ assigns a top-level constant
-  # and derives the identifier unless +identifier+ overrides it.
+  # and derives the identifier; the body may set +identifier+ like any other
+  # tool config.
   #
   #   tool = stub_tool("KbSearch") { def call(context:, **) = text("stubbed") }
   #
-  # Raises Riffer::ArgumentError when the constant is already defined, and
-  # Riffer::DuplicateIdentifierError when another tool already holds the
-  # identifier.
+  # Raises Riffer::ArgumentError when the constant is already defined or the
+  # stub ends up with no identifier, and Riffer::DuplicateIdentifierError when
+  # another tool already holds the identifier.
   #
   #--
-  #: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
-  def stub_tool(name = nil, identifier: nil, base: Riffer::Tool, &body)
-    build_stub(name, identifier: identifier, base: base, &body) #: singleton(Riffer::Tool)
+  #: (?(String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool(name = nil, base: Riffer::Tool, &body)
+    build_stub(name, base: base, &body) #: singleton(Riffer::Tool)
   end
 
   # Removes every stub built since the last reset — its registration and any
@@ -76,15 +78,16 @@ module Riffer::Testing
   private
 
   #--
-  #: ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
-  def build_stub(name, identifier:, base:, &body)
-    raise Riffer::ArgumentError, "a stub needs a name, an identifier, or both" if name.nil? && identifier.nil?
-
+  #: ((String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+  def build_stub(name, base:, &body)
     const_name = validate_const_name(name)
     stub = Class.new(base)
     configurable = stub #: untyped
-    configurable.identifier((identifier || Riffer::Helpers::Identifier.derive(const_name)).to_s)
+    configurable.identifier(Riffer::Helpers::Identifier.derive(const_name)) if const_name
     configurable.class_eval(&body) if body
+    if configurable.identifier.to_s.strip.empty?
+      raise Riffer::ArgumentError, "a stub needs a name, or an identifier set in its block"
+    end
 
     # The class must be registered while still anonymous: naming it first makes
     # it implicitly live, and +register+ rejects an identifier the registry

--- a/lib/riffer/testing.rb
+++ b/lib/riffer/testing.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Builds throwaway agents and tools a test suite can resolve by identifier, and
-# removes them again. Require <tt>riffer/testing/rspec</tt> or
-# <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
+# Builds throwaway agents and tools a test suite can resolve by identifier or
+# constant name, and removes them again. Require <tt>riffer/testing/rspec</tt>
+# or <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
 # example plus per-test cleanup; otherwise include this module and call +reset!+
 # from your own teardown, or call the methods on the module directly.
 #
@@ -12,56 +12,63 @@
 module Riffer::Testing
   extend self
 
-  # @rbs self.@registrations: Array[Class]?
+  # @rbs self.@registrations: Array[[Class, String?]]?
 
-  # Builds an agent class under +identifier+, evaluates the optional body in it,
-  # and makes it resolvable until the next +reset!+.
+  CONST_NAME_PATTERN = /\A[A-Z][A-Za-z0-9_]*\z/ #: Regexp
+  private_constant :CONST_NAME_PATTERN
+
+  # Builds an agent class, evaluates the optional body in it, and makes it
+  # resolvable until the next +reset!+. A +name+ assigns a top-level constant
+  # and derives the identifier unless +identifier+ overrides it.
   #
-  #   agent = stub_agent(identifier: "support_agent") { model "mock/gpt-5-mini" }
+  #   agent = stub_agent("SupportAgent") { model "mock/gpt-5-mini" }
   #
-  # Raises Riffer::DuplicateIdentifierError when another agent already holds the
+  # Raises Riffer::ArgumentError when the constant is already defined, and
+  # Riffer::DuplicateIdentifierError when another agent already holds the
   # identifier.
   #
   #--
-  #: (identifier: (String | Symbol), ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
-  def stub_agent(identifier:, base: Riffer::Agent, &body)
-    build_stub(base: base, identifier: identifier, &body) #: singleton(Riffer::Agent)
+  #: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent(name = nil, identifier: nil, base: Riffer::Agent, &body)
+    build_stub(name, identifier: identifier, base: base, &body) #: singleton(Riffer::Agent)
   end
 
-  # Builds a tool class under +identifier+, evaluates the optional body in it,
-  # and makes it resolvable until the next +reset!+.
+  # Builds a tool class, evaluates the optional body in it, and makes it
+  # resolvable until the next +reset!+. A +name+ assigns a top-level constant
+  # and derives the identifier unless +identifier+ overrides it.
   #
-  #   tool = stub_tool(identifier: "kb_search") do
-  #     def call(context:, **) = text("stubbed")
-  #   end
+  #   tool = stub_tool("KbSearch") { def call(context:, **) = text("stubbed") }
   #
-  # Raises Riffer::DuplicateIdentifierError when another tool already holds the
+  # Raises Riffer::ArgumentError when the constant is already defined, and
+  # Riffer::DuplicateIdentifierError when another tool already holds the
   # identifier.
   #
   #--
-  #: (identifier: (String | Symbol), ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
-  def stub_tool(identifier:, base: Riffer::Tool, &body)
-    build_stub(base: base, identifier: identifier, &body) #: singleton(Riffer::Tool)
+  #: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool(name = nil, identifier: nil, base: Riffer::Tool, &body)
+    build_stub(name, identifier: identifier, base: base, &body) #: singleton(Riffer::Tool)
   end
 
-  # Removes every stub built since the last reset, newest first, and forgets
-  # them. A no-op when nothing has been stubbed.
+  # Removes every stub built since the last reset — its registration and any
+  # constant it created — newest first, and forgets them. A no-op when nothing
+  # has been stubbed.
   #--
   #: () -> void
   def reset!
     tracked = Riffer::Testing.registrations
-    tracked.reverse_each do |stub|
+    tracked.reverse_each do |stub, const_name|
       registrable = stub.superclass #: untyped
       registrable.unregister(stub)
+      remove_stub_const(const_name, stub) if const_name
     end
     tracked.clear
   end
 
   # The stub classes awaiting cleanup. Lives on the module rather than the
-  # caller so an including test case and a direct <tt>Riffer::Testing.stub_*</tt>
-  # call share one list.
+  # caller so an including test case and a direct
+  # <tt>Riffer::Testing.stub_*</tt> call share one list.
   #--
-  #: () -> Array[Class]
+  #: () -> Array[[Class, String?]]
   def self.registrations # :nodoc:
     @registrations ||= []
   end
@@ -69,17 +76,52 @@ module Riffer::Testing
   private
 
   #--
-  #: (base: Class, identifier: (String | Symbol)) ?{ () [self: untyped] -> void } -> Class
-  def build_stub(base:, identifier:, &body)
+  #: ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+  def build_stub(name, identifier:, base:, &body)
+    raise Riffer::ArgumentError, "a stub needs a name, an identifier, or both" if name.nil? && identifier.nil?
+
+    const_name = validate_const_name(name)
     stub = Class.new(base)
     configurable = stub #: untyped
-    configurable.identifier(identifier.to_s)
+    configurable.identifier((identifier || Riffer::Helpers::Identifier.derive(const_name)).to_s)
     configurable.class_eval(&body) if body
 
+    # The class must be registered while still anonymous: naming it first makes
+    # it implicitly live, and +register+ rejects an identifier the registry
+    # already resolves — even to this same class.
     registrable = base #: untyped
     registrable.register(stub)
-    Riffer::Testing.registrations << stub
+    Object.const_set(const_name, stub) if const_name
+    Riffer::Testing.registrations << [stub, const_name]
 
     stub
+  end
+
+  #--
+  #: ((String | Symbol)?) -> String?
+  def validate_const_name(name)
+    return nil if name.nil?
+
+    const_name = name.to_s
+    unless CONST_NAME_PATTERN.match?(const_name)
+      raise Riffer::ArgumentError, "#{const_name.inspect} is not a simple top-level constant name"
+    end
+
+    # True of a pending autoload too — the name is taken either way.
+    if Object.const_defined?(const_name, false)
+      raise Riffer::ArgumentError, "#{const_name} is already defined; use stub_const to replace a real class"
+    end
+
+    const_name
+  end
+
+  # A test may have removed or replaced the constant itself, so never clobber
+  # one that no longer points at the stub.
+  #--
+  #: (String, Class) -> void
+  def remove_stub_const(const_name, stub)
+    return unless Object.const_defined?(const_name, false) && Object.const_get(const_name, false).equal?(stub)
+
+    Object.send(:remove_const, const_name)
   end
 end

--- a/lib/riffer/testing.rb
+++ b/lib/riffer/testing.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# Builds throwaway agents and tools a test suite can resolve by identifier, and
+# removes them again. Require <tt>riffer/testing/rspec</tt> or
+# <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
+# example plus per-test cleanup; otherwise include this module and call +reset!+
+# from your own teardown, or call the methods on the module directly.
+#
+# Tracking is not synchronized — stub from a single-threaded test, before
+# concurrent lookups begin.
+module Riffer::Testing
+  extend self
+
+  # @rbs self.@registrations: Array[Class]?
+
+  # Builds an agent class under +identifier+, evaluates the optional body in it,
+  # and makes it resolvable until the next +reset!+.
+  #
+  #   agent = stub_agent(identifier: "support_agent") { model "mock/gpt-5-mini" }
+  #
+  # Raises Riffer::DuplicateIdentifierError when another agent already holds the
+  # identifier.
+  #
+  #--
+  #: (identifier: (String | Symbol), ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent(identifier:, base: Riffer::Agent, &body)
+    build_stub(base: base, identifier: identifier, &body) #: singleton(Riffer::Agent)
+  end
+
+  # Builds a tool class under +identifier+, evaluates the optional body in it,
+  # and makes it resolvable until the next +reset!+.
+  #
+  #   tool = stub_tool(identifier: "kb_search") do
+  #     def call(context:, **) = text("stubbed")
+  #   end
+  #
+  # Raises Riffer::DuplicateIdentifierError when another tool already holds the
+  # identifier.
+  #
+  #--
+  #: (identifier: (String | Symbol), ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool(identifier:, base: Riffer::Tool, &body)
+    build_stub(base: base, identifier: identifier, &body) #: singleton(Riffer::Tool)
+  end
+
+  # Removes every stub built since the last reset, newest first, and forgets
+  # them. A no-op when nothing has been stubbed.
+  #--
+  #: () -> void
+  def reset!
+    tracked = Riffer::Testing.registrations
+    tracked.reverse_each do |stub|
+      registrable = stub.superclass #: untyped
+      registrable.unregister(stub)
+    end
+    tracked.clear
+  end
+
+  # The stub classes awaiting cleanup. Lives on the module rather than the
+  # caller so an including test case and a direct <tt>Riffer::Testing.stub_*</tt>
+  # call share one list.
+  #--
+  #: () -> Array[Class]
+  def self.registrations # :nodoc:
+    @registrations ||= []
+  end
+
+  private
+
+  #--
+  #: (base: Class, identifier: (String | Symbol)) ?{ () [self: untyped] -> void } -> Class
+  def build_stub(base:, identifier:, &body)
+    stub = Class.new(base)
+    configurable = stub #: untyped
+    configurable.identifier(identifier.to_s)
+    configurable.class_eval(&body) if body
+
+    registrable = base #: untyped
+    registrable.register(stub)
+    Riffer::Testing.registrations << stub
+
+    stub
+  end
+end

--- a/lib/riffer/testing/minitest.rb
+++ b/lib/riffer/testing/minitest.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# rbs-inline stays disabled here: the generated signature would name Minitest,
+# which a shipped signature must never reference. The hand-written stub lives in
+# sig/_private/riffer/testing/minitest.rbs.
+
+require "riffer"
+
+# Wiring only — minitest is never a riffer dependency; a consumer requires this
+# file from a test_helper that has already loaded the framework.
+module Riffer::Testing::MinitestCleanup
+  # Minitest reserves +after_teardown+ for library extensions; +teardown+
+  # belongs to the test author.
+  def after_teardown
+    Riffer::Testing.reset!
+    super
+  end
+end
+
+Minitest::Test.include(Riffer::Testing)
+Minitest::Test.include(Riffer::Testing::MinitestCleanup)

--- a/lib/riffer/testing/rspec.rb
+++ b/lib/riffer/testing/rspec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+require "riffer"
+
+# Wiring only — RSpec is never a riffer dependency; a consumer requires this
+# file from a spec_helper that has already loaded the framework.
+RSpec.configure do |config|
+  config.include Riffer::Testing
+  config.after { Riffer::Testing.reset! }
+end

--- a/sig/_private/minitest.rbs
+++ b/sig/_private/minitest.rbs
@@ -1,0 +1,9 @@
+# Minimal signatures for `minitest`, a development-only framework riffer never
+# depends on. Only the surface `lib/riffer/testing/minitest.rb` touches is
+# declared; the file is required by hand from a consumer's test_helper, so this
+# stub keeps Steep aware of the constants without a `library` dependency.
+module Minitest
+  class Test
+    def after_teardown: () -> void
+  end
+end

--- a/sig/_private/riffer/testing/minitest.rbs
+++ b/sig/_private/riffer/testing/minitest.rbs
@@ -1,0 +1,6 @@
+# Hand-written because the signature names `Minitest`, an optional
+# development-only framework that must never appear in a shipped signature —
+# `lib/riffer/testing/minitest.rb` therefore leaves rbs-inline disabled.
+module Riffer::Testing::MinitestCleanup : Minitest::Test
+  def after_teardown: () -> void
+end

--- a/sig/_private/rspec.rbs
+++ b/sig/_private/rspec.rbs
@@ -1,0 +1,7 @@
+# Minimal signatures for `rspec`, a development-only framework riffer never
+# depends on. Only the surface `lib/riffer/testing/rspec.rb` touches is
+# declared; the file is required by hand from a consumer's spec_helper, so this
+# stub keeps Steep aware of the constants without a `library` dependency.
+module RSpec
+  def self.configure: () { (untyped) -> void } -> void
+end

--- a/sig/_private/zeitwerk.rbs
+++ b/sig/_private/zeitwerk.rbs
@@ -5,6 +5,8 @@ module Zeitwerk
   class Loader
     def self.for_gem: (*untyped) -> Zeitwerk::Loader
 
+    def ignore: (*String) -> void
+
     def inflector: () -> untyped
 
     def setup: () -> void

--- a/sig/generated/riffer/helpers/identifier.rbs
+++ b/sig/generated/riffer/helpers/identifier.rbs
@@ -16,4 +16,12 @@ module Riffer::Helpers::Identifier
   # --
   # : (Module) -> String
   def for: (Module) -> String
+
+  # Returns the class-path name of a class or module, or +nil+ when anonymous.
+  # Tool classes shadow Module#name with the identifier DSL, so the real name
+  # must come from Module's own implementation.
+  #
+  # --
+  # : (Module) -> String?
+  def real_name: (Module) -> String?
 end

--- a/sig/generated/riffer/registrable.rbs
+++ b/sig/generated/riffer/registrable.rbs
@@ -39,10 +39,10 @@ module Riffer::Registrable : Class
   def all: () -> Array[Class]
 
   # Registers a direct subclass under its +identifier+, whether or not it is
-  # named. Unlike implicit registration it survives a name that no longer
-  # resolves, so an ephemeral class stays findable until +unregister+. Test
-  # suites are better served by Riffer::Testing, which stubs and cleans up for
-  # them.
+  # named — unlike implicit registration, it survives a name that no longer
+  # resolves, so an ephemeral class stays findable until +unregister+. Prefer
+  # Riffer::Testing for ordinary test setup, which stubs and cleans up
+  # automatically.
   #
   # Raises Riffer::ArgumentError when the identifier is blank or the class is
   # not a direct subclass, and Riffer::DuplicateIdentifierError when the

--- a/sig/generated/riffer/registrable.rbs
+++ b/sig/generated/riffer/registrable.rbs
@@ -40,10 +40,9 @@ module Riffer::Registrable : Class
 
   # Registers a direct subclass under its +identifier+, whether or not it is
   # named. Unlike implicit registration it survives a name that no longer
-  # resolves, so an ephemeral class stays findable until +unregister+.
-  #
-  #   klass = Class.new(Riffer::Tool) { identifier "stub_tool" }
-  #   Riffer::Tool.register(klass)
+  # resolves, so an ephemeral class stays findable until +unregister+. Test
+  # suites are better served by Riffer::Testing, which stubs and cleans up for
+  # them.
   #
   # Raises Riffer::ArgumentError when the identifier is blank or the class is
   # not a direct subclass, and Riffer::DuplicateIdentifierError when the
@@ -59,25 +58,7 @@ module Riffer::Registrable : Class
   # : (Class) -> void
   def unregister: (Class) -> void
 
-  # Registers each class for the duration of the block and returns the block's
-  # value.
-  #
-  #   Riffer::Tool.with_registered(stub_tool) do
-  #     agent.generate("...")
-  #   end
-  #
-  # Raises whatever +register+ raises, having first unregistered the classes it
-  # already registered.
-  #
-  # --
-  # : [T] (*Class) { () -> T } -> T
-  def with_registered: [T] (*Class) { () -> T } -> T
-
   private
-
-  # --
-  # : (Array[Class]) -> void
-  def unregister_all: (Array[Class]) -> void
 
   # Ruby invokes +inherited+ with +self+ bound to the direct superclass — the
   # only registry the new subclass joins — so busting self's memo is exactly

--- a/sig/generated/riffer/registrable.rbs
+++ b/sig/generated/riffer/registrable.rbs
@@ -1,7 +1,11 @@
 # Generated from lib/riffer/registrable.rb with RBS::Inline
 
-# Registry of a class's named direct subclasses, keyed by identifier. Extend it
+# Registry of a class's direct subclasses, keyed by identifier. Extend it
 # onto a base class to look up subclasses in constant time via +find+ and +all+.
+# Subclasses join implicitly by inheriting; +register+ adds one explicitly, for
+# ephemeral classes a test suite builds and tears down. Registration is not
+# synchronized — register during boot or from a single-threaded test, before
+# concurrent lookups begin.
 #
 #   class Riffer::Tool
 #     extend Riffer::Registrable
@@ -13,26 +17,67 @@
 module Riffer::Registrable : Class
   @identifier_registry: Hash[String, Class]?
 
+  @explicit_registrations: Hash[String, Class]?
+
   # Finds a registered subclass by identifier, or +nil+ when none matches.
-  # Only *named direct* subclasses are registered: grandchildren are not
-  # visible to a grandparent's +find+ (call +find+ on their direct parent
-  # instead), anonymous classes are never registered, and duplicate identifiers
-  # raise Riffer::DuplicateIdentifierError at first lookup.
+  # Implicit registration covers only *named direct* subclasses: grandchildren
+  # are not visible to a grandparent's +find+ (call +find+ on their direct
+  # parent instead), anonymous classes are never registered implicitly, and a
+  # subclass whose name no longer resolves back to it is dropped at the next
+  # registry rebuild. Duplicate identifiers raise
+  # Riffer::DuplicateIdentifierError at first lookup.
   #
   # --
   # : (String | Symbol) -> Class?
   def find: (String | Symbol) -> Class?
 
-  # Returns all registered subclasses. Only *named direct* subclasses are
-  # registered: grandchildren are not included (call +all+ on their direct
-  # parent instead), anonymous classes are never registered, and duplicate
-  # identifiers raise Riffer::DuplicateIdentifierError at first lookup.
+  # Returns all registered subclasses, implicit and explicit. Carries the same
+  # registration rules as +find+.
   #
   # --
   # : () -> Array[Class]
   def all: () -> Array[Class]
 
+  # Registers a direct subclass under its +identifier+, whether or not it is
+  # named. Unlike implicit registration it survives a name that no longer
+  # resolves, so an ephemeral class stays findable until +unregister+.
+  #
+  #   klass = Class.new(Riffer::Tool) { identifier "stub_tool" }
+  #   Riffer::Tool.register(klass)
+  #
+  # Raises Riffer::ArgumentError when the identifier is blank or the class is
+  # not a direct subclass, and Riffer::DuplicateIdentifierError when the
+  # identifier is already taken — including by this same class.
+  #
+  # --
+  # : (Class) -> void
+  def register: (Class) -> void
+
+  # Removes an explicit registration of +klass+, leaving implicit registrations
+  # untouched.
+  # --
+  # : (Class) -> void
+  def unregister: (Class) -> void
+
+  # Registers each class for the duration of the block and returns the block's
+  # value.
+  #
+  #   Riffer::Tool.with_registered(stub_tool) do
+  #     agent.generate("...")
+  #   end
+  #
+  # Raises whatever +register+ raises, having first unregistered the classes it
+  # already registered.
+  #
+  # --
+  # : [T] (*Class) { () -> T } -> T
+  def with_registered: [T] (*Class) { () -> T } -> T
+
   private
+
+  # --
+  # : (Array[Class]) -> void
+  def unregister_all: (Array[Class]) -> void
 
   # Ruby invokes +inherited+ with +self+ bound to the direct superclass — the
   # only registry the new subclass joins — so busting self's memo is exactly
@@ -47,5 +92,27 @@ module Riffer::Registrable : Class
 
   # --
   # : () -> Hash[String, Class]
+  def explicit_registrations: () -> Hash[String, Class]
+
+  # --
+  # : () -> Hash[String, Class]
   def build_identifier_registry: () -> Hash[String, Class]
+
+  # Class#subclasses keeps returning superseded generations of a reloaded or
+  # stubbed class, so a subclass counts only while its own name still resolves
+  # back to it. An anonymous class has no name to resolve and is skipped even
+  # with an explicit identifier — the MCP factory and serializer shells
+  # synthesize short-lived anonymous classes whose registration would flake
+  # with GC timing.
+  # --
+  # : (Class) -> bool
+  def live?: (Class) -> bool
+
+  # --
+  # : (Class) -> String
+  def identifier_key: (Class) -> String
+
+  # --
+  # : (String, Class, Class) -> void
+  def raise_duplicate_identifier!: (String, Class, Class) -> void
 end

--- a/sig/generated/riffer/testing.rbs
+++ b/sig/generated/riffer/testing.rbs
@@ -15,31 +15,33 @@ module Riffer::Testing
 
   # Builds an agent class, evaluates the optional body in it, and makes it
   # resolvable until the next +reset!+. A +name+ assigns a top-level constant
-  # and derives the identifier unless +identifier+ overrides it.
+  # and derives the identifier; the body may set +identifier+ like any other
+  # agent config.
   #
   #   agent = stub_agent("SupportAgent") { model "mock/gpt-5-mini" }
   #
-  # Raises Riffer::ArgumentError when the constant is already defined, and
-  # Riffer::DuplicateIdentifierError when another agent already holds the
-  # identifier.
+  # Raises Riffer::ArgumentError when the constant is already defined or the
+  # stub ends up with no identifier, and Riffer::DuplicateIdentifierError when
+  # another agent already holds the identifier.
   #
   # --
-  # : (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
-  def stub_agent: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  # : (?(String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent: (?(String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
 
   # Builds a tool class, evaluates the optional body in it, and makes it
   # resolvable until the next +reset!+. A +name+ assigns a top-level constant
-  # and derives the identifier unless +identifier+ overrides it.
+  # and derives the identifier; the body may set +identifier+ like any other
+  # tool config.
   #
   #   tool = stub_tool("KbSearch") { def call(context:, **) = text("stubbed") }
   #
-  # Raises Riffer::ArgumentError when the constant is already defined, and
-  # Riffer::DuplicateIdentifierError when another tool already holds the
-  # identifier.
+  # Raises Riffer::ArgumentError when the constant is already defined or the
+  # stub ends up with no identifier, and Riffer::DuplicateIdentifierError when
+  # another tool already holds the identifier.
   #
   # --
-  # : (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
-  def stub_tool: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  # : (?(String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool: (?(String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
 
   # Removes every stub built since the last reset — its registration and any
   # constant it created — newest first, and forgets them. A no-op when nothing
@@ -58,8 +60,8 @@ module Riffer::Testing
   private
 
   # --
-  # : ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
-  def build_stub: ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+  # : ((String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+  def build_stub: ((String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
 
   # --
   # : ((String | Symbol)?) -> String?

--- a/sig/generated/riffer/testing.rbs
+++ b/sig/generated/riffer/testing.rbs
@@ -1,0 +1,58 @@
+# Generated from lib/riffer/testing.rb with RBS::Inline
+
+# Builds throwaway agents and tools a test suite can resolve by identifier, and
+# removes them again. Require <tt>riffer/testing/rspec</tt> or
+# <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
+# example plus per-test cleanup; otherwise include this module and call +reset!+
+# from your own teardown, or call the methods on the module directly.
+#
+# Tracking is not synchronized — stub from a single-threaded test, before
+# concurrent lookups begin.
+module Riffer::Testing
+  self.@registrations: Array[Class]?
+
+  # Builds an agent class under +identifier+, evaluates the optional body in it,
+  # and makes it resolvable until the next +reset!+.
+  #
+  #   agent = stub_agent(identifier: "support_agent") { model "mock/gpt-5-mini" }
+  #
+  # Raises Riffer::DuplicateIdentifierError when another agent already holds the
+  # identifier.
+  #
+  # --
+  # : (identifier: (String | Symbol), ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent: (identifier: String | Symbol, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+
+  # Builds a tool class under +identifier+, evaluates the optional body in it,
+  # and makes it resolvable until the next +reset!+.
+  #
+  #   tool = stub_tool(identifier: "kb_search") do
+  #     def call(context:, **) = text("stubbed")
+  #   end
+  #
+  # Raises Riffer::DuplicateIdentifierError when another tool already holds the
+  # identifier.
+  #
+  # --
+  # : (identifier: (String | Symbol), ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool: (identifier: String | Symbol, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+
+  # Removes every stub built since the last reset, newest first, and forgets
+  # them. A no-op when nothing has been stubbed.
+  # --
+  # : () -> void
+  def reset!: () -> void
+
+  # The stub classes awaiting cleanup. Lives on the module rather than the
+  # caller so an including test case and a direct <tt>Riffer::Testing.stub_*</tt>
+  # call share one list.
+  # --
+  # : () -> Array[Class]
+  def self.registrations: () -> Array[Class]
+
+  private
+
+  # --
+  # : (base: Class, identifier: (String | Symbol)) ?{ () [self: untyped] -> void } -> Class
+  def build_stub: (base: Class, identifier: String | Symbol) ?{ () [self: untyped] -> void } -> Class
+end

--- a/sig/generated/riffer/testing.rbs
+++ b/sig/generated/riffer/testing.rbs
@@ -1,58 +1,73 @@
 # Generated from lib/riffer/testing.rb with RBS::Inline
 
-# Builds throwaway agents and tools a test suite can resolve by identifier, and
-# removes them again. Require <tt>riffer/testing/rspec</tt> or
-# <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
+# Builds throwaway agents and tools a test suite can resolve by identifier or
+# constant name, and removes them again. Require <tt>riffer/testing/rspec</tt>
+# or <tt>riffer/testing/minitest</tt> to get +stub_agent+/+stub_tool+ in every
 # example plus per-test cleanup; otherwise include this module and call +reset!+
 # from your own teardown, or call the methods on the module directly.
 #
 # Tracking is not synchronized — stub from a single-threaded test, before
 # concurrent lookups begin.
 module Riffer::Testing
-  self.@registrations: Array[Class]?
+  self.@registrations: Array[[ Class, String? ]]?
 
-  # Builds an agent class under +identifier+, evaluates the optional body in it,
-  # and makes it resolvable until the next +reset!+.
+  CONST_NAME_PATTERN: Regexp
+
+  # Builds an agent class, evaluates the optional body in it, and makes it
+  # resolvable until the next +reset!+. A +name+ assigns a top-level constant
+  # and derives the identifier unless +identifier+ overrides it.
   #
-  #   agent = stub_agent(identifier: "support_agent") { model "mock/gpt-5-mini" }
+  #   agent = stub_agent("SupportAgent") { model "mock/gpt-5-mini" }
   #
-  # Raises Riffer::DuplicateIdentifierError when another agent already holds the
+  # Raises Riffer::ArgumentError when the constant is already defined, and
+  # Riffer::DuplicateIdentifierError when another agent already holds the
   # identifier.
   #
   # --
-  # : (identifier: (String | Symbol), ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
-  def stub_agent: (identifier: String | Symbol, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  # : (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
+  def stub_agent: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Agent)) ?{ () [self: singleton(Riffer::Agent)] -> void } -> singleton(Riffer::Agent)
 
-  # Builds a tool class under +identifier+, evaluates the optional body in it,
-  # and makes it resolvable until the next +reset!+.
+  # Builds a tool class, evaluates the optional body in it, and makes it
+  # resolvable until the next +reset!+. A +name+ assigns a top-level constant
+  # and derives the identifier unless +identifier+ overrides it.
   #
-  #   tool = stub_tool(identifier: "kb_search") do
-  #     def call(context:, **) = text("stubbed")
-  #   end
+  #   tool = stub_tool("KbSearch") { def call(context:, **) = text("stubbed") }
   #
-  # Raises Riffer::DuplicateIdentifierError when another tool already holds the
+  # Raises Riffer::ArgumentError when the constant is already defined, and
+  # Riffer::DuplicateIdentifierError when another tool already holds the
   # identifier.
   #
   # --
-  # : (identifier: (String | Symbol), ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
-  def stub_tool: (identifier: String | Symbol, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  # : (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
+  def stub_tool: (?(String | Symbol)?, ?identifier: (String | Symbol)?, ?base: singleton(Riffer::Tool)) ?{ () [self: singleton(Riffer::Tool)] -> void } -> singleton(Riffer::Tool)
 
-  # Removes every stub built since the last reset, newest first, and forgets
-  # them. A no-op when nothing has been stubbed.
+  # Removes every stub built since the last reset — its registration and any
+  # constant it created — newest first, and forgets them. A no-op when nothing
+  # has been stubbed.
   # --
   # : () -> void
   def reset!: () -> void
 
   # The stub classes awaiting cleanup. Lives on the module rather than the
-  # caller so an including test case and a direct <tt>Riffer::Testing.stub_*</tt>
-  # call share one list.
+  # caller so an including test case and a direct
+  # <tt>Riffer::Testing.stub_*</tt> call share one list.
   # --
-  # : () -> Array[Class]
-  def self.registrations: () -> Array[Class]
+  # : () -> Array[[Class, String?]]
+  def self.registrations: () -> Array[[ Class, String? ]]
 
   private
 
   # --
-  # : (base: Class, identifier: (String | Symbol)) ?{ () [self: untyped] -> void } -> Class
-  def build_stub: (base: Class, identifier: String | Symbol) ?{ () [self: untyped] -> void } -> Class
+  # : ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+  def build_stub: ((String | Symbol)?, identifier: (String | Symbol)?, base: Class) ?{ () [self: untyped] -> void } -> Class
+
+  # --
+  # : ((String | Symbol)?) -> String?
+  def validate_const_name: ((String | Symbol)?) -> String?
+
+  # A test may have removed or replaced the constant itself, so never clobber
+  # one that no longer points at the stub.
+  # --
+  # : (String, Class) -> void
+  def remove_stub_const: (String, Class) -> void
 end

--- a/sig/generated/riffer/testing/rspec.rbs
+++ b/sig/generated/riffer/testing/rspec.rbs
@@ -1,0 +1,2 @@
+# Generated from lib/riffer/testing/rspec.rb with RBS::Inline
+

--- a/sig/manual/riffer/testing.rbs
+++ b/sig/manual/riffer/testing.rbs
@@ -1,0 +1,5 @@
+# `Riffer::Testing` uses `extend self`; rbs-inline doesn't emit that, so
+# re-extend here to expose its instance methods as singleton methods.
+module Riffer::Testing
+  extend ::Riffer::Testing
+end

--- a/test/riffer/agent/context_test.rb
+++ b/test/riffer/agent/context_test.rb
@@ -128,7 +128,7 @@ describe Riffer::Agent::Context do
     end
 
     it "accepts an Array of Riffer::Tool subclasses" do
-      tool = Class.new(Riffer::Tool)
+      tool = stub_tool("Tool")
       context.mcp_progressive_tools = [tool]
 
       expect(context.mcp_progressive_tools).must_equal [tool]
@@ -149,7 +149,7 @@ describe Riffer::Agent::Context do
     end
 
     it "exposes the written value via #[] (hash-style read still works)" do
-      tool = Class.new(Riffer::Tool)
+      tool = stub_tool("Tool")
       context.mcp_progressive_tools = [tool]
 
       expect(context[:mcp_progressive_tools]).must_equal [tool]
@@ -166,7 +166,7 @@ describe Riffer::Agent::Context do
     end
 
     it "accepts an Array of Riffer::Tool subclasses" do
-      tool = Class.new(Riffer::Tool)
+      tool = stub_tool("Tool")
       context.discovered_tools = [tool]
 
       expect(context.discovered_tools).must_equal [tool]
@@ -187,7 +187,7 @@ describe Riffer::Agent::Context do
     end
 
     it "exposes the written value via #[] (hash-style read still works)" do
-      tool = Class.new(Riffer::Tool)
+      tool = stub_tool("Tool")
       context.discovered_tools = [tool]
 
       expect(context[:discovered_tools]).must_equal [tool]
@@ -197,24 +197,16 @@ describe Riffer::Agent::Context do
   describe "#discover_tools" do
     let(:context) { Riffer::Agent::Context.new }
 
-    def named_tool(identifier)
-      n = identifier
-      Class.new(Riffer::Tool).tap do |klass|
-        klass.define_singleton_method(:name) { n }
-        klass.define_singleton_method(:identifier) { n }
-      end
-    end
-
     it "accumulates tools from a nil start" do
-      tool = named_tool("tool_a")
+      tool = stub_tool("ToolA")
       context.discover_tools([tool])
 
       expect(context.discovered_tools).must_equal [tool]
     end
 
     it "extends an existing set" do
-      tool_a = named_tool("tool_a")
-      tool_b = named_tool("tool_b")
+      tool_a = stub_tool("ToolA")
+      tool_b = stub_tool("ToolB")
       context.discover_tools([tool_a])
       context.discover_tools([tool_b])
 
@@ -223,7 +215,7 @@ describe Riffer::Agent::Context do
     end
 
     it "deduplicates by name" do
-      tool = named_tool("tool_a")
+      tool = stub_tool("ToolA")
       context.discover_tools([tool])
       context.discover_tools([tool])
 
@@ -231,7 +223,7 @@ describe Riffer::Agent::Context do
     end
 
     it "returns the updated array" do
-      tool = named_tool("tool_a")
+      tool = stub_tool("ToolA")
       result = context.discover_tools([tool])
 
       expect(result).must_equal [tool]

--- a/test/riffer/agent/serializer_test.rb
+++ b/test/riffer/agent/serializer_test.rb
@@ -15,8 +15,7 @@ end
 
 describe Riffer::Agent::Serializer do
   def build_agent_class(&block)
-    Class.new(Riffer::Agent) do
-      identifier "support"
+    stub_agent("Support") do
       model "mock/riffer-1"
       instructions "You are helpful."
       instance_eval(&block) if block
@@ -34,8 +33,7 @@ describe Riffer::Agent::Serializer do
     end
 
     it "resolves Proc-based model and instructions to strings" do
-      klass = Class.new(Riffer::Agent) do
-        identifier "dyn"
+      klass = stub_agent("Dyn") do
         model -> { "mock/riffer-1" }
         instructions ->(context) { "Hi #{context[:name]}" }
       end
@@ -240,8 +238,7 @@ describe Riffer::Agent::Serializer do
     end
 
     it "reconstructs the model string from the resolved provider and model name" do
-      klass = Class.new(Riffer::Agent) do
-        identifier "dyn"
+      klass = stub_agent("Dyn") do
         model -> { "mock/riffer-1" }
       end
 

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -312,6 +312,9 @@ describe Riffer::Agent do
 
   describe ".find" do
     it "is backed by the Registrable registry" do
+      agent = stub_agent(identifier: "findable_agent")
+
+      expect(Riffer::Agent.find("findable_agent")).must_equal agent
       expect(Riffer::Agent.find("no-such-agent")).must_be_nil
     end
   end

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 describe Riffer::Agent do
   let(:agent_class) do
-    Class.new(Riffer::Agent) do
+    stub_agent do
       identifier "test-agent"
       model "mock/riffer-1"
       instructions "You are a helpful assistant."
@@ -58,7 +58,7 @@ describe Riffer::Agent do
     end
 
     it "leaves the session empty when no instructions or skills are configured" do
-      bare = Class.new(Riffer::Agent) { model "mock/riffer-1" }.new
+      bare = stub_agent("BareAgent") { model "mock/riffer-1" }.new
 
       expect(bare.session.messages).must_equal []
     end
@@ -95,7 +95,7 @@ describe Riffer::Agent do
 
     describe "with invalid model format" do
       let(:invalid_agent_class) do
-        Class.new(Riffer::Agent) do
+        stub_agent("InvalidAgent") do
           model "invalid-format"
         end
       end
@@ -108,7 +108,7 @@ describe Riffer::Agent do
 
     describe "with unregistered provider" do
       it "raises Riffer::ArgumentError at Agent.new" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "nonexistent/gpt-4"
         end
         error = expect { klass.new }.must_raise(Riffer::ArgumentError)
@@ -118,7 +118,7 @@ describe Riffer::Agent do
 
     describe "with dynamic instructions" do
       it "resolves the Proc at Agent.new and seeds the session" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           instructions -> { "Dynamic instructions" }
         end
@@ -130,7 +130,7 @@ describe Riffer::Agent do
       end
 
       it "passes context to the Proc" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           instructions ->(context) { "You are assisting #{context[:name]}" }
         end
@@ -142,7 +142,7 @@ describe Riffer::Agent do
       end
 
       it "passes an empty context Hash when not provided" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           instructions ->(context) { context[:name].nil? ? "No name" : "With name #{context[:name]}" }
         end
@@ -155,7 +155,7 @@ describe Riffer::Agent do
 
       it "does not add a system message when the Proc returns nil" do
         returner = ->(_context) {}
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           instructions returner
         end
@@ -170,23 +170,23 @@ describe Riffer::Agent do
 
   describe ".config" do
     it "returns a Riffer::Agent::Config" do
-      klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+      klass = stub_agent("Agent") { model "mock/riffer-1" }
 
       expect(klass.config).must_be_instance_of Riffer::Agent::Config
     end
 
     it "returns the same instance across multiple reads on one class" do
-      klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+      klass = stub_agent("Agent") { model "mock/riffer-1" }
 
       expect(klass.config).must_be_same_as klass.config
     end
 
     it "is independent between sibling subclasses" do
-      sibling_a = Class.new(Riffer::Agent) do
+      sibling_a = stub_agent("SiblingAAgent") do
         model "mock/riffer-1"
         max_steps 3
       end
-      sibling_b = Class.new(Riffer::Agent) do
+      sibling_b = stub_agent("SiblingBAgent") do
         model "mock/riffer-1"
         max_steps 7
       end
@@ -197,11 +197,11 @@ describe Riffer::Agent do
     end
 
     it "is independent between parent and child subclasses" do
-      parent = Class.new(Riffer::Agent) do
+      parent = stub_agent("ParentAgent") do
         model "mock/riffer-1"
         max_steps 3
       end
-      child = Class.new(parent)
+      child = stub_agent("ChildAgent", base: parent)
 
       expect(child.config).wont_be_same_as parent.config
       # Each subclass starts fresh; only tool_runtime walks the chain.
@@ -225,7 +225,7 @@ describe Riffer::Agent do
     end
 
     it "ignores the class config when config: is passed" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions "Ignore me."
         max_steps 99
@@ -237,7 +237,7 @@ describe Riffer::Agent do
     end
 
     it "falls back to self.class.config when config: is omitted" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions "From class."
       end
@@ -272,7 +272,7 @@ describe Riffer::Agent do
     it "stores Params instance" do
       params = Riffer::Params.new
       params.required(:sentiment, String)
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
       end
       klass.structured_output(params)
@@ -281,7 +281,7 @@ describe Riffer::Agent do
     end
 
     it "stores Params from block DSL" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String, description: "The sentiment"
@@ -312,7 +312,7 @@ describe Riffer::Agent do
 
   describe ".find" do
     it "is backed by the Registrable registry" do
-      agent = stub_agent(identifier: "findable_agent")
+      agent = stub_agent("FindableAgent")
 
       expect(Riffer::Agent.find("findable_agent")).must_equal agent
       expect(Riffer::Agent.find("no-such-agent")).must_be_nil
@@ -327,7 +327,7 @@ describe Riffer::Agent do
     end
 
     it "passes context to tools" do
-      context_tool = Class.new(Riffer::Tool) do
+      context_tool = stub_tool("ClassGenerateContextTool") do
         description "Gets user info"
         params do
           required :field, String
@@ -336,11 +336,10 @@ describe Riffer::Agent do
           text(context[field.to_sym] || "unknown")
         end
       end
-      context_tool.identifier("class_generate_context_tool")
 
       tool = context_tool
       received_context = nil
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools lambda { |context|
           received_context = context
@@ -368,7 +367,7 @@ describe Riffer::Agent do
     end
 
     it "passes context to tools" do
-      context_tool = Class.new(Riffer::Tool) do
+      context_tool = stub_tool("ClassStreamContextTool") do
         description "Gets user info"
         params do
           required :field, String
@@ -377,11 +376,10 @@ describe Riffer::Agent do
           text(context[field.to_sym] || "unknown")
         end
       end
-      context_tool.identifier("class_stream_context_tool")
 
       tool = context_tool
       received_context = nil
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools lambda { |context|
           received_context = context
@@ -397,7 +395,7 @@ describe Riffer::Agent do
 
   describe ".uses_tools" do
     let(:weather_tool_class) do
-      Class.new(Riffer::Tool) do
+      stub_tool("WeatherTool") do
         description "Gets the weather"
 
         params do
@@ -412,7 +410,7 @@ describe Riffer::Agent do
 
     let(:agent_with_tools_class) do
       tool_class = weather_tool_class
-      Class.new(Riffer::Agent) do
+      stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [tool_class]
       end
@@ -428,7 +426,7 @@ describe Riffer::Agent do
 
     it "accepts a lambda" do
       tool_class = weather_tool_class
-      agent = Class.new(Riffer::Agent) do
+      agent = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools -> { [tool_class] }
       end
@@ -439,7 +437,7 @@ describe Riffer::Agent do
 
   describe ".tool_runtime" do
     it "stores a tool_runtime class" do
-      agent = Class.new(Riffer::Agent) do
+      agent = stub_agent("Agent") do
         model "mock/riffer-1"
         tool_runtime Riffer::Tools::Runtime::Threaded
       end
@@ -455,7 +453,7 @@ describe Riffer::Agent do
     end
 
     it "defaults to inline when no config" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
       end
 
@@ -463,7 +461,7 @@ describe Riffer::Agent do
     end
 
     it "resolves a ToolRuntime class to an instance" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         tool_runtime Riffer::Tools::Runtime::Threaded
       end
@@ -475,7 +473,7 @@ describe Riffer::Agent do
       original = Riffer.config.tool_runtime
       begin
         Riffer.config.tool_runtime = Riffer::Tools::Runtime::Threaded
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
 
@@ -489,7 +487,7 @@ describe Riffer::Agent do
       original = Riffer.config.tool_runtime
       begin
         Riffer.config.tool_runtime = Riffer::Tools::Runtime::Threaded
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           tool_runtime Riffer::Tools::Runtime::Inline
         end
@@ -502,7 +500,7 @@ describe Riffer::Agent do
 
     it "resolves freshly per agent instance, threading context into the Proc" do
       received_contexts = []
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         tool_runtime lambda { |context|
           received_contexts << context
@@ -536,7 +534,7 @@ describe Riffer::Agent do
 
     it "registers before guardrails" do
       gr = pass_guardrail_class
-      agent = Class.new(Riffer::Agent) do
+      agent = stub_agent("Agent") do
         model "mock/riffer-1"
       end
       agent.guardrail(:before, with: gr)
@@ -547,7 +545,7 @@ describe Riffer::Agent do
 
     it "stores options in config" do
       gr = pass_guardrail_class
-      agent = Class.new(Riffer::Agent) do
+      agent = stub_agent("Agent") do
         model "mock/riffer-1"
       end
       agent.guardrail(:before, with: gr, foo: :bar)
@@ -566,7 +564,7 @@ describe Riffer::Agent do
     end
 
     it "returns nil when no instructions configured" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
       end
 
@@ -574,7 +572,7 @@ describe Riffer::Agent do
     end
 
     it "resolves dynamic instructions using the init context" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions ->(context) { "Helping #{context[:name]}" }
       end
@@ -585,7 +583,7 @@ describe Riffer::Agent do
 
     it "returns nil when Proc returns nil" do
       returner = ->(_ctx) {}
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions returner
       end
@@ -602,7 +600,7 @@ describe Riffer::Agent do
     end
 
     it "returns a System message when skills are configured" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -619,7 +617,7 @@ describe Riffer::Agent do
     after { clear_mcp_registry! }
 
     it "accumulates mcp_configs with progressive flag per call" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         use_mcp :github
         use_mcp :jira, progressive: false
       end
@@ -663,13 +661,12 @@ describe Riffer::Agent do
     end
 
     it "merges MCP tools with uses_tools tools" do
-      static_tool = Class.new(Riffer::Tool) do
-        identifier "static_tool"
+      static_tool = stub_tool("StaticTool") do
         description "Static tool"
       end
       inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [static_tool]
         use_mcp :srv, progressive: false
@@ -682,13 +679,13 @@ describe Riffer::Agent do
     end
 
     it "raises ArgumentError when tools share the same name" do
-      static = Class.new(Riffer::Tool) do
+      static = stub_tool do
         identifier "srv__mcp_tool"
         description "Static tool"
       end
       inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [static]
         use_mcp :srv, progressive: false
@@ -701,7 +698,7 @@ describe Riffer::Agent do
     it "returns MCP tools even when uses_tools is not set" do
       inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_class])
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         use_mcp :srv, progressive: false
       end
@@ -715,7 +712,7 @@ describe Riffer::Agent do
       Riffer.config.mcp.credentials = lambda do |manifest:, matched_tags:, context:|
       end
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         use_mcp :srv, progressive: false
       end
@@ -730,7 +727,7 @@ describe Riffer::Agent do
       prev = Riffer.config.mcp.credentials
       Riffer.config.mcp.credentials = ->(manifest:, matched_tags:, context:) { { "Authorization" => "Bearer x" } }
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         use_mcp :srv, progressive: false
       end
@@ -764,7 +761,7 @@ describe Riffer::Agent do
       it "returns mcp_search instead of individual tool classes" do
         inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_a, fake_tool_b])
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :srv, progressive: true
         end
@@ -779,7 +776,7 @@ describe Riffer::Agent do
       it "search tool returns matching tools as inject_tools" do
         inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_a])
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :srv, progressive: true
         end
@@ -798,7 +795,7 @@ describe Riffer::Agent do
         inject_ready_registration(name: "srv", tags: [:srv], tools: [fake_tool_a])
         inject_ready_registration(name: "other", tags: [:other], tools: [fake_tool_b])
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :other, progressive: false
           use_mcp :srv, progressive: true
@@ -822,7 +819,7 @@ describe Riffer::Agent do
         inject_ready_registration(name: "srv1", tags: [:g1], tools: [fake_tool_a])
         inject_ready_registration(name: "srv2", tags: [:g2], tools: [fake_tool_b])
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :g1, progressive: true
           use_mcp :g2, progressive: true
@@ -844,7 +841,7 @@ describe Riffer::Agent do
         prev = Riffer.config.mcp.credentials
         Riffer.config.mcp.credentials = ->(**) {}
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :srv, progressive: true
         end
@@ -862,7 +859,7 @@ describe Riffer::Agent do
           matched_tags.include?(:srv) ? nil : { token: "tok" }
         }
 
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           use_mcp :other, progressive: false
           use_mcp :srv, progressive: true
@@ -878,7 +875,7 @@ describe Riffer::Agent do
       end
 
       it "mcp_configs stores the progressive flag" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           use_mcp :foo                       # default: true
           use_mcp :bar, progressive: false   # explicit opt-out
         end
@@ -889,7 +886,7 @@ describe Riffer::Agent do
       end
 
       it "defaults progressive to true when not specified" do
-        klass = Class.new(Riffer::Agent) { use_mcp :foo }
+        klass = stub_agent("Agent") { use_mcp :foo }
 
         expect(klass.mcp_configs.first[:progressive]).must_equal true
       end
@@ -898,9 +895,9 @@ describe Riffer::Agent do
 
   describe "#tools validation" do
     it "raises when a tool is missing a description" do
-      bad_tool = Class.new(Riffer::Tool) { identifier "bad_tool" }
+      bad_tool = stub_tool("BadTool")
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [bad_tool]
       end
@@ -910,7 +907,7 @@ describe Riffer::Agent do
     end
 
     it "raises when an MCP tool is missing a description" do
-      bad_mcp_tool = Class.new(Riffer::Tool) { identifier "bad_mcp_tool" }
+      bad_mcp_tool = stub_tool("BadMcpTool")
 
       manifest = Riffer::Mcp::Manifest.new(name: "srv", tags: [:srv], endpoint: "https://x.com", discovery_headers: {})
       reg = Riffer::Mcp::Registration.allocate
@@ -920,7 +917,7 @@ describe Riffer::Agent do
       store = Riffer::Mcp::Registry.instance_variable_get(:@store)
       Riffer::Mcp::Registry.instance_variable_get(:@mutex).synchronize { store["srv"] = reg }
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         use_mcp :srv, progressive: false
       end
@@ -934,8 +931,7 @@ describe Riffer::Agent do
 
   describe "interrupt! with experimental_history_healing" do
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "interrupt_heal_tool"
+      stub_tool("InterruptHealTool") do
         description "Slow tool"
         def call(context:)
           text("done")
@@ -948,7 +944,7 @@ describe Riffer::Agent do
     it "fills orphans and exposes healed_tool_call_ids when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -981,7 +977,7 @@ describe Riffer::Agent do
 
     it "leaves orphans in place when healing is off (default)" do
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -1004,7 +1000,7 @@ describe Riffer::Agent do
     it "does not fire on_message for placeholder tool messages" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -1030,8 +1026,7 @@ describe Riffer::Agent do
 
   describe "max_steps interrupt with experimental_history_healing" do
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "max_steps_heal_tool"
+      stub_tool("MaxStepsHealTool") do
         description "Loop tool"
         def call(context:)
           text("ok")
@@ -1044,7 +1039,7 @@ describe Riffer::Agent do
     it "fills orphan tool_use with the placeholder when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
         max_steps 1
@@ -1069,7 +1064,7 @@ describe Riffer::Agent do
 
     it "leaves orphan tool_use when healing is off" do
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
         max_steps 1
@@ -1090,7 +1085,7 @@ describe Riffer::Agent do
   end
 
   describe "seeded history with experimental_history_healing" do
-    let(:custom_class) { Class.new(Riffer::Agent) { model "mock/riffer-1" } }
+    let(:custom_class) { stub_agent("CustomAgent") { model "mock/riffer-1" } }
 
     after { Riffer.config.experimental_history_healing = false }
 
@@ -1134,14 +1129,13 @@ describe Riffer::Agent do
           Riffer::Messages::Assistant.new("", tool_calls: [tc]),
         ],
       )
-      tool = Class.new(Riffer::Tool) do
-        identifier "pending_seed_tool"
+      tool = stub_tool("PendingSeedTool") do
         description "Pending tool"
         def call(context:)
           text("done")
         end
       end
-      with_tools = Class.new(Riffer::Agent) do
+      with_tools = stub_agent("WithTools") do
         model "mock/riffer-1"
         uses_tools [tool]
       end

--- a/test/riffer/evals/evaluator_runner_test.rb
+++ b/test/riffer/evals/evaluator_runner_test.rb
@@ -26,7 +26,7 @@ describe Riffer::Evals::EvaluatorRunner do
   end
 
   let(:agent_class) do
-    Class.new(Riffer::Agent) do
+    stub_agent("Agent") do
       model "mock/mock-model"
       instructions "You are a helpful assistant."
     end
@@ -138,7 +138,7 @@ describe Riffer::Evals::EvaluatorRunner do
       end
       Riffer::Providers::Repository.register(:usage_mock) { usage_mock }
 
-      usage_agent = Class.new(Riffer::Agent) do
+      usage_agent = stub_agent("UsageAgent") do
         model "usage_mock/mock-model"
         instructions "You are a helpful assistant."
       end
@@ -171,7 +171,7 @@ describe Riffer::Evals::EvaluatorRunner do
   describe "context" do
     it "passes context to agent" do
       received_context = nil
-      context_agent = Class.new(Riffer::Agent) do
+      context_agent = stub_agent("ContextAgent") do
         model lambda { |context|
           received_context = context
           "mock/mock-model"
@@ -191,7 +191,7 @@ describe Riffer::Evals::EvaluatorRunner do
 
     it "allows per-scenario context to override top-level" do
       received_contexts = []
-      context_agent = Class.new(Riffer::Agent) do
+      context_agent = stub_agent("ContextAgent") do
         model lambda { |context|
           received_contexts << context
           "mock/mock-model"

--- a/test/riffer/mcp/registration_test.rb
+++ b/test/riffer/mcp/registration_test.rb
@@ -33,7 +33,7 @@ describe Riffer::Mcp::Registration do
     end
 
     it "returns tool classes after discovery" do
-      tool_class = Class.new(Riffer::Tool)
+      tool_class = stub_tool("Tool")
       reg = build_stub_registration(manifest, tools: [tool_class])
 
       assert_equal [tool_class], reg.tools

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -1052,8 +1052,7 @@ describe Riffer::Providers::AmazonBedrock do
   describe "prompt caching" do
     let(:model) { "us.anthropic.claude-haiku-4-5-20251001-v1:0" }
     let(:cache_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"
@@ -1438,8 +1437,7 @@ describe Riffer::Providers::AmazonBedrock do
 
   describe "tool schema strict mode" do
     it "applies strict_schema to tool parameters" do
-      tool = Class.new(Riffer::Tool) do
-        identifier "test_tool"
+      tool = stub_tool("TestTool") do
         description "A test tool"
         params do
           required :name, String
@@ -1458,8 +1456,7 @@ describe Riffer::Providers::AmazonBedrock do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -963,8 +963,7 @@ describe Riffer::Providers::Anthropic do
 
   describe "tool schema strict mode" do
     it "applies strict_schema to tool parameters" do
-      tool = Class.new(Riffer::Tool) do
-        identifier "test_tool"
+      tool = stub_tool("TestTool") do
         description "A test tool"
         params do
           required :name, String
@@ -983,8 +982,7 @@ describe Riffer::Providers::Anthropic do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/providers/azure_open_ai_test.rb
+++ b/test/riffer/providers/azure_open_ai_test.rb
@@ -251,8 +251,7 @@ describe Riffer::Providers::AzureOpenAI do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -301,7 +301,7 @@ describe Riffer::Providers::Base do
     let(:provider) { Riffer::Providers::Mock.new }
 
     let(:agent_class) do
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "chat-traced-agent"
         model "mock/riffer-1"
       end

--- a/test/riffer/providers/gemini_test.rb
+++ b/test/riffer/providers/gemini_test.rb
@@ -611,8 +611,7 @@ describe Riffer::Providers::Gemini do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/providers/mock_test.rb
+++ b/test/riffer/providers/mock_test.rb
@@ -310,8 +310,7 @@ describe Riffer::Providers::Mock do
       end
 
       it "stores tools parameter in calls" do
-        tool_class = Class.new(Riffer::Tool) do
-          identifier "test_tool"
+        tool_class = stub_tool("TestTool") do
           description "A test tool"
         end
         provider.generate_text(prompt: "Hello", tools: [tool_class])

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -74,8 +74,7 @@ describe Riffer::Providers::OpenAI do
     end
 
     it "derives tool_calls when the response carries tool calls" do
-      tool = Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      tool = stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"
@@ -1160,8 +1159,7 @@ describe Riffer::Providers::OpenAI do
 
   describe "tool schema strict mode" do
     it "applies strict_schema to tool parameters" do
-      tool = Class.new(Riffer::Tool) do
-        identifier "test_tool"
+      tool = stub_tool("TestTool") do
         description "A test tool"
         params do
           required :name, String
@@ -1180,8 +1178,7 @@ describe Riffer::Providers::OpenAI do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/providers/open_router_test.rb
+++ b/test/riffer/providers/open_router_test.rb
@@ -313,8 +313,7 @@ describe Riffer::Providers::OpenRouter do
     let(:provider) { Riffer::Providers::OpenRouter.new }
 
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"
@@ -573,8 +572,7 @@ describe Riffer::Providers::OpenRouter do
 
   describe "tool calling" do
     let(:weather_tool) do
-      Class.new(Riffer::Tool) do
-        identifier "get_weather"
+      stub_tool("GetWeather") do
         description "Get the current weather for a city"
         params do
           required :city, String, description: "The city name"

--- a/test/riffer/registrable_test.rb
+++ b/test/riffer/registrable_test.rb
@@ -2,6 +2,8 @@
 
 require "test_helper"
 
+require "tmpdir"
+
 # Named container so classes assigned beneath it get permanent names; each test
 # removes the constants it creates (the classes stay named — that's fine).
 # Every test builds a fresh anonymous base class, so its registry never
@@ -134,6 +136,221 @@ describe Riffer::Registrable do
 
       expect { base.find("dup-agent") }.must_raise Riffer::DuplicateIdentifierError
       expect { base.find("dup-agent") }.must_raise Riffer::DuplicateIdentifierError
+    end
+  end
+
+  describe "liveness of implicit registrations" do
+    let(:base) { Class.new(Riffer::Tool) }
+
+    it "skips a subclass whose constant has been removed" do
+      tool = define_named_subclass(base, :EphemeralTool, identifier: "ephemeral-tool")
+      RegistrableTestNamespace.send(:remove_const, :EphemeralTool)
+
+      expect(base.find("ephemeral-tool")).must_be_nil
+      expect(base.all).wont_include tool
+    end
+
+    it "skips a stale generation sharing a name with a live subclass" do
+      stale = define_named_subclass(base, :ReloadedTool, identifier: "reloaded-tool")
+      RegistrableTestNamespace.send(:remove_const, :ReloadedTool)
+      live = define_named_subclass(base, :ReloadedTool, identifier: "reloaded-tool")
+
+      expect(base.find("reloaded-tool")).must_equal live
+      expect(base.all).wont_include stale
+    end
+
+    it "skips a subclass whose constant now points elsewhere" do
+      tool = define_named_subclass(base, :ReplacedTool, identifier: "replaced-tool")
+      RegistrableTestNamespace.send(:remove_const, :ReplacedTool)
+      RegistrableTestNamespace.const_set(:ReplacedTool, Class.new)
+
+      expect(base.find("replaced-tool")).must_be_nil
+      expect(base.all).wont_include tool
+    end
+
+    it "leaves a pending autoload for a superseded generation untouched" do
+      Dir.mktmpdir("registrable-autoload") do |dir|
+        stale = define_named_subclass(base, :AutoloadedTool, identifier: "autoloaded-tool")
+        RegistrableTestNamespace.send(:remove_const, :AutoloadedTool)
+        # The autoloaded file cannot name the anonymous base, so it reads it back
+        # out of the thread rather than through a constant the registry would see.
+        Thread.current[:registrable_autoload_base] = base
+        path = File.join(dir, "autoloaded_tool.rb")
+        File.write(path, <<~RUBY)
+          RegistrableTestNamespace.const_set(
+            :AutoloadedTool,
+            Class.new(Thread.current[:registrable_autoload_base]) { identifier "autoloaded-tool" },
+          )
+        RUBY
+        RegistrableTestNamespace.autoload(:AutoloadedTool, path)
+
+        expect(base.all).wont_include stale
+        expect(RegistrableTestNamespace.autoload?(:AutoloadedTool)).must_equal path
+
+        live = RegistrableTestNamespace::AutoloadedTool
+
+        expect(base.find("autoloaded-tool")).must_equal live
+      ensure
+        Thread.current[:registrable_autoload_base] = nil
+      end
+    end
+  end
+
+  describe "register" do
+    let(:base) { Class.new(Riffer::Tool) }
+
+    it "registers an anonymous class under its explicit identifier" do
+      tool = Class.new(base) { identifier "registered-tool" }
+
+      base.register(tool)
+
+      expect(base.find("registered-tool")).must_equal tool
+      expect(base.all).must_equal [tool]
+    end
+
+    it "registers an anonymous agent class" do
+      agent_base = Class.new(Riffer::Agent)
+      agent = Class.new(agent_base) { identifier "registered-agent" }
+
+      agent_base.register(agent)
+
+      expect(agent_base.find("registered-agent")).must_equal agent
+    end
+
+    it "raises ArgumentError when the identifier is blank" do
+      tool = Class.new(base)
+
+      error = expect { base.register(tool) }.must_raise Riffer::ArgumentError
+
+      expect(error.message).must_include "identifier"
+    end
+
+    it "raises ArgumentError for a class that is not a direct subclass" do
+      child = define_named_subclass(base, :ChildTool)
+      grandchild = Class.new(child) { identifier "grandchild-tool" }
+
+      expect { base.register(grandchild) }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises ArgumentError for a class outside the lineage" do
+      error = expect { base.register(Object) }.must_raise Riffer::ArgumentError
+
+      expect(error.message).must_include "direct subclass"
+    end
+
+    it "raises DuplicateIdentifierError against an implicit registration" do
+      implicit = define_named_subclass(base, :ImplicitTool, identifier: "shared-tool")
+      explicit = Class.new(base) { identifier "shared-tool" }
+
+      error = expect { base.register(explicit) }.must_raise Riffer::DuplicateIdentifierError
+
+      expect(error.message).must_include "shared-tool"
+      expect(error.message).must_include implicit.to_s
+    end
+
+    it "raises DuplicateIdentifierError against another explicit registration" do
+      first = Class.new(base) { identifier "shared-tool" }
+      second = Class.new(base) { identifier "shared-tool" }
+      base.register(first)
+
+      expect { base.register(second) }.must_raise Riffer::DuplicateIdentifierError
+    end
+
+    it "raises DuplicateIdentifierError when re-registering the same class" do
+      tool = Class.new(base) { identifier "shared-tool" }
+      base.register(tool)
+
+      expect { base.register(tool) }.must_raise Riffer::DuplicateIdentifierError
+    end
+
+    it "does not report a duplicate when a registered class also registers implicitly" do
+      tool = Class.new(base) { identifier "overlaid-tool" }
+      base.register(tool)
+      RegistrableTestNamespace.const_set(:OverlaidTool, tool)
+
+      expect(base.find("overlaid-tool")).must_equal tool
+      expect(base.all).must_equal [tool]
+    end
+
+    it "raises DuplicateIdentifierError when a later subclass claims an explicit identifier" do
+      explicit = Class.new(base) { identifier "shared-tool" }
+      base.register(explicit)
+      implicit = define_named_subclass(base, :LateTool, identifier: "shared-tool")
+
+      error = expect { base.find("shared-tool") }.must_raise Riffer::DuplicateIdentifierError
+
+      expect(error.message).must_include explicit.to_s
+      expect(error.message).must_include implicit.to_s
+    end
+  end
+
+  describe "unregister" do
+    let(:base) { Class.new(Riffer::Tool) }
+
+    it "removes an explicit registration" do
+      tool = Class.new(base) { identifier "temporary-tool" }
+      base.register(tool)
+
+      base.unregister(tool)
+
+      expect(base.find("temporary-tool")).must_be_nil
+      expect(base.all).wont_include tool
+    end
+
+    it "leaves other registrations alone when the class was never registered" do
+      registered = Class.new(base) { identifier "kept-tool" }
+      base.register(registered)
+      other = Class.new(base) { identifier "absent-tool" }
+
+      base.unregister(other)
+
+      expect(base.find("kept-tool")).must_equal registered
+    end
+
+    it "never removes an implicit registration" do
+      tool = define_named_subclass(base, :ImplicitTool, identifier: "implicit-tool")
+
+      base.unregister(tool)
+
+      expect(base.find("implicit-tool")).must_equal tool
+    end
+  end
+
+  describe "with_registered" do
+    let(:base) { Class.new(Riffer::Tool) }
+
+    it "registers every class for the duration of the block and returns its value" do
+      first = Class.new(base) { identifier "first-tool" }
+      second = Class.new(base) { identifier "second-tool" }
+
+      result = base.with_registered(first, second) do
+        [base.find("first-tool"), base.find("second-tool")]
+      end
+
+      expect(result).must_equal [first, second]
+      expect(base.all).must_be_empty
+    end
+
+    it "unregisters when the block raises" do
+      tool = Class.new(base) { identifier "raising-tool" }
+
+      expect do
+        base.with_registered(tool) { raise Riffer::Error, "boom" }
+      end.must_raise Riffer::Error
+
+      expect(base.find("raising-tool")).must_be_nil
+    end
+
+    it "unwinds partial registrations when a later class collides" do
+      first = Class.new(base) { identifier "first-tool" }
+      colliding = Class.new(base) { identifier "first-tool" }
+
+      expect do
+        base.with_registered(first, colliding) { flunk "block must not run" }
+      end.must_raise Riffer::DuplicateIdentifierError
+
+      expect(base.find("first-tool")).must_be_nil
+      expect(base.all).must_be_empty
     end
   end
 end

--- a/test/riffer/registrable_test.rb
+++ b/test/riffer/registrable_test.rb
@@ -315,42 +315,4 @@ describe Riffer::Registrable do
       expect(base.find("implicit-tool")).must_equal tool
     end
   end
-
-  describe "with_registered" do
-    let(:base) { Class.new(Riffer::Tool) }
-
-    it "registers every class for the duration of the block and returns its value" do
-      first = Class.new(base) { identifier "first-tool" }
-      second = Class.new(base) { identifier "second-tool" }
-
-      result = base.with_registered(first, second) do
-        [base.find("first-tool"), base.find("second-tool")]
-      end
-
-      expect(result).must_equal [first, second]
-      expect(base.all).must_be_empty
-    end
-
-    it "unregisters when the block raises" do
-      tool = Class.new(base) { identifier "raising-tool" }
-
-      expect do
-        base.with_registered(tool) { raise Riffer::Error, "boom" }
-      end.must_raise Riffer::Error
-
-      expect(base.find("raising-tool")).must_be_nil
-    end
-
-    it "unwinds partial registrations when a later class collides" do
-      first = Class.new(base) { identifier "first-tool" }
-      colliding = Class.new(base) { identifier "first-tool" }
-
-      expect do
-        base.with_registered(first, colliding) { flunk "block must not run" }
-      end.must_raise Riffer::DuplicateIdentifierError
-
-      expect(base.find("first-tool")).must_be_nil
-      expect(base.all).must_be_empty
-    end
-  end
 end

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -31,7 +31,7 @@ end
 
 describe Riffer::Agent::Run do
   let(:agent_class) do
-    Class.new(Riffer::Agent) do
+    stub_agent do
       identifier "test-agent"
       model "mock/riffer-1"
       instructions "You are a helpful assistant."
@@ -73,7 +73,7 @@ describe Riffer::Agent::Run do
     end
 
     it "raises when structured_output is configured" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -93,7 +93,7 @@ describe Riffer::Agent::Run do
 
   describe "#generate with structured_output" do
     it "returns Response with parsed structured_output from class-level schema" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -111,7 +111,7 @@ describe Riffer::Agent::Run do
     end
 
     it "sets structured_output to nil when LLM returns invalid JSON" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -128,7 +128,7 @@ describe Riffer::Agent::Run do
     end
 
     it "preserves raw content when structured_output parsing fails" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -148,7 +148,7 @@ describe Riffer::Agent::Run do
       params = Riffer::Params.new
       params.required(:sentiment, String)
 
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output params
       end
@@ -170,7 +170,7 @@ describe Riffer::Agent::Run do
     end
 
     it "stores structured_output hash on the assistant message in agent.session.messages" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -190,7 +190,7 @@ describe Riffer::Agent::Run do
     end
 
     it "makes structured_output available via on_message callback" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -214,7 +214,7 @@ describe Riffer::Agent::Run do
 
   describe "#stream with structured_output" do
     it "raises ArgumentError when class-level structured_output is configured" do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         structured_output do
           required :sentiment, String
@@ -293,7 +293,7 @@ describe Riffer::Agent::Run do
     describe "with before guardrail that blocks" do
       let(:agent_with_blocking_input) do
         gr = block_input_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
@@ -340,7 +340,7 @@ describe Riffer::Agent::Run do
     describe "with after guardrail that blocks" do
       let(:agent_with_blocking_output) do
         gr = block_output_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:after, with: gr)
@@ -369,7 +369,7 @@ describe Riffer::Agent::Run do
     describe "with transform guardrails" do
       let(:agent_with_transform) do
         gr = transform_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:around, with: gr)
@@ -453,7 +453,7 @@ describe Riffer::Agent::Run do
     describe "with before guardrail that blocks" do
       let(:agent_with_blocking_input) do
         gr = block_input_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
@@ -485,7 +485,7 @@ describe Riffer::Agent::Run do
     describe "with after guardrail that blocks" do
       let(:agent_with_blocking_output) do
         gr = block_output_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:after, with: gr)
@@ -534,7 +534,7 @@ describe Riffer::Agent::Run do
 
       let(:agent_with_stream_transform) do
         gr = transform_guardrail_class
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
         end
         klass.guardrail(:before, with: gr)
@@ -572,8 +572,7 @@ describe Riffer::Agent::Run do
     end
 
     it "accumulates token usage across tool loops" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "token_usage_test_tool"
+      tool_class = stub_tool("TokenUsageTestTool") do
         description "Test tool"
         def call(context:)
           text("done")
@@ -581,7 +580,7 @@ describe Riffer::Agent::Run do
       end
 
       tc = tool_class
-      agent_with_tools = Class.new(Riffer::Agent) do
+      agent_with_tools = stub_agent("AgentWithTools") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -666,7 +665,7 @@ describe Riffer::Agent::Run do
           block("Output blocked")
         end
       end
-      klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+      klass = stub_agent("Agent") { model "mock/riffer-1" }
       klass.guardrail(:after, with: gr)
 
       agent = klass.new
@@ -682,7 +681,7 @@ describe Riffer::Agent::Run do
           block("Input blocked")
         end
       end
-      klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+      klass = stub_agent("Agent") { model "mock/riffer-1" }
       klass.guardrail(:before, with: gr)
 
       response = klass.new.generate("Hi")
@@ -701,8 +700,7 @@ describe Riffer::Agent::Run do
     end
 
     it "accumulates steps across a tool loop" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "response_steps_tool"
+      tool_class = stub_tool("ResponseStepsTool") do
         description "Test tool"
         def call(context:)
           text("done")
@@ -710,7 +708,7 @@ describe Riffer::Agent::Run do
       end
 
       tc = tool_class
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -729,7 +727,7 @@ describe Riffer::Agent::Run do
           block("Input blocked")
         end
       end
-      klass = Class.new(Riffer::Agent) { model "mock/riffer-1" }
+      klass = stub_agent("Agent") { model "mock/riffer-1" }
       klass.guardrail(:before, with: gr)
 
       response = klass.new.generate("Hi")
@@ -773,8 +771,7 @@ describe Riffer::Agent::Run do
     end
 
     it "accumulates token usage across tool loops" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "stream_token_usage_test_tool"
+      tool_class = stub_tool("StreamTokenUsageTestTool") do
         description "Test tool"
         def call(context:)
           text("done")
@@ -782,7 +779,7 @@ describe Riffer::Agent::Run do
       end
 
       tc = tool_class
-      agent_with_tools = Class.new(Riffer::Agent) do
+      agent_with_tools = stub_agent("AgentWithTools") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -807,8 +804,7 @@ describe Riffer::Agent::Run do
 
   describe "pending tool calls on fresh generate" do
     it "does not execute pending tool calls" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "fresh_generate_tool"
+      tool_class = stub_tool("FreshGenerateTool") do
         description "Simple tool"
         def call(context:)
           text("done")
@@ -816,7 +812,7 @@ describe Riffer::Agent::Run do
       end
 
       tc = tool_class
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -842,8 +838,7 @@ describe Riffer::Agent::Run do
 
   describe "pending tool call resume with #stream" do
     it "resumes pending tools in streaming mode" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "stream_pending_tool"
+      tool_class = stub_tool("StreamPendingTool") do
         description "Simple tool"
         def call(context:)
           text("done")
@@ -851,7 +846,7 @@ describe Riffer::Agent::Run do
       end
 
       tc = tool_class
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -895,8 +890,7 @@ describe Riffer::Agent::Run do
 
   describe "interrupt! with experimental_history_healing" do
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "interrupt_heal_tool"
+      stub_tool("InterruptHealTool") do
         description "Slow tool"
         def call(context:)
           text("done")
@@ -910,7 +904,7 @@ describe Riffer::Agent::Run do
     it "fills orphans and exposes healed_tool_call_ids when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -943,7 +937,7 @@ describe Riffer::Agent::Run do
 
     it "leaves orphans in place when healing is off (default)" do
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -966,7 +960,7 @@ describe Riffer::Agent::Run do
     it "does not fire on_message for placeholder tool messages" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
       end
@@ -992,8 +986,7 @@ describe Riffer::Agent::Run do
 
   describe "max_steps interrupt with experimental_history_healing" do
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "max_steps_heal_tool"
+      stub_tool("MaxStepsHealTool") do
         description "Loop tool"
         def call(context:)
           text("ok")
@@ -1007,7 +1000,7 @@ describe Riffer::Agent::Run do
     it "fills orphan tool_use with the placeholder when healing is on" do
       Riffer.config.experimental_history_healing = true
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
         max_steps 1
@@ -1032,7 +1025,7 @@ describe Riffer::Agent::Run do
 
     it "leaves orphan tool_use when healing is off" do
       tc = tool_class
-      custom_class = Class.new(Riffer::Agent) do
+      custom_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tc]
         max_steps 1
@@ -1053,7 +1046,7 @@ describe Riffer::Agent::Run do
   end
 
   describe "seeded history with experimental_history_healing" do
-    let(:custom_class) { Class.new(Riffer::Agent) { model "mock/riffer-1" } }
+    let(:custom_class) { stub_agent("CustomAgent") { model "mock/riffer-1" } }
 
     before { @original_history_healing = Riffer.config.experimental_history_healing }
     after { Riffer.config.experimental_history_healing = @original_history_healing }
@@ -1098,14 +1091,13 @@ describe Riffer::Agent::Run do
           Riffer::Messages::Assistant.new("", tool_calls: [tc]),
         ],
       )
-      tool = Class.new(Riffer::Tool) do
-        identifier "pending_seed_tool"
+      tool = stub_tool("PendingSeedTool") do
         description "Pending tool"
         def call(context:)
           text("done")
         end
       end
-      with_tools = Class.new(Riffer::Agent) do
+      with_tools = stub_agent("WithTools") do
         model "mock/riffer-1"
         uses_tools [tool]
       end
@@ -1120,7 +1112,7 @@ describe Riffer::Agent::Run do
 
   describe "tool calling" do
     let(:weather_tool_class) do
-      Class.new(Riffer::Tool) do
+      stub_tool("WeatherTool") do
         description "Gets the weather"
 
         params do
@@ -1134,7 +1126,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:context_tool_class) do
-      Class.new(Riffer::Tool) do
+      stub_tool("ContextTool") do
         description "Gets user info"
 
         params do
@@ -1150,8 +1142,7 @@ describe Riffer::Agent::Run do
     describe "#generate with tools" do
       it "adds tool message after executing tool call" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1175,8 +1166,7 @@ describe Riffer::Agent::Run do
 
       it "includes tool result in tool message content" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1200,8 +1190,7 @@ describe Riffer::Agent::Run do
 
       it "returns final response after tool execution" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1223,8 +1212,7 @@ describe Riffer::Agent::Run do
 
       it "passes context to tools" do
         tool_class = context_tool_class
-        tool_class.identifier("context_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1247,7 +1235,7 @@ describe Riffer::Agent::Run do
       end
 
       it "returns error message for unknown tool" do
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools []
         end
@@ -1270,7 +1258,7 @@ describe Riffer::Agent::Run do
       end
 
       it "sets error attributes for unknown tool" do
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools []
         end
@@ -1296,8 +1284,7 @@ describe Riffer::Agent::Run do
 
       it "handles validation errors gracefully" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1321,8 +1308,7 @@ describe Riffer::Agent::Run do
 
       it "sets error attributes for validation errors" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1347,8 +1333,7 @@ describe Riffer::Agent::Run do
 
       it "does not set error attributes for successful tool calls" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1374,8 +1359,7 @@ describe Riffer::Agent::Run do
 
       it "passes tools to provider" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1389,8 +1373,7 @@ describe Riffer::Agent::Run do
 
       it "passes correct number of tools to provider" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1406,8 +1389,7 @@ describe Riffer::Agent::Run do
     describe "#stream with tools" do
       it "yields tool call events" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1431,8 +1413,7 @@ describe Riffer::Agent::Run do
 
       it "adds tool messages during streaming" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1456,8 +1437,7 @@ describe Riffer::Agent::Run do
 
       it "passes context in streaming mode" do
         tool_class = context_tool_class
-        tool_class.identifier("context_tool")
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1482,7 +1462,7 @@ describe Riffer::Agent::Run do
 
     describe "tool timeouts" do
       let(:slow_tool_class) do
-        Class.new(Riffer::Tool) do
+        stub_tool("SlowTool") do
           description "A slow tool"
           timeout 0.01
 
@@ -1494,7 +1474,7 @@ describe Riffer::Agent::Run do
       end
 
       let(:fast_tool_class) do
-        Class.new(Riffer::Tool) do
+        stub_tool("FastTool") do
           description "A fast tool"
 
           def call(context:)
@@ -1505,9 +1485,8 @@ describe Riffer::Agent::Run do
 
       it "times out slow tools" do
         tool_class = slow_tool_class
-        tool_class.identifier("slow_tool")
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1531,9 +1510,8 @@ describe Riffer::Agent::Run do
 
       it "sets error content and error_type for timeout" do
         tool_class = slow_tool_class
-        tool_class.identifier("slow_tool")
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1558,9 +1536,8 @@ describe Riffer::Agent::Run do
 
       it "uses tool-level timeout in error message" do
         tool_class = slow_tool_class
-        tool_class.identifier("slow_tool")
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1585,9 +1562,8 @@ describe Riffer::Agent::Run do
 
       it "fast tools do not timeout" do
         tool_class = fast_tool_class
-        tool_class.identifier("fast_tool")
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools [tool_class]
         end
@@ -1614,10 +1590,9 @@ describe Riffer::Agent::Run do
     describe "with lambda-based tools" do
       it "evaluates lambda at resolution time" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
         call_count = 0
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools lambda {
             call_count += 1
@@ -1633,10 +1608,9 @@ describe Riffer::Agent::Run do
 
       it "passes context to lambda when it accepts a parameter" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
         received_context = nil
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools lambda { |context|
             received_context = context
@@ -1653,19 +1627,17 @@ describe Riffer::Agent::Run do
       end
 
       it "allows conditional tool resolution based on context" do
-        admin_tool_class = Class.new(Riffer::Tool) do
+        admin_tool_class = stub_tool("AdminTool") do
           description "Admin only tool"
           params {}
           def call(context:)
             text("admin action")
           end
         end
-        admin_tool_class.identifier("admin_tool")
 
         basic_tool_class = weather_tool_class
-        basic_tool_class.identifier("weather_tool")
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools lambda { |context|
             tools = [basic_tool_class]
@@ -1692,10 +1664,9 @@ describe Riffer::Agent::Run do
 
       it "evaluates lambda once per agent instance" do
         tool_class = weather_tool_class
-        tool_class.identifier("weather_tool")
         call_values = []
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           uses_tools lambda { |context|
             call_values << context[:call]
@@ -1714,7 +1685,7 @@ describe Riffer::Agent::Run do
   describe "#generate" do
     describe "with model_options" do
       let(:options_agent_class) do
-        Class.new(Riffer::Agent) do
+        stub_agent do
           identifier "options-agent"
           model "mock/riffer-1"
           instructions "You are a helpful assistant."
@@ -1741,8 +1712,7 @@ describe Riffer::Agent::Run do
 
     describe "with max_steps" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "max_steps_tool"
+        stub_tool("MaxStepsTool") do
           description "Simple tool"
           def call(context:)
             text("done")
@@ -1752,7 +1722,7 @@ describe Riffer::Agent::Run do
 
       it "runs unlimited steps when max_steps is nil" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps nil
           uses_tools [tc]
@@ -1770,7 +1740,7 @@ describe Riffer::Agent::Run do
 
       it "limits LLM calls when max_steps is set" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 2
           uses_tools [tc]
@@ -1788,7 +1758,7 @@ describe Riffer::Agent::Run do
 
       it "returns last assistant response content when limit is reached" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
@@ -1805,7 +1775,7 @@ describe Riffer::Agent::Run do
 
       it "sets interrupted? to true when limit is reached" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
@@ -1822,7 +1792,7 @@ describe Riffer::Agent::Run do
 
       it "sets interrupt_reason to :max_steps when limit is reached" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
@@ -1882,7 +1852,7 @@ describe Riffer::Agent::Run do
   describe "#stream" do
     describe "with model_options" do
       let(:options_agent_class) do
-        Class.new(Riffer::Agent) do
+        stub_agent do
           identifier "options-stream-agent"
           model "mock/riffer-1"
           instructions "You are a helpful assistant."
@@ -1909,8 +1879,7 @@ describe Riffer::Agent::Run do
 
     describe "with max_steps" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "stream_max_steps_tool"
+        stub_tool("StreamMaxStepsTool") do
           description "Simple tool"
           def call(context:)
             text("done")
@@ -1920,7 +1889,7 @@ describe Riffer::Agent::Run do
 
       it "limits LLM calls when max_steps is set" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 2
           uses_tools [tc]
@@ -1938,7 +1907,7 @@ describe Riffer::Agent::Run do
 
       it "emits Interrupt event with :max_steps reason when limit is reached" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 1
           uses_tools [tc]
@@ -1957,7 +1926,7 @@ describe Riffer::Agent::Run do
 
       it "does not emit Interrupt event when limit is not reached" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 10
           uses_tools [tc]
@@ -2096,7 +2065,7 @@ describe Riffer::Agent::Run do
 
   describe "dynamic model selection" do
     it "resolves lambda for generate" do
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { "mock/riffer-1" }
       end
 
@@ -2106,7 +2075,7 @@ describe Riffer::Agent::Run do
     end
 
     it "resolves lambda for stream" do
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { "mock/riffer-1" }
       end
 
@@ -2116,7 +2085,7 @@ describe Riffer::Agent::Run do
     end
 
     it "uses resolved model for provider lookup" do
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { "mock/riffer-1" }
       end
 
@@ -2129,7 +2098,7 @@ describe Riffer::Agent::Run do
 
     it "evaluates the model lambda once per agent instance" do
       call_count = 0
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model lambda {
           call_count += 1
           "mock/riffer-1"
@@ -2144,7 +2113,7 @@ describe Riffer::Agent::Run do
 
     it "resolves model per agent instance based on context" do
       models_used = []
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model lambda { |context|
           model = context&.dig(:premium) ? "mock/riffer-premium" : "mock/riffer-basic"
           models_used << model
@@ -2159,7 +2128,7 @@ describe Riffer::Agent::Run do
     end
 
     it "passes resolved model name to provider" do
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { "mock/my-model" }
       end
 
@@ -2171,7 +2140,7 @@ describe Riffer::Agent::Run do
     end
 
     it "raises on invalid lambda return without slash" do
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { "invalid-format" }
       end
 
@@ -2181,7 +2150,7 @@ describe Riffer::Agent::Run do
 
     it "raises on nil lambda return" do
       value = nil
-      dynamic_agent_class = Class.new(Riffer::Agent) do
+      dynamic_agent_class = stub_agent("DynamicAgent") do
         model -> { value }
       end
 
@@ -2190,7 +2159,7 @@ describe Riffer::Agent::Run do
     end
 
     it "static string still works" do
-      static_agent_class = Class.new(Riffer::Agent) do
+      static_agent_class = stub_agent("StaticAgent") do
         model "mock/riffer-1"
       end
 
@@ -2225,8 +2194,7 @@ describe Riffer::Agent::Run do
 
     describe "during tool use" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "emit_weather_tool"
+        stub_tool("EmitWeatherTool") do
           description "Gets the weather"
           params do
             required :city, String
@@ -2240,7 +2208,7 @@ describe Riffer::Agent::Run do
       let(:emitted) { [] }
       let(:agent) do
         tc = tool_class
-        agent_with_tools = Class.new(Riffer::Agent) do
+        agent_with_tools = stub_agent("AgentWithTools") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2292,8 +2260,7 @@ describe Riffer::Agent::Run do
 
     describe "when tool fails" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "failing_tool"
+        stub_tool("FailingTool") do
           description "A failing tool"
           params do
             required :value, String
@@ -2307,7 +2274,7 @@ describe Riffer::Agent::Run do
       let(:emitted) { [] }
       let(:tool_message) do
         tc = tool_class
-        agent_with_tools = Class.new(Riffer::Agent) do
+        agent_with_tools = stub_agent("AgentWithTools") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2374,8 +2341,7 @@ describe Riffer::Agent::Run do
 
     describe "throw during tool execution" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "interrupt_partial_tool"
+        stub_tool("InterruptPartialTool") do
           description "Simple tool"
           def call(context:)
             text("done")
@@ -2385,7 +2351,7 @@ describe Riffer::Agent::Run do
 
       it "stops tool execution on interrupt and resumes pending tools" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2426,7 +2392,7 @@ describe Riffer::Agent::Run do
 
       it "resumes all pending tools when interrupt fires on assistant callback" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2594,8 +2560,7 @@ describe Riffer::Agent::Run do
 
     describe "with tools" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "resume_weather_tool"
+        stub_tool("ResumeWeatherTool") do
           description "Gets the weather"
           params do
             required :city, String
@@ -2608,7 +2573,7 @@ describe Riffer::Agent::Run do
 
       it "completes tool loop after resume" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2679,8 +2644,7 @@ describe Riffer::Agent::Run do
       end
 
       it "uses init context for tool execution" do
-        context_tool = Class.new(Riffer::Tool) do
-          identifier "resume_context_tool"
+        context_tool = stub_tool("ResumeContextTool") do
           description "Gets user info"
           params do
             required :field, String
@@ -2691,7 +2655,7 @@ describe Riffer::Agent::Run do
         end
 
         tc = context_tool
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -2728,8 +2692,7 @@ describe Riffer::Agent::Run do
       end
 
       it "executes pending tool calls left by a prior interrupt" do
-        tc = Class.new(Riffer::Tool) do
-          identifier "cross_process_pending_tool"
+        tc = stub_tool("CrossProcessPendingTool") do
           description "Simple tool"
           def call(context:)
             text("done")
@@ -2737,7 +2700,7 @@ describe Riffer::Agent::Run do
         end
 
         tool = tc
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           uses_tools [tool]
         end
@@ -2779,8 +2742,7 @@ describe Riffer::Agent::Run do
 
     describe "auto-derived step offset" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "resume_step_tool"
+        stub_tool("ResumeStepTool") do
           description "Simple tool"
           def call(context:)
             text("done")
@@ -2790,7 +2752,7 @@ describe Riffer::Agent::Run do
 
       it "enforces max_steps across sessions" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 3
           uses_tools [tc]
@@ -2822,7 +2784,7 @@ describe Riffer::Agent::Run do
 
       it "enforces max_steps on cross-process resume via message counting" do
         tc = tool_class
-        custom_agent_class = Class.new(Riffer::Agent) do
+        custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
           max_steps 4
           uses_tools [tc]
@@ -2851,7 +2813,7 @@ describe Riffer::Agent::Run do
 
     describe "with structured_output" do
       it "returns parsed structured_output on in-memory resume" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           structured_output do
             required :sentiment, String
@@ -2879,7 +2841,7 @@ describe Riffer::Agent::Run do
       end
 
       it "returns parsed structured_output on cross-process resume" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent("Agent") do
           model "mock/riffer-1"
           structured_output do
             required :sentiment, String
@@ -3035,8 +2997,7 @@ describe Riffer::Agent::Run do
     end
 
     it "executes pending tool calls on string continuation" do
-      tc = Class.new(Riffer::Tool) do
-        identifier "continuation_pending_tool"
+      tc = stub_tool("ContinuationPendingTool") do
         description "Simple tool"
         def call(context:)
           text("done")
@@ -3044,7 +3005,7 @@ describe Riffer::Agent::Run do
       end
 
       tool = tc
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         uses_tools [tool]
       end
@@ -3084,8 +3045,7 @@ describe Riffer::Agent::Run do
     end
 
     it "enforces max_steps across continuations" do
-      tc = Class.new(Riffer::Tool) do
-        identifier "continuation_step_tool"
+      tc = stub_tool("ContinuationStepTool") do
         description "Simple tool"
         def call(context:)
           text("done")
@@ -3093,7 +3053,7 @@ describe Riffer::Agent::Run do
       end
 
       tool = tc
-      custom_agent_class = Class.new(Riffer::Agent) do
+      custom_agent_class = stub_agent("CustomAgent") do
         model "mock/riffer-1"
         max_steps 3
         uses_tools [tool]
@@ -3190,8 +3150,7 @@ describe Riffer::Agent::Run do
 
     describe "during tool calling loop" do
       let(:tool_class) do
-        Class.new(Riffer::Tool) do
-          identifier "stream_emit_weather_tool"
+        stub_tool("StreamEmitWeatherTool") do
           description "Gets the weather"
           params do
             required :city, String
@@ -3205,7 +3164,7 @@ describe Riffer::Agent::Run do
       let(:emitted) { [] }
       let(:agent) do
         tc = tool_class
-        agent_with_tools = Class.new(Riffer::Agent) do
+        agent_with_tools = stub_agent("AgentWithTools") do
           model "mock/riffer-1"
           uses_tools [tc]
         end
@@ -3263,15 +3222,14 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class) do
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
     end
 
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "run_tracing_tool"
+      stub_tool("RunTracingTool") do
         description "Traced tool"
         def call(context:)
           text("done")
@@ -3281,7 +3239,7 @@ describe Riffer::Agent::Run do
 
     let(:agent_class_with_tools) do
       tc = tool_class
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
         uses_tools [tc]
@@ -3289,7 +3247,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class_with_blocking_input) do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
@@ -3298,7 +3256,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class_with_blocking_output) do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
@@ -3307,7 +3265,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class_with_passing_guardrail) do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
@@ -3316,7 +3274,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class_with_transform_guardrail) do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
@@ -3325,7 +3283,7 @@ describe Riffer::Agent::Run do
     end
 
     let(:agent_class_with_raising_guardrail) do
-      klass = Class.new(Riffer::Agent) do
+      klass = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
       end
@@ -3490,7 +3448,7 @@ describe Riffer::Agent::Run do
 
     it "records the max steps interrupt reason" do
       tc = tool_class
-      agent_with_max_steps = Class.new(Riffer::Agent) do
+      agent_with_max_steps = stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
         uses_tools [tc]
@@ -3714,15 +3672,14 @@ describe Riffer::Agent::Run do
 
   describe "tags" do
     let(:agent_class) do
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "tagged-agent"
         model "mock/riffer-1"
       end
     end
 
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "run_tags_tool"
+      stub_tool("RunTagsTool") do
         description "Tagged tool"
         def call(context:)
           text("done")
@@ -3732,7 +3689,7 @@ describe Riffer::Agent::Run do
 
     let(:agent_class_with_tools) do
       tc = tool_class
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "tagged-agent"
         model "mock/riffer-1"
         uses_tools [tc]
@@ -3836,7 +3793,7 @@ describe Riffer::Agent::Run do
       end
 
       it "stamps riffer.tag.* on the execute_guardrail span" do
-        klass = Class.new(Riffer::Agent) do
+        klass = stub_agent do
           identifier "tagged-agent"
           model "mock/riffer-1"
         end

--- a/test/riffer/skills/agent_integration_test.rb
+++ b/test/riffer/skills/agent_integration_test.rb
@@ -7,7 +7,7 @@ describe "Agent skills integration" do
 
   describe "generate with skills" do
     it "injects skills catalog into separate system message" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions "You are helpful."
         skills do
@@ -28,7 +28,7 @@ describe "Agent skills integration" do
     end
 
     it "uses Markdown renderer for mock provider by default" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -46,7 +46,7 @@ describe "Agent skills integration" do
     end
 
     it "allows custom adapter override" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -64,7 +64,7 @@ describe "Agent skills integration" do
     end
 
     it "uses XML renderer for mock provider when the model name contains claude" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/claude-sonnet-4-6"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -84,7 +84,7 @@ describe "Agent skills integration" do
     it "explicit adapter wins over model-aware default" do
       # Mock with a "claude" model name would default to XML; explicit
       # MarkdownAdapter must still take precedence.
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/claude-sonnet-4-6"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -103,7 +103,7 @@ describe "Agent skills integration" do
     end
 
     it "selects XmlAdapter for amazon_bedrock with an Anthropic model id" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "amazon_bedrock/us.anthropic.claude-sonnet-4-6"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -119,7 +119,7 @@ describe "Agent skills integration" do
     end
 
     it "selects MarkdownAdapter for amazon_bedrock with a non-Anthropic model id" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "amazon_bedrock/us.amazon.nova-lite-v1:0"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -135,7 +135,7 @@ describe "Agent skills integration" do
     end
 
     it "includes skill_activate tool in resolved tools" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -151,15 +151,14 @@ describe "Agent skills integration" do
     end
 
     it "merges skill tools with existing tools" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "my_tool"
+      tool_class = stub_tool("MyTool") do
         description "A custom tool"
         def call(context:)
           text("ok")
         end
       end
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [tool_class]
         skills do
@@ -177,6 +176,8 @@ describe "Agent skills integration" do
     end
 
     it "raises on tool name conflict" do
+      # Not a stub: the identifier deliberately collides with the real
+      # Riffer::Skills::ActivateTool, which the registry would reject.
       conflict_tool = Class.new(Riffer::Tool) do
         identifier "skill_activate"
         description "Conflicts with skill_activate"
@@ -185,7 +186,7 @@ describe "Agent skills integration" do
         end
       end
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [conflict_tool]
         skills do
@@ -198,15 +199,14 @@ describe "Agent skills integration" do
     end
 
     it "passes skills context in context" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "spy_tool"
+      tool_class = stub_tool("SpyTool") do
         description "Captures context"
         def call(context:)
           text(context[:skills].skills.keys.sort.join(","))
         end
       end
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [tool_class]
         skills do
@@ -227,7 +227,7 @@ describe "Agent skills integration" do
     end
 
     it "handles Proc backend" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend lambda { |_ctx|
@@ -247,7 +247,7 @@ describe "Agent skills integration" do
 
     it "generates no system message when skills backend returns empty" do
       Dir.mktmpdir do |dir|
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           skills do
             backend Riffer::Skills::FilesystemBackend.new(dir)
@@ -267,7 +267,7 @@ describe "Agent skills integration" do
       original_default = Riffer.config.skills.default_backend
       Riffer.config.skills.default_backend = Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           # no per-agent backend; should pick up the global default
@@ -296,7 +296,7 @@ describe "Agent skills integration" do
       end.new
       Riffer.config.skills.default_backend = decoy_backend
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -316,15 +316,14 @@ describe "Agent skills integration" do
 
   describe "#tools" do
     it "returns uses_tools when no skills configured" do
-      tool_class = Class.new(Riffer::Tool) do
-        identifier "my_tool"
+      tool_class = stub_tool("MyTool") do
         description "A tool"
         def call(context:)
           text("ok")
         end
       end
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         uses_tools [tool_class]
       end
@@ -333,7 +332,7 @@ describe "Agent skills integration" do
     end
 
     it "appends skill_activate when skills block is configured" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -346,15 +345,14 @@ describe "Agent skills integration" do
     end
 
     it "uses the per-agent activate_tool override" do
-      custom = Class.new(Riffer::Tool) do
-        identifier "my_activate"
+      custom = stub_tool("MyActivate") do
         description "Custom"
         def call(context:)
           text("ok")
         end
       end
 
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -371,7 +369,7 @@ describe "Agent skills integration" do
 
   describe "activated skills" do
     it "appends activated skill bodies to skills system message" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions "Base instructions."
         skills do
@@ -397,7 +395,7 @@ describe "Agent skills integration" do
     end
 
     it "omits catalog entirely when all skills are pre-activated" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -418,7 +416,7 @@ describe "Agent skills integration" do
     end
 
     it "raises on unknown activated skill" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -431,7 +429,7 @@ describe "Agent skills integration" do
     end
 
     it "supports Proc for activate" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -451,7 +449,7 @@ describe "Agent skills integration" do
 
   describe "stream with skills" do
     it "injects skills catalog into separate system message" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         instructions "You are helpful."
         skills do
@@ -474,7 +472,7 @@ describe "Agent skills integration" do
 
   describe "stream emits SkillActivation events" do
     it "emits SkillActivation event when skill is activated via tool call" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -493,7 +491,7 @@ describe "Agent skills integration" do
     end
 
     it "does not emit duplicate events for re-activation of the same skill" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -511,7 +509,7 @@ describe "Agent skills integration" do
     end
 
     it "composes with and restores the consumer's on_activate across a stream" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -533,7 +531,7 @@ describe "Agent skills integration" do
 
   describe "skill activation end-to-end" do
     it "activates a skill via tool call and returns body" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -555,7 +553,7 @@ describe "Agent skills integration" do
     end
 
     it "returns error for unknown skill activation" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -574,7 +572,7 @@ describe "Agent skills integration" do
     end
 
     it "answers a re-activation with a pointer instead of the body" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -596,7 +594,7 @@ describe "Agent skills integration" do
 
   describe "user-explicit activation" do
     it "injects the wrapped body as a user message and pointers later model activations" do
-      agent_class = Class.new(Riffer::Agent) do
+      agent_class = stub_agent("Agent") do
         model "mock/riffer-1"
         skills do
           backend Riffer::Skills::FilesystemBackend.new(SKILLS_FIXTURES_PATH)
@@ -634,7 +632,7 @@ describe "Agent skills integration" do
         write_skill(dir, "code-review", "Reviews code.")
         write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           skills do
             backend Riffer::Skills::FilesystemBackend.new(dir)
@@ -650,7 +648,7 @@ describe "Agent skills integration" do
         write_skill(dir, "code-review", "Reviews code.")
         write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           skills do
             backend Riffer::Skills::FilesystemBackend.new(dir)
@@ -665,7 +663,7 @@ describe "Agent skills integration" do
       Dir.mktmpdir do |dir|
         write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           skills do
             backend Riffer::Skills::FilesystemBackend.new(dir)
@@ -680,7 +678,7 @@ describe "Agent skills integration" do
       Dir.mktmpdir do |dir|
         write_skill(dir, "deploy-prod", "Deploys to production.", disable_model_invocation: true)
 
-        agent_class = Class.new(Riffer::Agent) do
+        agent_class = stub_agent("Agent") do
           model "mock/riffer-1"
           skills do
             backend Riffer::Skills::FilesystemBackend.new(dir)

--- a/test/riffer/skills/markdown_adapter_test.rb
+++ b/test/riffer/skills/markdown_adapter_test.rb
@@ -22,8 +22,7 @@ describe Riffer::Skills::MarkdownAdapter do
     end
 
     it "uses the configured skill_activate_tool name in the prompt" do
-      custom = Class.new(Riffer::Tool) do
-        identifier "custom_activate"
+      custom = stub_tool("CustomActivate") do
         description "Custom"
         def call(context:)
           text("ok")

--- a/test/riffer/skills/xml_adapter_test.rb
+++ b/test/riffer/skills/xml_adapter_test.rb
@@ -31,8 +31,7 @@ describe Riffer::Skills::XmlAdapter do
     end
 
     it "uses the configured skill_activate_tool name in the prompt" do
-      custom = Class.new(Riffer::Tool) do
-        identifier "custom_activate"
+      custom = stub_tool("CustomActivate") do
         description "Custom"
         def call(context:)
           text("ok")

--- a/test/riffer/testing_test.rb
+++ b/test/riffer/testing_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Testing do
+  it "makes a stubbed tool findable by identifier" do
+    tool = stub_tool(identifier: "stubbed_kb_search")
+
+    expect(Riffer::Tool.find("stubbed_kb_search")).must_equal tool
+  end
+
+  it "evaluates the body in the stubbed tool" do
+    tool = stub_tool(identifier: "stubbed_echo") do
+      description "Echoes a canned answer"
+
+      def call(context:, **) = text("stubbed")
+    end
+
+    expect(tool.description).must_equal "Echoes a canned answer"
+    expect(tool.new.call(context: nil).content).must_equal "stubbed"
+  end
+
+  it "makes a stubbed agent findable by identifier" do
+    agent = stub_agent(identifier: "stubbed_support_agent") { model "mock/riffer-1" }
+
+    expect(Riffer::Agent.find("stubbed_support_agent")).must_equal agent
+    expect(agent.model).must_equal "mock/riffer-1"
+  end
+
+  it "stubs onto an intermediate base class" do
+    base = Class.new(Riffer::Tool)
+    tool = stub_tool(identifier: "stubbed_child_tool", base: base)
+
+    expect(base.find("stubbed_child_tool")).must_equal tool
+    expect(Riffer::Tool.find("stubbed_child_tool")).must_be_nil
+  end
+
+  it "raises DuplicateIdentifierError when the identifier is already taken" do
+    stub_tool(identifier: "stubbed_duplicate")
+
+    expect { stub_tool(identifier: "stubbed_duplicate") }.must_raise Riffer::DuplicateIdentifierError
+  end
+
+  describe "reset!" do
+    it "unregisters tracked stubs newest first" do
+      base = Class.new(Riffer::Tool)
+      unregistered = []
+      base.define_singleton_method(:unregister) do |klass|
+        unregistered << klass.identifier
+        super(klass)
+      end
+      stub_tool(identifier: "first_reset_tool", base: base)
+      stub_tool(identifier: "second_reset_tool", base: base)
+
+      Riffer::Testing.reset!
+
+      expect(unregistered).must_equal %w[second_reset_tool first_reset_tool]
+    end
+
+    it "forgets the stubs it removed" do
+      stub_tool(identifier: "stubbed_cleared_tool")
+
+      Riffer::Testing.reset!
+
+      expect(Riffer::Tool.find("stubbed_cleared_tool")).must_be_nil
+      expect(Riffer::Testing.registrations).must_be_empty
+    end
+
+    it "is a no-op when nothing is stubbed" do
+      Riffer::Testing.reset!
+
+      expect(Riffer::Testing.registrations).must_be_empty
+    end
+
+    it "shares tracking between an including test case and the module" do
+      tool = Riffer::Testing.stub_tool(identifier: "stubbed_module_call")
+
+      reset!
+
+      expect(Riffer::Tool.all).wont_include tool
+    end
+  end
+
+  describe "the minitest adapter" do
+    it "resets stubs once a test finishes" do
+      test_case = Class.new(Minitest::Test) do
+        def test_stubs_a_tool
+          stub_tool(identifier: "stubbed_adapter_cleanup")
+        end
+      end
+
+      test_case.new("test_stubs_a_tool").run
+
+      expect(Riffer::Tool.find("stubbed_adapter_cleanup")).must_be_nil
+    end
+  end
+end

--- a/test/riffer/testing_test.rb
+++ b/test/riffer/testing_test.rb
@@ -3,14 +3,14 @@
 require "test_helper"
 
 describe Riffer::Testing do
-  it "makes a stubbed tool findable by identifier" do
-    tool = stub_tool(identifier: "stubbed_kb_search")
+  it "makes a stubbed tool findable by its derived identifier" do
+    tool = stub_tool("StubbedKbSearch")
 
     expect(Riffer::Tool.find("stubbed_kb_search")).must_equal tool
   end
 
   it "evaluates the body in the stubbed tool" do
-    tool = stub_tool(identifier: "stubbed_echo") do
+    tool = stub_tool("StubbedEcho") do
       description "Echoes a canned answer"
 
       def call(context:, **) = text("stubbed")
@@ -20,8 +20,8 @@ describe Riffer::Testing do
     expect(tool.new.call(context: nil).content).must_equal "stubbed"
   end
 
-  it "makes a stubbed agent findable by identifier" do
-    agent = stub_agent(identifier: "stubbed_support_agent") { model "mock/riffer-1" }
+  it "makes a stubbed agent findable by its derived identifier" do
+    agent = stub_agent("StubbedSupportAgent") { model "mock/riffer-1" }
 
     expect(Riffer::Agent.find("stubbed_support_agent")).must_equal agent
     expect(agent.model).must_equal "mock/riffer-1"
@@ -29,20 +29,21 @@ describe Riffer::Testing do
 
   it "stubs onto an intermediate base class" do
     base = Class.new(Riffer::Tool)
-    tool = stub_tool(identifier: "stubbed_child_tool", base: base)
+    tool = stub_tool("StubbedChildTool", base: base)
 
     expect(base.find("stubbed_child_tool")).must_equal tool
     expect(Riffer::Tool.find("stubbed_child_tool")).must_be_nil
   end
 
-  it "raises ArgumentError when neither a name nor an identifier is given" do
+  it "raises ArgumentError when neither a name nor a body identifier is given" do
     expect { stub_tool }.must_raise Riffer::ArgumentError
+    expect { stub_tool { description "nameless" } }.must_raise Riffer::ArgumentError
   end
 
   it "raises DuplicateIdentifierError when the identifier is already taken" do
-    stub_tool(identifier: "stubbed_duplicate")
+    stub_tool("StubbedDuplicate")
 
-    expect { stub_tool(identifier: "stubbed_duplicate") }.must_raise Riffer::DuplicateIdentifierError
+    expect { stub_tool { identifier "stubbed_duplicate" } }.must_raise Riffer::DuplicateIdentifierError
   end
 
   describe "a named stub" do
@@ -61,21 +62,13 @@ describe Riffer::Testing do
       expect(Riffer::Tool.find("stubbed_symbol_tool")).must_equal tool
     end
 
-    it "prefers the identifier keyword over the name" do
-      tool = stub_tool("StubbedOverriddenTool", identifier: "stubbed_kwarg_identifier")
-
-      expect(Object.const_get(:StubbedOverriddenTool)).must_equal tool
-      expect(Riffer::Tool.find("stubbed_kwarg_identifier")).must_equal tool
-      expect(Riffer::Tool.find("stubbed_overridden_tool")).must_be_nil
-    end
-
-    it "prefers an identifier declared in the body" do
-      tool = stub_tool("StubbedBodyTool", identifier: "stubbed_kwarg_loses") do
+    it "prefers an identifier declared in the body over the derived one" do
+      tool = stub_tool("StubbedBodyTool") do
         identifier "stubbed_body_wins"
       end
 
       expect(Riffer::Tool.find("stubbed_body_wins")).must_equal tool
-      expect(Riffer::Tool.find("stubbed_kwarg_loses")).must_be_nil
+      expect(Riffer::Tool.find("stubbed_body_tool")).must_be_nil
     end
 
     it "raises ArgumentError for a name that is not a simple constant name" do
@@ -93,6 +86,15 @@ describe Riffer::Testing do
     end
   end
 
+  describe "an anonymous stub" do
+    it "registers under the identifier its body declares without naming a constant" do
+      tool = stub_tool { identifier "stubbed_anonymous_tool" }
+
+      expect(Riffer::Tool.find("stubbed_anonymous_tool")).must_equal tool
+      expect(Riffer::Helpers::Identifier.real_name(tool)).must_be_nil
+    end
+  end
+
   describe "reset!" do
     it "unregisters tracked stubs newest first" do
       base = Class.new(Riffer::Tool)
@@ -101,8 +103,8 @@ describe Riffer::Testing do
         unregistered << klass.identifier
         super(klass)
       end
-      stub_tool(identifier: "first_reset_tool", base: base)
-      stub_tool(identifier: "second_reset_tool", base: base)
+      stub_tool("FirstResetTool", base: base)
+      stub_tool("SecondResetTool", base: base)
 
       Riffer::Testing.reset!
 
@@ -110,7 +112,7 @@ describe Riffer::Testing do
     end
 
     it "forgets the stubs it removed" do
-      stub_tool(identifier: "stubbed_cleared_tool")
+      stub_tool("StubbedClearedTool")
 
       Riffer::Testing.reset!
 
@@ -157,7 +159,7 @@ describe Riffer::Testing do
     end
 
     it "shares tracking between an including test case and the module" do
-      tool = Riffer::Testing.stub_tool(identifier: "stubbed_module_call")
+      tool = Riffer::Testing.stub_tool("StubbedModuleCall")
 
       reset!
 
@@ -169,7 +171,7 @@ describe Riffer::Testing do
     it "resets stubs once a test finishes" do
       test_case = Class.new(Minitest::Test) do
         def test_stubs_a_tool
-          stub_tool(identifier: "stubbed_adapter_cleanup")
+          stub_tool("StubbedAdapterCleanup")
         end
       end
 

--- a/test/riffer/testing_test.rb
+++ b/test/riffer/testing_test.rb
@@ -35,10 +35,62 @@ describe Riffer::Testing do
     expect(Riffer::Tool.find("stubbed_child_tool")).must_be_nil
   end
 
+  it "raises ArgumentError when neither a name nor an identifier is given" do
+    expect { stub_tool }.must_raise Riffer::ArgumentError
+  end
+
   it "raises DuplicateIdentifierError when the identifier is already taken" do
     stub_tool(identifier: "stubbed_duplicate")
 
     expect { stub_tool(identifier: "stubbed_duplicate") }.must_raise Riffer::DuplicateIdentifierError
+  end
+
+  describe "a named stub" do
+    it "assigns the constant and derives the identifier from it" do
+      agent = stub_agent("StubbedNamedAgent")
+
+      expect(Object.const_get(:StubbedNamedAgent)).must_equal agent
+      expect(agent.identifier).must_equal "stubbed_named_agent"
+      expect(Riffer::Agent.find("stubbed_named_agent")).must_equal agent
+    end
+
+    it "accepts a symbol name" do
+      tool = stub_tool(:StubbedSymbolTool)
+
+      expect(Object.const_get(:StubbedSymbolTool)).must_equal tool
+      expect(Riffer::Tool.find("stubbed_symbol_tool")).must_equal tool
+    end
+
+    it "prefers the identifier keyword over the name" do
+      tool = stub_tool("StubbedOverriddenTool", identifier: "stubbed_kwarg_identifier")
+
+      expect(Object.const_get(:StubbedOverriddenTool)).must_equal tool
+      expect(Riffer::Tool.find("stubbed_kwarg_identifier")).must_equal tool
+      expect(Riffer::Tool.find("stubbed_overridden_tool")).must_be_nil
+    end
+
+    it "prefers an identifier declared in the body" do
+      tool = stub_tool("StubbedBodyTool", identifier: "stubbed_kwarg_loses") do
+        identifier "stubbed_body_wins"
+      end
+
+      expect(Riffer::Tool.find("stubbed_body_wins")).must_equal tool
+      expect(Riffer::Tool.find("stubbed_kwarg_loses")).must_be_nil
+    end
+
+    it "raises ArgumentError for a name that is not a simple constant name" do
+      expect { stub_tool("Riffer::StubbedNamespaced") }.must_raise Riffer::ArgumentError
+      expect { stub_tool("stubbed_lowercase") }.must_raise Riffer::ArgumentError
+    end
+
+    it "raises ArgumentError when the constant is already defined" do
+      Object.const_set(:StubbedTakenName, Module.new)
+
+      expect { stub_tool("StubbedTakenName") }.must_raise Riffer::ArgumentError
+      expect(Riffer::Tool.find("stubbed_taken_name")).must_be_nil
+    ensure
+      Object.send(:remove_const, :StubbedTakenName)
+    end
   end
 
   describe "reset!" do
@@ -64,6 +116,38 @@ describe Riffer::Testing do
 
       expect(Riffer::Tool.find("stubbed_cleared_tool")).must_be_nil
       expect(Riffer::Testing.registrations).must_be_empty
+    end
+
+    it "removes the constant a named stub created" do
+      tool = stub_tool("StubbedResetTool")
+
+      Riffer::Testing.reset!
+
+      expect(Object.const_defined?(:StubbedResetTool, false)).must_equal false
+      expect(Riffer::Tool.find("stubbed_reset_tool")).must_be_nil
+      expect(Riffer::Tool.all).wont_include tool
+    end
+
+    it "leaves a constant the test has already replaced" do
+      stub_tool("StubbedReplacedTool")
+      replacement = Module.new
+      Object.send(:remove_const, :StubbedReplacedTool)
+      Object.const_set(:StubbedReplacedTool, replacement)
+
+      Riffer::Testing.reset!
+
+      expect(Object.const_get(:StubbedReplacedTool)).must_equal replacement
+    ensure
+      Object.send(:remove_const, :StubbedReplacedTool) if Object.const_defined?(:StubbedReplacedTool, false)
+    end
+
+    it "tolerates a constant the test has already removed" do
+      tool = stub_tool("StubbedVanishedTool")
+      Object.send(:remove_const, :StubbedVanishedTool)
+
+      Riffer::Testing.reset!
+
+      expect(Riffer::Tool.all).wont_include tool
     end
 
     it "is a no-op when nothing is stubbed" do

--- a/test/riffer/tool_test.rb
+++ b/test/riffer/tool_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 describe Riffer::Tool do
   let(:weather_tool_class) do
-    Class.new(Riffer::Tool) do
+    stub_tool("WeatherTool") do
       description "Gets the current weather"
 
       params do
@@ -19,7 +19,7 @@ describe Riffer::Tool do
   end
 
   let(:simple_tool_class) do
-    Class.new(Riffer::Tool) do
+    stub_tool("SimpleTool") do
       description "A simple tool"
 
       def call(context:, **_kwargs)
@@ -30,7 +30,7 @@ describe Riffer::Tool do
 
   describe "#call" do
     it "raises NotImplementedError when not implemented" do
-      tool_class = Class.new(Riffer::Tool)
+      tool_class = stub_tool("Tool")
       tool = tool_class.new
 
       expect { tool.call(context: nil) }.must_raise(NotImplementedError)
@@ -44,7 +44,7 @@ describe Riffer::Tool do
     end
 
     it "receives context" do
-      tool_class = Class.new(Riffer::Tool) do
+      tool_class = stub_tool("Tool") do
         def call(context:, **_kwargs)
           text(context[:user_id])
         end
@@ -80,7 +80,7 @@ describe Riffer::Tool do
     end
 
     it "passes context to call" do
-      tool_class = Class.new(Riffer::Tool) do
+      tool_class = stub_tool("Tool") do
         params do
           required :name, String
         end
@@ -103,7 +103,7 @@ describe Riffer::Tool do
     end
 
     it "returns a timeout_error response when execution exceeds timeout" do
-      slow_tool_class = Class.new(Riffer::Tool) do
+      slow_tool_class = stub_tool("SlowTool") do
         timeout 0.01
 
         def call(context:)
@@ -119,7 +119,7 @@ describe Riffer::Tool do
     end
 
     it "includes timeout duration in error message" do
-      slow_tool_class = Class.new(Riffer::Tool) do
+      slow_tool_class = stub_tool("SlowTool") do
         timeout 0.01
 
         def call(context:)
@@ -134,7 +134,7 @@ describe Riffer::Tool do
     end
 
     it "returns an unhandled_error response for a Timeout::Error raised by the tool body" do
-      external_timeout_tool_class = Class.new(Riffer::Tool) do
+      external_timeout_tool_class = stub_tool("ExternalTimeoutTool") do
         def call(context:)
           raise Timeout::Error, "external service timed out"
         end
@@ -147,7 +147,7 @@ describe Riffer::Tool do
     end
 
     it "returns a timeout_error response for a Riffer::TimeoutError raised by the tool body" do
-      timeout_raising_tool_class = Class.new(Riffer::Tool) do
+      timeout_raising_tool_class = stub_tool("TimeoutRaisingTool") do
         def call(context:)
           raise Riffer::TimeoutError
         end
@@ -159,7 +159,7 @@ describe Riffer::Tool do
     end
 
     it "returns an unhandled_error response for a Riffer::ValidationError raised by the tool body" do
-      validation_raising_tool_class = Class.new(Riffer::Tool) do
+      validation_raising_tool_class = stub_tool("ValidationRaisingTool") do
         def call(context:)
           raise Riffer::ValidationError, "nested validation failed"
         end
@@ -172,7 +172,7 @@ describe Riffer::Tool do
     end
 
     it "completes successfully when within timeout" do
-      fast_tool_class = Class.new(Riffer::Tool) do
+      fast_tool_class = stub_tool("FastTool") do
         timeout 1
 
         def call(context:)
@@ -187,7 +187,7 @@ describe Riffer::Tool do
     end
 
     it "returns an execution_error response for ToolExecutionError" do
-      failing_tool_class = Class.new(Riffer::Tool) do
+      failing_tool_class = stub_tool("FailingTool") do
         def call(context:)
           raise Riffer::ToolExecutionError, "Expected failure"
         end
@@ -201,7 +201,7 @@ describe Riffer::Tool do
     end
 
     it "carries no exception on a deliberate error response" do
-      failing_tool_class = Class.new(Riffer::Tool) do
+      failing_tool_class = stub_tool("FailingTool") do
         def call(context:)
           raise Riffer::ToolExecutionError, "Expected failure"
         end
@@ -213,7 +213,7 @@ describe Riffer::Tool do
     end
 
     it "folds an arbitrary StandardError into an unhandled_error response" do
-      buggy_tool_class = Class.new(Riffer::Tool) do
+      buggy_tool_class = stub_tool("BuggyTool") do
         def call(context:)
           raise "Something went wrong"
         end
@@ -227,7 +227,7 @@ describe Riffer::Tool do
     end
 
     it "folds a programming bug into an unhandled_error response" do
-      buggy_tool_class = Class.new(Riffer::Tool) do
+      buggy_tool_class = stub_tool("BuggyTool") do
         def call(context:)
           nil.nonexistent_method
         end
@@ -240,7 +240,7 @@ describe Riffer::Tool do
     end
 
     it "carries the rescued exception on an unhandled_error response" do
-      buggy_tool_class = Class.new(Riffer::Tool) do
+      buggy_tool_class = stub_tool("BuggyTool") do
         def call(context:)
           raise "Something went wrong"
         end
@@ -253,7 +253,7 @@ describe Riffer::Tool do
     end
 
     it "returns an unhandled_error response when tool does not return Response" do
-      bad_tool_class = Class.new(Riffer::Tool) do
+      bad_tool_class = stub_tool("BadTool") do
         def call(context:)
           "raw string instead of Response"
         end
@@ -266,7 +266,7 @@ describe Riffer::Tool do
     end
 
     it "raises NotImplementedError when call is not implemented" do
-      tool_class = Class.new(Riffer::Tool)
+      tool_class = stub_tool("Tool")
 
       expect { tool_class.new.call_with_validation(context: nil) }.must_raise(NotImplementedError)
     end

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -4,8 +4,7 @@ require "test_helper"
 
 describe Riffer::Tools::Runtime do
   let(:weather_tool_class) do
-    Class.new(Riffer::Tool) do
-      identifier "weather_tool"
+    stub_tool("WeatherTool") do
       description "Gets the weather"
 
       params do
@@ -19,8 +18,7 @@ describe Riffer::Tools::Runtime do
   end
 
   let(:slow_tool_class) do
-    Class.new(Riffer::Tool) do
-      identifier "slow_tool"
+    stub_tool("SlowTool") do
       description "A slow tool"
       timeout 0.01
 
@@ -121,8 +119,7 @@ describe Riffer::Tools::Runtime do
     end
 
     it "returns unhandled_error response for RuntimeError" do
-      error_tool = Class.new(Riffer::Tool) do
-        identifier "error_tool"
+      error_tool = stub_tool("ErrorTool") do
         description "Raises an error"
 
         def call(context:, **)
@@ -141,8 +138,7 @@ describe Riffer::Tools::Runtime do
     end
 
     it "returns error response for ToolExecutionError" do
-      error_tool = Class.new(Riffer::Tool) do
-        identifier "tool_exec_error_tool"
+      error_tool = stub_tool("ToolExecErrorTool") do
         description "Raises a ToolExecutionError"
 
         def call(context:, **)
@@ -161,8 +157,7 @@ describe Riffer::Tools::Runtime do
     end
 
     it "returns unhandled_error response for NoMethodError, carrying the exception" do
-      buggy_tool = Class.new(Riffer::Tool) do
-        identifier "buggy_tool"
+      buggy_tool = stub_tool("BuggyTool") do
         description "Has a bug"
 
         def call(context:, **)
@@ -323,8 +318,7 @@ describe Riffer::Tools::Runtime do
     end
 
     let(:buggy_tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "buggy_tool"
+      stub_tool("BuggyTool") do
         description "Has a bug"
 
         def call(context:, **)
@@ -344,8 +338,7 @@ describe Riffer::Tools::Runtime do
     end
 
     let(:tool_class) do
-      Class.new(Riffer::Tool) do
-        identifier "integration_tool"
+      stub_tool("IntegrationTool") do
         description "Traced tool"
         def call(context:)
           text("done")
@@ -355,7 +348,7 @@ describe Riffer::Tools::Runtime do
 
     let(:agent_class_with_tools) do
       tc = tool_class
-      Class.new(Riffer::Agent) do
+      stub_agent do
         identifier "traced-agent"
         model "mock/riffer-1"
         uses_tools [tc]
@@ -555,8 +548,7 @@ describe Riffer::Tools::Runtime::Inline do
   end
 
   it "executes tool calls sequentially" do
-    weather_tool = Class.new(Riffer::Tool) do
-      identifier "weather_tool"
+    weather_tool = stub_tool("WeatherTool") do
       description "Gets the weather"
 
       params do
@@ -584,8 +576,7 @@ describe Riffer::Tools::Runtime::Fibers do
   it "executes tool calls concurrently" do
     seen = []
 
-    tracking_tool = Class.new(Riffer::Tool) do
-      identifier "tracking_tool"
+    tracking_tool = stub_tool("TrackingTool") do
       description "Tracks fibers"
 
       define_method(:call) do |context:, **|
@@ -614,8 +605,7 @@ describe Riffer::Tools::Runtime::Threaded do
     thread_ids = Mutex.new
     seen = []
 
-    tracking_tool = Class.new(Riffer::Tool) do
-      identifier "tracking_tool"
+    tracking_tool = stub_tool("TrackingTool") do
       description "Tracks threads"
 
       define_method(:call) do |context:, **|

--- a/test/shipped_signatures_test.rb
+++ b/test/shipped_signatures_test.rb
@@ -13,7 +13,7 @@ describe "shipped RBS signatures" do
     shipped_dirs = %w[generated manual]
 
     # Root namespaces of optional dependencies that must not leak into shipped sigs.
-    forbidden_roots = %w[OpenAI Anthropic Aws MCP Async Zeitwerk Seahorse Faraday]
+    forbidden_roots = %w[OpenAI Anthropic Aws MCP Async Zeitwerk Seahorse Faraday RSpec Minitest]
 
     # Matches the root segment of a qualified RBS type reference, allowing a leading `::` and
     # ignoring segments nested under another namespace — so `Riffer::Providers::OpenAI` has

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require "minitest/autorun"
 require "minitest/spec"
 
 require "riffer"
+require "riffer/testing/minitest"
 
 require "vcr"
 require "webmock/minitest"


### PR DESCRIPTION
## Problem

`Riffer::Registrable` derives membership from `Class#subclasses`, which keeps returning superseded class generations — RSpec's `stub_const` re-creates a class per example, and Zeitwerk dev-mode reload does the same. Old generations linger with the same name and identifier until GC, so the first `find` after a reload or across stubbed examples could raise `DuplicateIdentifierError` from classes whose constant already points at a newer object.

Downstream test suites also had no sanctioned way to make an ephemeral tool or agent class resolvable by identifier — and per review feedback, consumer tests shouldn't need any knowledge of the registry to do it.

## Solution

Three layers:

- **Liveness filter.** `build_identifier_registry` keeps only subclasses whose real name still resolves back to the same object, walking each namespace segment with `autoload?(segment, false)` / `const_get(segment, false)` so probing a pending autoload never triggers a load mid-build. The check runs at rebuild time only — `find`/`all` stay O(1) memoized hash reads; a constant removed or restored with no subsequent rebuild trigger keeps serving the old memo until the next rebuild, a documented trade-off.
- **Minimal explicit-registration primitives.** Public `register(klass)` / `unregister(klass)` on `Registrable`: identifier from the class itself, direct subclass only, `Riffer::DuplicateIdentifierError` for any identifier collision between distinct classes in both directions (a class present in both the explicit overlay and the implicit sweep is not a duplicate of itself). Unsynchronized, matching `Providers::Repository`.
- **`Riffer::Testing`** — the consumer-facing story. `stub_agent("FaqAgent") { … }` / `stub_tool(...)` build a subclass, optionally assign it a top-level constant (so workflow runners or persisted class names resolve it like a real class, with the identifier derived from the name exactly as in production — a stub that needs no constant sets `identifier "..."` in its block, like any other config), evaluate the body, and register it in one call; `Riffer::Testing.reset!` removes everything stubbed since the last reset. Opt-in one-line adapters (`require "riffer/testing/rspec"` / `require "riffer/testing/minitest"`) wire the cleanup into each framework's lifecycle, so tests never see the registry. A leaked stub fails loudly — the next stub of the same identifier raises, pointing at missing adapter wiring. The adapters are Zeitwerk-ignored and neither rspec nor minitest becomes a dependency.

An earlier `with_registered` block API was removed in favor of the factories. New `docs/TESTING.md` is the consumer guide; riffer's own suite dogfoods the factories and the minitest adapter throughout (~300 call sites converted from ad-hoc `Class.new` fixtures).

## Proof

CI covers it: 33 new tests across `test/riffer/registrable_test.rb` and `test/riffer/testing_test.rb`, including regression tests verified red without each guard (pending-autoload segment walk, register guard ordering, self-collision identity exemption, adapter cleanup via an inner `Minitest::Test`). Eager-load test proves the Zeitwerk ignores; `shipped_signatures_test` forbids `RSpec`/`Minitest` types in shipped sigs. Full `bin/rake` (2284 runs, RuboCop, Steep) and `bin/rake docs:check` (28 pages) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable testing helpers for stubbing agents and tools, with registration tracking and reset support.
  - Added RSpec and Minitest integrations for automatic test cleanup.
  - Added explicit registration and unregistration for agents and tools.
  - Improved handling of anonymous and renamed classes during registry lookups.

- **Bug Fixes**
  - Registry rebuilding now removes stale implicit registrations while preserving explicit registrations.

- **Documentation**
  - Expanded registration guidance and added a dedicated testing guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

