### PR TITLE
feat: expand finish reason vocabulary and close provider gaps

### DIFF
--- a/docs/MESSAGES.md
+++ b/docs/MESSAGES.md
@@ -83,16 +83,18 @@ The cache buckets are subsets of `input_tokens`, never additions to it — summi
 
 `finish_reason` carries the same meaning for every provider — each adapter maps its raw wire value (Anthropic's `end_turn`, OpenAI's response status, Gemini's `STOP`, …) into a normalized vocabulary:
 
-| Value             | Meaning                                                         |
-| ----------------- | --------------------------------------------------------------- |
-| `:stop`           | The model finished its turn naturally (or hit a stop sequence). |
-| `:length`         | Output was truncated at the max-token limit.                    |
-| `:tool_calls`     | The model stopped to call tools.                                |
-| `:content_filter` | A provider safety system blocked or cut the response.           |
-| `:error`          | The provider reported an error finish.                          |
-| `:other`          | A provider-specific value with no normalized equivalent.        |
+| Value               | Meaning                                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `:stop`             | The model finished its turn naturally (or hit a stop sequence).                                                         |
+| `:length`           | Output was truncated at the max-token limit.                                                                            |
+| `:tool_calls`       | The model stopped to call tools.                                                                                        |
+| `:content_filter`   | A provider safety system blocked or cut the response.                                                                   |
+| `:context_window`   | Input plus output hit the model's context window; trim or compact history rather than raising `max_tokens`.             |
+| `:malformed_output` | The model emitted output the provider could not parse, such as an invalid tool call; retry or nudge rather than backing off. |
+| `:error`            | The provider reported an error finish.                                                                                  |
+| `:other`            | A provider-specific value with no normalized equivalent.                                                                |
 
-`finish_reason` is `nil` when the provider doesn't report one. Use it to detect truncation without parsing provider responses:
+`finish_reason` is `nil` when the provider doesn't report one. The provider's raw wire value travels alongside on the `FinishReasonDone` stream event and the `riffer.finish_reason.raw` trace attribute — for OpenRouter that is the upstream model's `native_finish_reason`, and for a failed OpenAI response it is the error code. Use `finish_reason` to detect truncation without parsing provider responses:
 
 ```ruby
 response = agent.generate("Summarize this document")

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -153,7 +153,7 @@ Usage on this span is the run total, aggregated across every step. See [Token us
 | `gen_ai.output.messages`                   | string   | When `capture_messages` is on (JSON)                                          |
 | `error.type`                               | string   | On an unhandled exception                                                     |
 
-`gen_ai.response.finish_reasons` is an array of exactly one normalized value, from the fixed vocabulary `stop`, `length`, `tool_calls`, `content_filter`, `error`, `other`. When the provider's raw wire value carries more nuance than the normalized one, the raw string is preserved on `riffer.finish_reason.raw`.
+`gen_ai.response.finish_reasons` is an array of exactly one normalized value, from the fixed vocabulary `stop`, `length`, `tool_calls`, `content_filter`, `context_window`, `malformed_output`, `error`, `other`. When the provider's raw wire value carries more nuance than the normalized one, the raw string is preserved on `riffer.finish_reason.raw`.
 
 ## `execute_tool {tool}` — the tool call span
 

--- a/docs/providers/CUSTOM_PROVIDERS.md
+++ b/docs/providers/CUSTOM_PROVIDERS.md
@@ -252,7 +252,7 @@ Riffer::StreamEvents::FinishReasonDone.new(
 
 ## Finish Reasons
 
-`Riffer::Providers::FinishReason` is the same kind of normalized contract — map your provider's raw finish/stop value into the vocabulary defined in [Messages — Finish Reasons](../MESSAGES.md#finish-reasons) (`:stop`, `:length`, `:tool_calls`, `:content_filter`, `:error`, `:other`), keeping the raw wire value alongside:
+`Riffer::Providers::FinishReason` is the same kind of normalized contract — map your provider's raw finish/stop value into the vocabulary defined in [Messages — Finish Reasons](../MESSAGES.md#finish-reasons) (`:stop`, `:length`, `:tool_calls`, `:content_filter`, `:context_window`, `:malformed_output`, `:error`, `:other`), keeping the raw wire value alongside:
 
 ```ruby
 def extract_finish_reason(response)

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -17,6 +17,9 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     "tool_use" => :tool_calls,
     "guardrail_intervened" => :content_filter,
     "content_filtered" => :content_filter,
+    "malformed_model_output" => :malformed_output,
+    "malformed_tool_use" => :malformed_output,
+    "model_context_window_exceeded" => :context_window,
   }.freeze #: Hash[String, Symbol]
 
   # Returns the skill adapter for the Bedrock model — XML for Anthropic models

