### PR TITLE
fix(agent): type stream's enumerator as returning Response

### DIFF
--- a/docs/AGENT_LIFECYCLE.md
+++ b/docs/AGENT_LIFECYCLE.md
@@ -59,6 +59,14 @@ response = MyAgent.generate('What is in this image?', files: [
 
 Streams a response as an Enumerator. Same prompt/files semantics as `generate`.
 
+Consuming the enumerator with a block returns the same `Riffer::Agent::Response` that `generate` would, so you can stream events to the user and still inspect the final outcome:
+
+```ruby
+response = MyAgent.stream('Tell me a story').each { |event| handle(event) }
+response.outcome.reason  # => :completed
+response.content
+```
+
 ```ruby
 # New conversation (class method — recommended for simple calls)
 MyAgent.stream('Tell me a story').each do |event|

--- a/lib/riffer/agent.rb
+++ b/lib/riffer/agent.rb
@@ -155,7 +155,7 @@ class Riffer::Agent
 
   # Streams a response using a new agent instance.
   #--
-  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
   def self.stream(prompt = nil, files: nil, context: nil, tags: {})
     new(context: context).stream(prompt, files: files, tags: tags)
   end
@@ -304,13 +304,14 @@ class Riffer::Agent
     Riffer::Agent::Run.generate(agent: self, prompt: prompt, files: files, tags: tags)
   end
 
-  # Streams a response from the agent, returning an +Enumerator+ of
-  # +Riffer::StreamEvents+. See +#generate+ for prompt/files/tags semantics.
+  # Streams a response from the agent as an +Enumerator+ of
+  # +Riffer::StreamEvents+ whose block-form +each+ returns the final
+  # Riffer::Agent::Response. See +#generate+ for prompt/files/tags semantics.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
   #--
-  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  #: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
   def stream(prompt = nil, files: nil, tags: {})
     if @structured_output
       raise Riffer::ArgumentError,

--- a/lib/riffer/agent/run.rb
+++ b/lib/riffer/agent/run.rb
@@ -20,7 +20,7 @@ module Riffer::Agent::Run
   # for prompt/files semantics.
   #
   #--
-  #: (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  #: (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
   def stream(agent:, prompt: nil, files: nil, tags: {})
     append_user_message(agent, prompt, files: files)
     # The enumerator body runs in its own fiber, where the fiber-local OTEL

--- a/sig/generated/riffer/agent.rbs
+++ b/sig/generated/riffer/agent.rbs
@@ -113,8 +113,8 @@ class Riffer::Agent
 
   # Streams a response using a new agent instance.
   # --
-  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def self.stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
+  def self.stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?context: Hash[Symbol, untyped]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
 
   # Reconstructs a runnable agent from a wire hash produced by +#to_h+.
   # --
@@ -208,14 +208,15 @@ class Riffer::Agent
   # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Riffer::Agent::Response
   def generate: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[String | Symbol, untyped]) -> Riffer::Agent::Response
 
-  # Streams a response from the agent, returning an +Enumerator+ of
-  # +Riffer::StreamEvents+. See +#generate+ for prompt/files/tags semantics.
+  # Streams a response from the agent as an +Enumerator+ of
+  # +Riffer::StreamEvents+ whose block-form +each+ returns the final
+  # Riffer::Agent::Response. See +#generate+ for prompt/files/tags semantics.
   #
   # Raises Riffer::ArgumentError if structured output is configured.
   #
   # --
-  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
+  def stream: (?String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
 
   # Interrupts the agent loop from an +on_message+ callback. Equivalent to
   # <tt>throw :riffer_interrupt, reason</tt>.

--- a/sig/generated/riffer/agent/run.rbs
+++ b/sig/generated/riffer/agent/run.rbs
@@ -14,8 +14,8 @@ module Riffer::Agent::Run
   # for prompt/files semantics.
   #
   # --
-  # : (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
-  def stream: (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, void]
+  # : (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[(String | Symbol), untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
+  def stream: (agent: Riffer::Agent, ?prompt: String?, ?files: Array[Hash[Symbol, untyped] | Riffer::Messages::FilePart]?, ?tags: Hash[String | Symbol, untyped]) -> Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]
 
   private
 

--- a/test/riffer/run_test.rb
+++ b/test/riffer/run_test.rb
@@ -65,6 +65,16 @@ describe Riffer::Agent::Run do
       expect(Riffer::Agent::Run.stream(agent: agent, prompt: "hi")).must_be_instance_of Enumerator
     end
 
+    it "returns the run response when the enumerator is consumed with a block" do
+      agent = agent_class.new
+
+      response = Riffer::Agent::Run.stream(agent: agent, prompt: "hi").each { |_| }
+
+      expect(response).must_be_instance_of Riffer::Agent::Response
+      expect(response.outcome.reason).must_equal :completed
+      expect(response.content).must_equal agent.session.messages.last.content
+    end
+
     it "stamps the streamed finish reason on the accumulated assistant message" do
       agent = agent_class.new
       Riffer::Agent::Run.stream(agent: agent, prompt: "hi").each { |_| }


### PR DESCRIPTION
## Problem

`Agent.stream`, `Agent#stream`, and `Run.stream` were typed as `Enumerator[Riffer::StreamEvents::Base, void]`. The second type parameter is what `each` returns when given a block, and at runtime that value is the final `Riffer::Agent::Response` from the run loop, not `void`. Steep-checked consumers who write `response = agent.stream("hi").each { |e| ... }` therefore got a `void` back from the type checker even though the object is a fully usable response.

## Solution

The three inline `#:` annotations now declare `Enumerator[Riffer::StreamEvents::Base, Riffer::Agent::Response]`, and `sig/generated/` is regenerated. The RDoc on `Agent#stream` and the `stream` section of `docs/AGENT_LIFECYCLE.md` mention the block-form return so the behaviour is discoverable rather than incidental.

The provider-level `Providers::Base#stream_text` and the private `Run.call_llm_stream` keep `void`. Their enumerator bodies return nothing meaningful, so that type is already correct.

## Proof

CI is sufficient. A new test in `test/riffer/run_test.rb` asserts that block-form `each` on the stream enumerator returns a completed `Riffer::Agent::Response` whose content matches the last session message. `bin/rake` passes locally: tests, RuboCop, and Steep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that consuming a stream with a block returns the completed response, including its content and outcome reason.

* **Bug Fixes**
  * Corrected streaming API type information to reflect the response returned after stream consumption.

* **Tests**
  * Added coverage confirming that streamed runs return the final response and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->