### PR TITLE
fix(runner): make Fibers runner safe inside a running Async reactor

### DIFF
--- a/docs/TOOL_ADVANCED.md
+++ b/docs/TOOL_ADVANCED.md
@@ -220,6 +220,8 @@ end
 
 Fibers use cooperative scheduling — they yield control at I/O boundaries (network calls, file reads, sleep). CPU-bound tools will not benefit from the fibers runtime. Be mindful of fiber-local state (`Fiber.[]`) and note that `Thread.current[]` values are shared across all fibers in the same thread.
 
+The fibers runtime is safe to use inside an existing reactor. When called from plain Ruby it starts its own reactor and blocks until every tool call finishes. When the process is already inside an Async task — for example under Falcon, or inside an `Async do ... end` block — it joins the current task instead of starting a nested reactor, so it is safe to call from request handlers.
+
 ### Custom Runtimes
 
 Create a custom runtime by subclassing `Riffer::Tools::Runtime` and overriding the private `dispatch_tool_call` method:

--- a/lib/riffer/runner/fibers.rb
+++ b/lib/riffer/runner/fibers.rb
@@ -5,6 +5,8 @@
 # +max_concurrency+ caps simultaneous fibers via an <tt>Async::Semaphore</tt>.
 # If multiple fibers raise, only the first exception is re-raised after all
 # finish.
+# Joins the current reactor task when one is already running, and otherwise
+# starts its own.
 class Riffer::Runner::Fibers < Riffer::Runner
   # @rbs @max_concurrency: Integer?
 
@@ -25,15 +27,15 @@ class Riffer::Runner::Fibers < Riffer::Runner
     results = Array.new(items.size)
     errors = Array.new(items.size)
 
-    Async do
-      barrier = Async::Barrier.new
-      max = @max_concurrency
-      parent = if max
-                 Async::Semaphore.new(max, parent: barrier)
-               else
-                 barrier
-               end
+    barrier = Async::Barrier.new
+    max = @max_concurrency
+    parent = if max
+               Async::Semaphore.new(max, parent: barrier)
+             else
+               barrier
+             end
 
+    Sync do
       items.each_with_index do |item, index|
         parent.async do
           results[index] = yield(item)
@@ -43,6 +45,8 @@ class Riffer::Runner::Fibers < Riffer::Runner
       end
 
       barrier.wait
+    ensure
+      barrier.stop
     end
 
     first_error = errors.compact.first

--- a/sig/_private/async.rbs
+++ b/sig/_private/async.rbs
@@ -10,6 +10,8 @@ module Async
     def async: () { () -> void } -> untyped
 
     def wait: () -> void
+
+    def stop: () -> void
   end
 
   class Semaphore
@@ -21,4 +23,6 @@ end
 
 module Kernel
   def Async: () { () -> void } -> untyped
+
+  def Sync: () { () -> void } -> untyped
 end

--- a/sig/generated/riffer/runner/fibers.rbs
+++ b/sig/generated/riffer/runner/fibers.rbs
@@ -4,6 +4,8 @@
 # +max_concurrency+ caps simultaneous fibers via an <tt>Async::Semaphore</tt>.
 # If multiple fibers raise, only the first exception is re-raised after all
 # finish.
+# Joins the current reactor task when one is already running, and otherwise
+# starts its own.
 class Riffer::Runner::Fibers < Riffer::Runner
   @max_concurrency: Integer?
 

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -111,6 +111,53 @@ describe Riffer::Runner::Fibers do
         end
       end.must_raise RuntimeError
     end
+
+    it "returns complete ordered results inside a running reactor" do
+      runner = Riffer::Runner::Fibers.new
+
+      Async do
+        results = runner.map([1, 2, 3], context: nil) do |n|
+          sleep 0.01
+          n * 2
+        end
+
+        expect(results).must_equal [2, 4, 6]
+      end
+    end
+
+    it "honours max_concurrency inside a running reactor" do
+      runner = Riffer::Runner::Fibers.new(max_concurrency: 2)
+      concurrent = 0
+      max_concurrent = 0
+
+      Async do
+        runner.map([1, 2, 3, 4], context: nil) do |n|
+          concurrent += 1
+          max_concurrent = [max_concurrent, concurrent].max
+          sleep 0.02
+          concurrent -= 1
+          n
+        end
+
+        expect(max_concurrent).must_be :<=, 2
+      end
+    end
+
+    it "raises the first error inside a running reactor" do
+      runner = Riffer::Runner::Fibers.new
+
+      Async do
+        error = expect do
+          runner.map([1, 2, 3], context: nil) do |n|
+            raise ArgumentError, "boom #{n}" if n > 1
+
+            n
+          end
+        end.must_raise ArgumentError
+
+        expect(error.message).must_equal "boom 2"
+      end
+    end
   end
 end
 

--- a/test/riffer/runner_test.rb
+++ b/test/riffer/runner_test.rb
@@ -115,7 +115,7 @@ describe Riffer::Runner::Fibers do
     it "returns complete ordered results inside a running reactor" do
       runner = Riffer::Runner::Fibers.new
 
-      Async do
+      Sync do
         results = runner.map([1, 2, 3], context: nil) do |n|
           sleep 0.01
           n * 2
@@ -130,8 +130,8 @@ describe Riffer::Runner::Fibers do
       concurrent = 0
       max_concurrent = 0
 