--- a/lib/riffer/providers/anthropic.rb
+++ b/lib/riffer/providers/anthropic.rb
@@ -12,6 +12,10 @@ class Riffer::Providers::Anthropic < Riffer::Providers::Base
     "max_tokens" => :length,
     "tool_use" => :tool_calls,
     "refusal" => :content_filter,
+    "model_context_window_exceeded" => :context_window,
+    # A paused server-tool turn resumes only by re-sending the response; the
+    # agent loop does not do that, so it has no normalized equivalent.
+    "pause_turn" => :other,
   }.freeze #: Hash[String, Symbol]
 
   # Returns the XML skill adapter for Anthropic/Claude.

--- a/lib/riffer/providers/finish_reason.rb
+++ b/lib/riffer/providers/finish_reason.rb
@@ -5,7 +5,7 @@
 # wire value. +reason+ carries the same meaning for every provider.
 class Riffer::Providers::FinishReason
   # The normalized vocabulary every provider maps into.
-  VALUES = %i[stop length tool_calls content_filter error other].freeze #: Array[Symbol]
+  VALUES = %i[stop length tool_calls content_filter context_window malformed_output error other].freeze #: Array[Symbol]
 
   # The normalized reason.
   attr_reader :reason #: Symbol

--- a/lib/riffer/providers/gemini.rb
+++ b/lib/riffer/providers/gemini.rb
@@ -17,7 +17,16 @@ class Riffer::Providers::Gemini < Riffer::Providers::Base
     "PROHIBITED_CONTENT" => :content_filter,
     "SPII" => :content_filter,
     "IMAGE_SAFETY" => :content_filter,
-    "MALFORMED_FUNCTION_CALL" => :error,
+    "IMAGE_PROHIBITED_CONTENT" => :content_filter,
+    "IMAGE_RECITATION" => :content_filter,
+    "LANGUAGE" => :content_filter,
+    "MALFORMED_FUNCTION_CALL" => :malformed_output,
+    "UNEXPECTED_TOOL_CALL" => :malformed_output,
+    "NO_IMAGE" => :error,
+    "TOO_MANY_TOOL_CALLS" => :other,
+    "OTHER" => :other,
+    "IMAGE_OTHER" => :other,
+    "FINISH_REASON_UNSPECIFIED" => :other,
   }.freeze #: Hash[String, Symbol]
 
   # The GenAI semconv well-known provider name.

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -148,7 +148,7 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     when :incomplete
       incomplete_finish_reason(typed_response)
     when :failed
-      Riffer::Providers::FinishReason.new(reason: :error, raw: "failed")
+      Riffer::Providers::FinishReason.new(reason: :error, raw: typed_response.error&.code&.to_s || "failed")
     else
       Riffer::Providers::FinishReason.new(reason: :other, raw: status.to_s)
     end

--- a/lib/riffer/providers/open_ai.rb
+++ b/lib/riffer/providers/open_ai.rb
@@ -5,6 +5,21 @@
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
   WEB_SEARCH_TOOL_TYPE = "web_search_preview" #: String
 
+  # The Responses API has no finish_reason field. The response +status+ is
+  # the primary signal; an +incomplete+ status is only meaningful together
+  # with <tt>incomplete_details.reason</tt>, so that branch nests one level.
+  FINISH_REASONS = {
+    "completed" => :stop,
+    "incomplete" => {
+      "max_output_tokens" => :length,
+      "content_filter" => :content_filter,
+    },
+    "failed" => :error,
+    "cancelled" => :other,
+    "in_progress" => :other,
+    "queued" => :other,
+  }.freeze #: Hash[String, Symbol | Hash[String, Symbol]]
+
   # The GenAI semconv well-known provider name.
   #--
   #: () -> String
@@ -133,40 +148,32 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
     build_finish_reason(response)
   end
 
