### PR TITLE
feat!: report how a run ended through Response#outcome

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -168,6 +168,19 @@ end
 
 The LLM response is automatically parsed and validated against the schema. Access the result via `response.structured_output`.
 
+When the response is not valid JSON or does not satisfy the schema, `response.structured_output` is `nil`, `response.outcome.reason` is `:invalid_structured_output`, and `response.outcome.detail` carries the parse or validation message:
+
+```ruby
+response = SentimentAgent.generate('Analyze: "I love this!"')
+
+if response.outcome.success?
+  response.structured_output  # => {sentiment: "positive", score: 0.95}
+else
+  response.outcome.reason     # => :invalid_structured_output
+  response.outcome.detail     # => "score is required"
+end
+```
+
 #### Nested Objects
 
 Use `Hash` with a block to define nested object schemas:

--- a/docs/AGENT_LIFECYCLE.md
+++ b/docs/AGENT_LIFECYCLE.md
@@ -30,9 +30,8 @@ agent.generate(prompt = nil, files: nil)
 ```ruby
 # New conversation (class method — recommended for simple calls)
 response = MyAgent.generate('Hello', context: {user_id: 123})
-puts response.content       # Access the response text
-puts response.blocked?      # Check if guardrail blocked (always false without guardrails)
-puts response.interrupted?  # Check if a callback interrupted the loop
+puts response.content         # Access the response text
+puts response.outcome.reason  # How the run ended (:completed, :guardrail_blocked, :interrupted, ...)
 
 # New conversation (instance method — when you need message history or callbacks)
 agent = MyAgent.new(context: {user_id: 123})
@@ -142,9 +141,9 @@ Works with both `generate` and `stream`. Only emits agent-generated messages (As
 
 Callbacks can interrupt the agent loop. This is useful for human-in-the-loop approval, cost limits, or content filtering.
 
-Use `agent.interrupt!` (or the lower-level `throw :riffer_interrupt`) to stop the loop. The response will have `interrupted?` set to `true` and contain the accumulated content up to the point of interruption.
+Use `agent.interrupt!` (or the lower-level `throw :riffer_interrupt`) to stop the loop. The response's `outcome.reason` will be `:interrupted` and `content` will hold the accumulated content up to the point of interruption.
 
-An optional reason can be passed to `interrupt!`. It is available via `interrupt_reason` on the response (generate) or `reason` on the `Interrupt` event (stream):
+An optional reason can be passed to `interrupt!`. It is available via `outcome.detail` on the response (generate) or `reason` on the `Interrupt` event (stream):
 
 ```ruby
 agent = MyAgent.new
@@ -155,9 +154,9 @@ agent.session.on_message do |msg|
 end
 
 response = agent.generate('Call the tool')
-response.interrupted?      # => true
-response.interrupt_reason  # => "needs human approval"
-response.content           # => last assistant content before interrupt
+response.outcome.reason  # => :interrupted
+response.outcome.detail  # => "needs human approval"
+response.content         # => last assistant content before interrupt
 ```
 
 **Streaming** — interrupts emit an `Interrupt` event:
@@ -188,7 +187,7 @@ agent.session.on_message { |msg| throw :riffer_interrupt if needs_approval?(msg)
 
 response = agent.generate('Do something risky')
 
-if response.interrupted?
+if response.outcome.reason == :interrupted
   approve_action(agent.session.messages)
   response = agent.generate('Approved, go ahead')  # executes pending tools, then calls the LLM
   # or: agent.generate                              # resume without a new turn
@@ -306,17 +305,43 @@ agent.context[:skills]        # the Skills::Context, if skills configured
 | Attribute              | Type                        | Description                                                                                      |
 | ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------ |
 | `content`              | `String`                    | The response text                                                                                |
+| `outcome`              | `Outcome`                   | How the run ended — `reason` and optional `detail` (see below)                                   |
 | `structured_output`    | `Hash` / `nil`              | Parsed and validated structured output (see below)                                               |
-| `blocked?`             | `Boolean`                   | `true` if a guardrail tripwire fired                                                             |
 | `tripwire`             | `Tripwire` / `nil`          | The guardrail tripwire that blocked the request                                                  |
 | `modified?`            | `Boolean`                   | `true` if a guardrail modified the content                                                       |
 | `modifications`        | `Array`                     | List of guardrail modifications applied                                                          |
-| `interrupted?`         | `Boolean`                   | `true` if the loop was interrupted                                                               |
-| `interrupt_reason`     | `String` / `Symbol` / `nil` | The reason passed to `throw :riffer_interrupt`                                                   |
 | `messages`             | `Array`                     | Full message history from the conversation                                                       |
 | `healed_tool_call_ids` | `Array[String]`             | `tool_call` ids filled with placeholder results during interrupt healing (else `[]`)             |
 | `token_usage`          | `TokenUsage` / `nil`        | Aggregate `Riffer::Providers::TokenUsage` across this run's LLM calls (`nil` when none reported) |
 | `steps`                | `Integer`                   | LLM calls made during this run (`0` when a before-guardrail blocks first); not the session's cumulative count |
+
+### response.outcome
+
+`response.outcome` is a `Riffer::Agent::Outcome` — the single place to read how the run ended. `reason` is always one of the values below; `detail` is a `String` with the specifics when there are any, else `nil`. `outcome.success?` is shorthand for `reason == :completed`.
+
+| Reason                       | Source                                                     | `detail`                                  |
+| ---------------------------- | ---------------------------------------------------------- | ----------------------------------------- |
+| `:completed`                 | The loop ended normally                                    | `nil`                                     |
+| `:guardrail_blocked`         | A guardrail tripwire fired (`tripwire` is set)             | The tripwire reason                       |
+| `:max_steps`                 | The `max_steps` limit was reached                          | `nil`                                     |
+| `:interrupted`               | A callback called `interrupt!` / `throw :riffer_interrupt` | The interrupt reason, or `nil`            |
+| `:length`, `:content_filter`, `:context_window`, `:malformed_output`, `:error`, `:other` | The assistant message's normalized `finish_reason` (see [Messages — Finish Reasons](MESSAGES.md#finish-reasons)) | The provider's raw finish value (`finish_reason_raw`), or `nil` |
+| `:invalid_structured_output` | The final message failed JSON parsing or schema validation | The parse or validation error             |
+
+When several apply, the most causal wins: a guardrail block outranks an interrupt, an interrupt outranks the provider's finish reason, and the provider's finish reason outranks a structured output failure. A run that hit `:length` and therefore produced invalid JSON reports `:length`.
+
+```ruby
+agent = MyAgent.new
+response = agent.generate('Hello')
+
+case response.outcome.reason
+when :completed                 then puts response.content
+when :guardrail_blocked         then puts "Blocked: #{response.outcome.detail}"
+when :interrupted, :max_steps   then response = agent.generate('Continue')
+when :invalid_structured_output then warn response.outcome.detail
+else warn "Provider stopped early: #{response.outcome.reason}"
+end
+```
 
 ### response.structured_output
 
@@ -328,7 +353,7 @@ response.content            # => raw JSON string from the LLM
 response.structured_output  # => {sentiment: "positive", score: 0.95}
 ```
 
-Returns `nil` when structured output is not configured or when validation fails.
+Returns `nil` when structured output is not configured, or when parsing or validation fails — in which case `response.outcome.reason` is `:invalid_structured_output` and `response.outcome.detail` carries the error.
 
 The assistant message in the message history stores the parsed hash, so you can access structured output directly from persisted messages:
 

--- a/docs/AGENT_LIFECYCLE.md
+++ b/docs/AGENT_LIFECYCLE.md
@@ -300,7 +300,7 @@ agent.context[:skills]        # the Skills::Context, if skills configured
 
 ## Response Attributes
 
