### PR TITLE
fix: accept JSON integers for Float params

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -115,6 +115,8 @@ Options:
 
 `Riffer::Params::Boolean` is the preferred way to declare boolean parameters. `TrueClass` and `FalseClass` continue to work for backwards compatibility.
 
+A `Float` param accepts a whole number too, since JSON Schema's `number` covers integers — a model returning `120` for a `Float` is valid, and the validated value is coerced to `120.0`. `Integer` stays strict: `1.0` is rejected, matching JSON Schema's `integer`.
+
 ### Nested Parameters
 
 Tool params support the same nested DSL as structured output — nested objects (`Hash` with block), typed arrays (`Array, of:`), and arrays of objects (`Array` with block). See the [structured output section in Agents](AGENTS.md#nested-objects) for full syntax.

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -79,6 +79,11 @@ class Riffer::Params
 
   # Validates arguments against parameter definitions.
   #
+  # A Float param accepts an Integer (JSON Schema <tt>"number"</tt> covers
+  # integers) and its value is coerced with +to_f+, so callers always get a
+  # Float. The same holds for the items of an <tt>of: Float</tt> array. No other
+  # type is coerced.
+  #
   # Raises Riffer::ValidationError if validation fails.
   #
   #--
@@ -112,7 +117,7 @@ class Riffer::Params
 
       value = validate_nested(param, value, errors)
 
-      validated[param.name] = value
+      validated[param.name] = param.type == Float ? value.to_f : value
     end
 
     raise Riffer::ValidationError, errors.join("; ") if errors.any?
@@ -178,7 +183,6 @@ class Riffer::Params
       validate_nested_array_of_objects(param, value, errors)
     elsif param.type == Array && param.item_type
       validate_typed_array(param, value, errors)
-      value
     else
       value
     end
@@ -218,20 +222,29 @@ class Riffer::Params
     end
   end
 
+  # Returns the array with +of: Float+ items coerced to Float; every other item
+  # type is returned untouched.
   #--
-  #: (Riffer::Params::Param, Array[untyped], Array[String]) -> void
+  #: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_typed_array(param, value, errors)
     item_type = param.item_type
-    return unless item_type
+    return value unless item_type
 
     type_name = Riffer::Params::Param::TYPE_MAPPINGS[item_type]
     valid_item = if [Riffer::Params::Boolean, TrueClass, FalseClass].include?(item_type)
                    ->(item) { [true, false].include?(item) }
+                 elsif item_type == Float
+                   ->(item) { item.is_a?(Numeric) }
                  else
                    ->(item) { item.is_a?(item_type) }
                  end
-    value.each_with_index do |item, i|
-      errors << "#{param.name}[#{i}] must be a #{type_name}" unless valid_item.call(item)
+    value.map.with_index do |item, i|
+      unless valid_item.call(item)
+        errors << "#{param.name}[#{i}] must be a #{type_name}"
+        next item
+      end
+
+      item_type == Float ? item.to_f : item
     end
   end
 end

--- a/lib/riffer/params.rb
+++ b/lib/riffer/params.rb
@@ -117,7 +117,7 @@ class Riffer::Params
 
       value = validate_nested(param, value, errors)
 
-      validated[param.name] = param.type == Float ? value.to_f : value
+      validated[param.name] = coerce_value(param.type, value)
     end
 
     raise Riffer::ValidationError, errors.join("; ") if errors.any?
@@ -222,8 +222,7 @@ class Riffer::Params
     end
   end
 
-  # Returns the array with +of: Float+ items coerced to Float; every other item
-  # type is returned untouched.
+  # Returns the array with its valid items coerced by +coerce_value+.
   #--
   #: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_typed_array(param, value, errors)
@@ -244,7 +243,19 @@ class Riffer::Params
         next item
       end
 
-      item_type == Float ? item.to_f : item
+      coerce_value(item_type, item)
     end
+  end
+
+  # Coerces an already-validated value to the Ruby type its param declares.
+  # Only Float coerces today, because JSON Schema "number" accepts integers and
+  # callers should not get a type that depends on whether the model wrote a
+  # decimal point. Add a branch here rather than inline at a call site.
+  #--
+  #: (Module, untyped) -> untyped
+  def coerce_value(type, value)
+    return value.to_f if type == Float
+
+    value
   end
 end

--- a/lib/riffer/params/param.rb
+++ b/lib/riffer/params/param.rb
@@ -114,6 +114,11 @@ class Riffer::Params::Param
 
   # Validates that a value matches the expected type.
   #
+  # A Float param maps to JSON Schema <tt>"number"</tt>, which covers integers,
+  # so a whole number arrives as an Integer and must be accepted. Integer stays
+  # strict, matching JSON Schema <tt>"integer"</tt>, which excludes
+  # <tt>1.0</tt>. +true+ and +false+ are not Numeric in Ruby, so they are still
+  # rejected for a Float param.
   #--
   #: (untyped) -> bool
   def valid_type?(value)
@@ -121,6 +126,8 @@ class Riffer::Params::Param
 
     if [Riffer::Params::Boolean, TrueClass, FalseClass].include?(type)
       [true, false].include?(value)
+    elsif type == Float
+      value.is_a?(Numeric)
     else
       value.is_a?(type)
     end

--- a/lib/riffer/params/param.rb
+++ b/lib/riffer/params/param.rb
@@ -114,11 +114,6 @@ class Riffer::Params::Param
 
   # Validates that a value matches the expected type.
   #
-  # A Float param maps to JSON Schema <tt>"number"</tt>, which covers integers,
-  # so a whole number arrives as an Integer and must be accepted. Integer stays
-  # strict, matching JSON Schema <tt>"integer"</tt>, which excludes
-  # <tt>1.0</tt>. +true+ and +false+ are not Numeric in Ruby, so they are still
-  # rejected for a Float param.
   #--
   #: (untyped) -> bool
   def valid_type?(value)

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -76,9 +76,16 @@ class Riffer::Params
   # : (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_nested_array_of_objects: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
 
-  # Returns the array with +of: Float+ items coerced to Float; every other item
-  # type is returned untouched.
+  # Returns the array with its valid items coerced by +coerce_value+.
   # --
   # : (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_typed_array: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
+
+  # Coerces an already-validated value to the Ruby type its param declares.
+  # Only Float coerces today, because JSON Schema "number" accepts integers and
+  # callers should not get a type that depends on whether the model wrote a
+  # decimal point. Add a branch here rather than inline at a call site.
+  # --
+  # : (Module, untyped) -> untyped
+  def coerce_value: (Module, untyped) -> untyped
 end

--- a/sig/generated/riffer/params.rbs
+++ b/sig/generated/riffer/params.rbs
@@ -40,6 +40,11 @@ class Riffer::Params
 
   # Validates arguments against parameter definitions.
   #
+  # A Float param accepts an Integer (JSON Schema <tt>"number"</tt> covers
+  # integers) and its value is coerced with +to_f+, so callers always get a
+  # Float. The same holds for the items of an <tt>of: Float</tt> array. No other
+  # type is coerced.
+  #
   # Raises Riffer::ValidationError if validation fails.
   #
   # --
@@ -71,7 +76,9 @@ class Riffer::Params
   # : (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
   def validate_nested_array_of_objects: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
 
+  # Returns the array with +of: Float+ items coerced to Float; every other item
+  # type is returned untouched.
   # --
-  # : (Riffer::Params::Param, Array[untyped], Array[String]) -> void
-  def validate_typed_array: (Riffer::Params::Param, Array[untyped], Array[String]) -> void
+  # : (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
+  def validate_typed_array: (Riffer::Params::Param, Array[untyped], Array[String]) -> Array[untyped]
 end

--- a/sig/generated/riffer/params/param.rbs
+++ b/sig/generated/riffer/params/param.rbs
@@ -60,6 +60,11 @@ class Riffer::Params::Param
 
   # Validates that a value matches the expected type.
   #
+  # A Float param maps to JSON Schema <tt>"number"</tt>, which covers integers,
+  # so a whole number arrives as an Integer and must be accepted. Integer stays
+  # strict, matching JSON Schema <tt>"integer"</tt>, which excludes
+  # <tt>1.0</tt>. +true+ and +false+ are not Numeric in Ruby, so they are still
+  # rejected for a Float param.
   # --
   # : (untyped) -> bool
   def valid_type?: (untyped) -> bool

--- a/sig/generated/riffer/params/param.rbs
+++ b/sig/generated/riffer/params/param.rbs
@@ -60,11 +60,6 @@ class Riffer::Params::Param
 
   # Validates that a value matches the expected type.
   #
-  # A Float param maps to JSON Schema <tt>"number"</tt>, which covers integers,
-  # so a whole number arrives as an Integer and must be accepted. Integer stays
-  # strict, matching JSON Schema <tt>"integer"</tt>, which excludes
-  # <tt>1.0</tt>. +true+ and +false+ are not Numeric in Ruby, so they are still
-  # rejected for a Float param.
   # --
   # : (untyped) -> bool
   def valid_type?: (untyped) -> bool

--- a/test/riffer/params/param_test.rb
+++ b/test/riffer/params/param_test.rb
@@ -60,10 +60,34 @@ describe Riffer::Params::Param do
       expect(param.valid_type?(42)).must_equal true
     end
 
+    it "returns false for a float on an integer param" do
+      param = Riffer::Params::Param.new(name: :count, type: Integer, required: true)
+
+      expect(param.valid_type?(1.5)).must_equal false
+    end
+
     it "returns true for valid float type" do
       param = Riffer::Params::Param.new(name: :amount, type: Float, required: true)
 
       expect(param.valid_type?(3.14)).must_equal true
+    end
+
+    it "returns true for an integer on a float param" do
+      param = Riffer::Params::Param.new(name: :amount, type: Float, required: true)
+
+      expect(param.valid_type?(120)).must_equal true
+    end
+
+    it "returns false for a numeric string on a float param" do
+      param = Riffer::Params::Param.new(name: :amount, type: Float, required: true)
+
+      expect(param.valid_type?("120")).must_equal false
+    end
+
+    it "returns false for a boolean on a float param" do
+      param = Riffer::Params::Param.new(name: :amount, type: Float, required: true)
+
+      expect(param.valid_type?(true)).must_equal false
     end
 
     it "returns true for true boolean value" do

--- a/test/riffer/params_test.rb
+++ b/test/riffer/params_test.rb
@@ -360,6 +360,92 @@ describe Riffer::Params do
 
       expect(result[:items]).must_equal [{ name: "A" }, { name: "B" }]
     end
+
+    it "accepts a float for a Float param" do
+      params = Riffer::Params.new
+      params.required(:price, Float)
+
+      expect(params.validate({ price: 120.5 })[:price]).must_equal 120.5
+    end
+
+    it "accepts an integer for a Float param and coerces it to a float" do
+      params = Riffer::Params.new
+      params.required(:price, Float)
+      result = params.validate({ price: 120 })
+
+      expect(result[:price]).must_equal 120.0
+      expect(result[:price]).must_be_instance_of Float
+    end
+
+    it "rejects a string for a Float param" do
+      params = Riffer::Params.new
+      params.required(:price, Float)
+      error = expect { params.validate({ price: "120" }) }.must_raise(Riffer::ValidationError)
+
+      expect(error.message).must_match(/price must be a number/)
+    end
+
+    it "rejects a boolean for a Float param" do
+      params = Riffer::Params.new
+      params.required(:price, Float)
+      error = expect { params.validate({ price: true }) }.must_raise(Riffer::ValidationError)
+
+      expect(error.message).must_match(/price must be a number/)
+    end
+
+    it "rejects a float for an Integer param" do
+      params = Riffer::Params.new
+      params.required(:quantity, Integer)
+      error = expect { params.validate({ quantity: 1.5 }) }.must_raise(Riffer::ValidationError)
+
+      expect(error.message).must_match(/quantity must be an? integer/)
+    end
+
+    it "accepts an integer for a Float param nested in an array of objects" do
+      params = Riffer::Params.new
+      params.required(:treatments, Array) do
+        required :price, Float
+      end
+      result = params.validate({ treatments: [{ price: 120 }] })
+
+      expect(result[:treatments]).must_equal [{ price: 120.0 }]
+      expect(result[:treatments].first[:price]).must_be_instance_of Float
+    end
+
+    it "accepts an integer for a Float param nested in a Hash" do
+      params = Riffer::Params.new
+      params.required(:invoice, Hash) do
+        required :total, Float
+      end
+      result = params.validate({ invoice: { total: 120 } })
+
+      expect(result[:invoice][:total]).must_be_instance_of Float
+    end
+
+    it "accepts mixed numerics in an of: Float array and coerces them to floats" do
+      params = Riffer::Params.new
+      params.required(:scores, Array, of: Float)
+      result = params.validate({ scores: [1, 2.5] })
+
+      expect(result[:scores]).must_equal [1.0, 2.5]
+      expect(result[:scores].map(&:class)).must_equal [Float, Float]
+    end
+
+    it "rejects a non-numeric item in an of: Float array" do
+      params = Riffer::Params.new
+      params.required(:scores, Array, of: Float)
+      error = expect { params.validate({ scores: [1, "2"] }) }.must_raise(Riffer::ValidationError)
+
+      expect(error.message).must_match(/scores\[1\] must be a number/)
+    end
+
+    it "rejects a float item in an of: Integer array" do
+      params = Riffer::Params.new
+      params.required(:counts, Array, of: Integer)
+      error = expect { params.validate({ counts: [1, 2.5] }) }.must_raise(Riffer::ValidationError)
+
+      expect(error.message).must_match(/counts\[1\] must be an? integer/)
+    end
   end
 
   describe "#to_json_schema" do


### PR DESCRIPTION
## What broke

Any whole-number value for a `Float` param failed validation:

```ruby
p = Riffer::Params.new
p.required :treatments, Array do
  required :price, Float
end
Riffer::Agent::StructuredOutput.new(p).parse_and_validate('{"treatments":[{"price":120}]}').error
# => "Validation error: treatments[0].price must be a number"
```

## Why

`Param#valid_type?` checked `value.is_a?(type)`. `Float` maps to JSON Schema `"number"`, and `"number"` includes integers — so a model returning `120` is valid per the schema we emit, but `JSON.parse` yields an `Integer` and the `is_a?(Float)` check rejected it. `Params#validate_typed_array` had the same defect for `of: Float` arrays.

## Fix

- `Param#valid_type?`: a `Float` param accepts any `Numeric`. `true`/`false` are not `Numeric` in Ruby, so booleans are still rejected.
- `Params#validate_typed_array`: same rule for `of: Float` items.
- `Integer` stays strict — JSON Schema `"integer"` excludes `1.0`.

## Coercion decision

The validated value for a `Float` param is coerced with `to_f`, and so are `of: Float` array items, so callers always receive a `Float` rather than a type that varies with whether the model happened to emit a decimal point. Nothing else is coerced — this is not a general string-to-number conversion.

After the fix the repro returns `{treatments: [{price: 120.0}]}` with no error.

`bundle exec rake` (test + rubocop + steep) is green; RBS regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Float parameters now accept whole-number and decimal numeric values, converting them to floating-point values.
  - The same behavior applies to nested parameters and typed arrays containing Float values.
  - Invalid strings and boolean values continue to be rejected.

- **Bug Fixes**
  - Integer parameters continue to reject fractional numeric values.

- **Documentation**
  - Updated tool documentation to clarify numeric coercion and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->