-  # The Responses API reports no finish_reason field, so one is derived.
   #--
   #: (untyped) -> Riffer::Providers::FinishReason?
   def build_finish_reason(response)
     typed_response = response #: OpenAI::Models::Responses::Response
-    status = typed_response.status
+    status = typed_response.status&.to_s
     return nil unless status
 
-    case status.to_sym
-    when :completed
-      reason = extract_tool_calls(typed_response).empty? ? :stop : :tool_calls
-      Riffer::Providers::FinishReason.new(reason: reason, raw: "completed")
-    when :incomplete
-      incomplete_finish_reason(typed_response)
-    when :failed
-      Riffer::Providers::FinishReason.new(reason: :error, raw: typed_response.error&.code&.to_s || "failed")
-    else
-      Riffer::Providers::FinishReason.new(reason: :other, raw: status.to_s)
-    end
+    detail = finish_detail(typed_response, status)
+    mapping = FINISH_REASONS.fetch(status, :other)
+    reason = mapping.is_a?(Hash) ? mapping.fetch(detail.to_s, :other) : mapping
+    # A completed response signals tool use only through its output items.
+    reason = :tool_calls if reason == :stop && !extract_tool_calls(typed_response).empty?
+
+    Riffer::Providers::FinishReason.new(reason: reason, raw: detail || status)
   end
 
+  # The nested field that names the cause behind an ambiguous status.
   #--
-  #: (untyped) -> Riffer::Providers::FinishReason
-  def incomplete_finish_reason(response)
+  #: (untyped, String) -> String?
+  def finish_detail(response, status)
     typed_response = response #: OpenAI::Models::Responses::Response
-    raw = typed_response.incomplete_details&.reason&.to_s
 
-    reason = case raw
-             when "max_output_tokens" then :length
-             when "content_filter" then :content_filter
-             else :other
-             end
-
-    Riffer::Providers::FinishReason.new(reason: reason, raw: raw || "incomplete")
+    case status
+    when "incomplete" then typed_response.incomplete_details&.reason&.to_s
+    when "failed" then typed_response.error&.code&.to_s
+    end
   end
 
   #--

--- a/lib/riffer/providers/open_router.rb
+++ b/lib/riffer/providers/open_router.rb
@@ -133,18 +133,30 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
   #: (untyped) -> Riffer::Providers::FinishReason?
   def extract_finish_reason(response)
     typed_response = response #: OpenAI::Models::Chat::ChatCompletion
-    build_finish_reason(typed_response.choices.first&.finish_reason)
+    choice = typed_response.choices.first
+    build_finish_reason(choice&.finish_reason, native: native_finish_reason(choice))
   end
 
+  # +native+ is the upstream model's own finish reason, which OpenRouter
+  # reports alongside its normalized one; it wins as +raw+ when present.
   #--
-  #: (untyped) -> Riffer::Providers::FinishReason?
-  def build_finish_reason(finish_reason)
+  #: (untyped, ?native: untyped) -> Riffer::Providers::FinishReason?
+  def build_finish_reason(finish_reason, native: nil)
     return nil unless finish_reason
 
-    raw = finish_reason.to_s
-    return nil if raw.empty?
+    normalized = finish_reason.to_s
+    return nil if normalized.empty?
 
-    Riffer::Providers::FinishReason.new(reason: FINISH_REASONS.fetch(raw, :other), raw: raw)
+    raw = native.to_s.empty? ? normalized : native.to_s
+    Riffer::Providers::FinishReason.new(reason: FINISH_REASONS.fetch(normalized, :other), raw: raw)
+  end
+
+  # +native_finish_reason+ is outside the OpenAI schema, so it is only
+  # reachable through the SDK model's raw data hash.
+  #--
+  #: (untyped) -> untyped
+  def native_finish_reason(choice)
+    choice && choice.to_h[:native_finish_reason]
   end
 
   #--
@@ -187,6 +199,7 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
       reasoning: +"",
       tool_calls: {},
       finish_reason: nil,
+      native_finish_reason: nil,
     } #: Hash[Symbol, untyped]
 
     # Use stream_raw (not stream) — the latter yields a higher-level
@@ -211,7 +224,7 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
 
     yielder << Riffer::StreamEvents::TextDone.new(state[:text]) unless state[:text].empty?
     yielder << Riffer::StreamEvents::ReasoningDone.new(state[:reasoning]) unless state[:reasoning].empty?
