### PR TITLE
feat(bedrock): moving cachePoint so the conversation tail is cached

### DIFF
--- a/docs/providers/AMAZON_BEDROCK.md
+++ b/docs/providers/AMAZON_BEDROCK.md
@@ -107,7 +107,7 @@ model_options cache_control: {type: "ephemeral"}
 model_options cache_control: {type: "ephemeral", ttl: "1h"}
 ```
 
-Both checkpoints share the same `ttl`. Caching is opt-in: omit `cache_control` and no cachePoint is sent. A checkpoint is only honored once the content before it clears the model's minimum token count — 1,024 tokens for Sonnet 4.6 and Sonnet 5, 512 for Opus 5, 4,096 for Haiku 4.5 — and is silently ignored below it, so short conversations may see no cache reads at first. On models that don't support `cachePoint`, the Converse request errors. Verify hits via `response.token_usage.cache_read_tokens`, which should grow with each step of an agent loop as the conversation accumulates.
+Both checkpoints share the same `ttl`. Caching is opt-in: omit `cache_control` and no cachePoint is sent. A checkpoint is only honored once the content before it clears the model's minimum token count (see the per-model limits in the [AWS prompt caching guide](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)) and is silently ignored below it, so short conversations may see no cache reads at first. On models that don't support `cachePoint`, the Converse request errors. Verify hits via `response.token_usage.cache_read_tokens`, which should grow with each step of an agent loop as the conversation accumulates.
 
 ## Example
 

--- a/docs/providers/AMAZON_BEDROCK.md
+++ b/docs/providers/AMAZON_BEDROCK.md
@@ -94,7 +94,10 @@ model_options additional_model_request_fields: {
 
 ### cache_control
 
-Enable prompt caching for models that support it (Claude, Nova). Riffer appends a single Converse `cachePoint` to the stable prefix — after the system array, or after the tools when there is no system prompt — so system instructions and tool definitions are reused across the calls in an agent loop and across conversation turns. The volatile message tail is never cached.
+Enable prompt caching for models that support it (Claude, Nova). Riffer mirrors Anthropic's automatic caching with two Converse `cachePoint` blocks:
+
+- A **static** checkpoint at the end of the stable prefix — after the system array, or after the tools when there is no system prompt — so system instructions and tool definitions are reused across every call.
+- A **moving** checkpoint after the last content block of the final message (a user turn or a batch of tool results). Bedrock looks back roughly 20 content blocks from a checkpoint for the longest cached prefix, so the second and later calls in a tool loop, and later turns in a conversation, read the accumulated conversation from cache instead of re-billing it at the full input rate.
 
 ```ruby
 # 5-minute TTL (default)
