### PR TITLE
docs: fix stale API references in mock provider guide

### DIFF
--- a/docs/providers/MOCK_PROVIDER.md
+++ b/docs/providers/MOCK_PROVIDER.md
@@ -21,13 +21,14 @@ Use `stub_response` to queue responses:
 ```ruby
 # Get the provider instance from the agent
 agent = TestableAgent.new
-provider = agent.send(:provider_instance)
+provider = agent.provider
 
 # Stub a simple text response
 provider.stub_response("Hello, I'm here to help!")
 
 # Now generate will return the stubbed response
 response = agent.generate("Hi")
+response.content
 # => "Hello, I'm here to help!"
 ```
 
@@ -55,10 +56,10 @@ provider.stub_response("First response")
 provider.stub_response("Second response")
 provider.stub_response("Third response")
 
-agent.generate("Message 1")  # => "First response"
-agent.generate("Message 2")  # => "Second response"
-agent.generate("Message 3")  # => "Third response"
-agent.generate("Message 4")  # => "Mock response" (default)
+agent.generate("Message 1").content  # => "First response"
+agent.generate("Message 2").content  # => "Second response"
+agent.generate("Message 3").content  # => "Third response"
+agent.generate("Message 4").content  # => "Mock response" (default)
 ```
 
 ## Inspecting Calls
@@ -92,7 +93,7 @@ require 'minitest/autorun'
 class MyAgentTest < Minitest::Test
   def setup
     @agent = TestableAgent.new
-    @provider = @agent.send(:provider_instance)
+    @provider = @agent.provider
   end
 
   def test_generates_response
@@ -146,18 +147,24 @@ text_done = events.find { |e| e.is_a?(Riffer::StreamEvents::TextDone) }
 
 ## Web Search
 
-The test provider emits web search events when `web_search: true` is passed to the stream call:
+The mock provider emits web search events when `web_search: true` is set in the agent's `model_options`:
 
 ```ruby
-provider.stub_response("Here are the latest results.")
+class SearchingAgent < Riffer::Agent
+  model 'mock/any'
+  model_options web_search: true
+end
+
+agent = SearchingAgent.new
+agent.provider.stub_response("Here are the latest results.")
 
 events = []
-agent.stream("What's new in Ruby?", web_search: true).each { |e| events << e }
+agent.stream("What's new in Ruby?").each { |e| events << e }
 
 # Events include WebSearchStatus and WebSearchDone before text events
-search_deltas = events.select { |e| e.is_a?(Riffer::StreamEvents::WebSearchStatus) }
+search_statuses = events.select { |e| e.is_a?(Riffer::StreamEvents::WebSearchStatus) }
 search_done = events.find { |e| e.is_a?(Riffer::StreamEvents::WebSearchDone) }
-search_done.query    # => "test search query"
+search_done.query    # => "mock search query"
 search_done.sources  # => [{title: "Example", url: "https://example.com"}]
 ```
 


### PR DESCRIPTION
## Problem

`docs/providers/MOCK_PROVIDER.md` told readers to grab the mock provider with `agent.send(:provider_instance)`. `Riffer::Agent` has never defined that method, so anyone following the page hit `NoMethodError` on the very first sample. While the page was open, the other samples turned out to have drifted from the current API too: they treated `agent.generate` as returning a String, passed `web_search: true` as a keyword to `agent.stream` (which only accepts `files:` and `tags:`), and showed a search query literal the mock does not emit.

## Solution

Every sample on the page now matches the shipped API and is pinned to a real definition in `lib/`:

- `agent.send(:provider_instance)` becomes the public `agent.provider` reader (`lib/riffer/agent.rb`), which the agent test suite already uses for exactly this purpose.
- `agent.generate(...)` samples chain `.content`, since `generate` returns a `Riffer::Agent::Response`.
- The Web Search sample configures `model_options web_search: true` on an agent class, which is the only path by which the option reaches the mock's stream handling. The prose is updated to match.
- The expected `search_done.query` is corrected to `"mock search query"`, and the collected `WebSearchStatus` events are named `search_statuses` instead of `search_deltas`.

Docs-only change. No new page, so no `docs-site/manifest.yml` entry is needed.

## Proof

Every corrected sample was executed against `lib/` with `bundle exec ruby -Ilib` and produced exactly the values shown in the `# =>` comments, with no `NoMethodError` or `ArgumentError`. CI covers rubocop, steep, and the test suite, none of which touch this file, so the docs-site build is the only relevant check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)