-    yield_finish_reason(yielder, build_finish_reason(state[:finish_reason]))
+    yield_finish_reason(yielder, build_finish_reason(state[:finish_reason], native: state[:native_finish_reason]))
   end
 
   #--
@@ -228,6 +241,7 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
     end
 
     state[:finish_reason] = choice.finish_reason if choice&.finish_reason
+    state[:native_finish_reason] = native_finish_reason(choice) || state[:native_finish_reason]
 
     emit_tool_call_done_events(state: state, yielder: yielder) if choice && finish_reason_is_tool_calls?(choice)
 

--- a/sig/generated/riffer/providers/open_ai.rbs
+++ b/sig/generated/riffer/providers/open_ai.rbs
@@ -4,6 +4,11 @@
 class Riffer::Providers::OpenAI < Riffer::Providers::Base
   WEB_SEARCH_TOOL_TYPE: String
 
+  # The Responses API has no finish_reason field. The response +status+ is
+  # the primary signal; an +incomplete+ status is only meaningful together
+  # with <tt>incomplete_details.reason</tt>, so that branch nests one level.
+  FINISH_REASONS: Hash[String, Symbol | Hash[String, Symbol]]
+
   # The GenAI semconv well-known provider name.
   # --
   # : () -> String
@@ -50,14 +55,14 @@ class Riffer::Providers::OpenAI < Riffer::Providers::Base
   # : (untyped) -> Riffer::Providers::FinishReason?
   def extract_finish_reason: (untyped) -> Riffer::Providers::FinishReason?
 
-  # The Responses API reports no finish_reason field, so one is derived.
   # --
   # : (untyped) -> Riffer::Providers::FinishReason?
   def build_finish_reason: (untyped) -> Riffer::Providers::FinishReason?
 
+  # The nested field that names the cause behind an ambiguous status.
   # --
-  # : (untyped) -> Riffer::Providers::FinishReason
-  def incomplete_finish_reason: (untyped) -> Riffer::Providers::FinishReason
+  # : (untyped, String) -> String?
+  def finish_detail: (untyped, String) -> String?
 
   # --
   # : (untyped) -> String

--- a/sig/generated/riffer/providers/open_router.rbs
+++ b/sig/generated/riffer/providers/open_router.rbs
@@ -57,9 +57,17 @@ class Riffer::Providers::OpenRouter < Riffer::Providers::Base
   # : (untyped) -> Riffer::Providers::FinishReason?
   def extract_finish_reason: (untyped) -> Riffer::Providers::FinishReason?
 
+  # +native+ is the upstream model's own finish reason, which OpenRouter
+  # reports alongside its normalized one; it wins as +raw+ when present.
   # --
-  # : (untyped) -> Riffer::Providers::FinishReason?
-  def build_finish_reason: (untyped) -> Riffer::Providers::FinishReason?
+  # : (untyped, ?native: untyped) -> Riffer::Providers::FinishReason?
+  def build_finish_reason: (untyped, ?native: untyped) -> Riffer::Providers::FinishReason?
+
+  # +native_finish_reason+ is outside the OpenAI schema, so it is only
+  # reachable through the SDK model's raw data hash.
+  # --
+  # : (untyped) -> untyped
+  def native_finish_reason: (untyped) -> untyped
 
   # --
   # : (untyped) -> String

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -191,6 +191,14 @@ describe Riffer::Messages::Assistant do
       expect(message.finish_reason).must_be_nil
     end
 
+    it "accepts context_window and malformed_output" do
+      reasons = %i[context_window malformed_output].map do |reason|
+        Riffer::Messages::Assistant.new("Cut", finish_reason: reason).finish_reason
+      end
+
+      expect(reasons).must_equal %i[context_window malformed_output]
+    end
+
     it "raises on a value outside the normalized vocabulary" do
       error = expect { Riffer::Messages::Assistant.new("Bad", finish_reason: :bogus) }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_include ":bogus"

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -48,6 +48,18 @@ describe Riffer::Providers::AmazonBedrock do
       expect(provider.send(:build_finish_reason, "content_filtered").reason).must_equal :content_filter
     end
 