-`Riffer::Agent::Response` is returned by `generate`:
+`Riffer::Agent::Response` is returned by `generate`. Start with `response.outcome`: its `reason` says how the run ended, and everything else on the response is detail for that reason. `response.content` and `response.structured_output` are only meaningful when the reason is `:completed`; see [response.outcome](#responseoutcome) for the full vocabulary.
 
 | Attribute              | Type                        | Description                                                                                      |
 | ---------------------- | --------------------------- | ------------------------------------------------------------------------------------------------ |

--- a/docs/AGENT_LOOP.md
+++ b/docs/AGENT_LOOP.md
@@ -34,7 +34,7 @@ The agent loop normally runs until the LLM produces a response with no tool call
 Guardrails are registered at class definition time and run automatically on every request. When a guardrail calls `block`, it sets a **tripwire** that stops the loop immediately. The LLM is never called (for `:before` guardrails) or its response is discarded (for `:after` guardrails).
 
 - **When to use:** Policy enforcement that should always apply — content filtering, input validation, length limits.
-- **Response:** `response.blocked?` returns `true`, `response.tripwire` contains the reason and metadata.
+- **Response:** `response.outcome.reason` is `:guardrail_blocked`, `response.tripwire` contains the reason and metadata.
 - **Streaming:** Yields a `GuardrailTripwire` event.
 - **Resumable:** No. A tripwire is a hard stop. The caller must change the input and start a new `generate`/`stream` call.
 
@@ -45,7 +45,7 @@ class MyAgent < Riffer::Agent
 end
 
 response = MyAgent.generate('blocked input')
-response.blocked?          # => true
+response.outcome.reason    # => :guardrail_blocked
 response.tripwire.reason   # => "Content policy violation"
 ```
 
@@ -54,7 +54,7 @@ response.tripwire.reason   # => "Content policy violation"
 Callbacks registered with `on_message` can call `agent.interrupt!` (or `throw :riffer_interrupt`) to pause the loop at any point — after receiving an assistant message, after a tool result, etc. The caller controls exactly when and why to interrupt.
 
 - **When to use:** Flow control that depends on runtime decisions — human-in-the-loop approval, budget tracking, conditional pausing.
-- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` contains the optional reason.
+- **Response:** `response.outcome.reason` is `:interrupted`, `response.outcome.detail` contains the optional reason.
 - **Streaming:** Yields an `Interrupt` event with a `reason` attribute.
 - **Resumable:** Yes. Call `generate('Continue')` or `stream('Continue')` on the same agent instance to resume. For cross-process resume, pass persisted messages as an array to a new agent. Pending tool calls are automatically executed before the LLM loop resumes.
 
@@ -65,8 +65,8 @@ agent.session.on_message do |msg|
 end
 
 response = agent.generate('Do something risky')
-response.interrupted?      # => true
-response.interrupt_reason  # => "approval needed"
+response.outcome.reason    # => :interrupted
+response.outcome.detail    # => "approval needed"
 response = agent.generate('Approved, continue')  # continues where it left off
 ```
 
@@ -75,7 +75,7 @@ response = agent.generate('Approved, continue')  # continues where it left off
 The `max_steps` class method caps the number of LLM call steps in the tool-use loop. When the step count reaches the limit, the loop interrupts automatically with reason `:max_steps`.
 
 - **When to use:** Safety net to prevent runaway tool-use loops — useful when agents have access to many tools or operate autonomously.
-- **Response:** `response.interrupted?` returns `true`, `response.interrupt_reason` is `:max_steps`.
+- **Response:** `response.outcome.reason` is `:max_steps`.
 - **Streaming:** Yields an `Interrupt` event with `reason: :max_steps`.
 - **Resumable:** Yes. Call `generate('Continue')` or `stream('Continue')` on the same agent instance to resume. For cross-process resume, pass persisted messages as an array to a new agent. Pending tool calls are automatically executed before the LLM loop resumes.
 
@@ -86,8 +86,7 @@ class MyAgent < Riffer::Agent
 end
 
 response = MyAgent.generate('Do a complex task')
-response.interrupted?      # => true (if 8 steps were reached)
-response.interrupt_reason  # => :max_steps
+response.outcome.reason    # => :max_steps (if 8 steps were reached)
 ```
 
 ### Unhandled Exceptions
@@ -101,6 +100,6 @@ If a guardrail, provider call, or other internal code raises an exception, it pr
 | Defined       | At class level (`guardrail :before`) | At instance level (`on_message`)     | At class level (`max_steps 8`)       |
 | Fires         | Automatically on every request       | When callback logic decides          | When step count reaches limit        |
 | Resumable     | No                                   | Yes (call `generate`/`stream` again) | Yes (call `generate`/`stream` again) |
-| Response flag | `blocked?`                           | `interrupted?`                       | `interrupted?`                       |
+| Outcome reason | `:guardrail_blocked`                | `:interrupted`                       | `:max_steps`                         |
 | Stream event  | `GuardrailTripwire`                  | `Interrupt`                          | `Interrupt`                          |
 | Purpose       | Policy enforcement                   | Flow control                         | Runaway loop prevention              |

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -28,10 +28,10 @@ class MyAgent < Riffer::Agent
 end
 
 response = MyAgent.generate("Hello!")
-response.blocked?  # => false
+response.outcome.reason    # => :completed
 
 response = MyAgent.generate("You are a badword")
-response.blocked?          # => true
+response.outcome.reason    # => :guardrail_blocked
 response.tripwire.reason   # => "Profanity detected"
 ```
 
@@ -195,7 +195,7 @@ end
 response = MyAgent.generate("Hello")
 
 response.content        # The response text
-response.blocked?       # true if a guardrail blocked execution
+response.outcome.reason # :guardrail_blocked if a guardrail blocked execution
 response.tripwire       # Tripwire object with block details (if blocked)
 response.modified?      # true if any guardrail transformed data
 response.modifications  # Array of Modification records
@@ -206,7 +206,7 @@ response.modifications  # Array of Modification records
 ```ruby
 response = MyAgent.generate("Hello")
 
-if response.blocked?
+if response.outcome.reason == :guardrail_blocked
   puts "Blocked: #{response.tripwire.reason}"
   puts "Phase: #{response.tripwire.phase}"
   puts "Guardrail: #{response.tripwire.guardrail}"

--- a/docs/MESSAGES.md
+++ b/docs/MESSAGES.md
@@ -49,7 +49,8 @@ msg.role           # => :assistant
 msg.content        # => "I'm doing well, thank you!"
 msg.tool_calls     # => []
 msg.token_usage    # => nil or Riffer::Providers::TokenUsage
-msg.finish_reason  # => nil or a normalized Symbol (see below)
+msg.finish_reason      # => nil or a normalized Symbol (see below)
+msg.finish_reason_raw  # => nil or the provider's raw wire value (e.g. "max_tokens")
 
 # Response with tool calls
 msg = Riffer::Messages::Assistant.new("", tool_calls: [
@@ -94,7 +95,7 @@ The cache buckets are subsets of `input_tokens`, never additions to it — summi
 | `:error`            | The provider reported an error finish.                                                                                  |
 | `:other`            | A provider-specific value with no normalized equivalent.                                                                |
 
-`finish_reason` is `nil` when the provider doesn't report one. The provider's raw wire value travels alongside on the `FinishReasonDone` stream event and the `riffer.finish_reason.raw` trace attribute — for OpenRouter that is the upstream model's `native_finish_reason`, and for a failed OpenAI response it is the error code. Use `finish_reason` to detect truncation without parsing provider responses:
+`finish_reason` is `nil` when the provider doesn't report one. The provider's raw wire value travels alongside as `finish_reason_raw` on the message (round-tripped through `to_h` / `from_hash`), on the `FinishReasonDone` stream event, and as the `riffer.finish_reason.raw` trace attribute — for OpenRouter that is the upstream model's `native_finish_reason`, and for a failed OpenAI response it is the error code. Use `finish_reason` to detect truncation without parsing provider responses:
 
 ```ruby
 response = agent.generate("Summarize this document")
@@ -103,7 +104,7 @@ retry_with_higher_limit if agent.session.messages.last.finish_reason == :length
 
 #### Structured Output on Messages
 
-When an agent has `structured_output` configured, the final assistant message stores the parsed hash directly. The `structured_output?` predicate checks for a non-nil value:
+When an agent has `structured_output` configured, the final assistant message stores the parsed hash directly. The message holds the parsed JSON, not the schema-validated result; schema validation is reported on `response.outcome` (see [Agent Lifecycle — response.outcome](AGENT_LIFECYCLE.md#responseoutcome)). The `structured_output?` predicate checks for a non-nil value:
 
 ```ruby
 msg = Riffer::Messages::Assistant.new('{"sentiment":"positive"}', structured_output: {sentiment: "positive"})

--- a/docs/STREAM_EVENTS.md
+++ b/docs/STREAM_EVENTS.md
@@ -215,7 +215,7 @@ Emitted when the agent loop is interrupted. This can happen in two ways:
 - An `on_message` callback calls `agent.interrupt!` or `throw :riffer_interrupt` (reason is a String or `nil`).
 - The `max_steps` limit is reached (reason is the Symbol `:max_steps`).
 
-This is the streaming equivalent of `Response#interrupted?` in generate mode.
+This is the streaming equivalent of `response.outcome.reason == :interrupted` (or `:max_steps`) in generate mode.
 
 ```ruby
 # Callback interrupt with a string reason

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -113,6 +113,8 @@ Any tags passed to `#generate` / `#stream` via `tags:` are stamped on **all four
 | `gen_ai.usage.cache_read.input_tokens`     | int    | When the provider reported cache reads               |
 | `gen_ai.usage.cache_creation.input_tokens` | int    | When the provider reported cache writes              |
 | `riffer.cost`                              | float  | When every call in the run was priced                |
+| `riffer.outcome.reason`                    | string | Always — the `response.outcome.reason`               |
+| `riffer.outcome.detail`                    | string | When `response.outcome.detail` is present            |
 | `riffer.interrupt.reason`                  | string | On interrupt (e.g. approval needed, max steps)       |
 | `riffer.tripwire.guardrail`                | string | On a guardrail tripwire, when the guardrail is named |
 | `riffer.tripwire.reason`                   | string | On a guardrail tripwire                              |
@@ -271,7 +273,7 @@ When enabled, content is serialized as GenAI-semconv JSON strings. File attachme
 The span and attribute shape is a public, versioned contract, in two tiers:
 
 - **`gen_ai.*`** tracks the OpenTelemetry GenAI semantic conventions, pinned to schema version `1.37.0`. That convention is still "Development" status upstream and its attribute names may change; Riffer absorbs such renames deliberately in a release, never silently, with a CHANGELOG entry.
-- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.cost`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.guardrail.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
+- **`riffer.*`** is Riffer-owned (`riffer.steps`, `riffer.cost`, `riffer.outcome.*`, `riffer.interrupt.reason`, `riffer.tripwire.*`, `riffer.guardrail.*`, `riffer.finish_reason.raw`) and changes only through a normal version bump and CHANGELOG entry.
 
 The semantic-convention schema version is a documented pin rather than a span attribute — the OpenTelemetry Ruby API can't attach a schema URL to a tracer. The runtime version signal is the instrumentation scope: every span carries scope name `riffer` at the gem version that emitted it. Pin the Riffer version your dashboards depend on, and watch the CHANGELOG for tracing entries before upgrading.
 

--- a/lib/riffer/agent/outcome.rb
+++ b/lib/riffer/agent/outcome.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+# rbs_inline: enabled
+
+# How a run ended — the single place to read whether the agent completed
+# normally and, if not, why. +detail+ carries the specifics when there are any:
+# the tripwire reason, the interrupt reason, the provider's raw finish value,
+# or the structured output parse/validation error.
+#
+#   response = agent.generate("Analyze this")
+#   case response.outcome.reason
+#   when :completed then puts response.structured_output
+#   when :invalid_structured_output then warn response.outcome.detail
+#   end
+class Riffer::Agent::Outcome
+  # Finish reasons that mean the provider cut the turn short; they surface as
+  # the run's outcome verbatim.
+  PROVIDER_STOP_REASONS = %i[length content_filter context_window malformed_output error other].freeze #: Array[Symbol]
+
+  # The vocabulary every run ends in.
+  VALUES = (%i[completed guardrail_blocked interrupted max_steps invalid_structured_output] +
+            PROVIDER_STOP_REASONS).freeze #: Array[Symbol]
+
+  # Why the run ended.
+  attr_reader :reason #: Symbol
+
+  # Human-readable specifics for +reason+, when there are any.
+  attr_reader :detail #: String?
+
+  # Raises Riffer::ArgumentError when +reason+ is outside VALUES.
+  #--
+  #: (reason: Symbol, ?detail: String?) -> void
+  def initialize(reason:, detail: nil)
+    unless VALUES.include?(reason)
+      raise Riffer::ArgumentError, "reason must be one of #{VALUES.inspect}, got #{reason.inspect}"
+    end
+
+    @reason = reason
+    @detail = detail
+  end
+
+  # Returns true when the run completed normally.
+  #
+  #--
+  #: () -> bool
+  def success?
+    reason == :completed
+  end
+end

--- a/lib/riffer/agent/outcome.rb
+++ b/lib/riffer/agent/outcome.rb
@@ -12,9 +12,13 @@
 #   when :invalid_structured_output then warn response.outcome.detail
 #   end
 class Riffer::Agent::Outcome
-  # Finish reasons that mean the provider cut the turn short; they surface as
-  # the run's outcome verbatim.
-  PROVIDER_STOP_REASONS = %i[length content_filter context_window malformed_output error other].freeze #: Array[Symbol]
+  # Finish reasons that end a turn normally; every other finish reason means the
+  # provider cut the turn short and surfaces as the run's outcome verbatim.
+  NORMAL_FINISH_REASONS = %i[stop tool_calls].freeze #: Array[Symbol]
+
+  # Derived from the provider vocabulary so a new finish reason becomes an
+  # outcome without a second list to update.
+  PROVIDER_STOP_REASONS = (Riffer::Providers::FinishReason::VALUES - NORMAL_FINISH_REASONS).freeze #: Array[Symbol]
 
   # The vocabulary every run ends in.
   VALUES = (%i[completed guardrail_blocked interrupted max_steps invalid_structured_output] +

--- a/lib/riffer/agent/response.rb
+++ b/lib/riffer/agent/response.rb
@@ -1,29 +1,28 @@
 # frozen_string_literal: true
 # rbs_inline: enabled
 
-# Wraps an agent generation response. When a guardrail blocks execution,
-# +content+ is empty and +tripwire+ carries the block details.
+# Wraps an agent generation response. +outcome+ says how the run ended; when a
+# guardrail blocks execution, +content+ is empty and +tripwire+ carries the
+# block details.
 #
 #   response = agent.generate("Hello")
-#   if response.blocked?
-#     puts "Blocked: #{response.tripwire.reason}"
-#   else
+#   if response.outcome.success?
 #     puts response.content
+#   else
+#     puts "#{response.outcome.reason}: #{response.outcome.detail}"
 #   end
 class Riffer::Agent::Response
-  # @rbs @interrupted: bool
-
   # The response content.
   attr_reader :content #: String
+
+  # How the run ended.
+  attr_reader :outcome #: Riffer::Agent::Outcome
 
   # The tripwire if execution was blocked.
   attr_reader :tripwire #: Riffer::Guardrails::Tripwire?
 
   # The modifications made by guardrails during processing.
   attr_reader :modifications #: Array[Riffer::Guardrails::Modification]
-
-  # The reason provided with the interrupt, if any.
-  attr_reader :interrupt_reason #: (String | Symbol)?
 
   # The parsed structured output, if structured output was configured.
   attr_reader :structured_output #: Hash[Symbol, untyped]?
@@ -45,10 +44,9 @@ class Riffer::Agent::Response
   #--
   #: (
   #    String,
+  #    outcome: Riffer::Agent::Outcome,
   #    ?tripwire: Riffer::Guardrails::Tripwire?,
   #    ?modifications: Array[Riffer::Guardrails::Modification],
-  #    ?interrupted: bool,
-  #    ?interrupt_reason: (String | Symbol)?,
   #    ?structured_output: Hash[Symbol, untyped]?,
   #    ?messages: Array[Riffer::Messages::Base],
   #    ?healed_tool_call_ids: Array[String],
@@ -57,10 +55,9 @@ class Riffer::Agent::Response
   #  ) -> void
   def initialize(
     content,
+    outcome:,
     tripwire: nil,
     modifications: [],
-    interrupted: false,
-    interrupt_reason: nil,
     structured_output: nil,
     messages: [],
     healed_tool_call_ids: [],
@@ -68,23 +65,14 @@ class Riffer::Agent::Response
     steps: 0
   )
     @content = content
+    @outcome = outcome
     @tripwire = tripwire
     @modifications = modifications
-    @interrupted = interrupted
-    @interrupt_reason = interrupt_reason
     @structured_output = structured_output
     @messages = messages
     @healed_tool_call_ids = healed_tool_call_ids
     @token_usage = token_usage
     @steps = steps
-  end
-
-  # Returns true if the response was blocked by a guardrail.
-  #
-  #--
-  #: () -> bool
-  def blocked?
-    !tripwire.nil?
   end
 
   # Returns true if any guardrail modified data during processing.
@@ -93,14 +81,5 @@ class Riffer::Agent::Response
   #: () -> bool
   def modified?
     modifications.any?
-  end
-
-  # Returns true if the agent loop was interrupted by a callback
-  # via <tt>throw :riffer_interrupt</tt>.
-  #
-  #--
-  #: () -> bool
-  def interrupted?
-    @interrupted
   end
 end

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -155,6 +155,7 @@ module Riffer::Agent::Run
     accumulated_tool_calls = [] #: Array[Riffer::Messages::Assistant::ToolCall]
     accumulated_token_usage = nil #: Riffer::Providers::TokenUsage?
     accumulated_finish_reason = nil #: Symbol?
+    accumulated_finish_reason_raw = nil #: String?
 
     call_llm_stream(agent, tags).each do |event|
       stream_yielder << event
@@ -178,6 +179,7 @@ module Riffer::Agent::Run
         accumulated_token_usage = event.token_usage
       when Riffer::StreamEvents::FinishReasonDone
         accumulated_finish_reason = event.finish_reason
+        accumulated_finish_reason_raw = event.raw_finish_reason
       end
     end
 
@@ -186,6 +188,7 @@ module Riffer::Agent::Run
       tool_calls: accumulated_tool_calls,
       token_usage: accumulated_token_usage,
       finish_reason: accumulated_finish_reason,
+      finish_reason_raw: accumulated_finish_reason_raw,
     )
   end
 
@@ -207,6 +210,7 @@ module Riffer::Agent::Run
     build_response(
       agent,
       "",
+      outcome: Riffer::Agent::Outcome.new(reason: :guardrail_blocked, detail: tripwire.reason),
       tripwire: tripwire,
       modifications: all_modifications,
       token_usage: token_usage,
@@ -215,16 +219,37 @@ module Riffer::Agent::Run
   end
 
   #--
-  #: (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
-  def final_response(agent, all_modifications, **extra)
-    response = agent.session.final_assistant_message
+  #: (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
+  def final_response(agent, all_modifications, interrupted: false, interrupt_reason: nil, **extra)
+    message = agent.session.final_assistant_message
+    result = structured_output_result(agent, message)
     build_response(
       agent,
-      response&.content || "",
+      message&.content || "",
+      outcome: final_outcome(message, result, interrupted: interrupted, interrupt_reason: interrupt_reason),
       modifications: all_modifications,
-      structured_output: validate_structured_output(agent, response),
+      structured_output: result&.object,
       **extra,
     )
+  end
+
+  # Ordered most-causal first: a stop the caller forced outranks what the
+  # provider reported, which outranks how riffer post-processed the content.
+  #--
+  #: (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome
+  def final_outcome(message, result, interrupted:, interrupt_reason:)
+    finish_reason = message&.finish_reason
+    if interrupted && interrupt_reason == Riffer::Agent::INTERRUPT_MAX_STEPS
+      Riffer::Agent::Outcome.new(reason: :max_steps)
+    elsif interrupted
+      Riffer::Agent::Outcome.new(reason: :interrupted, detail: interrupt_reason&.to_s)
+    elsif finish_reason && Riffer::Agent::Outcome::PROVIDER_STOP_REASONS.include?(finish_reason)
+      Riffer::Agent::Outcome.new(reason: finish_reason, detail: message&.finish_reason_raw)
+    elsif result&.failure?
+      Riffer::Agent::Outcome.new(reason: :invalid_structured_output, detail: result.error)
+    else
+      Riffer::Agent::Outcome.new(reason: :completed)
+    end
   end
 
   #--
@@ -327,11 +352,11 @@ module Riffer::Agent::Run
   end
 
   #--
-  #: (Riffer::Agent, Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
-  def validate_structured_output(agent, response)
-    return unless response&.structured_output? && agent.structured_output
+  #: (Riffer::Agent, Riffer::Messages::Assistant?) -> Riffer::Agent::StructuredOutput::Result?
+  def structured_output_result(agent, message)
+    return unless message && agent.structured_output
 
-    agent.structured_output.parse_and_validate(response.content).object
+    agent.structured_output.parse_and_validate(message.content)
   end
 
   #--
@@ -358,10 +383,9 @@ module Riffer::Agent::Run
   #: (
   #    Riffer::Agent,
   #    String,
+  #    outcome: Riffer::Agent::Outcome,
   #    ?tripwire: Riffer::Guardrails::Tripwire?,
   #    ?modifications: Array[Riffer::Guardrails::Modification],
-  #    ?interrupted: bool,
-  #    ?interrupt_reason: (String | Symbol)?,
   #    ?structured_output: Hash[Symbol, untyped]?,
   #    ?healed_tool_call_ids: Array[String],
   #    ?token_usage: Riffer::Providers::TokenUsage?,
@@ -370,10 +394,9 @@ module Riffer::Agent::Run
   def build_response(
     agent,
     content,
+    outcome:,
     tripwire: nil,
     modifications: [],
-    interrupted: false,
-    interrupt_reason: nil,
     structured_output: nil,
     healed_tool_call_ids: [],
     token_usage: nil,
@@ -382,10 +405,9 @@ module Riffer::Agent::Run
     messages = agent.session.messages
     Riffer::Agent::Response.new(
       content,
+      outcome: outcome,
       tripwire: tripwire,
       modifications: modifications,
-      interrupted: interrupted,
-      interrupt_reason: interrupt_reason,
       structured_output: structured_output,
       messages: messages.frozen? ? messages : messages.dup.freeze,
       healed_tool_call_ids: healed_tool_call_ids,
@@ -460,7 +482,12 @@ module Riffer::Agent::Run
     span.set_attribute("riffer.steps", response.steps)
     Riffer::Tracing.record_usage(span, response.token_usage)
 
-    span.set_attribute("riffer.interrupt.reason", response.interrupt_reason.to_s) if response.interrupt_reason
+    outcome = response.outcome
+    span.set_attribute("riffer.outcome.reason", outcome.reason.to_s)
+    detail = outcome.detail
+    span.set_attribute("riffer.outcome.detail", detail) if detail
+    interrupt_reason = interrupt_reason_attribute(outcome)
+    span.set_attribute("riffer.interrupt.reason", interrupt_reason) if interrupt_reason
 
     tripwire = response.tripwire
     return unless tripwire
@@ -469,5 +496,14 @@ module Riffer::Agent::Run
     span.set_attribute("riffer.tripwire.guardrail", identifier) unless identifier.empty?
     span.set_attribute("riffer.tripwire.reason", tripwire.reason)
     span.set_attribute("riffer.tripwire.phase", tripwire.phase.to_s)
+  end
+
+  #--
+  #: (Riffer::Agent::Outcome) -> String?
+  def interrupt_reason_attribute(outcome)
+    case outcome.reason
+    when :max_steps then Riffer::Agent::INTERRUPT_MAX_STEPS.to_s
+    when :interrupted then outcome.detail
+    end
   end
 end

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -222,7 +222,7 @@ module Riffer::Agent::Run
   #: (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
   def final_response(agent, all_modifications, interrupted: false, interrupt_reason: nil, **extra)
     message = agent.session.final_assistant_message
-    result = structured_output_result(agent, message)
+    result = agent.structured_output && structured_output_result(agent, message)
     build_response(
       agent,
       message&.content || "",
@@ -233,8 +233,10 @@ module Riffer::Agent::Run
     )
   end
 
-  # Ordered most-causal first: a stop the caller forced outranks what the
-  # provider reported, which outranks how riffer post-processed the content.
+  # Checked in the order things happened. The loop being stopped (max_steps or
+  # an interrupt) beats the provider's finish reason, which beats riffer's own
+  # validation of the content. A truncated response that also fails the schema
+  # therefore reports :length, not :invalid_structured_output.
   #--
   #: (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome
   def final_outcome(message, result, interrupted:, interrupt_reason:)
@@ -243,7 +245,7 @@ module Riffer::Agent::Run
       Riffer::Agent::Outcome.new(reason: :max_steps)
     elsif interrupted
       Riffer::Agent::Outcome.new(reason: :interrupted, detail: interrupt_reason&.to_s)
-    elsif finish_reason && Riffer::Agent::Outcome::PROVIDER_STOP_REASONS.include?(finish_reason)
+    elsif finish_reason && !Riffer::Agent::Outcome::NORMAL_FINISH_REASONS.include?(finish_reason)
       Riffer::Agent::Outcome.new(reason: finish_reason, detail: message&.finish_reason_raw)
     elsif result&.failure?
       Riffer::Agent::Outcome.new(reason: :invalid_structured_output, detail: result.error)
@@ -354,9 +356,9 @@ module Riffer::Agent::Run
   #--
   #: (Riffer::Agent, Riffer::Messages::Assistant?) -> Riffer::Agent::StructuredOutput::Result?
   def structured_output_result(agent, message)
-    return unless message && agent.structured_output
+    return unless message
 
-    agent.structured_output.parse_and_validate(message.content)
+    agent.structured_output&.parse_and_validate(message.content)
   end
 
   #--

--- a/lib/riffer/agent/session.rb
+++ b/lib/riffer/agent/session.rb
@@ -203,6 +203,8 @@ class Riffer::Agent::Session
         tool_calls: attrs.fetch(:tool_calls, old.tool_calls),
         token_usage: attrs.fetch(:token_usage, old.token_usage),
         structured_output: attrs.fetch(:structured_output, old.structured_output),
+        finish_reason: attrs.fetch(:finish_reason, old.finish_reason),
+        finish_reason_raw: attrs.fetch(:finish_reason_raw, old.finish_reason_raw),
       )
     when Riffer::Messages::Tool
       Riffer::Messages::Tool.new(

--- a/lib/riffer/messages/assistant.rb
+++ b/lib/riffer/messages/assistant.rb
@@ -19,11 +19,31 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # <tt>Riffer::Providers::FinishReason::VALUES</tt>).
   attr_reader :finish_reason #: Symbol?
 
+  # The provider's raw finish-reason value behind +finish_reason+, when one
+  # exists on the wire.
+  attr_reader :finish_reason_raw #: String?
+
   # Raises Riffer::ArgumentError when +finish_reason+ is outside the
   # normalized vocabulary.
   #--
-  #: (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::Providers::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?finish_reason: Symbol?) -> void
-  def initialize(content, id: nil, tool_calls: [], token_usage: nil, structured_output: nil, finish_reason: nil)
+  #: (
+  #    String,
+  #    ?id: String?,
+  #    ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall],
+  #    ?token_usage: Riffer::Providers::TokenUsage?,
+  #    ?structured_output: Hash[Symbol, untyped]?,
+  #    ?finish_reason: Symbol?,
+  #    ?finish_reason_raw: String?
+  #  ) -> void
+  def initialize(
+    content,
+    id: nil,
+    tool_calls: [],
+    token_usage: nil,
+    structured_output: nil,
+    finish_reason: nil,
+    finish_reason_raw: nil
+  )
     if finish_reason && !Riffer::Providers::FinishReason::VALUES.include?(finish_reason)
       values = Riffer::Providers::FinishReason::VALUES.inspect
       raise Riffer::ArgumentError, "finish_reason must be one of #{values}, got #{finish_reason.inspect}"
@@ -34,6 +54,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     @token_usage = token_usage
     @structured_output = structured_output
     @finish_reason = finish_reason
+    @finish_reason_raw = finish_reason_raw
   end
 
   #--
@@ -71,6 +92,7 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
     hash[:token_usage] = token_usage.to_h if token_usage
     hash[:structured_output] = structured_output if structured_output?
     hash[:finish_reason] = finish_reason if finish_reason
+    hash[:finish_reason_raw] = finish_reason_raw if finish_reason_raw
     hash
   end
 end

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -37,6 +37,7 @@ class Riffer::Messages::Base
         tool_calls: tool_calls,
         structured_output: structured_output,
         finish_reason: finish_reason,
+        finish_reason_raw: msg[:finish_reason_raw],
       )
     when :system
       Riffer::Messages::System.new(content, id: id)

--- a/lib/riffer/messages/base.rb
+++ b/lib/riffer/messages/base.rb
@@ -14,39 +14,30 @@ class Riffer::Messages::Base
 
     raise Riffer::ArgumentError, "Message must be a Hash or Message object, got #{msg.class}" unless msg.is_a?(Hash)
 
-    role = msg[:role]
-    content = msg[:content]
+    raise Riffer::ArgumentError, "Message hash must include a 'role' key" if msg[:role].nil? || msg[:role].empty?
 
-    raise Riffer::ArgumentError, "Message hash must include a 'role' key" if role.nil? || role.empty?
-
-    id = msg[:id]
-
-    case role.to_sym
+    case msg[:role].to_sym
     when :user
       files = (msg[:files] || []).map { |f| Riffer::Messages::FilePart.from_hash(f) }
-      Riffer::Messages::User.new(content, id: id, files: files)
+      Riffer::Messages::User.new(msg[:content], id: msg[:id], files: files)
     when :assistant
       tool_calls = (msg[:tool_calls] || []).map do |tc|
         tc.is_a?(Riffer::Messages::Assistant::ToolCall) ? tc : Riffer::Messages::Assistant::ToolCall.new(**tc)
       end
-      structured_output = msg[:structured_output]
-      finish_reason = msg[:finish_reason]&.to_sym
       Riffer::Messages::Assistant.new(
-        content,
-        id: id,
+        msg[:content],
+        id: msg[:id],
         tool_calls: tool_calls,
-        structured_output: structured_output,
-        finish_reason: finish_reason,
+        structured_output: msg[:structured_output],
+        finish_reason: msg[:finish_reason]&.to_sym,
         finish_reason_raw: msg[:finish_reason_raw],
       )
     when :system
-      Riffer::Messages::System.new(content, id: id)
+      Riffer::Messages::System.new(msg[:content], id: msg[:id])
     when :tool
-      tool_call_id = msg[:tool_call_id]
-      name = msg[:name]
-      Riffer::Messages::Tool.new(content, id: id, tool_call_id: tool_call_id, name: name)
+      Riffer::Messages::Tool.new(msg[:content], id: msg[:id], tool_call_id: msg[:tool_call_id], name: msg[:name])
     else
-      raise Riffer::ArgumentError, "Unknown message role: #{role}"
+      raise Riffer::ArgumentError, "Unknown message role: #{msg[:role]}"
     end
   end
 

--- a/lib/riffer/providers/base.rb
+++ b/lib/riffer/providers/base.rb
@@ -71,6 +71,7 @@ class Riffer::Providers::Base
         token_usage: token_usage,
         structured_output: structured_output,
         finish_reason: finish_reason&.reason,
+        finish_reason_raw: finish_reason&.raw,
       )
     end
   end

--- a/sig/generated/riffer/agent/outcome.rbs
+++ b/sig/generated/riffer/agent/outcome.rbs
@@ -1,0 +1,37 @@
+# Generated from lib/riffer/agent/outcome.rb with RBS::Inline
+
+# How a run ended — the single place to read whether the agent completed
+# normally and, if not, why. +detail+ carries the specifics when there are any:
+# the tripwire reason, the interrupt reason, the provider's raw finish value,
+# or the structured output parse/validation error.
+#
+#   response = agent.generate("Analyze this")
+#   case response.outcome.reason
+#   when :completed then puts response.structured_output
+#   when :invalid_structured_output then warn response.outcome.detail
+#   end
+class Riffer::Agent::Outcome
+  # Finish reasons that mean the provider cut the turn short; they surface as
+  # the run's outcome verbatim.
+  PROVIDER_STOP_REASONS: Array[Symbol]
+
+  # The vocabulary every run ends in.
+  VALUES: Array[Symbol]
+
+  # Why the run ended.
+  attr_reader reason: Symbol
+
+  # Human-readable specifics for +reason+, when there are any.
+  attr_reader detail: String?
+
+  # Raises Riffer::ArgumentError when +reason+ is outside VALUES.
+  # --
+  # : (reason: Symbol, ?detail: String?) -> void
+  def initialize: (reason: Symbol, ?detail: String?) -> void
+
+  # Returns true when the run completed normally.
+  #
+  # --
+  # : () -> bool
+  def success?: () -> bool
+end

--- a/sig/generated/riffer/agent/outcome.rbs
+++ b/sig/generated/riffer/agent/outcome.rbs
@@ -11,8 +11,12 @@
 #   when :invalid_structured_output then warn response.outcome.detail
 #   end
 class Riffer::Agent::Outcome
-  # Finish reasons that mean the provider cut the turn short; they surface as
-  # the run's outcome verbatim.
+  # Finish reasons that end a turn normally; every other finish reason means the
+  # provider cut the turn short and surfaces as the run's outcome verbatim.
+  NORMAL_FINISH_REASONS: Array[Symbol]
+
+  # Derived from the provider vocabulary so a new finish reason becomes an
+  # outcome without a second list to update.
   PROVIDER_STOP_REASONS: Array[Symbol]
 
   # The vocabulary every run ends in.

--- a/sig/generated/riffer/agent/response.rbs
+++ b/sig/generated/riffer/agent/response.rbs
@@ -1,28 +1,27 @@
 # Generated from lib/riffer/agent/response.rb with RBS::Inline
 
-# Wraps an agent generation response. When a guardrail blocks execution,
-# +content+ is empty and +tripwire+ carries the block details.
+# Wraps an agent generation response. +outcome+ says how the run ended; when a
+# guardrail blocks execution, +content+ is empty and +tripwire+ carries the
+# block details.
 #
 #   response = agent.generate("Hello")
-#   if response.blocked?
-#     puts "Blocked: #{response.tripwire.reason}"
-#   else
+#   if response.outcome.success?
 #     puts response.content
+#   else
+#     puts "#{response.outcome.reason}: #{response.outcome.detail}"
 #   end
 class Riffer::Agent::Response
-  @interrupted: bool
-
   # The response content.
   attr_reader content: String
+
+  # How the run ended.
+  attr_reader outcome: Riffer::Agent::Outcome
 
   # The tripwire if execution was blocked.
   attr_reader tripwire: Riffer::Guardrails::Tripwire?
 
   # The modifications made by guardrails during processing.
   attr_reader modifications: Array[Riffer::Guardrails::Modification]
-
-  # The reason provided with the interrupt, if any.
-  attr_reader interrupt_reason: (String | Symbol)?
 
   # The parsed structured output, if structured output was configured.
   attr_reader structured_output: Hash[Symbol, untyped]?
@@ -44,34 +43,20 @@ class Riffer::Agent::Response
   # --
   # : (
   #     String,
+  #     outcome: Riffer::Agent::Outcome,
   #     ?tripwire: Riffer::Guardrails::Tripwire?,
   #     ?modifications: Array[Riffer::Guardrails::Modification],
-  #     ?interrupted: bool,
-  #     ?interrupt_reason: (String | Symbol)?,
   #     ?structured_output: Hash[Symbol, untyped]?,
   #     ?messages: Array[Riffer::Messages::Base],
   #     ?healed_tool_call_ids: Array[String],
   #     ?token_usage: Riffer::Providers::TokenUsage?,
   #     ?steps: Integer
   #   ) -> void
-  def initialize: (String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String], ?token_usage: Riffer::Providers::TokenUsage?, ?steps: Integer) -> void
-
-  # Returns true if the response was blocked by a guardrail.
-  #
-  # --
-  # : () -> bool
-  def blocked?: () -> bool
+  def initialize: (String, outcome: Riffer::Agent::Outcome, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?structured_output: Hash[Symbol, untyped]?, ?messages: Array[Riffer::Messages::Base], ?healed_tool_call_ids: Array[String], ?token_usage: Riffer::Providers::TokenUsage?, ?steps: Integer) -> void
 
   # Returns true if any guardrail modified data during processing.
   #
   # --
   # : () -> bool
   def modified?: () -> bool
-
-  # Returns true if the agent loop was interrupted by a callback
-  # via <tt>throw :riffer_interrupt</tt>.
-  #
-  # --
-  # : () -> bool
-  def interrupted?: () -> bool
 end

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -45,8 +45,14 @@ module Riffer::Agent::Run
   def tripwire_response: (Riffer::Agent, Enumerator::Yielder?, Riffer::Guardrails::Tripwire, Array[Riffer::Guardrails::Modification], ?token_usage: Riffer::Providers::TokenUsage?, ?steps: Integer) -> Riffer::Agent::Response
 
   # --
-  # : (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
-  def final_response: (Riffer::Agent, Array[Riffer::Guardrails::Modification], **untyped) -> Riffer::Agent::Response
+  # : (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
+  def final_response: (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
+
+  # Ordered most-causal first: a stop the caller forced outranks what the
+  # provider reported, which outranks how riffer post-processed the content.
+  # --
+  # : (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome
+  def final_outcome: (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome
 
   # --
   # : (Riffer::Agent, ?Hash[String, String]) -> Riffer::Messages::Assistant
@@ -77,8 +83,8 @@ module Riffer::Agent::Run
   def run_after_guardrails: (Riffer::Agent, Riffer::Messages::Assistant, Enumerator::Yielder?, Array[Riffer::Guardrails::Modification], ?Hash[String, String]) { (Riffer::Guardrails::Tripwire) -> void } -> untyped
 
   # --
-  # : (Riffer::Agent, Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
-  def validate_structured_output: (Riffer::Agent, Riffer::Messages::Assistant?) -> Hash[Symbol, untyped]?
+  # : (Riffer::Agent, Riffer::Messages::Assistant?) -> Riffer::Agent::StructuredOutput::Result?
+  def structured_output_result: (Riffer::Agent, Riffer::Messages::Assistant?) -> Riffer::Agent::StructuredOutput::Result?
 
   # --
   # : (Riffer::Agent) -> Array[singleton(Riffer::Tool)]
@@ -96,16 +102,15 @@ module Riffer::Agent::Run
   # : (
   #     Riffer::Agent,
   #     String,
+  #     outcome: Riffer::Agent::Outcome,
   #     ?tripwire: Riffer::Guardrails::Tripwire?,
   #     ?modifications: Array[Riffer::Guardrails::Modification],
-  #     ?interrupted: bool,
-  #     ?interrupt_reason: (String | Symbol)?,
   #     ?structured_output: Hash[Symbol, untyped]?,
   #     ?healed_tool_call_ids: Array[String],
   #     ?token_usage: Riffer::Providers::TokenUsage?,
   #     ?steps: Integer
   #   ) -> Riffer::Agent::Response
-  def build_response: (Riffer::Agent, String, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String], ?token_usage: Riffer::Providers::TokenUsage?, ?steps: Integer) -> Riffer::Agent::Response
+  def build_response: (Riffer::Agent, String, outcome: Riffer::Agent::Outcome, ?tripwire: Riffer::Guardrails::Tripwire?, ?modifications: Array[Riffer::Guardrails::Modification], ?structured_output: Hash[Symbol, untyped]?, ?healed_tool_call_ids: Array[String], ?token_usage: Riffer::Providers::TokenUsage?, ?steps: Integer) -> Riffer::Agent::Response
 
   # Raises when +files+ are supplied without a +prompt+ — the provider needs
   # text to anchor the attachments.
@@ -136,4 +141,8 @@ module Riffer::Agent::Run
   # --
   # : (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Agent::Response) -> void
   def record_run_outcome: (Riffer::Tracing::Otel::Span | Riffer::Tracing::NoOp::Span, Riffer::Agent::Response) -> void
+
+  # --
+  # : (Riffer::Agent::Outcome) -> String?
+  def interrupt_reason_attribute: (Riffer::Agent::Outcome) -> String?
 end

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -48,8 +48,10 @@ module Riffer::Agent::Run
   # : (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
   def final_response: (Riffer::Agent, Array[Riffer::Guardrails::Modification], ?interrupted: bool, ?interrupt_reason: (String | Symbol)?, **untyped) -> Riffer::Agent::Response
 
-  # Ordered most-causal first: a stop the caller forced outranks what the
-  # provider reported, which outranks how riffer post-processed the content.
+  # Checked in the order things happened. The loop being stopped (max_steps or
+  # an interrupt) beats the provider's finish reason, which beats riffer's own
+  # validation of the content. A truncated response that also fails the schema
+  # therefore reports :length, not :invalid_structured_output.
   # --
   # : (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome
   def final_outcome: (Riffer::Messages::Assistant?, Riffer::Agent::StructuredOutput::Result?, interrupted: bool, interrupt_reason: (String | Symbol)?) -> Riffer::Agent::Outcome

--- a/sig/generated/riffer/messages/assistant.rbs
+++ b/sig/generated/riffer/messages/assistant.rbs
@@ -27,11 +27,23 @@ class Riffer::Messages::Assistant < Riffer::Messages::Base
   # <tt>Riffer::Providers::FinishReason::VALUES</tt>).
   attr_reader finish_reason: Symbol?
 
+  # The provider's raw finish-reason value behind +finish_reason+, when one
+  # exists on the wire.
+  attr_reader finish_reason_raw: String?
+
   # Raises Riffer::ArgumentError when +finish_reason+ is outside the
   # normalized vocabulary.
   # --
-  # : (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::Providers::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?finish_reason: Symbol?) -> void
-  def initialize: (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::Providers::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?finish_reason: Symbol?) -> void
+  # : (
+  #    String,
+  #    ?id: String?,
+  #    ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall],
+  #    ?token_usage: Riffer::Providers::TokenUsage?,
+  #    ?structured_output: Hash[Symbol, untyped]?,
+  #    ?finish_reason: Symbol?,
+  #    ?finish_reason_raw: String?
+  #  ) -> void
+  def initialize: (String, ?id: String?, ?tool_calls: Array[Riffer::Messages::Assistant::ToolCall], ?token_usage: Riffer::Providers::TokenUsage?, ?structured_output: Hash[Symbol, untyped]?, ?finish_reason: Symbol?, ?finish_reason_raw: String?) -> void
 
   # --
   # : () -> Symbol

--- a/test/riffer/agent/outcome_test.rb
+++ b/test/riffer/agent/outcome_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Riffer::Agent::Outcome do
+  describe "#initialize" do
+    it "exposes the reason" do
+      outcome = Riffer::Agent::Outcome.new(reason: :interrupted, detail: "needs approval")
+
+      expect(outcome.reason).must_equal :interrupted
+    end
+
+    it "exposes the detail" do
+      outcome = Riffer::Agent::Outcome.new(reason: :interrupted, detail: "needs approval")
+
+      expect(outcome.detail).must_equal "needs approval"
+    end
+
+    it "defaults detail to nil" do
+      outcome = Riffer::Agent::Outcome.new(reason: :completed)
+
+      expect(outcome.detail).must_be_nil
+    end
+
+    it "accepts every value in the vocabulary" do
+      reasons = Riffer::Agent::Outcome::VALUES.map { |v| Riffer::Agent::Outcome.new(reason: v).reason }
+
+      expect(reasons).must_equal %i[
+        completed guardrail_blocked interrupted max_steps invalid_structured_output
+        length content_filter context_window malformed_output error other
+      ]
+    end
+
+    it "raises on a reason outside the vocabulary" do
+      error = expect { Riffer::Agent::Outcome.new(reason: :bogus) }.must_raise(Riffer::ArgumentError)
+      expect(error.message).must_include ":bogus"
+    end
+  end
+
+  describe "#success?" do
+    it "returns true when completed" do
+      expect(Riffer::Agent::Outcome.new(reason: :completed).success?).must_equal true
+    end
+
+    it "returns false for every other reason" do
+      others = (Riffer::Agent::Outcome::VALUES - [:completed]).map { |v| Riffer::Agent::Outcome.new(reason: v).success? }
+
+      expect(others.uniq).must_equal [false]
+    end
+  end
+end

--- a/test/riffer/agent/outcome_test.rb
+++ b/test/riffer/agent/outcome_test.rb
@@ -22,6 +22,12 @@ describe Riffer::Agent::Outcome do
       expect(outcome.detail).must_be_nil
     end
 
+    it "covers every provider finish reason, so none can fall through to :completed" do
+      covered = Riffer::Agent::Outcome::NORMAL_FINISH_REASONS + Riffer::Agent::Outcome::VALUES
+
+      expect(Riffer::Providers::FinishReason::VALUES - covered).must_be_empty
+    end
+
     it "accepts every value in the vocabulary" do
       reasons = Riffer::Agent::Outcome::VALUES.map { |v| Riffer::Agent::Outcome.new(reason: v).reason }
 

--- a/test/riffer/agent/response_test.rb
+++ b/test/riffer/agent/response_test.rb
@@ -3,15 +3,21 @@
 require "test_helper"
 
 describe Riffer::Agent::Response do
+  let(:completed) { Riffer::Agent::Outcome.new(reason: :completed) }
+
   describe "#initialize" do
     it "stores the content" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.content).must_equal "Hello!"
     end
 
+    it "requires an outcome" do
+      expect { Riffer::Agent::Response.new("Hello!") }.must_raise ArgumentError
+    end
+
     it "defaults tripwire to nil" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.tripwire).must_be_nil
     end
@@ -22,15 +28,24 @@ describe Riffer::Agent::Response do
         guardrail: Riffer::Guardrail,
         phase: :before,
       )
-      response = Riffer::Agent::Response.new("", tripwire: tripwire)
+      outcome = Riffer::Agent::Outcome.new(reason: :guardrail_blocked, detail: "blocked")
+      response = Riffer::Agent::Response.new("", outcome: outcome, tripwire: tripwire)
 
       expect(response.tripwire).must_equal tripwire
     end
   end
 
+  describe "#outcome" do
+    it "returns the outcome" do
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
+
+      expect(response.outcome).must_be_same_as completed
+    end
+  end
+
   describe "#modifications" do
     it "defaults to empty array" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.modifications).must_equal []
     end
@@ -41,7 +56,7 @@ describe Riffer::Agent::Response do
         phase: :before,
         message_indices: [0],
       )
-      response = Riffer::Agent::Response.new("Hello!", modifications: [modification])
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed, modifications: [modification])
 
       expect(response.modifications).must_equal [modification]
     end
@@ -49,7 +64,7 @@ describe Riffer::Agent::Response do
 
   describe "#modified?" do
     it "returns false when no modifications" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.modified?).must_equal false
     end
@@ -60,40 +75,25 @@ describe Riffer::Agent::Response do
         phase: :before,
         message_indices: [0],
       )
-      response = Riffer::Agent::Response.new("Hello!", modifications: [modification])
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed, modifications: [modification])
 
       expect(response.modified?).must_equal true
     end
   end
 
-  describe "#blocked?" do
-    it "returns false when no tripwire" do
-      response = Riffer::Agent::Response.new("Hello!")
-
-      expect(response.blocked?).must_equal false
-    end
-
-    it "returns true when tripwire present" do
-      tripwire = Riffer::Guardrails::Tripwire.new(
-        reason: "blocked",
-        guardrail: Riffer::Guardrail,
-        phase: :before,
-      )
-      response = Riffer::Agent::Response.new("", tripwire: tripwire)
-
-      expect(response.blocked?).must_equal true
-    end
-  end
-
   describe "#structured_output" do
     it "defaults to nil" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.structured_output).must_be_nil
     end
 
     it "stores the structured output" do
-      response = Riffer::Agent::Response.new("Hello!", structured_output: { sentiment: "positive", score: 0.9 })
+      response = Riffer::Agent::Response.new(
+        "Hello!",
+        outcome: completed,
+        structured_output: { sentiment: "positive", score: 0.9 },
+      )
 
       expect(response.structured_output).must_equal({ sentiment: "positive", score: 0.9 })
     end
@@ -101,14 +101,14 @@ describe Riffer::Agent::Response do
 
   describe "#messages" do
     it "defaults to empty array" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.messages).must_equal []
     end
 
     it "stores the messages" do
       messages = [Riffer::Messages::User.new("Hi"), Riffer::Messages::Assistant.new("Hello")]
-      response = Riffer::Agent::Response.new("Hello!", messages: messages)
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed, messages: messages)
 
       expect(response.messages).must_equal messages
     end
@@ -116,14 +116,14 @@ describe Riffer::Agent::Response do
 
   describe "#token_usage" do
     it "defaults to nil" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.token_usage).must_be_nil
     end
 
     it "stores the token usage" do
       usage = Riffer::Providers::TokenUsage.new(input_tokens: 100, output_tokens: 50)
-      response = Riffer::Agent::Response.new("Hello!", token_usage: usage)
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed, token_usage: usage)
 
       expect(response.token_usage).must_equal usage
     end
@@ -131,29 +131,15 @@ describe Riffer::Agent::Response do
 
   describe "#steps" do
     it "defaults to zero" do
-      response = Riffer::Agent::Response.new("Hello!")
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed)
 
       expect(response.steps).must_equal 0
     end
 
     it "stores the step count" do
-      response = Riffer::Agent::Response.new("Hello!", steps: 3)
+      response = Riffer::Agent::Response.new("Hello!", outcome: completed, steps: 3)
 
       expect(response.steps).must_equal 3
-    end
-  end
-
-  describe "#interrupted?" do
-    it "returns false by default" do
-      response = Riffer::Agent::Response.new("Hello!")
-
-      expect(response.interrupted?).must_equal false
-    end
-
-    it "returns true when interrupted" do
-      response = Riffer::Agent::Response.new("Hello!", interrupted: true)
-
-      expect(response.interrupted?).must_equal true
     end
   end
 end

--- a/test/riffer/agent/session_test.rb
+++ b/test/riffer/agent/session_test.rb
@@ -201,6 +201,14 @@ describe Riffer::Agent::Session do
       expect(result.token_usage).must_be_same_as usage
     end
 
+    it "preserves finish_reason and finish_reason_raw on assistant" do
+      a = Riffer::Messages::Assistant.new("old", id: "a_x", finish_reason: :length, finish_reason_raw: "max_tokens")
+      s = Riffer::Agent::Session.new(messages: [a])
+      result = s.update(id: "a_x", content: "new")
+
+      expect([result.finish_reason, result.finish_reason_raw]).must_equal [:length, "max_tokens"]
+    end
+
     it "preserves files on a user message" do
       file = Riffer::Messages::FilePart.new(media_type: "text/plain", data: "x")
       u = Riffer::Messages::User.new("old", id: "u_x", files: [file])

--- a/test/riffer/agent_test.rb
+++ b/test/riffer/agent_test.rb
@@ -965,7 +965,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Call tools")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
       expect(result.healed_tool_call_ids.length).must_equal 2
       expect(agent.session.orphaned_tool_call_ids).must_equal []
       tools = agent.session.messages.grep(Riffer::Messages::Tool)
@@ -992,7 +992,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Call tools")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
       expect(result.healed_tool_call_ids).must_equal []
       expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
@@ -1052,8 +1052,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Loop forever")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.outcome.reason).must_equal :max_steps
       expect(result.healed_tool_call_ids.length).must_equal 1
       expect(agent.session.orphaned_tool_call_ids).must_equal []
       synth = agent.session.messages.last
@@ -1077,8 +1076,7 @@ describe Riffer::Agent do
 
       result = agent.generate("Loop forever")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.outcome.reason).must_equal :max_steps
       expect(result.healed_tool_call_ids).must_equal []
       expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
@@ -1144,7 +1142,7 @@ describe Riffer::Agent do
       agent.provider.stub_response("All done!")
       result = agent.generate
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
     end
   end
 end

--- a/test/riffer/messages/assistant_test.rb
+++ b/test/riffer/messages/assistant_test.rb
@@ -171,6 +171,18 @@ describe Riffer::Messages::Assistant do
       expect(message.to_h[:finish_reason]).must_equal :stop
     end
 
+    it "includes finish_reason_raw when present" do
+      message = Riffer::Messages::Assistant.new("Done", finish_reason: :stop, finish_reason_raw: "end_turn")
+
+      expect(message.to_h[:finish_reason_raw]).must_equal "end_turn"
+    end
+
+    it "excludes finish_reason_raw when nil" do
+      message = Riffer::Messages::Assistant.new("Done", finish_reason: :stop)
+
+      expect(message.to_h.key?(:finish_reason_raw)).must_equal false
+    end
+
     it "excludes finish_reason when nil" do
       message = Riffer::Messages::Assistant.new("No finish reason")
 

--- a/test/riffer/messages/base_test.rb
+++ b/test/riffer/messages/base_test.rb
@@ -204,6 +204,13 @@ describe Riffer::Messages::Base do
         expect(result.finish_reason).must_equal :stop
       end
 
+      it "round-trips finish_reason_raw through to_h" do
+        message = Riffer::Messages::Assistant.new("Hello", finish_reason: :stop, finish_reason_raw: "end_turn")
+        result = Riffer::Messages::Base.from_hash(message.to_h)
+
+        expect(result.finish_reason_raw).must_equal "end_turn"
+      end
+
       it "defaults to nil when not provided" do
         result = Riffer::Messages::Base.from_hash({ role: "assistant", content: "Hello" })
 

--- a/test/riffer/providers/base_test.rb
+++ b/test/riffer/providers/base_test.rb
@@ -25,6 +25,14 @@ class ChatTracingSilentStreamProvider < Riffer::Providers::Mock
   def execute_stream(params, yielder); end
 end
 
+class RawFinishReasonProvider < Riffer::Providers::Mock
+  private
+
+  def extract_finish_reason(_response)
+    Riffer::Providers::FinishReason.new(reason: :length, raw: "max_tokens")
+  end
+end
+
 describe Riffer::Providers::Base do
   let(:provider) { Riffer::Providers::Base.new }
 
@@ -45,6 +53,28 @@ describe Riffer::Providers::Base do
 
     it "falls back to unknown for anonymous classes" do
       expect(Class.new(Riffer::Providers::Base).semconv_provider_name).must_equal "unknown"
+    end
+  end
+
+  describe "#generate_text finish reason" do
+    let(:provider) { RawFinishReasonProvider.new }
+
+    it "sets the normalized finish_reason on the message" do
+      result = provider.generate_text(prompt: "Hello", model: "riffer-1")
+
+      expect(result.finish_reason).must_equal :length
+    end
+
+    it "sets finish_reason_raw on the message" do
+      result = provider.generate_text(prompt: "Hello", model: "riffer-1")
+
+      expect(result.finish_reason_raw).must_equal "max_tokens"
+    end
+
+    it "leaves finish_reason_raw nil when the provider reports no raw value" do
+      result = Riffer::Providers::Mock.new.generate_text(prompt: "Hello", model: "riffer-1")
+
+      expect(result.finish_reason_raw).must_be_nil
     end
   end
 

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -212,6 +212,96 @@ describe Riffer::Agent::Run do
     end
   end
 
+  describe "#generate outcome" do
+    let(:schema_agent_class) do
+      stub_agent("Agent") do
+        model "mock/riffer-1"
+        structured_output do
+          required :a, Integer
+        end
+      end
+    end
+
+    it "is :completed with nil detail when the run finishes normally" do
+      result = agent_class.generate("Hello")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:completed, nil]
+    end
+
+    it "is :completed with structured_output populated when the schema validates" do
+      agent = schema_agent_class.new
+      agent.provider.stub_response('{"a": 1}')
+      result = agent.generate("Go")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:completed, nil]
+      expect(result.structured_output).must_equal({ a: 1 })
+    end
+
+    it "is :invalid_structured_output with the validation error when a required key is missing" do
+      agent = schema_agent_class.new
+      agent.provider.stub_response('{"b": 1}')
+      result = agent.generate("Go")
+
+      expect(result.structured_output).must_be_nil
+      expect(result.outcome.reason).must_equal :invalid_structured_output
+      expect(result.outcome.detail).must_include "a is required"
+    end
+
+    it "is :invalid_structured_output with the parse error when the content is not JSON" do
+      agent = schema_agent_class.new
+      agent.provider.stub_response("not json")
+      result = agent.generate("Go")
+
+      expect(result.structured_output).must_be_nil
+      expect(result.outcome.reason).must_equal :invalid_structured_output
+      expect(result.outcome.detail).must_match(/\AJSON parse error/)
+    end
+
+    it "is :guardrail_blocked with the tripwire reason" do
+      klass = stub_agent("Agent") do
+        model "mock/riffer-1"
+      end
+      klass.guardrail(:before, with: RunTracingBlockingInputGuardrail)
+      result = klass.generate("Hello")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:guardrail_blocked, "Input blocked"]
+    end
+
+    it "is :interrupted with the interrupt reason" do
+      agent = agent_class.new
+      agent.session.on_message { |_msg| agent.interrupt!("needs approval") }
+      result = agent.generate("Hello")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:interrupted, "needs approval"]
+    end
+
+    it "is :interrupted with nil detail when no reason is given" do
+      agent = agent_class.new
+      agent.session.on_message { |_msg| agent.interrupt! }
+      result = agent.generate("Hello")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:interrupted, nil]
+    end
+
+    it "reports the provider finish reason ahead of a structured output failure" do
+      agent = schema_agent_class.new
+      agent.provider.stub_response('{"b": 1}', finish_reason: :length)
+      result = agent.generate("Go")
+
+      expect(result.structured_output).must_be_nil
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:length, nil]
+    end
+
+    it "reports the interrupt ahead of the provider finish reason" do
+      agent = agent_class.new
+      agent.provider.stub_response("Truncated", finish_reason: :length)
+      agent.session.on_message { |_msg| agent.interrupt!("stop") }
+      result = agent.generate("Hello")
+
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:interrupted, "stop"]
+    end
+  end
+
   describe "#stream with structured_output" do
     it "raises ArgumentError when class-level structured_output is configured" do
       klass = stub_agent("Agent") do
@@ -281,7 +371,7 @@ describe Riffer::Agent::Run do
     it "response is not blocked without guardrails" do
       result = agent_class.generate("Hello")
 
-      expect(result.blocked?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
     end
 
     it "response content is accessible" do
@@ -303,7 +393,7 @@ describe Riffer::Agent::Run do
       it "returns blocked response" do
         result = agent_with_blocking_input.generate("Hello")
 
-        expect(result.blocked?).must_equal true
+        expect(result.outcome.reason).must_equal :guardrail_blocked
       end
 
       it "has tripwire with reason" do
@@ -350,7 +440,7 @@ describe Riffer::Agent::Run do
       it "returns blocked response" do
         result = agent_with_blocking_output.generate("Hello")
 
-        expect(result.blocked?).must_equal true
+        expect(result.outcome.reason).must_equal :guardrail_blocked
       end
 
       it "has tripwire with after phase" do
@@ -393,7 +483,7 @@ describe Riffer::Agent::Run do
       it "returns unblocked response" do
         result = agent_with_transform.generate("Hello")
 
-        expect(result.blocked?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
       end
 
       it "response is modified" do
@@ -829,7 +919,7 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Call tool")
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
       tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
       expect(tool_messages.length).must_equal 1
@@ -925,7 +1015,7 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Call tools")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
       expect(result.healed_tool_call_ids.length).must_equal 2
       expect(agent.session.orphaned_tool_call_ids).must_equal []
       tools = agent.session.messages.grep(Riffer::Messages::Tool)
@@ -952,7 +1042,7 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Call tools")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
       expect(result.healed_tool_call_ids).must_equal []
       expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
@@ -1013,8 +1103,7 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Loop forever")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.outcome.reason).must_equal :max_steps
       expect(result.healed_tool_call_ids.length).must_equal 1
       expect(agent.session.orphaned_tool_call_ids).must_equal []
       synth = agent.session.messages.last
@@ -1038,8 +1127,7 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Loop forever")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal Riffer::Agent::INTERRUPT_MAX_STEPS
+      expect(result.outcome.reason).must_equal :max_steps
       expect(result.healed_tool_call_ids).must_equal []
       expect(agent.session.orphaned_tool_call_ids.length).must_equal 1
     end
@@ -1106,7 +1194,7 @@ describe Riffer::Agent::Run do
       agent.provider.stub_response("All done!")
       result = agent.generate
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
     end
   end
 
@@ -1773,7 +1861,7 @@ describe Riffer::Agent::Run do
         expect(result.content).must_equal "I need a tool"
       end
 
-      it "sets interrupted? to true when limit is reached" do
+      it "sets the outcome reason to :max_steps when limit is reached" do
         tc = tool_class
         custom_agent_class = stub_agent("CustomAgent") do
           model "mock/riffer-1"
@@ -1787,24 +1875,7 @@ describe Riffer::Agent::Run do
 
         result = agent.generate("Do stuff")
 
-        expect(result.interrupted?).must_equal true
-      end
-
-      it "sets interrupt_reason to :max_steps when limit is reached" do
-        tc = tool_class
-        custom_agent_class = stub_agent("CustomAgent") do
-          model "mock/riffer-1"
-          max_steps 1
-          uses_tools [tc]
-        end
-
-        agent = custom_agent_class.new
-        provider = agent.provider
-        provider.stub_response("", tool_calls: [{ name: "max_steps_tool", arguments: "{}" }])
-
-        result = agent.generate("Do stuff")
-
-        expect(result.interrupt_reason).must_equal :max_steps
+        expect([result.outcome.reason, result.outcome.detail]).must_equal [:max_steps, nil]
       end
     end
 
@@ -2306,12 +2377,12 @@ describe Riffer::Agent::Run do
   end
 
   describe "interruptible callbacks with #generate" do
-    it "returns response with interrupted? true" do
+    it "returns response with an :interrupted outcome" do
       agent = agent_class.new
       agent.session.on_message { |_msg| throw :riffer_interrupt }
       result = agent.generate("Hello")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
     end
 
     it "returns accumulated content" do
@@ -2327,16 +2398,16 @@ describe Riffer::Agent::Run do
       agent.session.on_message { |_msg| throw :riffer_interrupt, "needs approval" }
       result = agent.generate("Hello")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal "needs approval"
+      expect(result.outcome.reason).must_equal :interrupted
+      expect(result.outcome.detail).must_equal "needs approval"
     end
 
-    it "returns nil interrupt_reason when no reason given" do
+    it "returns nil outcome detail when no reason given" do
       agent = agent_class.new
       agent.session.on_message { |_msg| throw :riffer_interrupt }
       result = agent.generate("Hello")
 
-      expect(result.interrupt_reason).must_be_nil
+      expect(result.outcome.detail).must_be_nil
     end
 
     describe "throw during tool execution" do
@@ -2377,14 +2448,14 @@ describe Riffer::Agent::Run do
 
         result = agent.generate("Call tools")
 
-        expect(result.interrupted?).must_equal true
+        expect(result.outcome.reason).must_equal :interrupted
         tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
         expect(tool_messages.length).must_equal 1
 
         result = agent.generate("Continue")
 
-        expect(result.interrupted?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
         tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
         expect(tool_messages.length).must_equal 2
@@ -2418,14 +2489,14 @@ describe Riffer::Agent::Run do
 
         result = agent.generate("Call tools")
 
-        expect(result.interrupted?).must_equal true
+        expect(result.outcome.reason).must_equal :interrupted
         tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
         expect(tool_messages.length).must_equal 0
 
         result = agent.generate("Continue")
 
-        expect(result.interrupted?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
         tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
         expect(tool_messages.length).must_equal 2
@@ -2450,15 +2521,15 @@ describe Riffer::Agent::Run do
         agent.session.on_message { |_msg| agent.interrupt! }
         result = agent.generate("Hello")
 
-        expect(result.interrupted?).must_equal true
+        expect(result.outcome.reason).must_equal :interrupted
       end
 
-      it "passes reason to interrupt_reason" do
+      it "passes reason to the outcome detail" do
         agent = agent_class.new
         agent.session.on_message { |_msg| agent.interrupt!(:needs_approval) }
         result = agent.generate("Hello")
 
-        expect(result.interrupt_reason).must_equal :needs_approval
+        expect(result.outcome.detail).must_equal "needs_approval"
       end
 
       it "defaults reason to nil" do
@@ -2466,7 +2537,7 @@ describe Riffer::Agent::Run do
         agent.session.on_message { |_msg| agent.interrupt! }
         result = agent.generate("Hello")
 
-        expect(result.interrupt_reason).must_be_nil
+        expect(result.outcome.detail).must_be_nil
       end
     end
   end
@@ -2478,7 +2549,7 @@ describe Riffer::Agent::Run do
       result = agent.generate("Continue")
 
       expect(result).must_be_instance_of Riffer::Agent::Response
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
     end
 
     it "returns a Response" do
@@ -2508,10 +2579,10 @@ describe Riffer::Agent::Run do
       agent.generate("Hello")
       result = agent.generate("Continue")
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
     end
 
-    it "returns nil interrupt_reason on successful resume" do
+    it "returns a :completed outcome on successful resume" do
       agent = agent_class.new
       interrupted_once = false
       agent.session.on_message do |_msg|
@@ -2523,7 +2594,7 @@ describe Riffer::Agent::Run do
       agent.generate("Hello")
       result = agent.generate("Continue")
 
-      expect(result.interrupt_reason).must_be_nil
+      expect([result.outcome.reason, result.outcome.detail]).must_equal [:completed, nil]
     end
 
     it "preserves messages from original generate" do
@@ -2598,11 +2669,11 @@ describe Riffer::Agent::Run do
 
         result = agent.generate("What's the weather?")
 
-        expect(result.interrupted?).must_equal true
+        expect(result.outcome.reason).must_equal :interrupted
 
         result = agent.generate("Continue")
 
-        expect(result.interrupted?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
         expect(result.content).must_equal "The weather is nice!"
       end
     end
@@ -2624,7 +2695,7 @@ describe Riffer::Agent::Run do
         agent = agent_class.new(session: Riffer::Agent::Session.new(messages: [Riffer::Messages::User.new("Hello")]))
         result = agent.generate
 
-        expect(result.interrupted?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
       end
 
       it "accepts a new prompt to continue the seeded conversation" do
@@ -2724,7 +2795,7 @@ describe Riffer::Agent::Run do
 
         result = agent.generate
 
-        expect(result.interrupted?).must_equal false
+        expect(result.outcome.reason).must_equal :completed
 
         tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
@@ -2773,13 +2844,12 @@ describe Riffer::Agent::Run do
 
         result = agent.generate("Do stuff")
 
-        expect(result.interrupted?).must_equal true
+        expect(result.outcome.reason).must_equal :interrupted
 
         # Resume via generate with array: step offset is auto-derived from assistant messages
         result = agent.generate("Continue")
 
-        expect(result.interrupted?).must_equal true
-        expect(result.interrupt_reason).must_equal :max_steps
+        expect(result.outcome.reason).must_equal :max_steps
       end
 
       it "enforces max_steps on cross-process resume via message counting" do
@@ -2806,8 +2876,7 @@ describe Riffer::Agent::Run do
 
         result = agent.generate
 
-        expect(result.interrupted?).must_equal true
-        expect(result.interrupt_reason).must_equal :max_steps
+        expect(result.outcome.reason).must_equal :max_steps
       end
     end
 
@@ -2986,11 +3055,11 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Hello")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
 
       result = agent.generate("Continue please")
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
       user_messages = agent.session.messages.grep(Riffer::Messages::User)
 
       expect(user_messages.length).must_equal 2
@@ -3031,14 +3100,14 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Call tools")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
       tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
       expect(tool_messages.length).must_equal 1
 
       result = agent.generate("Go ahead")
 
-      expect(result.interrupted?).must_equal false
+      expect(result.outcome.reason).must_equal :completed
       tool_messages = agent.session.messages.grep(Riffer::Messages::Tool)
 
       expect(tool_messages.length).must_equal 2
@@ -3073,12 +3142,11 @@ describe Riffer::Agent::Run do
 
       result = agent.generate("Do stuff")
 
-      expect(result.interrupted?).must_equal true
+      expect(result.outcome.reason).must_equal :interrupted
 
       result = agent.generate("Continue")
 
-      expect(result.interrupted?).must_equal true
-      expect(result.interrupt_reason).must_equal :max_steps
+      expect(result.outcome.reason).must_equal :max_steps
     end
 
     it "continues conversation with stream" do
@@ -3457,6 +3525,36 @@ describe Riffer::Agent::Run do
       generate_with_tool_loop(agent_with_max_steps.new)
 
       expect(run_span.attributes["riffer.interrupt.reason"]).must_equal "max_steps"
+    end
+
+    it "records the outcome reason on a completed run" do
+      agent_class.new.generate("Hello")
+
+      expect(run_span.attributes["riffer.outcome.reason"]).must_equal "completed"
+    end
+
+    it "omits the outcome detail when there is none" do
+      agent_class.new.generate("Hello")
+
+      expect(run_span.attributes).wont_include "riffer.outcome.detail"
+    end
+
+    it "records the outcome reason and detail on an interrupt" do
+      agent = agent_class.new
+      agent.session.on_message { |msg| agent.interrupt!("approval needed") if msg.is_a?(Riffer::Messages::Assistant) }
+      agent.generate("Hello")
+
+      expect(run_span.attributes.slice("riffer.outcome.reason", "riffer.outcome.detail")).must_equal(
+        { "riffer.outcome.reason" => "interrupted", "riffer.outcome.detail" => "approval needed" },
+      )
+    end
+
+    it "omits the interrupt reason on an interrupt without one" do
+      agent = agent_class.new
+      agent.session.on_message { |msg| agent.interrupt! if msg.is_a?(Riffer::Messages::Assistant) }
+      agent.generate("Hello")
+
+      expect(run_span.attributes).wont_include "riffer.interrupt.reason"
     end
 
     it "keeps the span status unset on interrupts" do


### PR DESCRIPTION
## Problem

When a structured-output response fails JSON parsing or schema validation, `response.structured_output` is nil and nothing on the response says why. `Run` discarded the message carried by `StructuredOutput::Result#error`, so a consumer whose schema requires `:a` and whose model returned `{"b": 1}` saw only a nil and hit `NoMethodError` far from the cause. `docs/AGENTS.md` said output is "automatically parsed and validated" and never described the failure case.

The fix exposed a broader shape problem. Knowing whether a run produced a usable result already meant checking `blocked?`, `interrupted?`, and `messages.last.finish_reason` separately, and adding a fourth accessor for structured output would have made that worse. Providers constrain generation but none of them report a schema mismatch on the wire, so Riffer's own validation is the only uniform signal and it needs a first-class home.

## Solution

`Riffer::Agent::Outcome` is a small value object with a normalized `reason` and an optional `detail` string, exposed as `response.outcome`. It mirrors the shape of `Providers::FinishReason`. The vocabulary is `:completed`, `:guardrail_blocked`, `:interrupted`, `:max_steps`, `:invalid_structured_output`, plus the abnormal provider finish reasons passed through verbatim. Precedence runs most-causal first: tripwire, then max_steps, then interrupt, then provider finish, then schema failure, then completed. A truncated response that also fails validation reports `:length`, with the raw stop value in `detail`.

`Run` now validates whenever a schema is configured rather than only when the provider's own JSON parse succeeded, which makes the parse-error branch reachable for the first time. The assistant message keeps the provider's parsed hash, and `MESSAGES.md` now says that it is parsed rather than schema-validated.

`Messages::Assistant` gains `finish_reason_raw` so the provider's raw stop value survives in generate mode instead of only on the stream event and trace attribute. `Session#rebuild_message` had been dropping `finish_reason` on history mutation and now carries both fields. Tracing gains `riffer.outcome.reason` and `riffer.outcome.detail`; the existing interrupt and tripwire span attributes are kept so dashboards keep working.

This is a breaking change. `Response#blocked?`, `Response#interrupted?`, and `Response#interrupt_reason` are removed in favour of `outcome.reason`, and `Response.new` requires `outcome:`. `response.tripwire` still carries the full tripwire object. No deprecation shim is provided, matching how prior API changes in this repo have shipped. Streaming is unchanged, no exception is raised, and a repair loop that feeds validation errors back to the model is out of scope.

## Proof

CI runs `bin/rake` (test, RuboCop, Steep). Locally: 2325 runs, 3485 assertions, 0 failures, 0 errors; no RuboCop offenses; no Steep type errors.

New run-level tests cover the reported reproduction (`{"b": 1}` against a schema requiring `:a` yields `:invalid_structured_output` with "a is required" in `detail`), non-JSON content, tripwire, interrupt with and without a reason, max_steps, and both precedence cases. Message tests cover `finish_reason_raw` round-tripping through `to_h`/`from_h` and surviving `rebuild_message`. A grep confirms no reference to the removed members remains in `lib/`, `docs/`, or `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added unified response outcomes with reasons, optional details, and success status.
  - Preserved provider-specific raw finish reasons alongside normalized values.
  - Structured-output failures now report validation details through the response outcome.

- **Breaking Changes**
  - Replaced separate interruption and blocking response helpers with the unified outcome API. Update integrations accordingly.

- **Documentation**
  - Updated lifecycle, guardrail, streaming, tracing, message, and structured-output guidance to reflect the new response outcome and finish-reason behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->