-      Async do
-        runner.map([1, 2, 3, 4], context: nil) do |n|
+      Sync do
+        results = runner.map([1, 2, 3, 4], context: nil) do |n|
           concurrent += 1
           max_concurrent = [max_concurrent, concurrent].max
           sleep 0.02
@@ -139,14 +139,15 @@ describe Riffer::Runner::Fibers do
           n
         end
 
-        expect(max_concurrent).must_be :<=, 2
+        expect(results).must_equal [1, 2, 3, 4]
+        expect(max_concurrent).must_equal 2
       end
     end
 
     it "raises the first error inside a running reactor" do
       runner = Riffer::Runner::Fibers.new
 
-      Async do
+      Sync do
         error = expect do
           runner.map([1, 2, 3], context: nil) do |n|
             raise ArgumentError, "boom #{n}" if n > 1

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -598,6 +598,31 @@ describe Riffer::Tools::Runtime::Fibers do
     expect(results.length).must_equal 3
     expect(seen.uniq.length).must_equal 3
   end
+
+  it "returns every tool result inside a running reactor" do
+    slow_tool = stub_tool("SlowishTool") do
+      description "Sleeps then responds"
+
+      def call(context:, **)
+        sleep 0.01
+        text("done")
+      end
+    end
+
+    runtime = Riffer::Tools::Runtime::Fibers.new
+    tool_calls = Array.new(3) do |i|
+      Riffer::Messages::Assistant::ToolCall.new(
+        call_id: "cid_#{i}", name: "slowish_tool", arguments: "{}",
+      )
+    end
+
+    Async do
+      results = runtime.execute(tool_calls, tools: [slow_tool], context: nil)
+
+      expect(results.length).must_equal 3
+      expect(results.compact.map { |(_, response)| response.content }).must_equal %w[done done done]
+    end
+  end
 end
 
 describe Riffer::Tools::Runtime::Threaded do

--- a/test/riffer/tools/runtime_test.rb
+++ b/test/riffer/tools/runtime_test.rb
@@ -616,11 +616,11 @@ describe Riffer::Tools::Runtime::Fibers do
       )
     end
 
-    Async do
+    Sync do
       results = runtime.execute(tool_calls, tools: [slow_tool], context: nil)
 
       expect(results.length).must_equal 3
-      expect(results.compact.map { |(_, response)| response.content }).must_equal %w[done done done]
+      expect(results.map { |(_, response)| response.content }).must_equal %w[done done done]
     end
   end
 end


### PR DESCRIPTION
## Problem

`Riffer::Runner::Fibers#map` wrapped its barrier in `Async do ... end`. When the caller is already inside an Async task (Falcon, or any `Async { }` block), the kernel `Async` method does not block: it schedules a child task and returns immediately, so `map` read the `results` array before the fibers had finished.

Reproduced against async 2.45.0. `Riffer::Runner::Fibers.new.map([1, 2, 3], context: nil) { |i| i * 10 }` returns `[10, 20, 30]` from plain Ruby but `[10, nil, nil]` inside `Async do ... end`, and `[nil, nil, nil]` once the block yields. Any consumer hosting riffer under Falcon or the async gem got nil tool results from `Riffer::Tools::Runtime::Fibers`. There was no test for the in-reactor case and `docs/TOOL_ADVANCED.md` did not say whether the runtime was reactor-safe.

## Solution

Swap `Async do` for `Sync do`, the async gem's own helper for this situation. With a current task it yields inline on that task; with no reactor it starts one and blocks until the block finishes. Our code gains no branching on `Async::Task.current?`.

The barrier and semaphore are constructed above the `Sync` block so an `ensure barrier.stop` can cancel any still-running children if the host cancels its task mid-flight. This is the pattern the async gem documents for `Barrier`. Both constructors resolve their parent task lazily at `.async` time, so building them before the reactor exists is safe. Keeping the assignment inside the block was tried first, but Steep could not type the `ensure` reference.

Two subtleties in the tests are deliberate. Assertions live inside the `Async do` block because asserting after it passes against the buggy code: the reactor drains and fills the same `results` array before the outer assertion runs. The runtime test uses `results.compact` because a `NoMethodError` on nil inside a top-level Async task is logged and swallowed by the async gem, while `Minitest::Assertion` propagates.

Also adds RBS stubs for `Kernel#Sync` and `Async::Barrier#stop` in `sig/_private/async.rbs`, and a paragraph in the Fibers Runtime section of `docs/TOOL_ADVANCED.md` stating the runtime is reactor-safe.

## Proof

Locally: `bin/test` (2305 runs, 0 failures), `bin/lint` (no offenses), `bin/typecheck` (no type errors). CI runs the same default rake task.

Four new tests cover the in-reactor path. Three in `test/riffer/runner_test.rb` (full ordered results with a yielding block, `max_concurrency` honoured, first error re-raised) and one in `test/riffer/tools/runtime_test.rb` asserting three real tool results with no nils. Each was confirmed to fail against the pre-fix code by temporarily reverting `Sync` to `Async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fibers-based operations now work smoothly within an existing Async reactor while continuing to run independently when no reactor is active.
  - Reactor resources are reliably stopped after synchronization completes.

- **Documentation**
  - Added guidance describing Fibers runtime behavior in standalone and existing Async contexts.

- **Tests**
  - Added coverage for ordered results, concurrency limits, error propagation, and delayed tool calls within Async reactors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->