+    it "normalizes malformed_model_output to malformed_output" do
+      expect(provider.send(:build_finish_reason, "malformed_model_output").reason).must_equal :malformed_output
+    end
+
+    it "normalizes malformed_tool_use to malformed_output" do
+      expect(provider.send(:build_finish_reason, "malformed_tool_use").reason).must_equal :malformed_output
+    end
+
+    it "normalizes model_context_window_exceeded to context_window" do
+      expect(provider.send(:build_finish_reason, "model_context_window_exceeded").reason).must_equal :context_window
+    end
+
     it "normalizes unknown values to other and keeps the raw value" do
       finish_reason = provider.send(:build_finish_reason, "mystery")
 

--- a/test/riffer/providers/anthropic_test.rb
+++ b/test/riffer/providers/anthropic_test.rb
@@ -53,10 +53,20 @@ describe Riffer::Providers::Anthropic do
       expect(provider.send(:build_finish_reason, :refusal).reason).must_equal :content_filter
     end
 
-    it "normalizes unknown values to other and keeps the raw value" do
+    it "normalizes model_context_window_exceeded to context_window" do
+      expect(provider.send(:build_finish_reason, :model_context_window_exceeded).reason).must_equal :context_window
+    end
+
+    it "normalizes pause_turn to other and keeps the raw value" do
       finish_reason = provider.send(:build_finish_reason, :pause_turn)
 
       expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "pause_turn"]
+    end
+
+    it "normalizes unknown values to other and keeps the raw value" do
+      finish_reason = provider.send(:build_finish_reason, :mystery)
+
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "mystery"]
     end
 
     it "returns nil without a stop reason" do

--- a/test/riffer/providers/finish_reason_test.rb
+++ b/test/riffer/providers/finish_reason_test.rb
@@ -22,6 +22,12 @@ describe Riffer::Providers::FinishReason do
       expect(finish_reason.raw).must_be_nil
     end
 
+    it "accepts every value in the vocabulary" do
+      reasons = Riffer::Providers::FinishReason::VALUES.map { |v| Riffer::Providers::FinishReason.new(reason: v).reason }
+
+      expect(reasons).must_equal %i[stop length tool_calls content_filter context_window malformed_output error other]
+    end
+
     it "raises on a reason outside the vocabulary" do
       error = expect { Riffer::Providers::FinishReason.new(reason: :bogus) }.must_raise(Riffer::ArgumentError)
       expect(error.message).must_include ":bogus"

--- a/test/riffer/providers/gemini_test.rb
+++ b/test/riffer/providers/gemini_test.rb
@@ -39,14 +39,36 @@ describe Riffer::Providers::Gemini do
       expect(provider.send(:build_finish_reason, "SAFETY", tool_calls: false).reason).must_equal :content_filter
     end
 
-    it "normalizes MALFORMED_FUNCTION_CALL to error" do
-      expect(provider.send(:build_finish_reason, "MALFORMED_FUNCTION_CALL", tool_calls: false).reason).must_equal :error
+    it "normalizes every safety-style value to content_filter" do
+      raws = %w[RECITATION BLOCKLIST PROHIBITED_CONTENT SPII IMAGE_SAFETY IMAGE_PROHIBITED_CONTENT IMAGE_RECITATION
+                LANGUAGE]
+      reasons = raws.map { |raw| provider.send(:build_finish_reason, raw, tool_calls: false).reason }.uniq
+
+      expect(reasons).must_equal [:content_filter]
+    end
+
+    it "normalizes MALFORMED_FUNCTION_CALL and UNEXPECTED_TOOL_CALL to malformed_output" do
+      raws = %w[MALFORMED_FUNCTION_CALL UNEXPECTED_TOOL_CALL]
+      reasons = raws.map { |raw| provider.send(:build_finish_reason, raw, tool_calls: false).reason }.uniq
+
+      expect(reasons).must_equal [:malformed_output]
+    end
+
+    it "normalizes NO_IMAGE to error" do
+      expect(provider.send(:build_finish_reason, "NO_IMAGE", tool_calls: false).reason).must_equal :error
+    end
+
+    it "normalizes catch-all values to other" do
+      raws = %w[TOO_MANY_TOOL_CALLS OTHER IMAGE_OTHER FINISH_REASON_UNSPECIFIED]
+      reasons = raws.map { |raw| provider.send(:build_finish_reason, raw, tool_calls: false).reason }.uniq
+
+      expect(reasons).must_equal [:other]
     end
 
     it "normalizes unknown values to other and keeps the raw value" do