@@ -104,7 +107,7 @@ model_options cache_control: {type: "ephemeral"}
 model_options cache_control: {type: "ephemeral", ttl: "1h"}
 ```
 
-Caching is opt-in: omit `cache_control` and no cachePoint is sent. The breakpoint is only honored once the prefix clears the model's minimum token count; on models that don't support `cachePoint`, the Converse request errors. Verify hits via `response.token_usage.cache_read_tokens`.
+Both checkpoints share the same `ttl`. Caching is opt-in: omit `cache_control` and no cachePoint is sent. A checkpoint is only honored once the content before it clears the model's minimum token count — 1,024 tokens for Sonnet 4.6 and Sonnet 5, 512 for Opus 5, 4,096 for Haiku 4.5 — and is silently ignored below it, so short conversations may see no cache reads at first. On models that don't support `cachePoint`, the Converse request errors. Verify hits via `response.token_usage.cache_read_tokens`, which should grow with each step of an agent loop as the conversation accumulates.
 
 ## Example
 

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -129,13 +129,10 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     params
   end
 
-  # Converse chains +tools -> system -> messages+, so the +cachePoint+ at the
-  # end of the system array (or the tools array, when there is no system
-  # prompt) caches the stable prefix. The second, after the last content block
-  # of the final message, moves with the conversation: Bedrock looks back from
-  # it for the longest cached prefix, so later calls in a tool loop read the
-  # accumulated messages from cache. Both share a ttl because Bedrock rejects
-  # a 5m point placed ahead of a 1h one.
+  # Converse treats +tools -> system -> messages+ as one prefix and looks back
+  # from a +cachePoint+ for the longest cached run, so the point on the final
+  # message reuses the previous step's cache wherever that point sat. Mixed
+  # ttls must be ordered 1h before 5m, so both points share one.
   #--
   #: (Hash[Symbol, untyped], untyped) -> void
   def apply_cache_point(params, cache_control)

--- a/lib/riffer/providers/amazon_bedrock.rb
+++ b/lib/riffer/providers/amazon_bedrock.rb
@@ -129,21 +129,28 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
     params
   end
 
-  # Converse chains +tools -> system -> messages+, so a single +cachePoint+ at
-  # the end of the system array (or the tools array, when there is no system
-  # prompt) also caches the preceding sections.
+  # Converse chains +tools -> system -> messages+, so the +cachePoint+ at the
+  # end of the system array (or the tools array, when there is no system
+  # prompt) caches the stable prefix. The second, after the last content block
+  # of the final message, moves with the conversation: Bedrock looks back from
+  # it for the longest cached prefix, so later calls in a tool loop read the
+  # accumulated messages from cache. Both share a ttl because Bedrock rejects
+  # a 5m point placed ahead of a 1h one.
   #--
   #: (Hash[Symbol, untyped], untyped) -> void
   def apply_cache_point(params, cache_control)
     cache_point = { cache_point: build_cache_point(cache_control) }
     system = params[:system]
     tools = params.dig(:tool_config, :tools)
+    last_message = params[:messages].last
 
     if system && !system.empty?
       system << cache_point
     elsif tools && !tools.empty?
       tools << cache_point
     end
+
+    last_message[:content] << cache_point if last_message
   end
 
   #--

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -45,9 +45,13 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
-  # Converse chains +tools -> system -> messages+, so a single +cachePoint+ at
-  # the end of the system array (or the tools array, when there is no system
-  # prompt) also caches the preceding sections.
+  # Converse chains +tools -> system -> messages+, so the +cachePoint+ at the
+  # end of the system array (or the tools array, when there is no system
+  # prompt) caches the stable prefix. The second, after the last content block
+  # of the final message, moves with the conversation: Bedrock looks back from
+  # it for the longest cached prefix, so later calls in a tool loop read the
+  # accumulated messages from cache. Both share a ttl because Bedrock rejects
+  # a 5m point placed ahead of a 1h one.
   # --
   # : (Hash[Symbol, untyped], untyped) -> void
   def apply_cache_point: (Hash[Symbol, untyped], untyped) -> void

--- a/sig/generated/riffer/providers/amazon_bedrock.rbs
+++ b/sig/generated/riffer/providers/amazon_bedrock.rbs
@@ -45,13 +45,10 @@ class Riffer::Providers::AmazonBedrock < Riffer::Providers::Base
   # : (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
   def build_request_params: (Array[Riffer::Messages::Base], String?, Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
 
-  # Converse chains +tools -> system -> messages+, so the +cachePoint+ at the
-  # end of the system array (or the tools array, when there is no system
-  # prompt) caches the stable prefix. The second, after the last content block
-  # of the final message, moves with the conversation: Bedrock looks back from
-  # it for the longest cached prefix, so later calls in a tool loop read the
-  # accumulated messages from cache. Both share a ttl because Bedrock rejects
-  # a 5m point placed ahead of a 1h one.
+  # Converse treats +tools -> system -> messages+ as one prefix and looks back
+  # from a +cachePoint+ for the longest cached run, so the point on the final
+  # message reuses the previous step's cache wherever that point sat. Mixed
+  # ttls must be ordered 1h before 5m, so both points share one.
   # --
   # : (Hash[Symbol, untyped], untyped) -> void
   def apply_cache_point: (Hash[Symbol, untyped], untyped) -> void

--- a/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/prompt_caching/_generate_text/reads_previous_step_from_cache.yml
+++ b/test/fixtures/vcr_cassettes/Riffer_Providers_AmazonBedrock/prompt_caching/_generate_text/reads_previous_step_from_cache.yml
@@ -1,0 +1,420 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"Here is the handbook:\n\nSection
+        1. Clause 1 of the clinic handbook describes procedure number 1, which staff
+        follow when handling a case of type 1 during regular operating hours. Section
+        2. Clause 2 of the clinic handbook describes procedure number 2, which staff
+        follow when handling a case of type 2 during regular operating hours. Section
+        3. Clause 3 of the clinic handbook describes procedure number 3, which staff
+        follow when handling a case of type 3 during regular operating hours. Section
+        4. Clause 4 of the clinic handbook describes procedure number 4, which staff
+        follow when handling a case of type 4 during regular operating hours. Section
+        5. Clause 5 of the clinic handbook describes procedure number 5, which staff
+        follow when handling a case of type 5 during regular operating hours. Section
+        6. Clause 6 of the clinic handbook describes procedure number 6, which staff
+        follow when handling a case of type 6 during regular operating hours. Section
+        7. Clause 7 of the clinic handbook describes procedure number 7, which staff
+        follow when handling a case of type 7 during regular operating hours. Section
+        8. Clause 8 of the clinic handbook describes procedure number 8, which staff
+        follow when handling a case of type 8 during regular operating hours. Section
+        9. Clause 9 of the clinic handbook describes procedure number 9, which staff
+        follow when handling a case of type 9 during regular operating hours. Section
+        10. Clause 10 of the clinic handbook describes procedure number 10, which
+        staff follow when handling a case of type 10 during regular operating hours.
+        Section 11. Clause 11 of the clinic handbook describes procedure number 11,
+        which staff follow when handling a case of type 11 during regular operating
+        hours. Section 12. Clause 12 of the clinic handbook describes procedure number
+        12, which staff follow when handling a case of type 12 during regular operating
+        hours. Section 13. Clause 13 of the clinic handbook describes procedure number
+        13, which staff follow when handling a case of type 13 during regular operating
+        hours. Section 14. Clause 14 of the clinic handbook describes procedure number
+        14, which staff follow when handling a case of type 14 during regular operating
+        hours. Section 15. Clause 15 of the clinic handbook describes procedure number
+        15, which staff follow when handling a case of type 15 during regular operating
+        hours. Section 16. Clause 16 of the clinic handbook describes procedure number
+        16, which staff follow when handling a case of type 16 during regular operating
+        hours. Section 17. Clause 17 of the clinic handbook describes procedure number
+        17, which staff follow when handling a case of type 17 during regular operating
+        hours. Section 18. Clause 18 of the clinic handbook describes procedure number
+        18, which staff follow when handling a case of type 18 during regular operating
+        hours. Section 19. Clause 19 of the clinic handbook describes procedure number
+        19, which staff follow when handling a case of type 19 during regular operating
+        hours. Section 20. Clause 20 of the clinic handbook describes procedure number
+        20, which staff follow when handling a case of type 20 during regular operating
+        hours. Section 21. Clause 21 of the clinic handbook describes procedure number
+        21, which staff follow when handling a case of type 21 during regular operating
+        hours. Section 22. Clause 22 of the clinic handbook describes procedure number
+        22, which staff follow when handling a case of type 22 during regular operating
+        hours. Section 23. Clause 23 of the clinic handbook describes procedure number
+        23, which staff follow when handling a case of type 23 during regular operating
+        hours. Section 24. Clause 24 of the clinic handbook describes procedure number
+        24, which staff follow when handling a case of type 24 during regular operating
+        hours. Section 25. Clause 25 of the clinic handbook describes procedure number
+        25, which staff follow when handling a case of type 25 during regular operating
+        hours. Section 26. Clause 26 of the clinic handbook describes procedure number
+        26, which staff follow when handling a case of type 26 during regular operating
+        hours. Section 27. Clause 27 of the clinic handbook describes procedure number
+        27, which staff follow when handling a case of type 27 during regular operating
+        hours. Section 28. Clause 28 of the clinic handbook describes procedure number
+        28, which staff follow when handling a case of type 28 during regular operating
+        hours. Section 29. Clause 29 of the clinic handbook describes procedure number
+        29, which staff follow when handling a case of type 29 during regular operating
+        hours. Section 30. Clause 30 of the clinic handbook describes procedure number
+        30, which staff follow when handling a case of type 30 during regular operating
+        hours. Section 31. Clause 31 of the clinic handbook describes procedure number
+        31, which staff follow when handling a case of type 31 during regular operating
+        hours. Section 32. Clause 32 of the clinic handbook describes procedure number
+        32, which staff follow when handling a case of type 32 during regular operating
+        hours. Section 33. Clause 33 of the clinic handbook describes procedure number
+        33, which staff follow when handling a case of type 33 during regular operating
+        hours. Section 34. Clause 34 of the clinic handbook describes procedure number
+        34, which staff follow when handling a case of type 34 during regular operating
+        hours. Section 35. Clause 35 of the clinic handbook describes procedure number
+        35, which staff follow when handling a case of type 35 during regular operating
+        hours. Section 36. Clause 36 of the clinic handbook describes procedure number
+        36, which staff follow when handling a case of type 36 during regular operating
+        hours. Section 37. Clause 37 of the clinic handbook describes procedure number
+        37, which staff follow when handling a case of type 37 during regular operating
+        hours. Section 38. Clause 38 of the clinic handbook describes procedure number
+        38, which staff follow when handling a case of type 38 during regular operating
+        hours. Section 39. Clause 39 of the clinic handbook describes procedure number
+        39, which staff follow when handling a case of type 39 during regular operating
+        hours. Section 40. Clause 40 of the clinic handbook describes procedure number
+        40, which staff follow when handling a case of type 40 during regular operating
+        hours. Section 41. Clause 41 of the clinic handbook describes procedure number
+        41, which staff follow when handling a case of type 41 during regular operating
+        hours. Section 42. Clause 42 of the clinic handbook describes procedure number
+        42, which staff follow when handling a case of type 42 during regular operating
+        hours. Section 43. Clause 43 of the clinic handbook describes procedure number
+        43, which staff follow when handling a case of type 43 during regular operating
+        hours. Section 44. Clause 44 of the clinic handbook describes procedure number
+        44, which staff follow when handling a case of type 44 during regular operating
+        hours. Section 45. Clause 45 of the clinic handbook describes procedure number
+        45, which staff follow when handling a case of type 45 during regular operating
+        hours. Section 46. Clause 46 of the clinic handbook describes procedure number
+        46, which staff follow when handling a case of type 46 during regular operating
+        hours. Section 47. Clause 47 of the clinic handbook describes procedure number
+        47, which staff follow when handling a case of type 47 during regular operating
+        hours. Section 48. Clause 48 of the clinic handbook describes procedure number
+        48, which staff follow when handling a case of type 48 during regular operating
+        hours. Section 49. Clause 49 of the clinic handbook describes procedure number
+        49, which staff follow when handling a case of type 49 during regular operating
+        hours. Section 50. Clause 50 of the clinic handbook describes procedure number
+        50, which staff follow when handling a case of type 50 during regular operating
+        hours. Section 51. Clause 51 of the clinic handbook describes procedure number
+        51, which staff follow when handling a case of type 51 during regular operating
+        hours. Section 52. Clause 52 of the clinic handbook describes procedure number
+        52, which staff follow when handling a case of type 52 during regular operating
+        hours. Section 53. Clause 53 of the clinic handbook describes procedure number
+        53, which staff follow when handling a case of type 53 during regular operating
+        hours. Section 54. Clause 54 of the clinic handbook describes procedure number
+        54, which staff follow when handling a case of type 54 during regular operating
+        hours. Section 55. Clause 55 of the clinic handbook describes procedure number
+        55, which staff follow when handling a case of type 55 during regular operating
+        hours. Section 56. Clause 56 of the clinic handbook describes procedure number
+        56, which staff follow when handling a case of type 56 during regular operating
+        hours. Section 57. Clause 57 of the clinic handbook describes procedure number
+        57, which staff follow when handling a case of type 57 during regular operating
+        hours. Section 58. Clause 58 of the clinic handbook describes procedure number
+        58, which staff follow when handling a case of type 58 during regular operating
+        hours. Section 59. Clause 59 of the clinic handbook describes procedure number
+        59, which staff follow when handling a case of type 59 during regular operating
+        hours. Section 60. Clause 60 of the clinic handbook describes procedure number
+        60, which staff follow when handling a case of type 60 during regular operating
+        hours. Section 61. Clause 61 of the clinic handbook describes procedure number
+        61, which staff follow when handling a case of type 61 during regular operating
+        hours. Section 62. Clause 62 of the clinic handbook describes procedure number
+        62, which staff follow when handling a case of type 62 during regular operating
+        hours. Section 63. Clause 63 of the clinic handbook describes procedure number
+        63, which staff follow when handling a case of type 63 during regular operating
+        hours. Section 64. Clause 64 of the clinic handbook describes procedure number
+        64, which staff follow when handling a case of type 64 during regular operating
+        hours. Section 65. Clause 65 of the clinic handbook describes procedure number
+        65, which staff follow when handling a case of type 65 during regular operating
+        hours. Section 66. Clause 66 of the clinic handbook describes procedure number
+        66, which staff follow when handling a case of type 66 during regular operating
+        hours. Section 67. Clause 67 of the clinic handbook describes procedure number
+        67, which staff follow when handling a case of type 67 during regular operating
+        hours. Section 68. Clause 68 of the clinic handbook describes procedure number
+        68, which staff follow when handling a case of type 68 during regular operating
+        hours. Section 69. Clause 69 of the clinic handbook describes procedure number
+        69, which staff follow when handling a case of type 69 during regular operating
+        hours. Section 70. Clause 70 of the clinic handbook describes procedure number
+        70, which staff follow when handling a case of type 70 during regular operating
+        hours. Section 71. Clause 71 of the clinic handbook describes procedure number
+        71, which staff follow when handling a case of type 71 during regular operating
+        hours. Section 72. Clause 72 of the clinic handbook describes procedure number
+        72, which staff follow when handling a case of type 72 during regular operating
+        hours. Section 73. Clause 73 of the clinic handbook describes procedure number
+        73, which staff follow when handling a case of type 73 during regular operating
+        hours. Section 74. Clause 74 of the clinic handbook describes procedure number
+        74, which staff follow when handling a case of type 74 during regular operating
+        hours. Section 75. Clause 75 of the clinic handbook describes procedure number
+        75, which staff follow when handling a case of type 75 during regular operating
+        hours. Section 76. Clause 76 of the clinic handbook describes procedure number
+        76, which staff follow when handling a case of type 76 during regular operating
+        hours. Section 77. Clause 77 of the clinic handbook describes procedure number
+        77, which staff follow when handling a case of type 77 during regular operating
+        hours. Section 78. Clause 78 of the clinic handbook describes procedure number
+        78, which staff follow when handling a case of type 78 during regular operating
+        hours. Section 79. Clause 79 of the clinic handbook describes procedure number
+        79, which staff follow when handling a case of type 79 during regular operating
+        hours. Section 80. Clause 80 of the clinic handbook describes procedure number
+        80, which staff follow when handling a case of type 80 during regular operating
+        hours.\n\nWhat is the current cancellation policy?"},{"cachePoint":{"type":"default"}}]}],"system":[{"text":"You
+        are a clinic assistant. Call lookup_policy before answering a policy question."},{"cachePoint":{"type":"default"}}],"toolConfig":{"tools":[{"toolSpec":{"name":"lookup_policy","description":"Look
+        up the current wording of a named clinic policy","inputSchema":{"json":{"type":"object","properties":{"name":{"type":"string","description":"The
+        policy name"}},"required":["name"],"additionalProperties":false}}}}]}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 54ffd73f-93b1-4446-8b7b-0c757a0d5da3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.254.1 ua/2.1 api/bedrock_runtime#1.83.0 os/macos#25 md/arm64
+        lang/ruby#4.0.5 md/4.0.5 m/Z,b,D
+      Content-Length:
+      - '13273'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Sep 2026 18:21:03 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '567'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - 183a1877-51b9-4378-b7fa-1235322fc80d
+    body:
+      encoding: UTF-8
+      string: '{"metrics":{"latencyMs":1489},"output":{"message":{"content":[{"text":"Let
+        me look up the current cancellation policy for you right away."},{"toolUse":{"input":{"name":"cancellation"},"name":"lookup_policy","toolUseId":"tooluse_P3nbk6atWRa0Ub7fBJbhKJ","type":"tool_use"}}],"role":"assistant"}},"stopReason":"tool_use","usage":{"cacheDetails":[{"inputTokens":3488,"ttl":"5m"}],"cacheReadInputTokenCount":0,"cacheReadInputTokens":0,"cacheWriteInputTokenCount":3488,"cacheWriteInputTokens":3488,"inputTokens":3,"outputTokens":69,"serverToolUsage":{},"totalTokens":3560}}'
+  recorded_at: Fri, 11 Sep 2026 18:21:03 GMT
+- request:
+    method: post
+    uri: https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/converse
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":[{"text":"Here is the handbook:\n\nSection
+        1. Clause 1 of the clinic handbook describes procedure number 1, which staff
+        follow when handling a case of type 1 during regular operating hours. Section
+        2. Clause 2 of the clinic handbook describes procedure number 2, which staff
+        follow when handling a case of type 2 during regular operating hours. Section
+        3. Clause 3 of the clinic handbook describes procedure number 3, which staff
+        follow when handling a case of type 3 during regular operating hours. Section
+        4. Clause 4 of the clinic handbook describes procedure number 4, which staff
+        follow when handling a case of type 4 during regular operating hours. Section
+        5. Clause 5 of the clinic handbook describes procedure number 5, which staff
+        follow when handling a case of type 5 during regular operating hours. Section
+        6. Clause 6 of the clinic handbook describes procedure number 6, which staff
+        follow when handling a case of type 6 during regular operating hours. Section
+        7. Clause 7 of the clinic handbook describes procedure number 7, which staff
+        follow when handling a case of type 7 during regular operating hours. Section
+        8. Clause 8 of the clinic handbook describes procedure number 8, which staff
+        follow when handling a case of type 8 during regular operating hours. Section
+        9. Clause 9 of the clinic handbook describes procedure number 9, which staff
+        follow when handling a case of type 9 during regular operating hours. Section
+        10. Clause 10 of the clinic handbook describes procedure number 10, which
+        staff follow when handling a case of type 10 during regular operating hours.
+        Section 11. Clause 11 of the clinic handbook describes procedure number 11,
+        which staff follow when handling a case of type 11 during regular operating
+        hours. Section 12. Clause 12 of the clinic handbook describes procedure number
+        12, which staff follow when handling a case of type 12 during regular operating
+        hours. Section 13. Clause 13 of the clinic handbook describes procedure number
+        13, which staff follow when handling a case of type 13 during regular operating
+        hours. Section 14. Clause 14 of the clinic handbook describes procedure number
+        14, which staff follow when handling a case of type 14 during regular operating
+        hours. Section 15. Clause 15 of the clinic handbook describes procedure number
+        15, which staff follow when handling a case of type 15 during regular operating
+        hours. Section 16. Clause 16 of the clinic handbook describes procedure number
+        16, which staff follow when handling a case of type 16 during regular operating
+        hours. Section 17. Clause 17 of the clinic handbook describes procedure number
+        17, which staff follow when handling a case of type 17 during regular operating
+        hours. Section 18. Clause 18 of the clinic handbook describes procedure number
+        18, which staff follow when handling a case of type 18 during regular operating
+        hours. Section 19. Clause 19 of the clinic handbook describes procedure number
+        19, which staff follow when handling a case of type 19 during regular operating
+        hours. Section 20. Clause 20 of the clinic handbook describes procedure number
+        20, which staff follow when handling a case of type 20 during regular operating
+        hours. Section 21. Clause 21 of the clinic handbook describes procedure number
+        21, which staff follow when handling a case of type 21 during regular operating
+        hours. Section 22. Clause 22 of the clinic handbook describes procedure number
+        22, which staff follow when handling a case of type 22 during regular operating
+        hours. Section 23. Clause 23 of the clinic handbook describes procedure number
+        23, which staff follow when handling a case of type 23 during regular operating
+        hours. Section 24. Clause 24 of the clinic handbook describes procedure number
+        24, which staff follow when handling a case of type 24 during regular operating
+        hours. Section 25. Clause 25 of the clinic handbook describes procedure number
+        25, which staff follow when handling a case of type 25 during regular operating
+        hours. Section 26. Clause 26 of the clinic handbook describes procedure number
+        26, which staff follow when handling a case of type 26 during regular operating
+        hours. Section 27. Clause 27 of the clinic handbook describes procedure number
+        27, which staff follow when handling a case of type 27 during regular operating
+        hours. Section 28. Clause 28 of the clinic handbook describes procedure number
+        28, which staff follow when handling a case of type 28 during regular operating
+        hours. Section 29. Clause 29 of the clinic handbook describes procedure number
+        29, which staff follow when handling a case of type 29 during regular operating
+        hours. Section 30. Clause 30 of the clinic handbook describes procedure number
+        30, which staff follow when handling a case of type 30 during regular operating
+        hours. Section 31. Clause 31 of the clinic handbook describes procedure number
+        31, which staff follow when handling a case of type 31 during regular operating
+        hours. Section 32. Clause 32 of the clinic handbook describes procedure number
+        32, which staff follow when handling a case of type 32 during regular operating
+        hours. Section 33. Clause 33 of the clinic handbook describes procedure number
+        33, which staff follow when handling a case of type 33 during regular operating
+        hours. Section 34. Clause 34 of the clinic handbook describes procedure number
+        34, which staff follow when handling a case of type 34 during regular operating
+        hours. Section 35. Clause 35 of the clinic handbook describes procedure number
+        35, which staff follow when handling a case of type 35 during regular operating
+        hours. Section 36. Clause 36 of the clinic handbook describes procedure number
+        36, which staff follow when handling a case of type 36 during regular operating
+        hours. Section 37. Clause 37 of the clinic handbook describes procedure number
+        37, which staff follow when handling a case of type 37 during regular operating
+        hours. Section 38. Clause 38 of the clinic handbook describes procedure number
+        38, which staff follow when handling a case of type 38 during regular operating
+        hours. Section 39. Clause 39 of the clinic handbook describes procedure number
+        39, which staff follow when handling a case of type 39 during regular operating
+        hours. Section 40. Clause 40 of the clinic handbook describes procedure number
+        40, which staff follow when handling a case of type 40 during regular operating
+        hours. Section 41. Clause 41 of the clinic handbook describes procedure number
+        41, which staff follow when handling a case of type 41 during regular operating
+        hours. Section 42. Clause 42 of the clinic handbook describes procedure number
+        42, which staff follow when handling a case of type 42 during regular operating
+        hours. Section 43. Clause 43 of the clinic handbook describes procedure number
+        43, which staff follow when handling a case of type 43 during regular operating
+        hours. Section 44. Clause 44 of the clinic handbook describes procedure number
+        44, which staff follow when handling a case of type 44 during regular operating
+        hours. Section 45. Clause 45 of the clinic handbook describes procedure number
+        45, which staff follow when handling a case of type 45 during regular operating
+        hours. Section 46. Clause 46 of the clinic handbook describes procedure number
+        46, which staff follow when handling a case of type 46 during regular operating
+        hours. Section 47. Clause 47 of the clinic handbook describes procedure number
+        47, which staff follow when handling a case of type 47 during regular operating
+        hours. Section 48. Clause 48 of the clinic handbook describes procedure number
+        48, which staff follow when handling a case of type 48 during regular operating
+        hours. Section 49. Clause 49 of the clinic handbook describes procedure number
+        49, which staff follow when handling a case of type 49 during regular operating
+        hours. Section 50. Clause 50 of the clinic handbook describes procedure number
+        50, which staff follow when handling a case of type 50 during regular operating
+        hours. Section 51. Clause 51 of the clinic handbook describes procedure number
+        51, which staff follow when handling a case of type 51 during regular operating
+        hours. Section 52. Clause 52 of the clinic handbook describes procedure number
+        52, which staff follow when handling a case of type 52 during regular operating
+        hours. Section 53. Clause 53 of the clinic handbook describes procedure number
+        53, which staff follow when handling a case of type 53 during regular operating
+        hours. Section 54. Clause 54 of the clinic handbook describes procedure number
+        54, which staff follow when handling a case of type 54 during regular operating
+        hours. Section 55. Clause 55 of the clinic handbook describes procedure number
+        55, which staff follow when handling a case of type 55 during regular operating
+        hours. Section 56. Clause 56 of the clinic handbook describes procedure number
+        56, which staff follow when handling a case of type 56 during regular operating
+        hours. Section 57. Clause 57 of the clinic handbook describes procedure number
+        57, which staff follow when handling a case of type 57 during regular operating
+        hours. Section 58. Clause 58 of the clinic handbook describes procedure number
+        58, which staff follow when handling a case of type 58 during regular operating
+        hours. Section 59. Clause 59 of the clinic handbook describes procedure number
+        59, which staff follow when handling a case of type 59 during regular operating
+        hours. Section 60. Clause 60 of the clinic handbook describes procedure number
+        60, which staff follow when handling a case of type 60 during regular operating
+        hours. Section 61. Clause 61 of the clinic handbook describes procedure number
+        61, which staff follow when handling a case of type 61 during regular operating
+        hours. Section 62. Clause 62 of the clinic handbook describes procedure number
+        62, which staff follow when handling a case of type 62 during regular operating
+        hours. Section 63. Clause 63 of the clinic handbook describes procedure number
+        63, which staff follow when handling a case of type 63 during regular operating
+        hours. Section 64. Clause 64 of the clinic handbook describes procedure number
+        64, which staff follow when handling a case of type 64 during regular operating
+        hours. Section 65. Clause 65 of the clinic handbook describes procedure number
+        65, which staff follow when handling a case of type 65 during regular operating
+        hours. Section 66. Clause 66 of the clinic handbook describes procedure number
+        66, which staff follow when handling a case of type 66 during regular operating
+        hours. Section 67. Clause 67 of the clinic handbook describes procedure number
+        67, which staff follow when handling a case of type 67 during regular operating
+        hours. Section 68. Clause 68 of the clinic handbook describes procedure number
+        68, which staff follow when handling a case of type 68 during regular operating
+        hours. Section 69. Clause 69 of the clinic handbook describes procedure number
+        69, which staff follow when handling a case of type 69 during regular operating
+        hours. Section 70. Clause 70 of the clinic handbook describes procedure number
+        70, which staff follow when handling a case of type 70 during regular operating
+        hours. Section 71. Clause 71 of the clinic handbook describes procedure number
+        71, which staff follow when handling a case of type 71 during regular operating
+        hours. Section 72. Clause 72 of the clinic handbook describes procedure number
+        72, which staff follow when handling a case of type 72 during regular operating
+        hours. Section 73. Clause 73 of the clinic handbook describes procedure number
+        73, which staff follow when handling a case of type 73 during regular operating
+        hours. Section 74. Clause 74 of the clinic handbook describes procedure number
+        74, which staff follow when handling a case of type 74 during regular operating
+        hours. Section 75. Clause 75 of the clinic handbook describes procedure number
+        75, which staff follow when handling a case of type 75 during regular operating
+        hours. Section 76. Clause 76 of the clinic handbook describes procedure number
+        76, which staff follow when handling a case of type 76 during regular operating
+        hours. Section 77. Clause 77 of the clinic handbook describes procedure number
+        77, which staff follow when handling a case of type 77 during regular operating
+        hours. Section 78. Clause 78 of the clinic handbook describes procedure number
+        78, which staff follow when handling a case of type 78 during regular operating
+        hours. Section 79. Clause 79 of the clinic handbook describes procedure number
+        79, which staff follow when handling a case of type 79 during regular operating
+        hours. Section 80. Clause 80 of the clinic handbook describes procedure number
+        80, which staff follow when handling a case of type 80 during regular operating
+        hours.\n\nWhat is the current cancellation policy?"}]},{"role":"assistant","content":[{"text":"Let
+        me look up the current cancellation policy for you right away."},{"toolUse":{"toolUseId":"tooluse_P3nbk6atWRa0Ub7fBJbhKJ","name":"lookup_policy","input":{"name":"cancellation"}}}]},{"role":"user","content":[{"toolResult":{"toolUseId":"tooluse_P3nbk6atWRa0Ub7fBJbhKJ","content":[{"text":"Cancellations
+        require 24 hours notice."}]}},{"cachePoint":{"type":"default"}}]}],"system":[{"text":"You
+        are a clinic assistant. Call lookup_policy before answering a policy question."},{"cachePoint":{"type":"default"}}],"toolConfig":{"tools":[{"toolSpec":{"name":"lookup_policy","description":"Look
+        up the current wording of a named clinic policy","inputSchema":{"json":{"type":"object","properties":{"name":{"type":"string","description":"The
+        policy name"}},"required":["name"],"additionalProperties":false}}}}]}}'
+    headers:
+      Accept-Encoding:
+      - ''
+      Amz-Sdk-Invocation-Id:
+      - 8bff343f-d747-49c1-b656-d0e5db506f9c
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <AWS_BEDROCK_API_TOKEN>
+      User-Agent:
+      - aws-sdk-ruby3/3.254.1 ua/2.1 api/bedrock_runtime#1.83.0 os/macos#25 md/arm64
+        lang/ruby#4.0.5 md/4.0.5 m/Z,b,D
+      Content-Length:
+      - '13650'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 11 Sep 2026 18:21:05 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '665'
+      Connection:
+      - keep-alive
+      X-Amzn-Requestid:
+      - a0c4f257-cf55-406f-9ef2-8a909657f518
+    body:
+      encoding: UTF-8
+      string: '{"metrics":{"latencyMs":1506},"output":{"message":{"content":[{"text":"The
+        current **cancellation policy** is:\n\n> **Cancellations require 24 hours
+        notice.**\n\nThis means that if you need to cancel an appointment, please
+        make sure to do so at least **24 hours in advance**. If you have any further
+        questions or need assistance with a cancellation, feel free to ask!"}],"role":"assistant"}},"stopReason":"end_turn","usage":{"cacheDetails":[{"inputTokens":93,"ttl":"5m"}],"cacheReadInputTokenCount":3488,"cacheReadInputTokens":3488,"cacheWriteInputTokenCount":93,"cacheWriteInputTokens":93,"inputTokens":1,"outputTokens":73,"serverToolUsage":{},"totalTokens":3655}}'
+  recorded_at: Fri, 11 Sep 2026 18:21:05 GMT
+recorded_with: VCR 6.4.0

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -1194,54 +1194,6 @@ describe Riffer::Providers::AmazonBedrock do
       expect(params[:messages].last[:content].none? { |block| block.key?(:cache_point) }).must_equal true
     end
 
-    describe "against the SDK's param validation" do
-      # stub_responses: true skips the network but still runs the SDK's shape
-      # validation on the params, so a cachePoint in an invalid position
-      # raises instead of silently building. The SDK stubs an event stream as
-      # nil, so converse_stream needs an explicit empty stream to decode; its
-      # stub validator only accepts a Hash for that member.
-      let(:client) do
-        Aws::BedrockRuntime::Client.new(stub_responses: true).tap do |client|
-          client.stub_responses(:converse_stream, stream: {})
-        end
-      end
-      let(:request) do
-        {
-          messages: [
-            Riffer::Messages::System.new("Be concise"),
-            Riffer::Messages::User.new("Weather?"),
-            tool_call_message("tooluse_1"),
-            tool_result_message("tooluse_1"),
-          ],
-          model: model,
-          tools: [cache_tool],
-          cache_control: { type: "ephemeral" },
-        }
-      end
-
-      before do
-        provider # force SDK load so Aws::BedrockRuntime resolves for the client
-        Riffer.config.amazon_bedrock.client = client
-      end
-
-      it "sends both cachePoints on a generate request" do
-        provider.generate_text(**request)
-        params = client.api_requests.last[:params]
-
-        expect(params[:system].last).must_equal cache_point
-        expect(params[:messages].last[:content].last).must_equal cache_point
-      end
-
-      it "sends the same params on a streaming request" do
-        provider.generate_text(**request)
-        provider.stream_text(**request).to_a
-        generate_request, stream_request = client.api_requests
-
-        expect(stream_request[:operation_name]).must_equal :converse_stream
-        expect(stream_request[:params]).must_equal generate_request[:params]
-      end
-    end
-
     describe "#generate_text across the steps of a tool loop" do
       # Sonnet 4.6 ignores a checkpoint until 1,024 tokens precede it. The
       # system prompt alone stays well under that, so the static checkpoint

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -1241,6 +1241,71 @@ describe Riffer::Providers::AmazonBedrock do
         expect(stream_request[:params]).must_equal generate_request[:params]
       end
     end
+
+    describe "#generate_text across the steps of a tool loop" do
+      # Sonnet 4.6 ignores a checkpoint until 1,024 tokens precede it. The
+      # system prompt alone stays well under that, so the static checkpoint
+      # is a no-op and every cache read the second step sees has to come
+      # from the moving checkpoint on the first step's user message.
+      let(:model) { "us.anthropic.claude-sonnet-4-6" }
+      let(:lookup_tool) do
+        stub_tool("LookupPolicy") do
+          description "Look up the current wording of a named clinic policy"
+          params do
+            required :name, String, description: "The policy name"
+          end
+        end
+      end
+      let(:handbook) do
+        (1..80).map do |n|
+          "Section #{n}. Clause #{n} of the clinic handbook describes procedure number #{n}, " \
+            "which staff follow when handling a case of type #{n} during regular operating hours."
+        end.join(" ")
+      end
+      let(:first_step) do
+        [
+          Riffer::Messages::System.new(
+            "You are a clinic assistant. Call lookup_policy before answering a policy question.",
+          ),
+          Riffer::Messages::User.new(
+            "Here is the handbook:\n\n#{handbook}\n\nWhat is the current cancellation policy?",
+          ),
+        ]
+      end
+
+      it "reads the previous step's messages from cache on the next step of a tool loop" do
+        VCR.use_cassette(
+          "Riffer_Providers_AmazonBedrock/prompt_caching/_generate_text/reads_previous_step_from_cache",
+        ) do
+          first = provider.generate_text(
+            messages: first_step,
+            model: model,
+            tools: [lookup_tool],
+            cache_control: { type: "ephemeral" },
+          )
+
+          expect(first.tool_calls).wont_be_empty
+          expect(first.token_usage.cache_write_tokens).must_be :>, 1024
+
+          second = provider.generate_text(
+            messages: [
+              *first_step,
+              first,
+              Riffer::Messages::Tool.new(
+                "Cancellations require 24 hours notice.",
+                tool_call_id: first.tool_calls.first.call_id,
+                name: "lookup_policy",
+              ),
+            ],
+            model: model,
+            tools: [lookup_tool],
+            cache_control: { type: "ephemeral" },
+          )
+
+          expect(second.token_usage.cache_read_tokens).must_be :>=, first.token_usage.cache_write_tokens
+        end
+      end
+    end
   end
 
   describe "file handling" do

--- a/test/riffer/providers/amazon_bedrock_test.rb
+++ b/test/riffer/providers/amazon_bedrock_test.rb
@@ -1063,6 +1063,8 @@ describe Riffer::Providers::AmazonBedrock do
 
   describe "prompt caching" do
     let(:model) { "us.anthropic.claude-haiku-4-5-20251001-v1:0" }
+    let(:provider) { Riffer::Providers::AmazonBedrock.new }
+    let(:cache_point) { { cache_point: { type: "default" } } }
     let(:cache_tool) do
       stub_tool("GetWeather") do
         description "Get the current weather for a city"
@@ -1072,17 +1074,73 @@ describe Riffer::Providers::AmazonBedrock do
       end
     end
 
-    it "appends a cachePoint after the system array when a system prompt is present" do
-      provider = Riffer::Providers::AmazonBedrock.new
+    def tool_call_message(*call_ids)
+      Riffer::Messages::Assistant.new(
+        "",
+        tool_calls: call_ids.map do |call_id|
+          Riffer::Messages::Assistant::ToolCall.new(call_id: call_id, name: "get_weather", arguments: "{}")
+        end,
+      )
+    end
+
+    def tool_result_message(call_id)
+      Riffer::Messages::Tool.new("Sunny", tool_call_id: call_id, name: "get_weather")
+    end
+
+    it "appends a cachePoint after the system array and after the last user text block" do
       messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
 
       params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
 
-      expect(params[:system].last).must_equal({ cache_point: { type: "default" } })
+      expect(params[:system].last).must_equal cache_point
+      expect(params[:messages].last[:content]).must_equal [{ text: "Hello" }, cache_point]
+    end
+
+    it "places the moving cachePoint after the file parts of the last user message" do
+      image_base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+      file = Riffer::Messages::FilePart.new(data: image_base64, media_type: "image/png")
+      messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Describe", files: [file])]
+
+      params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
+      content = params[:messages].last[:content]
+
+      expect(content.length).must_equal 3
+      expect(content[1].key?(:image)).must_equal true
+      expect(content.last).must_equal cache_point
+    end
+
+    it "places the moving cachePoint as a sibling of a single tool_result block" do
+      messages = [
+        Riffer::Messages::System.new("Be concise"),
+        Riffer::Messages::User.new("Weather?"),
+        tool_call_message("tooluse_1"),
+        tool_result_message("tooluse_1"),
+      ]
+
+      params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
+      content = params[:messages].last[:content]
+
+      expect(content.map(&:keys)).must_equal [[:tool_result], [:cache_point]]
+      expect(content.first[:tool_result].key?(:cache_point)).must_equal false
+    end
+
+    it "places the moving cachePoint after several merged tool_result blocks" do
+      messages = [
+        Riffer::Messages::System.new("Be concise"),
+        Riffer::Messages::User.new("Weather?"),
+        tool_call_message("tooluse_1", "tooluse_2"),
+        tool_result_message("tooluse_1"),
+        tool_result_message("tooluse_2"),
+      ]
+
+      params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
+      content = params[:messages].last[:content]
+
+      expect(content.map(&:keys)).must_equal [[:tool_result], [:tool_result], [:cache_point]]
+      expect(content.map { |block| block[:tool_result]&.key?(:cache_point) }).must_equal [false, false, nil]
     end
 
     it "appends a cachePoint after the tools when there is no system prompt" do
-      provider = Riffer::Providers::AmazonBedrock.new
       messages = [Riffer::Messages::User.new("Hello")]
 
       params = provider.send(
@@ -1092,11 +1150,20 @@ describe Riffer::Providers::AmazonBedrock do
         { cache_control: { type: "ephemeral" }, tools: [cache_tool] },
       )
 
-      expect(params[:tool_config][:tools].last).must_equal({ cache_point: { type: "default" } })
+      expect(params[:tool_config][:tools].last).must_equal cache_point
+      expect(params[:messages].last[:content].last).must_equal cache_point
     end
 
-    it "translates the ttl onto the cachePoint" do
-      provider = Riffer::Providers::AmazonBedrock.new
+    it "only adds the static cachePoint when there are no messages" do
+      messages = [Riffer::Messages::System.new("Be concise")]
+
+      params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
+
+      expect(params[:system].last).must_equal cache_point
+      expect(params[:messages]).must_equal []
+    end
+
+    it "translates the ttl onto both cachePoints" do
       messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
 
       params = provider.send(
@@ -1107,10 +1174,10 @@ describe Riffer::Providers::AmazonBedrock do
       )
 
       expect(params[:system].last[:cache_point][:ttl]).must_equal "1h"
+      expect(params[:messages].last[:content].last[:cache_point][:ttl]).must_equal "1h"
     end
 
     it "does not pass cache_control through as a top-level param" do
-      provider = Riffer::Providers::AmazonBedrock.new
       messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
 
       params = provider.send(:build_request_params, messages, model, { cache_control: { type: "ephemeral" } })
@@ -1118,13 +1185,61 @@ describe Riffer::Providers::AmazonBedrock do
       expect(params.key?(:cache_control)).must_equal false
     end
 
-    it "adds no cachePoint when caching is not requested" do
-      provider = Riffer::Providers::AmazonBedrock.new
+    it "adds no cachePoint anywhere when caching is not requested" do
       messages = [Riffer::Messages::System.new("Be concise"), Riffer::Messages::User.new("Hello")]
 
       params = provider.send(:build_request_params, messages, model, {})
 
       expect(params[:system].none? { |block| block.key?(:cache_point) }).must_equal true
+      expect(params[:messages].last[:content].none? { |block| block.key?(:cache_point) }).must_equal true
+    end
+
+    describe "against the SDK's param validation" do
+      # stub_responses: true skips the network but still runs the SDK's shape
+      # validation on the params, so a cachePoint in an invalid position
+      # raises instead of silently building. The SDK stubs an event stream as
+      # nil, so converse_stream needs an explicit empty stream to decode; its
+      # stub validator only accepts a Hash for that member.
+      let(:client) do
+        Aws::BedrockRuntime::Client.new(stub_responses: true).tap do |client|
+          client.stub_responses(:converse_stream, stream: {})
+        end
+      end
+      let(:request) do
+        {
+          messages: [
+            Riffer::Messages::System.new("Be concise"),
+            Riffer::Messages::User.new("Weather?"),
+            tool_call_message("tooluse_1"),
+            tool_result_message("tooluse_1"),
+          ],
+          model: model,
+          tools: [cache_tool],
+          cache_control: { type: "ephemeral" },
+        }
+      end
+
+      before do
+        provider # force SDK load so Aws::BedrockRuntime resolves for the client
+        Riffer.config.amazon_bedrock.client = client
+      end
+
+      it "sends both cachePoints on a generate request" do
+        provider.generate_text(**request)
+        params = client.api_requests.last[:params]
+
+        expect(params[:system].last).must_equal cache_point
+        expect(params[:messages].last[:content].last).must_equal cache_point
+      end
+
+      it "sends the same params on a streaming request" do
+        provider.generate_text(**request)
+        provider.stream_text(**request).to_a
+        generate_request, stream_request = client.api_requests
+
+        expect(stream_request[:operation_name]).must_equal :converse_stream
+        expect(stream_request[:params]).must_equal generate_request[:params]
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

Riffer's `cache_control` model option is meant to mean the same thing on Anthropic and Bedrock. On Anthropic it maps to top-level `cache_control`, which the Messages API treats as automatic caching with a breakpoint that moves forward on every request. On Bedrock it was translated into a single Converse `cachePoint` at the end of the system array (or tools), a fixed breakpoint at the end of the static prefix. Nothing in `messages` was ever cached, and the docs said so.

## Solution

`apply_cache_point` now emits two checkpoints with the same `ttl`. The existing static one stays at the end of `system` (or `tools` when there is no system prompt). A second `cachePoint` is appended after the last content block of the final message in `params[:messages]`, as a sibling of whatever is there already (user text, file parts, or the merged `tool_result` blocks that `append_tool_result` produces), never nested inside a `tool_result`. Bedrock's simplified cache management looks back about 20 content blocks from a checkpoint for the longest cached prefix, so the second and later calls in a tool loop, and later turns in a conversation, read the accumulated prefix from cache. Keeping the static checkpoint guarantees the prefix still hits when the tail changes beyond that lookback. If `messages` is empty the behaviour is unchanged.

`build_cache_point`, the `ttl` passthrough, `build_token_usage`, and the Anthropic provider are untouched. The `cache_control` section of `docs/providers/AMAZON_BEDROCK.md` now describes both checkpoints, links the AWS guide for the per-model minimum token count below which a checkpoint is silently ignored, and notes that `cache_read_tokens` should grow with each step in an agent loop.

## Proof

CI runs the full suite, RuboCop, and Steep. New tests in `test/riffer/providers/amazon_bedrock_test.rb` cover the placement of the moving checkpoint after user text, after file parts, as a sibling of one and several merged tool results, the tools-only prefix, the no-messages fallback, `ttl: "1h"` on both checkpoints, and `cache_control` omitted.

A recorded VCR cassette runs a real two-step tool loop against `us.anthropic.claude-sonnet-4-6`. The system prompt is kept under the 1,024-token minimum so the static checkpoint is ignored and every cache read has to come from the moving checkpoint. Recorded usage:

| Step | cacheWriteInputTokens | cacheReadInputTokens | inputTokens (uncached) |
| ---- | --------------------- | -------------------- | ---------------------- |
| 1    | 3,488                 | 0                    | 3                      |
| 2    | 93                    | 3,488                | 1                      |

Step two reads the entire previous prefix back from cache and writes only the new assistant turn and tool result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Amazon Bedrock prompt caching now supports an additional moving cache checkpoint after the latest conversation content.
  - Cached prompts can be reused across multi-step tool interactions, including subsequent tool results and responses.
  - Cache expiration settings apply consistently across both static and moving checkpoints.

- **Documentation**
  - Expanded guidance covers checkpoint placement, minimum token requirements, cache-read behavior, shared expiration, and limitations for short conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->