### PR TITLE
fix(params): keep optional Hash params nullable in strict JSON Schema

### DIFF
--- a/lib/riffer/params/param.rb
+++ b/lib/riffer/params/param.rb
@@ -168,7 +168,8 @@ class Riffer::Params::Param
     elsif self.type == Array && item_type
       schema[:items] = { type: TYPE_MAPPINGS[item_type] }
     elsif self.type == Hash && nested_params
-      schema.merge!(nested_params.to_json_schema(strict: strict))
+      # The nested schema carries its own type: "object", which would clobber a nullable union.
+      schema.merge!(nested_params.to_json_schema(strict: strict).except(:type))
     end
 
     schema

--- a/test/riffer/params_test.rb
+++ b/test/riffer/params_test.rb
@@ -537,6 +537,42 @@ describe Riffer::Params do
       expect(items_schema[:properties]["note"][:type]).must_equal %w[string null]
     end
 
+    it "makes an optional object with nested params nullable" do
+      params = Riffer::Params.new
+      params.optional(:definition, Hash) do
+        required :name, String
+      end
+      schema = params.to_json_schema(strict: true)
+      definition = schema[:properties]["definition"]
+
+      expect(definition[:type]).must_equal %w[object null]
+      expect(definition[:properties]["name"][:type]).must_equal "string"
+      expect(definition[:required]).must_equal ["name"]
+    end
+
+    it "makes an optional array with nested params nullable" do
+      params = Riffer::Params.new
+      params.optional(:items, Array) do
+        required :name, String
+      end
+      schema = params.to_json_schema(strict: true)
+      items = schema[:properties]["items"]
+
+      expect(items[:type]).must_equal %w[array null]
+      expect(items[:items][:type]).must_equal "object"
+      expect(items[:items][:properties]["name"][:type]).must_equal "string"
+    end
+
+    it "makes an optional typed array nullable" do
+      params = Riffer::Params.new
+      params.optional(:tags, Array, of: String)
+      schema = params.to_json_schema(strict: true)
+      tags = schema[:properties]["tags"]
+
+      expect(tags[:type]).must_equal %w[array null]
+      expect(tags[:items]).must_equal({ type: "string" })
+    end
+
     it "keeps required properties non-nullable" do
       params = Riffer::Params.new
       params.required(:name, String)


### PR DESCRIPTION
## Problem

Under `strict: true`, `Riffer::Params#to_json_schema` renders optional params as a `[type, "null"]` union so providers with strict structured-output modes (OpenAI, Anthropic, Bedrock) can accept a missing value. That held for scalars and Arrays, but not for an optional `Hash` param declared with a nested block:

```ruby
optional :definition, Hash do
  required :name, String
end
```

The nested `Params` schema was merged into the parent wholesale, and its own `type: "object"` overwrote the `["object", "null"]` union. The param came out as a required, non-nullable object, so a model omitting or nulling it produced a schema violation.

## Solution

Merge the nested schema without its `type` key. The parent already carries the correct `type` (nullable union under strict, plain `"object"` otherwise), and `properties`, `required`, and `additionalProperties` still flow through from the nested schema. Non-strict output is unchanged because the excluded `type` was identical to the parent's.

Array params were checked and are unaffected: both nested-block and `of:` schemas land under `items`, a separate key, so the union was never clobbered. Tests now lock in nullable rendering for those shapes too.

No provider transforms the `type` key. Anthropic, Bedrock, OpenAI, and OpenRouter pass the strict schema through untouched, and the existing `anyOf` special case only applies when `enum` is set, so a plain `["object", "null"]` union is the shape they already accept for scalars. Gemini uses non-strict schemas and only strips `additionalProperties`.

## Proof

Three new tests in `test/riffer/params_test.rb` cover optional Hash with block, optional Array with block, and optional Array with `of:`, all under `strict: true`. `bin/rake` passes locally (test, rubocop, steep). CI covers the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected strict JSON Schema generation for nested hash schemas, preserving nullable type handling.
  - Optional nested objects, nested object arrays, and typed arrays now produce accurate nullable schemas.

- **Tests**
  - Added coverage to verify nested schema definitions and nullable type representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->