-      finish_reason = provider.send(:build_finish_reason, "LANGUAGE", tool_calls: false)
+      finish_reason = provider.send(:build_finish_reason, "MYSTERY", tool_calls: false)
 
-      expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "LANGUAGE"]
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "MYSTERY"]
     end
 
     it "returns nil without a finish reason" do

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -74,6 +74,29 @@ describe Riffer::Providers::OpenAI do
       expect(provider.send(:build_finish_reason, response)).must_be_nil
     end
 
+    it "maps each status without a nested detail, keeping the status as raw" do
+      derived = %w[completed failed cancelled in_progress queued].to_h do |status|
+        response = Struct.new(:status, :output, :error).new(status.to_sym, [], nil)
+        finish_reason = provider.send(:build_finish_reason, response)
+        [status, [finish_reason.reason, finish_reason.raw]]
+      end
+
+      expect(derived).must_equal(
+        "completed" => [:stop, "completed"],
+        "failed" => [:error, "failed"],
+        "cancelled" => [:other, "cancelled"],
+        "in_progress" => [:other, "in_progress"],
+        "queued" => [:other, "queued"],
+      )
+    end
+
+    it "covers every response status the SDK defines" do
+      provider # loads the openai gem, which the provider requires lazily
+      statuses = OpenAI::Models::Responses::ResponseStatus.values.map(&:to_s)
+
+      expect(Riffer::Providers::OpenAI::FINISH_REASONS.keys.sort).must_equal statuses.sort
+    end
+
     it "extracts the finish reason when generating" do
       VCR.use_cassette("Riffer_Providers_OpenAI/_generate_text/when_prompt_is_provided/returns_an_Assistant_message") do
         result = provider.generate_text(prompt: "Say hello", model: "gpt-5-mini")

--- a/test/riffer/providers/open_ai_test.rb
+++ b/test/riffer/providers/open_ai_test.rb
@@ -53,10 +53,19 @@ describe Riffer::Providers::OpenAI do
       expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "incomplete"]
     end
 
-    it "derives error from a failed response" do
-      response = Struct.new(:status).new(:failed)
+    it "derives error from a failed response and keeps the error code as raw" do
+      error = Struct.new(:code).new(:rate_limit_exceeded)
+      response = Struct.new(:status, :error).new(:failed, error)
+      finish_reason = provider.send(:build_finish_reason, response)
 
-      expect(provider.send(:build_finish_reason, response).reason).must_equal :error
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:error, "rate_limit_exceeded"]
+    end
+
+    it "falls back to failed as raw when a failed response carries no error code" do
+      response = Struct.new(:status, :error).new(:failed, nil)
+      finish_reason = provider.send(:build_finish_reason, response)
+
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:error, "failed"]
     end
 
     it "returns nil without a status" do

--- a/test/riffer/providers/open_router_test.rb
+++ b/test/riffer/providers/open_router_test.rb
@@ -49,6 +49,26 @@ describe Riffer::Providers::OpenRouter do
       expect([finish_reason.reason, finish_reason.raw]).must_equal [:other, "model_length"]
     end
 
+    it "prefers the upstream native finish reason as raw" do
+      finish_reason = provider.send(:build_finish_reason, :tool_calls, native: "tool_use")
+
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:tool_calls, "tool_use"]
+    end
+
+    it "falls back to the normalized value as raw without a native finish reason" do
+      finish_reason = provider.send(:build_finish_reason, :stop, native: "")
+
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:stop, "stop"]
+    end
+
+    it "reads native_finish_reason from the choice's raw data" do
+      choice = Struct.new(:finish_reason, :native_finish_reason).new(:stop, "end_turn")
+      response = Struct.new(:choices).new([choice])
+      finish_reason = provider.send(:extract_finish_reason, response)
+
+      expect([finish_reason.reason, finish_reason.raw]).must_equal [:stop, "end_turn"]
+    end
+
     it "returns nil without a finish reason" do
       expect(provider.send(:build_finish_reason, nil)).must_be_nil
     end
@@ -883,6 +903,16 @@ describe Riffer::Providers::OpenRouter do
       expect(done_events.first.name).must_equal "get_weather"
       expect(done_events.first.arguments).must_equal '{"city":"Toronto"}'
       expect(done_events.first.call_id).must_equal "call_abc"
+    end
+
+    it "carries the upstream native finish reason as raw on FinishReasonDone" do
+      native_choice_struct = Struct.new(:delta, :finish_reason, :native_finish_reason)
+      chunk = chunk_struct.new(choices: [native_choice_struct.new(nil, "stop", "end_turn")], usage: nil)
+      install_chunks(provider, [chunk])
+
+      done = provider.stream_text(prompt: "hi", model: "x/y").to_a.find { |e| e.is_a?(Riffer::StreamEvents::FinishReasonDone) }
+
+      expect([done.finish_reason, done.raw_finish_reason]).must_equal [:stop, "end_turn"]
     end
 
     it "assigns distinct fallback ids when multiple tool calls arrive without ids" do


### PR DESCRIPTION
## Problem

Every provider adapter maps its raw stop reason into a normalized `finish_reason`, but the mapping tables had drifted behind the providers' actual enums. Bedrock's `malformed_model_output`, `malformed_tool_use`, and `model_context_window_exceeded` all fell through to `:other`, as did Anthropic's `model_context_window_exceeded` and `pause_turn` and nine Gemini values. Callers detecting truncation or bad model output with `finish_reason` silently missed those cases.

The normalized vocabulary was also too coarse for two outcomes that more than one provider reports and that need a different reaction from the caller. A context window overflow looks like `:length` but is not fixed by raising `max_tokens`; the history has to be trimmed. A malformed tool call looks like `:error` but is not fixed by backing off; the request has to be retried or nudged.

## Solution

Two values join the normalized vocabulary, admitted under the rule that at least two providers emit the concept and the caller's correct reaction differs from every existing value:

- `:context_window` from Anthropic and Bedrock `model_context_window_exceeded`
- `:malformed_output` from Bedrock `malformed_model_output` / `malformed_tool_use` and Gemini `MALFORMED_FUNCTION_CALL` / `UNEXPECTED_TOOL_CALL`

Every remaining unmapped raw value is now listed explicitly in its provider table, so each table documents the full enum as reviewed. Anthropic's `pause_turn` maps to `:other` deliberately; resuming paused server-tool turns in the agent loop is out of scope. Gemini's `MALFORMED_FUNCTION_CALL` moves off `:error`, which is the one behavior change to an existing mapping.

Two `raw` fidelity fixes ride along. OpenRouter previously stored its own normalized string as `raw` and dropped the upstream model's `native_finish_reason`; it now prefers the native value, read from the SDK response hash since the field is outside the OpenAI schema. A failed OpenAI response now carries `error.code` as `raw` instead of the constant `"failed"`.

OpenAI gets a mapping table of its own. The Responses API reports no `finish_reason`, so the adapter previously derived one from a nested `case` over `status` and `incomplete_details.reason`. That logic is now a `FINISH_REASONS` constant listing every status the SDK defines, with the incomplete reasons nested beneath `incomplete`, so the full matrix is readable in one place like the other providers. Behavior is unchanged and a test pins the constant's keys to the SDK status enum.

Adding vocabulary values is additive. Callers already handle `:other`, and no existing value is renamed, so this is not a breaking change. Docs for the vocabulary are updated in MESSAGES.md, TRACING.md, and CUSTOM_PROVIDERS.md.

## Proof

CI runs the default rake task (tests, rubocop, steep). Locally it passes with 2301 runs, 0 failures, no offenses, no type errors. New tests cover every added mapping per provider, the vocabulary additions, `Assistant` accepting the new symbols, OpenRouter native raw with fallback on both the non-streaming and streaming paths, the OpenAI error-code raw with fallback, and a literal table over every OpenAI status. No new VCR cassettes were recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `context_window` and `malformed_output` finish reasons for clearer response outcomes.
  * Improved finish-reason handling across Amazon Bedrock, Anthropic, Gemini, OpenAI, and OpenRouter.
  * Preserved provider-specific raw finish reasons, including native OpenRouter reasons and OpenAI error codes.
  * Expanded handling for malformed outputs, context exhaustion, safety outcomes, tool calls, and other provider responses.

* **Documentation**
  * Updated finish-reason and tracing guidance, including handling recommendations and provider-specific details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
